### PR TITLE
refactor(apps/label): move views into /apis/web/label

### DIFF
--- a/src/dashboard/apigateway/apigateway/apis/web/__init__.py
+++ b/src/dashboard/apigateway/apigateway/apis/web/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # TencentBlueKing is pleased to support the open source community by making
 # 蓝鲸智云 - API 网关(BlueKing - APIGateway) available.
@@ -16,15 +15,3 @@
 # We undertake not to change the open source license (MIT license) applicable
 # to the current version of the project delivered to anyone in the future.
 #
-from django.urls import path
-
-from apigateway.apps.label.views import APILabelViewSet
-
-urlpatterns = [
-    path("", APILabelViewSet.as_view({"get": "list", "post": "create"}), name="labels"),
-    path(
-        "<int:id>/",
-        APILabelViewSet.as_view({"get": "retrieve", "put": "update", "delete": "destroy"}),
-        name="labels.detail",
-    ),
-]

--- a/src/dashboard/apigateway/apigateway/apis/web/label/__init__.py
+++ b/src/dashboard/apigateway/apigateway/apis/web/label/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # TencentBlueKing is pleased to support the open source community by making
 # 蓝鲸智云 - API 网关(BlueKing - APIGateway) available.

--- a/src/dashboard/apigateway/apigateway/apis/web/label/serializers.py
+++ b/src/dashboard/apigateway/apigateway/apis/web/label/serializers.py
@@ -24,7 +24,13 @@ from apigateway.common.fields import CurrentGatewayDefault
 from apigateway.core.validators import MaxCountPerGatewayValidator
 
 
-class APILabelSLZ(serializers.ModelSerializer):
+class APILabelOutputSLZ(serializers.Serializer):
+    id = serializers.IntegerField()
+    name = serializers.CharField()
+    updated_time = serializers.DateTimeField()
+
+
+class APILabelInputSLZ(serializers.ModelSerializer):
     api = serializers.HiddenField(default=CurrentGatewayDefault())
 
     class Meta:
@@ -33,10 +39,7 @@ class APILabelSLZ(serializers.ModelSerializer):
             "api",
             "id",
             "name",
-            "updated_time",
         ]
-        read_only_fields = ["id", "updated_time"]
-        lookup_field = "id"
 
         validators = [
             UniqueTogetherValidator(
@@ -52,7 +55,7 @@ class APILabelSLZ(serializers.ModelSerializer):
         ]
 
 
-class APILabelQuerySLZ(serializers.Serializer):
+class APILabelListQueryInputSLZ(serializers.Serializer):
     name = serializers.CharField(allow_blank=True, required=False)
     order_by = serializers.ChoiceField(
         choices=["name", "-name", "updated_time", "-updated_time"],

--- a/src/dashboard/apigateway/apigateway/apis/web/label/urls.py
+++ b/src/dashboard/apigateway/apigateway/apis/web/label/urls.py
@@ -1,0 +1,30 @@
+# -*- coding: utf-8 -*-
+#
+# TencentBlueKing is pleased to support the open source community by making
+# 蓝鲸智云 - API 网关(BlueKing - APIGateway) available.
+# Copyright (C) 2017 THL A29 Limited, a Tencent company. All rights reserved.
+# Licensed under the MIT License (the "License"); you may not use this file except
+# in compliance with the License. You may obtain a copy of the License at
+#
+#     http://opensource.org/licenses/MIT
+#
+# Unless required by applicable law or agreed to in writing, software distributed under
+# the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+# either express or implied. See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# We undertake not to change the open source license (MIT license) applicable
+# to the current version of the project delivered to anyone in the future.
+#
+from django.urls import path
+
+from .views import APILabelListCreateApi, APILabelRetrieveUpdateDestroyApi
+
+urlpatterns = [
+    path("", APILabelListCreateApi.as_view(), name="label.list_create"),
+    path(
+        "<int:id>/",
+        APILabelRetrieveUpdateDestroyApi.as_view(),
+        name="label.retrieve_update_destroy",
+    ),
+]

--- a/src/dashboard/apigateway/apigateway/apps/label/models.py
+++ b/src/dashboard/apigateway/apigateway/apps/label/models.py
@@ -17,9 +17,10 @@
 #
 from django.db import models
 
-from apigateway.apps.label.managers import APILabelManager, ResourceLabelManager
 from apigateway.common.mixins.models import OperatorModelMixin, TimestampedModelMixin
 from apigateway.core.models import Gateway, Resource
+
+from .managers import APILabelManager, ResourceLabelManager
 
 
 class APILabel(TimestampedModelMixin, OperatorModelMixin):
@@ -43,6 +44,7 @@ class APILabel(TimestampedModelMixin, OperatorModelMixin):
 class ResourceLabel(TimestampedModelMixin):
     """
     Resource label
+    resource - api_label
     """
 
     resource = models.ForeignKey(Resource, on_delete=models.CASCADE)

--- a/src/dashboard/apigateway/apigateway/tests/apis/web/__init__.py
+++ b/src/dashboard/apigateway/apigateway/tests/apis/web/__init__.py
@@ -1,0 +1,17 @@
+#
+# TencentBlueKing is pleased to support the open source community by making
+# 蓝鲸智云 - API 网关(BlueKing - APIGateway) available.
+# Copyright (C) 2017 THL A29 Limited, a Tencent company. All rights reserved.
+# Licensed under the MIT License (the "License"); you may not use this file except
+# in compliance with the License. You may obtain a copy of the License at
+#
+#     http://opensource.org/licenses/MIT
+#
+# Unless required by applicable law or agreed to in writing, software distributed under
+# the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+# either express or implied. See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# We undertake not to change the open source license (MIT license) applicable
+# to the current version of the project delivered to anyone in the future.
+#

--- a/src/dashboard/apigateway/apigateway/tests/apis/web/label/__init__.py
+++ b/src/dashboard/apigateway/apigateway/tests/apis/web/label/__init__.py
@@ -1,0 +1,17 @@
+#
+# TencentBlueKing is pleased to support the open source community by making
+# 蓝鲸智云 - API 网关(BlueKing - APIGateway) available.
+# Copyright (C) 2017 THL A29 Limited, a Tencent company. All rights reserved.
+# Licensed under the MIT License (the "License"); you may not use this file except
+# in compliance with the License. You may obtain a copy of the License at
+#
+#     http://opensource.org/licenses/MIT
+#
+# Unless required by applicable law or agreed to in writing, software distributed under
+# the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+# either express or implied. See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# We undertake not to change the open source license (MIT license) applicable
+# to the current version of the project delivered to anyone in the future.
+#

--- a/src/dashboard/apigateway/apigateway/tests/apis/web/label/test_serializers.py
+++ b/src/dashboard/apigateway/apigateway/tests/apis/web/label/test_serializers.py
@@ -20,13 +20,13 @@ import arrow
 from django.test import TestCase
 from django_dynamic_fixture import G
 
+from apigateway.apis.web.label.serializers import APILabelInputSLZ, APILabelOutputSLZ
 from apigateway.apps.label.models import APILabel
-from apigateway.apps.label.serializers import APILabelSLZ
 from apigateway.core.models import Gateway
 from apigateway.tests.utils.testing import create_request
 
 
-class TestAPILabelSLZ(TestCase):
+class TestAPILabelOutputSLZ(TestCase):
     def test_to_representation(self):
         gateway = G(Gateway)
         updated_time = arrow.get("2019-01-01 12:30:00").datetime
@@ -38,9 +38,11 @@ class TestAPILabelSLZ(TestCase):
             "updated_time": "2019-01-01 20:30:00",
         }
 
-        slz = APILabelSLZ(instance=api_label)
+        slz = APILabelOutputSLZ(instance=api_label)
         self.assertEqual(slz.data, expected)
 
+
+class TestAPILabelInputSLZ(TestCase):
     def test_to_internal_value(self):
         gateway = G(Gateway)
         api_label = G(APILabel, api=gateway, name="test")
@@ -95,7 +97,7 @@ class TestAPILabelSLZ(TestCase):
         ]
 
         for test in data:
-            slz = APILabelSLZ(instance=test["instance"], data=test, context={"request": request})
+            slz = APILabelInputSLZ(instance=test["instance"], data=test, context={"request": request})
             slz.is_valid()
             if test["will_error"]:
                 self.assertTrue(slz.errors)

--- a/src/dashboard/apigateway/apigateway/tests/apps/label/test_managers.py
+++ b/src/dashboard/apigateway/apigateway/tests/apps/label/test_managers.py
@@ -104,13 +104,6 @@ class TestAPILabelManager:
         result = APILabel.objects.get_label_ids(gateway)
         assert result == [l1.id, l2.id]
 
-    def test_get_label_names(self, fake_gateway):
-        l1 = G(APILabel, api=fake_gateway)
-        l2 = G(APILabel, api=fake_gateway)
-
-        result = APILabel.objects.get_label_names(fake_gateway)
-        assert set(result) == {l1.name, l2.name}
-
     def test_get_name_id_map(self):
         gateway = G(Gateway)
         l1 = G(APILabel, api=gateway, name="t1")

--- a/src/dashboard/apigateway/apigateway/urls.py
+++ b/src/dashboard/apigateway/apigateway/urls.py
@@ -60,7 +60,6 @@ urlpatterns = [
     path("backend/apis/<int:gateway_id>/ssl/", include("apigateway.apps.ssl_certificate.urls")),
     # apps: normal
     path("backend/apis/<int:gateway_id>/tests/", include("apigateway.apps.api_test.urls")),
-    path("backend/apis/<int:gateway_id>/labels/", include("apigateway.apps.label.urls")),
     path("backend/apis/<int:gateway_id>/logs/", include("apigateway.apps.access_log.urls")),
     path("backend/apis/<int:gateway_id>/metrics/", include("apigateway.apps.metrics.urls")),
     path("backend/apis/<int:gateway_id>/monitors/", include("apigateway.apps.monitor.urls")),
@@ -87,6 +86,11 @@ urlpatterns = [
     path("backend/docs/esb/", include("apigateway.apps.docs.esb.urls")),
     path("backend/docs/feature/", include("apigateway.apps.docs.feature.urls")),
     path("backend/docs/feedback/", include("apigateway.apps.docs.feedback.urls")),
+    # refactoring begin ------
+    # delete it later after frontend changed the url
+    path("backend/apis/<int:gateway_id>/labels/", include("apigateway.apis.web.label.urls")),
+    path("backend/gateways/<int:gateway_id>/labels/", include("apigateway.apis.web.label.urls")),
+    # refactoring end ------
 ]
 
 # add drf-yasg automatically generated documents


### PR DESCRIPTION
### Description

<!-- 关联相关issue Please include a summary of the change and which issue is fixed. -->
<!-- 给出必要的上下文以及review需要的必要信息 Please also include relevant motivation and context. -->

重构: apps/label, 将views 层抽到 `/apis/web/label`中

- 由于 label 模型十分简单, 所以这里的创建用了 ModelSerializer
- slz 和 view的命名做了限制, view能继承的父类做了规范化
- 模块内使用相对引用(作用域)
- reference: https://wklken.me/posts/2022/10/07/django-drf-inherit.html


### Checklist

- [x] 填写 PR 描述及相关 issue (write PR description and related issue)
- [x] 代码风格检查通过 (code style check passed)
- [x] PR 中包含单元测试 (include unit test)
- [x] 单元测试通过 (unit test passed)
- [x] 本地开发联调环境验证通过 (local development environment verification passed)
