### PR TITLE
feat: 修复 新建资源页面，环境配置中的超时时间是 30 秒，但添加资源时变成了 0 秒，数据未同步

### DIFF
--- a/src/dashboard-front/src/views/resource/setting/comps/back-config.vue
+++ b/src/dashboard-front/src/views/resource/setting/comps/back-config.vue
@@ -377,7 +377,7 @@ const handleServiceChange = async (backendId: number) => {
   const res = await getBackendsDetailData(common.apigwId, backendId);
   const resStorage: any = cloneDeep(res);
   const detailTimeout = props.detail?.backend?.config?.timeout;
-  if (detailTimeout !== 0) {
+  if (detailTimeout !== 0 && detailTimeout !== undefined && detailTimeout !== null) {
     res.configs.forEach((item:any) => {
       item.timeout = detailTimeout;
     });


### PR DESCRIPTION
Fixes # (issue)
- feat: 修复 新建资源页面，环境配置中的超时时间是 30 秒，但添加资源时变成了 0 秒，数据未同步