### PR TITLE
fix:api-breaker yaml

### DIFF
--- a/src/dashboard/apigateway/apigateway/fixtures/plugins.yaml
+++ b/src/dashboard/apigateway/apigateway/fixtures/plugins.yaml
@@ -1734,7 +1734,7 @@
                   }
                 },
                 "failures": {
-                  "description": "上游服务在一定时间内触发不健康状态的异常请求次数，最少 1 次。",
+                  "description": "上游服务在一定时间内触发不健康状态的异常请求次数。",
                   "title": "不健康次数",
                   "type": "integer",
                   "default": 3,
@@ -1769,7 +1769,7 @@
                   }
                 },
                 "successes": {
-                  "description": "上游服务触发健康状态的连续正常请求次数，最少 1 次。",
+                  "description": "上游服务触发健康状态的连续正常请求次数。",
                   "title": "健康次数",
                   "type": "integer",
                   "default": 3,
@@ -1883,7 +1883,7 @@
                   }
                 },
                 "failures": {
-                  "description": "The number of abnormal requests triggered by the upstream service in an unhealthy state within a certain period is at least one.",
+                  "description": "Number of unhealthy requests triggered by the upstream service within a certain period.",
                   "title": "Unhealthy times",
                   "type": "integer",
                   "default": 3,
@@ -1918,7 +1918,7 @@
                   }
                 },
                 "successes": {
-                  "description": "Indicates the number of consecutive normal requests triggered by the upstream service. The value is at least one.",
+                  "description": "Number of consecutive normal requests that the upstream service triggers the health status.",
                   "title": "Healthy number",
                   "type": "integer",
                   "default": 3,

--- a/src/dashboard/apigateway/apigateway/fixtures/plugins.yaml
+++ b/src/dashboard/apigateway/apigateway/fixtures/plugins.yaml
@@ -1629,8 +1629,8 @@
 - model: plugin.plugintype
   fields:
     code: api-breaker
-    name: API 熔断
-    name_en: API Breaker
+    name: 熔断
+    name_en: Circuit Breaker
     is_public: true
     scope: resource
     schema:
@@ -1658,13 +1658,17 @@
               "description": "当上游服务处于不健康状态时返回的 HTTP 错误码。",
               "title": "熔断响应状态码",
               "type": "integer",
+              "default": 502,
               "ui:rules": ["required"]
             },
             "break_response_body": {
               "description": "当上游服务处于不健康状态时返回的 HTTP 响应体信息。",
               "title": "熔断响应体",
               "type": "string",
-              "maxLength": 100
+              "ui:component": {
+                "type": "textarea",
+                "rows": 10
+              }
             },
             "break_response_headers": {
               "description": "当上游服务处于不健康状态时返回的 HTTP 响应头信息。",
@@ -1697,7 +1701,7 @@
               }
             },
             "max_breaker_sec": {
-              "description": "上游服务熔断的最大持续时间，以秒为单位。",
+              "description": "上游服务熔断的最大持续时间，以秒为单位，最小 3 秒。",
               "title": "最大熔断时间",
               "type": "integer",
               "default": 300,
@@ -1730,7 +1734,7 @@
                   }
                 },
                 "failures": {
-                  "description": "上游服务在一定时间内触发不健康状态的异常请求次数。",
+                  "description": "上游服务在一定时间内触发不健康状态的异常请求次数，最少 1 次。",
                   "title": "不健康次数",
                   "type": "integer",
                   "default": 3,
@@ -1765,7 +1769,7 @@
                   }
                 },
                 "successes": {
-                  "description": "上游服务触发健康状态的连续正常请求次数。",
+                  "description": "上游服务触发健康状态的连续正常请求次数，最少 1 次。",
                   "title": "健康次数",
                   "type": "integer",
                   "default": 3,
@@ -1802,6 +1806,7 @@
             "break_response_code": {
               "description": "HTTP error code returned when the upstream service is in an unhealthy state.",
               "title": "Fuse response status code",
+              "default": 502,
               "type": "integer",
               "ui:rules": ["required"]
             },
@@ -1809,7 +1814,10 @@
               "description": "HTTP response body information returned when the upstream service is in an unhealthy state.",
               "title": "Fuse response body",
               "type": "string",
-              "maxLength": 100
+              "ui:component": {
+                "type": "textarea",
+                "rows": 10
+              }
             },
             "break_response_headers": {
               "description": "The HTTP response header returned when the upstream service is in an unhealthy state.",
@@ -1842,7 +1850,7 @@
               }
             },
             "max_breaker_sec": {
-              "description": "Maximum duration of the upstream service meltdown, in seconds.",
+              "description": "The maximum duration of the upstream service meltdown, in seconds. The minimum duration is 3 seconds.",
               "title": "Maximum fusing time",
               "type": "integer",
               "default": 300,
@@ -1875,7 +1883,7 @@
                   }
                 },
                 "failures": {
-                  "description": "Number of unhealthy requests triggered by the upstream service within a certain period.",
+                  "description": "The number of abnormal requests triggered by the upstream service in an unhealthy state within a certain period is at least one.",
                   "title": "Unhealthy times",
                   "type": "integer",
                   "default": 3,
@@ -1910,7 +1918,7 @@
                   }
                 },
                 "successes": {
-                  "description": "Number of consecutive normal requests that the upstream service triggers the health status.",
+                  "description": "Indicates the number of consecutive normal requests triggered by the upstream service. The value is at least one.",
                   "title": "Healthy number",
                   "type": "integer",
                   "default": 3,


### PR DESCRIPTION
### Description
修复问题如下：
插件中文名： api 熔断  改成 熔断
插件英文名： API Breaker 改成  Circuit Breaker
熔断响应状态码：默认填  502
熔断响应体： 改成 多行文本框
最大熔断时间： 说明需要补充，最小 3 秒
<!-- 关联相关issue Please include a summary of the change and which issue is fixed. -->
<!-- 给出必要的上下文以及review需要的必要信息 Please also include relevant motivation and context. -->

Fixes # (issue)

### Checklist

- [x] 填写 PR 描述及相关 issue (write PR description and related issue)
- [ ] 代码风格检查通过 (code style check passed)
- [ ] PR 中包含单元测试 (include unit test)
- [ ] 单元测试通过 (unit test passed)
- [x] 本地开发联调环境验证通过 (local development environment verification passed)
