### PR TITLE
fix(dockerfile): lock the pip version to 23.0.1

### DIFF
--- a/src/dashboard/Dockerfile
+++ b/src/dashboard/Dockerfile
@@ -10,7 +10,9 @@ RUN pip config set global.index-url "${PYPI}"
 
 WORKDIR /app
 ADD build/requirements.txt /app/requirements.txt
-RUN pip install --upgrade pip
+# while the celery 4.4.7 can't be installed via pip >=24.x
+# RUN pip install --upgrade pip
+RUN pip install pip==23.0.1
 RUN pip install -r requirements.txt
 
 ADD build /app


### PR DESCRIPTION
### Description

<!-- 关联相关issue Please include a summary of the change and which issue is fixed. -->
<!-- 给出必要的上下文以及review需要的必要信息 Please also include relevant motivation and context. -->

Fixes 锁定pip版本，更高版本会导致celery 4.4.7装不上

### Checklist

- [ ] 填写 PR 描述及相关 issue (write PR description and related issue)
- [ ] 代码风格检查通过 (code style check passed)
- [ ] PR 中包含单元测试 (include unit test)
- [ ] 单元测试通过 (unit test passed)
- [ ] 本地开发联调环境验证通过 (local development environment verification passed)
