### PR TITLE
feat(standardization/names): gateway_name/stage_name/resource_name should not endswith - and _

### DIFF
--- a/src/dashboard/apigateway/apigateway/apis/open/gateway/serializers.py
+++ b/src/dashboard/apigateway/apigateway/apis/open/gateway/serializers.py
@@ -33,7 +33,7 @@ from apigateway.core.constants import (
     UserAuthTypeEnum,
 )
 from apigateway.core.models import Gateway, ReleaseHistory
-from apigateway.core.validators import BKAppCodeListValidator
+from apigateway.core.validators import BKAppCodeListValidator, NameValidator
 
 
 class GatewayQueryV1SLZ(serializers.Serializer):
@@ -78,7 +78,12 @@ class UserConfigSLZ(serializers.Serializer):
 
 
 class GatewaySyncSLZ(ExtensibleFieldMixin, serializers.ModelSerializer):
-    name = serializers.RegexField(API_NAME_PATTERN, label="网关名称", max_length=64)
+    name = serializers.RegexField(
+        API_NAME_PATTERN,
+        label="网关名称",
+        max_length=64,
+        validators=[NameValidator()],
+    )
     maintainers = serializers.ListField(child=serializers.CharField(), allow_empty=True, required=False)
     status = serializers.ChoiceField(choices=APIStatusEnum.choices(), default=APIStatusEnum.ACTIVE.value)
     # 只允许指定为普通网关或官方网关，不能指定为超级官方网关，超级官方网关会传递敏感参数到后端接口

--- a/src/dashboard/apigateway/apigateway/apps/gateway/serializers.py
+++ b/src/dashboard/apigateway/apigateway/apps/gateway/serializers.py
@@ -33,7 +33,7 @@ from apigateway.core.constants import (
     UserAuthTypeEnum,
 )
 from apigateway.core.models import Gateway
-from apigateway.core.validators import ReservedAPINameValidator
+from apigateway.core.validators import NameValidator, ReservedAPINameValidator
 from apigateway.utils.crypto import calculate_fingerprint
 
 
@@ -42,7 +42,7 @@ class GatewayCreateSLZ(serializers.ModelSerializer):
         API_NAME_PATTERN,
         label="网关名称",
         max_length=64,
-        validators=[ReservedAPINameValidator()],
+        validators=[ReservedAPINameValidator(), NameValidator()],
     )
     maintainers = serializers.ListField(child=serializers.CharField(), allow_empty=True)
     developers = serializers.ListField(child=serializers.CharField(), allow_empty=True, default=list)

--- a/src/dashboard/apigateway/apigateway/apps/resource/serializers.py
+++ b/src/dashboard/apigateway/apigateway/apps/resource/serializers.py
@@ -51,7 +51,7 @@ from apigateway.core.constants import (
 )
 from apigateway.core.models import Resource, StageResourceDisabled
 from apigateway.core.utils import get_path_display, get_resource_url
-from apigateway.core.validators import MaxCountPerGatewayValidator
+from apigateway.core.validators import MaxCountPerGatewayValidator, NameValidator
 
 
 class ResourceHostSLZ(HostSLZ):
@@ -224,7 +224,12 @@ class ProxyConfigsSLZ(serializers.Serializer):
 
 class ResourceSLZ(ExtensibleFieldMixin, serializers.ModelSerializer):
     api = serializers.HiddenField(default=CurrentGatewayDefault())
-    name = serializers.RegexField(RESOURCE_NAME_PATTERN, max_length=256, required=True)
+    name = serializers.RegexField(
+        RESOURCE_NAME_PATTERN,
+        max_length=256,
+        required=True,
+        validators=[NameValidator()],
+    )
     path = serializers.RegexField(PATH_PATTERN, max_length=2048)
     label_ids = serializers.ListField(label="标签ID", child=serializers.IntegerField(), allow_empty=True, required=False)
     proxy_type = serializers.ChoiceField(choices=ProxyTypeEnum.get_choices())

--- a/src/dashboard/apigateway/apigateway/apps/stage/serializers.py
+++ b/src/dashboard/apigateway/apigateway/apps/stage/serializers.py
@@ -41,7 +41,7 @@ from apigateway.core.constants import (
 )
 from apigateway.core.models import MicroGateway, Stage
 from apigateway.core.signals import reversion_update_signal
-from apigateway.core.validators import MaxCountPerGatewayValidator
+from apigateway.core.validators import MaxCountPerGatewayValidator, NameValidator
 
 
 class HostSLZ(serializers.Serializer):
@@ -128,7 +128,10 @@ class RateLimitSLZ(serializers.Serializer):
 
 class StageSLZ(ExtensibleFieldMixin, serializers.ModelSerializer):
     api = serializers.HiddenField(default=CurrentGatewayDefault())
-    name = serializers.RegexField(STAGE_NAME_PATTERN)
+    name = serializers.RegexField(
+        STAGE_NAME_PATTERN,
+        validators=[NameValidator()],
+    )
     vars = serializers.DictField(
         label="环境变量",
         child=serializers.CharField(allow_blank=True, required=True),

--- a/src/dashboard/apigateway/apigateway/core/validators.py
+++ b/src/dashboard/apigateway/apigateway/core/validators.py
@@ -84,6 +84,26 @@ class ReservedAPINameValidator:
                 raise serializers.ValidationError(_("网关名不能以【{prefix}】开头，其为官方保留字。").format(prefix=prefix))
 
 
+class NameValidator:
+    """currently:
+    - gateway_name can be endswith '-'
+    - stage name can be endswith '-' and '_'
+    - resource name can be endswith '-'
+    while build the key/name of etcd/helm/sdk, the '-'/'_' will be striped,
+    it would cause some problem if a-/a convert to the same key/name,
+    so, we check the name while creating gateway/stage/resource
+
+    since: 2024-01-16, make standardization
+    """
+
+    def __call__(self, value: str):
+        if value.endswith("-"):
+            raise serializers.ValidationError(_("名称不能以【-】结尾。"))
+
+        if value.endswith("_"):
+            raise serializers.ValidationError(_("名称不能以【_】结尾。"))
+
+
 class BKAppCodeValidator:
     def __call__(self, value):
         if not value:

--- a/src/dashboard/apigateway/apigateway/tests/apps/gateway/test_serializers.py
+++ b/src/dashboard/apigateway/apigateway/tests/apps/gateway/test_serializers.py
@@ -137,6 +137,20 @@ class TestAPICreateSLZ:
                 None,
                 True,
             ),
+            # name ends with invalid charactor
+            (
+                False,
+                {
+                    "name": "test-",
+                    "description": "test",
+                    "maintainers": ["admin"],
+                    "status": 1,
+                    "is_public": True,
+                    "user_auth_type": "ieod",
+                },
+                None,
+                True,
+            ),
             # name exists
             (
                 False,

--- a/src/dashboard/apigateway/apigateway/tests/apps/stage/test_serializers.py
+++ b/src/dashboard/apigateway/apigateway/tests/apps/stage/test_serializers.py
@@ -536,6 +536,30 @@ class TestStageSLZ:
                 },
                 False,
             ),
+            (
+                {
+                    "name": "test-",  # name not valid
+                    "description": "test",
+                    "vars": {
+                        "test": "123",
+                    },
+                    "proxy_http": {
+                        "timeout": 30,
+                        "upstreams": {
+                            "loadbalance": "roundrobin",
+                            "hosts": [
+                                {
+                                    "host": "http://www.a.com",
+                                }
+                            ],
+                        },
+                        "transform_headers": {
+                            "set": {"k1": "v1"},
+                        },
+                    },
+                },
+                True,
+            ),
         ],
     )
     def test_create(self, mocker, data, will_error, fake_gateway, fake_request):

--- a/src/dashboard/apigateway/apigateway/tests/core/test_validators.py
+++ b/src/dashboard/apigateway/apigateway/tests/core/test_validators.py
@@ -29,6 +29,7 @@ from apigateway.core.validators import (
     BKAppCodeListValidator,
     BKAppCodeValidator,
     MaxCountPerGatewayValidator,
+    NameValidator,
     ReservedAPINameValidator,
     ResourceIDValidator,
 )
@@ -256,6 +257,30 @@ class TestReservedAPINameValidator:
         settings.RESERVED_GATEWAY_NAME_PREFIXES = reserved_gateway_name_prefixes
 
         slz = self.APISLZ(data={"name": api_name})
+        slz.is_valid()
+
+        if will_error:
+            assert slz.errors
+        else:
+            assert not slz.errors
+
+
+class TestNameValidator:
+    class GatewaySLZ(serializers.Serializer):
+        name = serializers.CharField(validators=[NameValidator()])
+
+    @pytest.mark.parametrize(
+        "name, will_error",
+        [
+            ("abc", False),
+            ("abc-", True),
+            ("abc--", True),
+            ("abc_", True),
+            ("abc__", True),
+        ],
+    )
+    def test_validate(self, settings, name, will_error):
+        slz = self.GatewaySLZ(data={"name": name})
         slz.is_valid()
 
         if will_error:


### PR DESCRIPTION
### Description

<!-- 关联相关issue Please include a summary of the change and which issue is fixed. -->
<!-- 给出必要的上下文以及review需要的必要信息 Please also include relevant motivation and context. -->

Fixes gateway/stage/resource name 不能以 `-` 和 `_` 结尾

背景: `from blue_krill.cubing_case import shortcuts` 目前通过资源名称生成 etcd/helm/sdk 的唯一名称的时候, 会去掉末尾的`-`和`_`, 导致如果存在 `a_`和`a`, 生成的结果会重复导致覆盖(只有一个生效)或者直接冲突; 在这个版本中做标准化(在 1.13 前端也加上对应的校验)

### Checklist

- [x] 填写 PR 描述及相关 issue (write PR description and related issue)
- [x] 代码风格检查通过 (code style check passed)
- [x] PR 中包含单元测试 (include unit test)
- [x] 单元测试通过 (unit test passed)
- [x] 本地开发联调环境验证通过 (local development environment verification passed)
