### PR TITLE
fix: 获取 esb sdk 信息时，添加缓存

### DIFF
--- a/src/dashboard/apigateway/apigateway/apis/web/docs/esb/sdk/views.py
+++ b/src/dashboard/apigateway/apigateway/apis/web/docs/esb/sdk/views.py
@@ -25,7 +25,7 @@ from tencent_apigateway_common.django.translation import get_current_language_co
 
 from apigateway.biz.esb.decorators import check_board_exist
 from apigateway.biz.esb.sdk.models import DocTemplates, DummySDKDocContext, SDKDocContext
-from apigateway.biz.esb.sdk.sdk_factory import SDKFactory
+from apigateway.biz.esb.sdk.sdk_factory import ESBSDKFetcher
 from apigateway.common.error_codes import error_codes
 from apigateway.utils.responses import OKJsonResponse
 
@@ -58,7 +58,7 @@ class SDKListApi(generics.ListAPIView):
         sdks = []
 
         for board in settings.ESB_BOARD_CONFIGS:
-            sdk = SDKFactory.get_sdk(board, slz.validated_data["language"])
+            sdk = ESBSDKFetcher.get_sdk(board, slz.validated_data["language"])
             if not sdk:
                 continue
             sdks.append(sdk)
@@ -83,7 +83,7 @@ class SDKRetrieveApi(generics.RetrieveAPIView):
         slz = SDKRetrieveInputSLZ(data=request.query_params)
         slz.is_valid(raise_exception=True)
 
-        sdk = SDKFactory.get_sdk(board, slz.validated_data["language"])
+        sdk = ESBSDKFetcher.get_sdk(board, slz.validated_data["language"])
         if not sdk:
             raise error_codes.NOT_FOUND
 

--- a/src/dashboard/apigateway/apigateway/biz/esb/sdk/sdk_factory.py
+++ b/src/dashboard/apigateway/apigateway/biz/esb/sdk/sdk_factory.py
@@ -20,6 +20,7 @@ from abc import ABCMeta, abstractmethod
 from dataclasses import asdict, dataclass
 from typing import Optional
 
+from cachetools import TTLCache, cached
 from django.conf import settings
 from django.utils.translation import gettext as _
 from tencent_apigateway_common.pypi.pip import PipHelper
@@ -48,8 +49,9 @@ class PythonSDK:
         return data
 
 
-class SDKFactory:
+class ESBSDKFetcher:
     @staticmethod
+    @cached(cache=TTLCache(maxsize=100, ttl=3600))
     def get_sdk(board: str, language: str) -> Optional[PythonSDK]:
         if language == ProgrammingLanguageEnum.PYTHON.value:
             return PythonSDKManager.get_manager(board).get_sdk()

--- a/src/dashboard/apigateway/apigateway/tests/apis/web/docs/esb/sdk/test_views.py
+++ b/src/dashboard/apigateway/apigateway/tests/apis/web/docs/esb/sdk/test_views.py
@@ -18,7 +18,7 @@
 class TestSDKListApi:
     def test_list(self, mocker, faker, request_view):
         mocker.patch(
-            "apigateway.apis.web.docs.esb.sdk.views.SDKFactory.get_sdk",
+            "apigateway.apis.web.docs.esb.sdk.views.ESBSDKFetcher.get_sdk",
             return_value=mocker.MagicMock(
                 board_label=faker.pystr(),
                 sdk_name=faker.pystr(),
@@ -48,7 +48,7 @@ class TestSDKListApi:
 class TestSDKRetrieveApi:
     def test_retrieve(self, mock_board, mocker, faker, request_view):
         mocker.patch(
-            "apigateway.apis.web.docs.esb.sdk.views.SDKFactory.get_sdk",
+            "apigateway.apis.web.docs.esb.sdk.views.ESBSDKFetcher.get_sdk",
             return_value=None,
         )
         resp = request_view(
@@ -64,7 +64,7 @@ class TestSDKRetrieveApi:
         assert resp.status_code == 404
 
         mocker.patch(
-            "apigateway.apis.web.docs.esb.sdk.views.SDKFactory.get_sdk",
+            "apigateway.apis.web.docs.esb.sdk.views.ESBSDKFetcher.get_sdk",
             return_value=mocker.MagicMock(
                 board_label=faker.pystr(),
                 sdk_name=faker.pystr(),


### PR DESCRIPTION
### Description

<!-- 关联相关issue Please include a summary of the change and which issue is fixed. -->
<!-- 给出必要的上下文以及review需要的必要信息 Please also include relevant motivation and context. -->

esb sdk 的获取，是根据 settings 中配置的 sdk 列表，去 pypi 源拉取的。因数据量较少，及减少复杂度，没有存储到 db，现在拉取 sdk 较慢，因此加一个缓存


### Checklist

- [x] 填写 PR 描述及相关 issue (write PR description and related issue)
- [x] 代码风格检查通过 (code style check passed)
- [x] PR 中包含单元测试 (include unit test)
- [x] 单元测试通过 (unit test passed)
- [ ] 本地开发联调环境验证通过 (local development environment verification passed)
