### PR TITLE
fix(apps/metrics): prometheus proxy_error only means proxy fail, use status>=500 instead

### DIFF
--- a/src/dashboard/apigateway/apigateway/apps/metrics/prometheus/dimension.py
+++ b/src/dashboard/apigateway/apigateway/apps/metrics/prometheus/dimension.py
@@ -85,7 +85,8 @@ class FailedRequestsMetrics(BaseDimensionMetrics):
                 ("api_name", "=", gateway_name),
                 ("stage_name", "=", stage_name),
                 ("resource_name", "=", resource_name),
-                ("proxy_error", "=", "1"),
+                ("status", ">=", "500"),
+                # ("proxy_error", "=", "1"),
             ]
         )
         return f"sum(increase({self.metric_name_prefix}apigateway_api_requests_total{{" f"{labels}" f"}}[{step}]))"
@@ -166,7 +167,8 @@ class ResourceFailedRequestsMetrics(BaseDimensionMetrics):
                 ("api_name", "=", gateway_name),
                 ("stage_name", "=", stage_name),
                 ("resource_name", "=", resource_name),
-                ("proxy_error", "=", "1"),
+                ("status", ">=", "500"),
+                # ("proxy_error", "=", "1"),
             ]
         )
         return (

--- a/src/dashboard/apigateway/apigateway/tests/apps/metrics/prometheus/test_dimension.py
+++ b/src/dashboard/apigateway/apigateway/tests/apps/metrics/prometheus/test_dimension.py
@@ -74,7 +74,7 @@ class TestFailedRequestsMetrics:
                 },
                 "expected": (
                     'sum(increase(bk_apigateway_apigateway_api_requests_total{api_name="foo", '
-                    'stage_name="prod", resource_name="get_foo", proxy_error="1"}[1m]))'
+                    'stage_name="prod", resource_name="get_foo", status>="500"}[1m]))'
                 ),
             },
             {
@@ -86,7 +86,7 @@ class TestFailedRequestsMetrics:
                 },
                 "expected": (
                     'sum(increase(bk_apigateway_apigateway_api_requests_total{api_name="foo", '
-                    'stage_name="prod", proxy_error="1"}[1m]))'
+                    'stage_name="prod", status>="500"}[1m]))'
                 ),
             },
         ]
@@ -228,7 +228,7 @@ class TestResourceFailedRequestsMetrics:
                 },
                 "expected": (
                     'topk(10, sum(increase(bk_apigateway_apigateway_api_requests_total{api_name="foo", '
-                    'stage_name="prod", resource_name="get_foo", proxy_error="1"}[1m])) by (api_name, resource_name, matched_uri))'
+                    'stage_name="prod", resource_name="get_foo", status>="500"}[1m])) by (api_name, resource_name, matched_uri))'
                 ),
             },
             {
@@ -240,7 +240,7 @@ class TestResourceFailedRequestsMetrics:
                 },
                 "expected": (
                     'topk(10, sum(increase(bk_apigateway_apigateway_api_requests_total{api_name="foo", '
-                    'stage_name="prod", proxy_error="1"}[1m])) by (api_name, resource_name, matched_uri))'
+                    'stage_name="prod", status>="500"}[1m])) by (api_name, resource_name, matched_uri))'
                 ),
             },
         ]


### PR DESCRIPTION
### Description

<!-- 关联相关issue Please include a summary of the change and which issue is fixed. -->
<!-- 给出必要的上下文以及review需要的必要信息 Please also include relevant motivation and context. -->

- 新版产品图表中失败请求代表 >=500的请求，而非proxy_error

### Checklist

- [x] 填写 PR 描述及相关 issue (write PR description and related issue)
- [x] 代码风格检查通过 (code style check passed)
- [x] PR 中包含单元测试 (include unit test)
- [x] 单元测试通过 (unit test passed)
- [ ] 本地开发联调环境验证通过 (local development environment verification passed)
