### PR TITLE
fix(conf/default.py): default JWT_ISSUER should be `APIGW` while the apisix jwt set it as default

### DIFF
--- a/src/dashboard/apigateway/apigateway/conf/default.py
+++ b/src/dashboard/apigateway/apigateway/conf/default.py
@@ -537,7 +537,7 @@ APIGW_MANAGERS = env.list("APIGW_MANAGERS", default=["admin"])
 
 # 网关 jwt 签发者，必须与 apigateway 后端服务保持一致，
 # apigw-manager sdk 利用 issuer 支持获取不同网关实例同名网关的公钥，以支持同一后端服务接入不同网关实例
-JWT_ISSUER = env.str("BK_APIGW_JWT_ISSUER", "")
+JWT_ISSUER = env.str("BK_APIGW_JWT_ISSUER", "APIGW")
 
 # 检查保留的官方网关名
 CHECK_RESERVED_GATEWAY_NAME = True


### PR DESCRIPTION
### Description

<!-- 关联相关issue Please include a summary of the change and which issue is fixed. -->
<!-- 给出必要的上下文以及review需要的必要信息 Please also include relevant motivation and context. -->

fix:
- apisix 后端配置的 `local DEFAULT_JWT_ISSUER = "APIGW"`

### Checklist

- [x] 填写 PR 描述及相关 issue (write PR description and related issue)
- [ ] 代码风格检查通过 (code style check passed)
- [ ] PR 中包含单元测试 (include unit test)
- [ ] 单元测试通过 (unit test passed)
- [ ] 本地开发联调环境验证通过 (local development environment verification passed)
