### PR TITLE
feat: 修复前端问题

### DIFF
--- a/src/dashboard-front/src/components/auth/index.vue
+++ b/src/dashboard-front/src/components/auth/index.vue
@@ -1,13 +1,14 @@
 <template>
   <div class="bk-login-dialog" v-if="isShow">
     <div class="bk-login-wrapper">
-      <iframe :src="iframeSrc" scrolling="no" border="0" width="400" height="400" />
+      <iframe :src="iframeSrc" scrolling="no" border="0" :width="iframeWidth" :height="iframeHeight" />
     </div>
   </div>
 </template>
 
 <script lang="ts" setup>
 import { ref } from 'vue';
+import { ILoginData } from '@/common/auth';
 /**
  * app-auth
  * @desc 统一登录
@@ -16,15 +17,22 @@ import { ref } from 'vue';
 const loginCallbackURL = ref(`${window.SITE_URL}static/login_success.html?is_ajax=1`);
 const iframeSrc = ref(`${window.BK_LOGIN_URL}/?app_code=1&c_url=${loginCallbackURL.value}`);
 const isShow = ref(false);
+const iframeWidth = ref(400);
+const iframeHeight = ref(400);
 
 const hideLoginModal = () => {
   isShow.value = false;
 };
 
-const showLoginModal = (url: string) => {
+const showLoginModal = (payload: ILoginData) => {
+  const { login_plain_url, width, height } = payload;
   const version = +new Date();
-  iframeSrc.value = `${url}&ver=${version}`;
-  console.log(iframeSrc.value);
+  const url = new URL(login_plain_url);
+  iframeSrc.value = `${url.toString()}${url.search ? '&' : '?'}ver=${version}`;
+  // iframeSrc.value = `${login_plain_url}&ver=${version}`;
+  iframeWidth.value = width || 400;
+  iframeHeight.value = height || 400;
+  console.log('iframeSrc.value', iframeSrc.value);
   setTimeout(() => {
     isShow.value = true;
   }, 1000);

--- a/src/dashboard-front/src/http/fetch/error-interceptor.ts
+++ b/src/dashboard-front/src/http/fetch/error-interceptor.ts
@@ -17,7 +17,7 @@ export default (errorData: any, config: IFetchConfig) => {
       break;
       // 用户登录状态失效
     case 401:
-      console.error('errorerrorerrorerrorerrorerror', error);
+      console.log('401', error);
       if (error?.data?.login_plain_url) {
         const { width, height, login_url, login_plain_url } = error.data;
         mitt.emit('show-login-modal', {


### PR DESCRIPTION
Fixes # (issue)
- 【APIgateway1.13 】导入资源文档-点击模板示例及Swagger说明文档跳转地址不符合预期
- 环境概览-新建环境：前端需要校验权重必填 
- 环境页面问题 
- Tag 连载一起了 
- 环境概览：添加插件，确认按钮需要添加二次确认弹框 
- 【APIgateway1.13 】点击Swagger说明文档无反应
- 资源配置-生成版本：最新版本没有的时候直接不展示出来 
- 这个 编辑图标紧跟
- 资源配置：修改名称后鼠标失焦就保存 
- 【APIgateway1.13 】无法编辑组件
- 这里的yaml配置demo有个版本字段需要更新一下，后端导出已经更新
- 这里标签编辑离标签感觉有点远NIT 

