### PR TITLE
feat(apis/open): add new api/v2 for open apis

### DIFF
--- a/src/dashboard/apigateway/apigateway/apis/open/gateway/views.py
+++ b/src/dashboard/apigateway/apigateway/apis/open/gateway/views.py
@@ -55,7 +55,7 @@ from apigateway.utils.responses import V1OKJsonResponse
         operation_description="获取网关列表，网关需公开且已发布",
         query_serializer=serializers.GatewayListV1InputSLZ,
         responses={status.HTTP_200_OK: serializers.GatewayListV1OutputSLZ(many=True)},
-        tags=["OpenAPI.Gateway"],
+        tags=["OpenAPI.V1"],
     ),
 )
 class GatewayListApi(generics.ListAPIView):
@@ -132,7 +132,7 @@ class GatewayListApi(generics.ListAPIView):
     name="get",
     decorator=swagger_auto_schema(
         responses={status.HTTP_200_OK: serializers.GatewayRetrieveV1OutputSLZ()},
-        tags=["OpenAPI.Gateway"],
+        tags=["OpenAPI.V1"],
     ),
 )
 class GatewayIdRetrieveApi(generics.RetrieveAPIView):
@@ -153,7 +153,7 @@ class GatewayIdRetrieveApi(generics.RetrieveAPIView):
 class GatewayPublicKeyRetrieveApi(generics.RetrieveAPIView):
     permission_classes = [OpenAPIGatewayNamePermission]
 
-    @swagger_auto_schema(tags=["OpenAPI.Gateway"])
+    @swagger_auto_schema(tags=["OpenAPI.V1"])
     def get(self, request, gateway_name: str, *args, **kwargs):
         jwt = JWT.objects.get(gateway=request.gateway)
         return V1OKJsonResponse(
@@ -170,7 +170,7 @@ class GatewaySyncApi(generics.CreateAPIView):
     allow_gateway_not_exist = True
     serializer_class = serializers.GatewaySyncInputSLZ
 
-    @swagger_auto_schema(request_body=serializers.GatewaySyncInputSLZ, tags=["OpenAPI.Gateway"])
+    @swagger_auto_schema(request_body=serializers.GatewaySyncInputSLZ, tags=["OpenAPI.V1"])
     @transaction.atomic
     def post(self, request, gateway_name: str, *args, **kwargs):
         gateway = getattr(request, "gateway", None)
@@ -218,7 +218,7 @@ class GatewayRelatedAppUpdateStatusApi(generics.CreateAPIView):
     permission_classes = [OpenAPIGatewayRelatedAppPermission]
     serializer_class = serializers.GatewayUpdateStatusInputSLZ
 
-    @swagger_auto_schema(request_body=serializers.GatewayUpdateStatusInputSLZ, tags=["OpenAPI.Gateway"])
+    @swagger_auto_schema(request_body=serializers.GatewayUpdateStatusInputSLZ, tags=["OpenAPI.V1"])
     def post(self, request, *args, **kwargs):
         slz = self.get_serializer(request.gateway, data=request.data)
         slz.is_valid(raise_exception=True)
@@ -244,7 +244,7 @@ class GatewayRelatedAppAddApi(generics.CreateAPIView):
     permission_classes = [OpenAPIGatewayRelatedAppPermission]
     serializer_class = serializers.GatewayRelatedAppsAddInputSLZ
 
-    @swagger_auto_schema(request_body=serializers.GatewayRelatedAppsAddInputSLZ, tags=["OpenAPI.Gateway"])
+    @swagger_auto_schema(request_body=serializers.GatewayRelatedAppsAddInputSLZ, tags=["OpenAPI.V1"])
     @transaction.atomic
     def post(self, request, gateway_name: str, *args, **kwargs):
         slz = self.get_serializer(data=request.data)
@@ -283,7 +283,7 @@ class GatewayMaintainerUpdateApi(generics.UpdateAPIView):
     def get_queryset(self):
         return Gateway.objects.all()
 
-    @swagger_auto_schema(request_body=serializers.GatewayMaintainerUpdateInputSLZ, tags=["OpenAPI.Inner"])
+    @swagger_auto_schema(request_body=serializers.GatewayMaintainerUpdateInputSLZ, tags=["OpenAPI.V1"])
     def put(self, request, *args, **kwargs):
         slz = self.get_serializer(request.gateway, data=request.data)
         slz.is_valid(raise_exception=True)
@@ -322,7 +322,7 @@ class GatewayIdUpdateStatusApi(generics.UpdateAPIView):
     def get_queryset(self):
         return Gateway.objects.all()
 
-    @swagger_auto_schema(request_body=serializers.GatewayUpdateStatusInputSLZ, tags=["OpenAPI.Inner"])
+    @swagger_auto_schema(request_body=serializers.GatewayUpdateStatusInputSLZ, tags=["OpenAPI.V1"])
     def put(self, request, *args, **kwargs):
         instance = self.get_object()
 

--- a/src/dashboard/apigateway/apigateway/apis/open/permission/views.py
+++ b/src/dashboard/apigateway/apigateway/apis/open/permission/views.py
@@ -77,7 +77,7 @@ class ResourceViewSet(viewsets.ViewSet):
     @swagger_auto_schema(
         query_serializer=serializers.AppResourcePermissionInputSLZ(),
         responses={status.HTTP_200_OK: serializers.AppResourcePermissionOutputSLZ(many=True)},
-        tags=["OpenAPI.Permission"],
+        tags=["OpenAPI.V1"],
     )
     def list(self, request, *args, **kwargs):
         if not request.gateway.is_active_and_public:
@@ -285,7 +285,7 @@ class AppPermissionRenewAPIView(APIView):
     name="post",
     decorator=swagger_auto_schema(
         request_body=PaaSAppPermissionApplyV2InputSLZ,
-        tags=["OpenAPI.Permission"],
+        tags=["OpenAPI.V1"],
     ),
 )
 class AppPermissionApplyAPIView(APIView):

--- a/src/dashboard/apigateway/apigateway/apis/open/released/views.py
+++ b/src/dashboard/apigateway/apigateway/apis/open/released/views.py
@@ -37,7 +37,7 @@ from apigateway.utils.responses import V1OKJsonResponse
     name="get",
     decorator=swagger_auto_schema(
         responses={status.HTTP_200_OK: serializers.ReleasedResourceOutputSLZ()},
-        tags=["OpenAPI.Resource"],
+        tags=["OpenAPI.V1"],
     ),
 )
 class ReleasedResourceRetrieveApi(generics.RetrieveAPIView):
@@ -82,7 +82,7 @@ class ReleasedResourceRetrieveApi(generics.RetrieveAPIView):
     name="get",
     decorator=swagger_auto_schema(
         responses={status.HTTP_200_OK: serializers.ReleasedResourceListV1InputSLZ(many=True)},
-        tags=["OpenAPI.Resource"],
+        tags=["OpenAPI.V1"],
     ),
 )
 class ReleasedResourceListByGatewayNameApi(generics.ListAPIView):

--- a/src/dashboard/apigateway/apigateway/apis/open/resource/views.py
+++ b/src/dashboard/apigateway/apigateway/apis/open/resource/views.py
@@ -46,7 +46,7 @@ class ResourceSyncApi(generics.CreateAPIView):
     @swagger_auto_schema(
         request_body=ResourceImportInputSLZ,
         responses={status.HTTP_200_OK: ResourceSyncOutputSLZ()},
-        tags=["OpenAPI.Resource"],
+        tags=["OpenAPI.V1"],
     )
     @transaction.atomic
     def post(self, request, *args, **kwargs):

--- a/src/dashboard/apigateway/apigateway/apis/open/resource_doc/views.py
+++ b/src/dashboard/apigateway/apigateway/apis/open/resource_doc/views.py
@@ -45,7 +45,7 @@ class DocImportByArchiveApi(generics.CreateAPIView):
     @swagger_auto_schema(
         request_body=DocImportByArchiveV1InputSLZ,
         responses={status.HTTP_200_OK: ""},
-        tags=["OpenAPI.ResourceDoc"],
+        tags=["OpenAPI.V1"],
     )
     @transaction.atomic
     def post(self, request, *args, **kwargs):
@@ -75,7 +75,7 @@ class DocImportBySwaggerApi(generics.CreateAPIView):
     @swagger_auto_schema(
         request_body=DocImportBySwaggerV1InputSLZ,
         responses={status.HTTP_200_OK: ""},
-        tags=["OpenAPI.ResourceDoc"],
+        tags=["OpenAPI.V1"],
     )
     @transaction.atomic
     def post(self, request, *args, **kwargs):

--- a/src/dashboard/apigateway/apigateway/apis/open/resource_version/views.py
+++ b/src/dashboard/apigateway/apigateway/apis/open/resource_version/views.py
@@ -45,14 +45,14 @@ from .serializers import (
     name="get",
     decorator=swagger_auto_schema(
         responses={status.HTTP_200_OK: ""},
-        tags=["OpenAPI.ResourceVersion"],
+        tags=["OpenAPI.V1"],
     ),
 )
 @method_decorator(
     name="post",
     decorator=swagger_auto_schema(
         request_body=ResourceVersionCreateV1InputSLZ,
-        tags=["OpenAPI.ResourceVersion"],
+        tags=["OpenAPI.V1"],
     ),
 )
 class ResourceVersionListCreateApi(generics.ListCreateAPIView):
@@ -101,7 +101,7 @@ class ResourceVersionReleaseApi(generics.CreateAPIView):
     permission_classes = [OpenAPIGatewayRelatedAppPermission]
     serializer_class = ReleaseV1InputSLZ
 
-    @swagger_auto_schema(tags=["OpenAPI.ResourceVersion"])
+    @swagger_auto_schema(tags=["OpenAPI.V1"])
     @transaction.atomic
     def post(self, request, gateway_name: str, *args, **kwargs):
         slz = self.get_serializer(data=request.data, context={"request": request})
@@ -146,7 +146,7 @@ class ResourceVersionReleaseApi(generics.CreateAPIView):
 class ResourceVersionGetLatestApi(generics.RetrieveAPIView):
     permission_classes = [OpenAPIGatewayRelatedAppPermission]
 
-    @swagger_auto_schema(tags=["OpenAPI.ResourceVersion"])
+    @swagger_auto_schema(tags=["OpenAPI.V1"])
     def get(self, request, gateway_name: str, *args, **kwargs):
         resource_version = ResourceVersion.objects.get_latest_version(request.gateway.id)
 

--- a/src/dashboard/apigateway/apigateway/apis/open/stage/views.py
+++ b/src/dashboard/apigateway/apigateway/apis/open/stage/views.py
@@ -47,7 +47,7 @@ class StageListViewSet(viewsets.ModelViewSet):
 
     @swagger_auto_schema(
         responses={status.HTTP_200_OK: serializers.StageV1SLZ(many=True)},
-        tags=["OpenAPI.Stage"],
+        tags=["OpenAPI.V1"],
     )
     def list(self, request, gateway_name: str, *args, **kwargs):
         if not request.gateway.is_active_and_public:
@@ -68,7 +68,7 @@ class StageV1ViewSet(viewsets.ViewSet):
 
     @swagger_auto_schema(
         responses={status.HTTP_200_OK: serializers.StageWithResourceVersionV1SLZ(many=True)},
-        tags=["OpenAPI.Stage"],
+        tags=["OpenAPI.V1"],
     )
     def list_stages_with_resource_version(self, request, gateway_name: str, *args, **kwargs):
         queryset = Stage.objects.filter(gateway=self.request.gateway)
@@ -83,7 +83,7 @@ class StageV1ViewSet(viewsets.ViewSet):
 class StageSyncViewSet(viewsets.ViewSet):
     permission_classes = [OpenAPIGatewayRelatedAppPermission]
 
-    @swagger_auto_schema(request_body=StageSLZ, tags=["OpenAPI.Stage"])
+    @swagger_auto_schema(request_body=StageSLZ, tags=["OpenAPI.V1"])
     def sync(self, request, gateway_name: str, *args, **kwargs):
         instance = get_object_or_None(Stage, gateway=request.gateway, name=request.data.get("name", ""))
         data_before = get_model_dict(instance) if instance else {}

--- a/src/dashboard/apigateway/apigateway/apis/open/support/views.py
+++ b/src/dashboard/apigateway/apigateway/apis/open/support/views.py
@@ -43,7 +43,7 @@ class SDKGenerateViewSet(viewsets.ViewSet):
     @transaction.atomic
     @swagger_auto_schema(
         # todo: 是否需要将 support 改成 sdk？目前只有 sdk 相关的
-        tags=["OpenAPI.Support"],
+        tags=["OpenAPI.V1"],
     )
     def generate(self, request, gateway_name: str, *args, **kwargs):
         """创建资源版本对应的 SDK"""

--- a/src/dashboard/apigateway/apigateway/apis/v2/__init__.py
+++ b/src/dashboard/apigateway/apigateway/apis/v2/__init__.py
@@ -1,0 +1,17 @@
+#
+# TencentBlueKing is pleased to support the open source community by making
+# 蓝鲸智云 - API 网关(BlueKing - APIGateway) available.
+# Copyright (C) 2017 THL A29 Limited, a Tencent company. All rights reserved.
+# Licensed under the MIT License (the "License"); you may not use this file except
+# in compliance with the License. You may obtain a copy of the License at
+#
+#     http://opensource.org/licenses/MIT
+#
+# Unless required by applicable law or agreed to in writing, software distributed under
+# the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+# either express or implied. See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# We undertake not to change the open source license (MIT license) applicable
+# to the current version of the project delivered to anyone in the future.
+#

--- a/src/dashboard/apigateway/apigateway/apis/v2/inner/__init__.py
+++ b/src/dashboard/apigateway/apigateway/apis/v2/inner/__init__.py
@@ -1,0 +1,17 @@
+#
+# TencentBlueKing is pleased to support the open source community by making
+# 蓝鲸智云 - API 网关(BlueKing - APIGateway) available.
+# Copyright (C) 2017 THL A29 Limited, a Tencent company. All rights reserved.
+# Licensed under the MIT License (the "License"); you may not use this file except
+# in compliance with the License. You may obtain a copy of the License at
+#
+#     http://opensource.org/licenses/MIT
+#
+# Unless required by applicable law or agreed to in writing, software distributed under
+# the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+# either express or implied. See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# We undertake not to change the open source license (MIT license) applicable
+# to the current version of the project delivered to anyone in the future.
+#

--- a/src/dashboard/apigateway/apigateway/apis/v2/inner/serializers.py
+++ b/src/dashboard/apigateway/apigateway/apis/v2/inner/serializers.py
@@ -1,0 +1,56 @@
+# -*- coding: utf-8 -*-
+#
+# TencentBlueKing is pleased to support the open source community by making
+# 蓝鲸智云 - API 网关(BlueKing - APIGateway) available.
+# Copyright (C) 2017 THL A29 Limited, a Tencent company. All rights reserved.
+# Licensed under the MIT License (the "License"); you may not use this file except
+# in compliance with the License. You may obtain a copy of the License at
+#
+#     http://opensource.org/licenses/MIT
+#
+# Unless required by applicable law or agreed to in writing, software distributed under
+# the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+# either express or implied. See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# We undertake not to change the open source license (MIT license) applicable
+# to the current version of the project delivered to anyone in the future.
+#
+
+from rest_framework import serializers
+
+from apigateway.common.i18n.field import SerializerTranslatedField
+
+
+class GatewayListInputSLZ(serializers.Serializer):
+    name = serializers.CharField(required=False, allow_blank=True)
+    fuzzy = serializers.BooleanField(required=False)
+
+    class Meta:
+        ref_name = "apigateway.apis.v2.inner.serializers.GatewayListInputSLZ"
+
+
+class GatewayListOutputSLZ(serializers.Serializer):
+    id = serializers.IntegerField(read_only=True)
+    name = serializers.CharField(read_only=True)
+    description = SerializerTranslatedField(default_field="description_i18n", allow_blank=True, read_only=True)
+    maintainers = serializers.SerializerMethodField()
+
+    def get_maintainers(self, obj):
+        return obj.maintainers
+
+    class Meta:
+        ref_name = "apigateway.apis.v2.inner.serializers.GatewayListOutputSLZ"
+
+
+class GatewayRetrieveOutputSLZ(serializers.Serializer):
+    id = serializers.IntegerField(read_only=True)
+    name = serializers.CharField(read_only=True)
+    description = SerializerTranslatedField(default_field="description_i18n", allow_blank=True, read_only=True)
+    maintainers = serializers.SerializerMethodField()
+
+    def get_maintainers(self, obj):
+        return obj.maintainers
+
+    class Meta:
+        ref_name = "apigateway.apis.v2.inner.serializers.GatewayRetrieveOutputSLZ"

--- a/src/dashboard/apigateway/apigateway/apis/v2/inner/urls.py
+++ b/src/dashboard/apigateway/apigateway/apis/v2/inner/urls.py
@@ -1,0 +1,51 @@
+# -*- coding: utf-8 -*-
+#
+# TencentBlueKing is pleased to support the open source community by making
+# 蓝鲸智云 - API 网关 (BlueKing - APIGateway) available.
+# Copyright (C) 2017 THL A29 Limited, a Tencent company. All rights reserved.
+# Licensed under the MIT License (the "License"); you may not use this file except
+# in compliance with the License. You may obtain a copy of the License at
+#
+#     http://opensource.org/licenses/MIT
+#
+# Unless required by applicable law or agreed to in writing, software distributed under
+# the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+# either express or implied. See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# We undertake not to change the open source license (MIT license) applicable
+# to the current version of the project delivered to anyone in the future.
+#
+from django.urls import include, path
+
+from . import views
+
+urlpatterns = [
+    # /api/v2/inner/ 用于 paasv3 内部调用; 鉴权：来自于网关（主动授权）
+    # 所有的接口必须隐藏 + 不允许申请权限（需主动授权）
+    # 作为 resource 注册到网关时
+    # 1. isPublic: false              不公开
+    # 2. allowApplyPermission: false  不允许申请权限 (走的是 主动授权)
+    # 3. authConfig:
+    #      userVerifiedRequired: false   不需要用户认证
+    #      appVerifiedRequired: true     需要应用认证
+    #      resourcePermissionRequired: true 需要资源权限
+    path(
+        "gateways/",
+        include(
+            [
+                # GET /api/v2/inner/gateways/
+                path("", views.GatewayListApi.as_view(), name="openapi.v2.inner.gateway.list"),
+                path(
+                    "<slug:gateway_name>/",
+                    include(
+                        [
+                            # GET /api/v2/inner/gateways/{gateway_name}/
+                            path("", views.GatewayRetrieveApi.as_view(), name="openapi.v2.inner.gateway.retrieve"),
+                        ]
+                    ),
+                ),
+            ]
+        ),
+    ),
+]

--- a/src/dashboard/apigateway/apigateway/apis/v2/inner/views.py
+++ b/src/dashboard/apigateway/apigateway/apis/v2/inner/views.py
@@ -1,0 +1,103 @@
+# -*- coding: utf-8 -*-
+#
+# TencentBlueKing is pleased to support the open source community by making
+# 蓝鲸智云 - API 网关 (BlueKing - APIGateway) available.
+# Copyright (C) 2017 THL A29 Limited, a Tencent company. All rights reserved.
+# Licensed under the MIT License (the "License"); you may not use this file except
+# in compliance with the License. You may obtain a copy of the License at
+#
+#     http://opensource.org/licenses/MIT
+#
+# Unless required by applicable law or agreed to in writing, software distributed under
+# the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+# either express or implied. See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# We undertake not to change the open source license (MIT license) applicable
+# to the current version of the project delivered to anyone in the future.
+#
+
+import operator
+
+from django.utils.decorators import method_decorator
+from drf_yasg.utils import swagger_auto_schema
+from rest_framework import generics, status
+
+from apigateway.apis.v2.permissions import OpenAPIV2GatewayNamePermission, OpenAPIV2Permission
+from apigateway.biz.release import ReleaseHandler
+from apigateway.core.constants import GatewayStatusEnum
+from apigateway.core.models import Gateway
+from apigateway.utils.responses import OKJsonResponse
+
+from . import serializers
+
+# 注意：请使用 OpenAPIV2Permission / OpenAPIV2GatewayNamePermission, 有特殊情况请在类注释中说明
+
+
+@method_decorator(
+    name="get",
+    decorator=swagger_auto_schema(
+        operation_description="获取网关列表，网关需公开且已发布",
+        query_serializer=serializers.GatewayListInputSLZ,
+        responses={status.HTTP_200_OK: serializers.GatewayListOutputSLZ(many=True)},
+        tags=["OpenAPI.V2.Inner"],
+    ),
+)
+class GatewayListApi(generics.ListAPIView):
+    serializer_class = serializers.GatewayListOutputSLZ
+    permission_classes = [OpenAPIV2Permission]
+
+    def get_queryset(self):
+        return Gateway.objects.all()
+
+    def list(self, request, *args, **kwargs):
+        """
+        获取可用的网关列表
+        - 1. 已启用
+        - 2. 公开
+        - 3. 已发布
+        - 4. 满足 name 过滤条件
+        """
+        slz = serializers.GatewayListInputSLZ(data=request.query_params)
+        slz.is_valid(raise_exception=True)
+
+        name = slz.validated_data.get("name")
+        fuzzy = slz.validated_data.get("fuzzy")
+
+        queryset = Gateway.objects.filter(status=GatewayStatusEnum.ACTIVE.value, is_public=True)
+        if name:
+            # 模糊匹配，查询名称中包含 name 的网关 or 精确匹配，查询名称为 name 的网关
+            queryset = queryset.filter(name__contains=name) if fuzzy else queryset.filter(name=name)
+
+        # 过滤出用户类型为指定类型的网关
+        all_gateway_ids = list(queryset.values_list("id", flat=True))
+        # 过滤出已发布的网关 ID
+        released_gateway_ids = ReleaseHandler.filter_released_gateway_ids(all_gateway_ids)
+
+        queryset = queryset.filter(id__in=released_gateway_ids)
+        output_slz = self.get_serializer(queryset, many=True)
+        output_data = sorted(output_slz.data, key=operator.itemgetter("name"))
+
+        return OKJsonResponse(data=output_data)
+
+
+@method_decorator(
+    name="get",
+    decorator=swagger_auto_schema(
+        responses={status.HTTP_200_OK: serializers.GatewayRetrieveOutputSLZ()},
+        tags=["OpenAPI.V2.Inner"],
+    ),
+)
+class GatewayRetrieveApi(generics.RetrieveAPIView):
+    permission_classes = [OpenAPIV2GatewayNamePermission]
+    serializer_class = serializers.GatewayRetrieveOutputSLZ
+    lookup_url_kwarg = "gateway_name"
+    lookup_field = "name"
+
+    def get_queryset(self):
+        return Gateway.objects.all()
+
+    def retrieve(self, request, *args, **kwargs):
+        instance = self.get_object()
+        slz = self.get_serializer(instance)
+        return OKJsonResponse(data=slz.data)

--- a/src/dashboard/apigateway/apigateway/apis/v2/open/__init__.py
+++ b/src/dashboard/apigateway/apigateway/apis/v2/open/__init__.py
@@ -1,0 +1,17 @@
+#
+# TencentBlueKing is pleased to support the open source community by making
+# 蓝鲸智云 - API 网关(BlueKing - APIGateway) available.
+# Copyright (C) 2017 THL A29 Limited, a Tencent company. All rights reserved.
+# Licensed under the MIT License (the "License"); you may not use this file except
+# in compliance with the License. You may obtain a copy of the License at
+#
+#     http://opensource.org/licenses/MIT
+#
+# Unless required by applicable law or agreed to in writing, software distributed under
+# the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+# either express or implied. See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# We undertake not to change the open source license (MIT license) applicable
+# to the current version of the project delivered to anyone in the future.
+#

--- a/src/dashboard/apigateway/apigateway/apis/v2/open/serializers.py
+++ b/src/dashboard/apigateway/apigateway/apis/v2/open/serializers.py
@@ -1,0 +1,56 @@
+# -*- coding: utf-8 -*-
+#
+# TencentBlueKing is pleased to support the open source community by making
+# 蓝鲸智云 - API 网关(BlueKing - APIGateway) available.
+# Copyright (C) 2017 THL A29 Limited, a Tencent company. All rights reserved.
+# Licensed under the MIT License (the "License"); you may not use this file except
+# in compliance with the License. You may obtain a copy of the License at
+#
+#     http://opensource.org/licenses/MIT
+#
+# Unless required by applicable law or agreed to in writing, software distributed under
+# the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+# either express or implied. See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# We undertake not to change the open source license (MIT license) applicable
+# to the current version of the project delivered to anyone in the future.
+#
+
+from rest_framework import serializers
+
+from apigateway.common.i18n.field import SerializerTranslatedField
+
+
+class GatewayListInputSLZ(serializers.Serializer):
+    name = serializers.CharField(required=False, allow_blank=True)
+    fuzzy = serializers.BooleanField(required=False)
+
+    class Meta:
+        ref_name = "apigateway.apis.v2.open.serializers.GatewayListInputSLZ"
+
+
+class GatewayListOutputSLZ(serializers.Serializer):
+    id = serializers.IntegerField(read_only=True)
+    name = serializers.CharField(read_only=True)
+    description = SerializerTranslatedField(default_field="description_i18n", allow_blank=True, read_only=True)
+    maintainers = serializers.SerializerMethodField()
+
+    def get_maintainers(self, obj):
+        return obj.maintainers
+
+    class Meta:
+        ref_name = "apigateway.apis.v2.open.serializers.GatewayListOutputSLZ"
+
+
+class GatewayRetrieveOutputSLZ(serializers.Serializer):
+    id = serializers.IntegerField(read_only=True)
+    name = serializers.CharField(read_only=True)
+    description = SerializerTranslatedField(default_field="description_i18n", allow_blank=True, read_only=True)
+    maintainers = serializers.SerializerMethodField()
+
+    def get_maintainers(self, obj):
+        return obj.maintainers
+
+    class Meta:
+        ref_name = "apigateway.apis.v2.open.serializers.GatewayRetrieveOutputSLZ"

--- a/src/dashboard/apigateway/apigateway/apis/v2/open/urls.py
+++ b/src/dashboard/apigateway/apigateway/apis/v2/open/urls.py
@@ -1,0 +1,52 @@
+# -*- coding: utf-8 -*-
+#
+# TencentBlueKing is pleased to support the open source community by making
+# 蓝鲸智云 - API 网关 (BlueKing - APIGateway) available.
+# Copyright (C) 2017 THL A29 Limited, a Tencent company. All rights reserved.
+# Licensed under the MIT License (the "License"); you may not use this file except
+# in compliance with the License. You may obtain a copy of the License at
+#
+#     http://opensource.org/licenses/MIT
+#
+# Unless required by applicable law or agreed to in writing, software distributed under
+# the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+# either express or implied. See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# We undertake not to change the open source license (MIT license) applicable
+# to the current version of the project delivered to anyone in the future.
+#
+from django.urls import include, path
+
+from . import views
+
+urlpatterns = [
+    # /api/v2/open/ 用于第三方系统调用查询一些网关信息，正常情况禁止提供`写`接口，避免非网关的 related_app 对网关进行了修改
+    # 作为 resource 注册到网关时
+    # 1. isPublic: true              公开
+    # 2. allowApplyPermission: true  允许申请权限
+    # 3. authConfig:
+    #      userVerifiedRequired: false   不需要用户认证
+    #      appVerifiedRequired: true     需要应用认证
+    #      resourcePermissionRequired: true  需要资源权限
+    path(
+        "gateways/",
+        include(
+            [
+                # GET /api/v2/open/gateways/
+                path("", views.GatewayListApi.as_view(), name="openapi.v2.open.gateway.list"),
+                path(
+                    "<slug:gateway_name>/",
+                    include(
+                        [
+                            # GET /api/v2/open/gateways/{gateway_name}/
+                            path("", views.GatewayRetrieveApi.as_view(), name="openapi.v2.open.gateway.retrieve"),
+                            # GET /api/v2/open/gateways/{gateway_name}/public_key/
+                            # NOTE: this url been redirected to core-api, so no need to implement this
+                        ]
+                    ),
+                ),
+            ]
+        ),
+    ),
+]

--- a/src/dashboard/apigateway/apigateway/apis/v2/open/views.py
+++ b/src/dashboard/apigateway/apigateway/apis/v2/open/views.py
@@ -1,0 +1,103 @@
+# -*- coding: utf-8 -*-
+#
+# TencentBlueKing is pleased to support the open source community by making
+# 蓝鲸智云 - API 网关 (BlueKing - APIGateway) available.
+# Copyright (C) 2017 THL A29 Limited, a Tencent company. All rights reserved.
+# Licensed under the MIT License (the "License"); you may not use this file except
+# in compliance with the License. You may obtain a copy of the License at
+#
+#     http://opensource.org/licenses/MIT
+#
+# Unless required by applicable law or agreed to in writing, software distributed under
+# the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+# either express or implied. See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# We undertake not to change the open source license (MIT license) applicable
+# to the current version of the project delivered to anyone in the future.
+#
+
+import operator
+
+from django.utils.decorators import method_decorator
+from drf_yasg.utils import swagger_auto_schema
+from rest_framework import generics, status
+
+from apigateway.apis.v2.permissions import OpenAPIV2GatewayNamePermission, OpenAPIV2Permission
+from apigateway.biz.release import ReleaseHandler
+from apigateway.core.constants import GatewayStatusEnum
+from apigateway.core.models import Gateway
+from apigateway.utils.responses import OKJsonResponse
+
+from . import serializers
+
+# 注意：请使用 OpenAPIV2Permission / OpenAPIV2GatewayNamePermission, 有特殊情况请在类注释中说明
+
+
+@method_decorator(
+    name="get",
+    decorator=swagger_auto_schema(
+        operation_description="获取网关列表，网关需公开且已发布",
+        query_serializer=serializers.GatewayListInputSLZ,
+        responses={status.HTTP_200_OK: serializers.GatewayListOutputSLZ(many=True)},
+        tags=["OpenAPI.V2.Open"],
+    ),
+)
+class GatewayListApi(generics.ListAPIView):
+    serializer_class = serializers.GatewayListOutputSLZ
+    permission_classes = [OpenAPIV2Permission]
+
+    def get_queryset(self):
+        return Gateway.objects.all()
+
+    def list(self, request, *args, **kwargs):
+        """
+        获取可用的网关列表
+        - 1. 已启用
+        - 2. 公开
+        - 3. 已发布
+        - 4. 满足 name 过滤条件
+        """
+        slz = serializers.GatewayListInputSLZ(data=request.query_params)
+        slz.is_valid(raise_exception=True)
+
+        name = slz.validated_data.get("name")
+        fuzzy = slz.validated_data.get("fuzzy")
+
+        queryset = Gateway.objects.filter(status=GatewayStatusEnum.ACTIVE.value, is_public=True)
+        if name:
+            # 模糊匹配，查询名称中包含 name 的网关 or 精确匹配，查询名称为 name 的网关
+            queryset = queryset.filter(name__contains=name) if fuzzy else queryset.filter(name=name)
+
+        # 过滤出用户类型为指定类型的网关
+        all_gateway_ids = list(queryset.values_list("id", flat=True))
+        # 过滤出已发布的网关 ID
+        released_gateway_ids = ReleaseHandler.filter_released_gateway_ids(all_gateway_ids)
+
+        queryset = queryset.filter(id__in=released_gateway_ids)
+        output_slz = self.get_serializer(queryset, many=True)
+        output_data = sorted(output_slz.data, key=operator.itemgetter("name"))
+
+        return OKJsonResponse(data=output_data)
+
+
+@method_decorator(
+    name="get",
+    decorator=swagger_auto_schema(
+        responses={status.HTTP_200_OK: serializers.GatewayRetrieveOutputSLZ()},
+        tags=["OpenAPI.V2.Open"],
+    ),
+)
+class GatewayRetrieveApi(generics.RetrieveAPIView):
+    permission_classes = [OpenAPIV2GatewayNamePermission]
+    serializer_class = serializers.GatewayRetrieveOutputSLZ
+    lookup_url_kwarg = "gateway_name"
+    lookup_field = "name"
+
+    def get_queryset(self):
+        return Gateway.objects.all()
+
+    def retrieve(self, request, *args, **kwargs):
+        instance = self.get_object()
+        slz = self.get_serializer(instance)
+        return OKJsonResponse(data=slz.data)

--- a/src/dashboard/apigateway/apigateway/apis/v2/permissions.py
+++ b/src/dashboard/apigateway/apigateway/apis/v2/permissions.py
@@ -1,0 +1,115 @@
+# -*- coding: utf-8 -*-
+#
+# TencentBlueKing is pleased to support the open source community by making
+# 蓝鲸智云 - API 网关 (BlueKing - APIGateway) available.
+# Copyright (C) 2017 THL A29 Limited, a Tencent company. All rights reserved.
+# Licensed under the MIT License (the "License"); you may not use this file except
+# in compliance with the License. You may obtain a copy of the License at
+#
+#     http://opensource.org/licenses/MIT
+#
+# Unless required by applicable law or agreed to in writing, software distributed under
+# the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+# either express or implied. See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# We undertake not to change the open source license (MIT license) applicable
+# to the current version of the project delivered to anyone in the future.
+#
+
+from django.http import Http404
+from django.utils.translation import gettext_lazy
+from rest_framework import permissions
+
+from apigateway.core.models import Gateway, GatewayRelatedApp
+from apigateway.utils.django import get_object_or_None
+
+
+class OpenAPIV2Permission(permissions.BasePermission):
+    """仅验证来自于网关的请求
+    适用：申请网关接口权限后，就能访问的接口，路径参数中没有 gateway_id or gateway_name
+    """
+
+    message = gettext_lazy("只能通过网关访问该接口")
+
+    def has_permission(self, request, view):
+        # openapi 的请求来源必须是网关，此时经过网关的中间件（所有都开启了应用认证）, 请求中会注入 app 对象
+        if not hasattr(request, "app"):
+            return False
+
+        return True
+
+
+class OpenAPIV2GatewayNamePermission(permissions.BasePermission):
+    """验证来自于网关的请求，并且路径参数中有 gateway_name, 且这个 gateway_name 对应网关存在
+    适用：申请网关接口权限后 + 路径参数中 gateway_name 的接口
+    """
+
+    message = gettext_lazy("只能通过网关访问该接口，并且 gateway_name 对应网关必须存在")
+
+    def has_permission(self, request, view):
+        # openapi 的请求来源必须是网关，此时经过网关的中间件（所有都开启了应用认证）, 请求中会注入 app 对象
+        if not hasattr(request, "app"):
+            return False
+
+        # 路径参数 gateway_id 必须存在
+        gateway_obj = self.get_gateway_object(view)
+
+        if not gateway_obj:
+            raise Http404
+        request.gateway = gateway_obj
+
+        return True
+
+    def get_gateway_object(self, view):
+        """
+        根据路径参数 gateway_name 获取网关对象
+        若 gateway_name 不在路径参数中，或网关不存在，返回 None
+        """
+        lookup_url_kwarg = "gateway_name"
+
+        if lookup_url_kwarg not in view.kwargs:
+            return None
+
+        filter_kwargs = {"name": view.kwargs[lookup_url_kwarg]}
+        return get_object_or_None(Gateway, **filter_kwargs)
+
+
+class OpenAPIV2GatewayRelatedAppPermission(permissions.BasePermission):
+    """验证来自于网关的请求 + 路径参数中有 gateway_name, 且这个 gateway_name 对应网关存在 + 这个应用有操作这个网关的权限 (GatewayRelatedApp)
+    适用：SDK 使用的 API，某个应用通过网关的接口对网关进行变更
+    """
+
+    message = gettext_lazy("应用无操作网关权限")
+
+    def has_permission(self, request, view):
+        # openapi 的请求来源必须是网关，此时经过网关的中间件（所有都开启了应用认证）, 请求中会注入 app 对象
+        if not hasattr(request, "app"):
+            return False
+
+        gateway_obj = self.get_gateway_object(view)
+
+        # NOTE: only for GatewaySyncApi /<slug:gateway_name>/sync/, at that time, the gateway_obj is None
+        # DO NOT USE IN OTHER PLACE
+        if not gateway_obj and getattr(view, "allow_gateway_not_exist", False):
+            return True
+
+        if not gateway_obj:
+            raise Http404
+
+        request.gateway = gateway_obj
+
+        return GatewayRelatedApp.objects.filter(gateway=request.gateway, bk_app_code=request.app.app_code).exists()
+
+    def get_gateway_object(self, view):
+        """
+        根据路径参数 gateway_name 获取网关对象
+        若 gateway_name 不在路径参数中，或网关不存在，返回 None
+        """
+        lookup_url_kwarg = "gateway_name"
+
+        if lookup_url_kwarg not in view.kwargs:
+            return None
+
+        filter_kwargs = {"name": view.kwargs[lookup_url_kwarg]}
+        return get_object_or_None(Gateway, **filter_kwargs)

--- a/src/dashboard/apigateway/apigateway/apis/v2/sync/__init__.py
+++ b/src/dashboard/apigateway/apigateway/apis/v2/sync/__init__.py
@@ -1,0 +1,17 @@
+#
+# TencentBlueKing is pleased to support the open source community by making
+# 蓝鲸智云 - API 网关(BlueKing - APIGateway) available.
+# Copyright (C) 2017 THL A29 Limited, a Tencent company. All rights reserved.
+# Licensed under the MIT License (the "License"); you may not use this file except
+# in compliance with the License. You may obtain a copy of the License at
+#
+#     http://opensource.org/licenses/MIT
+#
+# Unless required by applicable law or agreed to in writing, software distributed under
+# the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+# either express or implied. See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# We undertake not to change the open source license (MIT license) applicable
+# to the current version of the project delivered to anyone in the future.
+#

--- a/src/dashboard/apigateway/apigateway/apis/v2/sync/serializers.py
+++ b/src/dashboard/apigateway/apigateway/apis/v2/sync/serializers.py
@@ -1,0 +1,35 @@
+# -*- coding: utf-8 -*-
+#
+# TencentBlueKing is pleased to support the open source community by making
+# 蓝鲸智云 - API 网关(BlueKing - APIGateway) available.
+# Copyright (C) 2017 THL A29 Limited, a Tencent company. All rights reserved.
+# Licensed under the MIT License (the "License"); you may not use this file except
+# in compliance with the License. You may obtain a copy of the License at
+#
+#     http://opensource.org/licenses/MIT
+#
+# Unless required by applicable law or agreed to in writing, software distributed under
+# the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+# either express or implied. See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# We undertake not to change the open source license (MIT license) applicable
+# to the current version of the project delivered to anyone in the future.
+#
+
+from rest_framework import serializers
+
+from apigateway.biz.validators import BKAppCodeListValidator
+
+
+class GatewayRelatedAppsAddInputSLZ(serializers.Serializer):
+    related_app_codes = serializers.ListField(
+        child=serializers.CharField(),
+        allow_empty=False,
+        required=True,
+        max_length=10,
+        validators=[BKAppCodeListValidator()],
+    )
+
+    class Meta:
+        ref_name = "apigateway.apis.v2.sync.serializers.GatewayRelatedAppsAddInputSLZ"

--- a/src/dashboard/apigateway/apigateway/apis/v2/sync/urls.py
+++ b/src/dashboard/apigateway/apigateway/apis/v2/sync/urls.py
@@ -1,0 +1,64 @@
+# -*- coding: utf-8 -*-
+#
+# TencentBlueKing is pleased to support the open source community by making
+# 蓝鲸智云 - API 网关 (BlueKing - APIGateway) available.
+# Copyright (C) 2017 THL A29 Limited, a Tencent company. All rights reserved.
+# Licensed under the MIT License (the "License"); you may not use this file except
+# in compliance with the License. You may obtain a copy of the License at
+#
+#     http://opensource.org/licenses/MIT
+#
+# Unless required by applicable law or agreed to in writing, software distributed under
+# the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+# either express or implied. See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# We undertake not to change the open source license (MIT license) applicable
+# to the current version of the project delivered to anyone in the future.
+#
+from django.urls import include, path
+
+from . import views
+
+urlpatterns = [
+    # /api/v2/sync/ 用于 SDK 同步网关; 鉴权：来自于网关+related_apps
+    # 问题：是否隐藏 + 不可申请权限？还是说公开 + 说明只能是 related_app 操作？
+    # 作为 resource 注册到网关时
+    # 1. isPublic: true              公开
+    # 2. allowApplyPermission: false  不允许申请权限 (走的是 related_apps 判定)
+    # 3. authConfig:
+    #      userVerifiedRequired: false   不需要用户认证
+    #      appVerifiedRequired: true     需要应用认证
+    #      resourcePermissionRequired: false 不需要资源权限
+    path(
+        "gateways/<slug:gateway_name>/",
+        include(
+            [
+                # POST /api/v2/sync/gateways/{gateway_name}/
+                # path("", views.GatewaySyncApi.as_view(), name="openapi.v2.sync.gateway.sync"),
+                # GET /api/v2/sync/gateways/{gateway_name}/public_key/
+                # NOTE: this url been redirected to core-api, so no need to implement this
+                path(
+                    "related-apps/",
+                    include(
+                        [
+                            # POST /api/v2/sync/gateways/{gateway_name}/related-apps/
+                            path(
+                                "",
+                                views.GatewayRelatedAppAddApi.as_view(),
+                                name="openapi.v2.sync.gateway.add_related_apps",
+                            ),
+                            # TODO:
+                            # DELETE /api/v2/sync/gateways/{gateway_name}/related-apps/{app_code}/
+                            # path(
+                            #     "{app_code}/",
+                            #     views.GatewayRelatedAppDeleteApi.as_view(),
+                            #     name="openapi.v2.sync.gateway.delete_related_apps",
+                            # ),
+                        ]
+                    ),
+                ),
+            ]
+        ),
+    ),
+]

--- a/src/dashboard/apigateway/apigateway/apis/v2/sync/views.py
+++ b/src/dashboard/apigateway/apigateway/apis/v2/sync/views.py
@@ -1,0 +1,78 @@
+# -*- coding: utf-8 -*-
+#
+# TencentBlueKing is pleased to support the open source community by making
+# 蓝鲸智云 - API 网关 (BlueKing - APIGateway) available.
+# Copyright (C) 2017 THL A29 Limited, a Tencent company. All rights reserved.
+# Licensed under the MIT License (the "License"); you may not use this file except
+# in compliance with the License. You may obtain a copy of the License at
+#
+#     http://opensource.org/licenses/MIT
+#
+# Unless required by applicable law or agreed to in writing, software distributed under
+# the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+# either express or implied. See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# We undertake not to change the open source license (MIT license) applicable
+# to the current version of the project delivered to anyone in the future.
+#
+
+
+from django.conf import settings
+from django.db import transaction
+from django.utils.decorators import method_decorator
+from drf_yasg.utils import swagger_auto_schema
+from rest_framework import generics, status
+
+from apigateway.apis.v2.permissions import OpenAPIV2GatewayRelatedAppPermission
+from apigateway.apps.audit.constants import OpTypeEnum
+from apigateway.biz.audit import Auditor
+from apigateway.biz.gateway_related_app import GatewayRelatedAppHandler
+from apigateway.utils.responses import OKJsonResponse
+
+from . import serializers
+
+# 注意：请使用 OpenAPIV2GatewayRelatedAppPermission, 有特殊情况请在类注释中说明
+
+
+@method_decorator(
+    name="post",
+    decorator=swagger_auto_schema(
+        operation_description="添加网关关联的应用",
+        request_body=serializers.GatewayRelatedAppsAddInputSLZ,
+        responses={status.HTTP_201_CREATED: ""},
+        tags=["OpenAPI.V2.Sync"],
+    ),
+)
+class GatewayRelatedAppAddApi(generics.CreateAPIView):
+    permission_classes = [OpenAPIV2GatewayRelatedAppPermission]
+    serializer_class = serializers.GatewayRelatedAppsAddInputSLZ
+
+    @transaction.atomic
+    def post(self, request, gateway_name: str, *args, **kwargs):
+        slz = self.get_serializer(data=request.data)
+        slz.is_valid(raise_exception=True)
+
+        input_app_codes = slz.validated_data["related_app_codes"]
+
+        exist_related_app_codes = GatewayRelatedAppHandler.get_related_app_codes(request.gateway.id)
+        missing_app_codes = set(input_app_codes) - set(exist_related_app_codes)
+        for bk_app_code in missing_app_codes:
+            GatewayRelatedAppHandler.add_related_app(request.gateway.id, bk_app_code)
+
+        data_after = GatewayRelatedAppHandler.get_related_app_codes(request.gateway.id)
+
+        # record audit log
+        gateway = request.gateway
+        username = request.user.username or settings.GATEWAY_DEFAULT_CREATOR
+        Auditor.record_gateway_op_success(
+            op_type=OpTypeEnum.MODIFY,
+            username=username,
+            gateway_id=gateway.id,
+            instance_id=gateway.id,
+            instance_name=gateway.name,
+            data_before={"related_app_codes": exist_related_app_codes},
+            data_after={"related_app_codes": data_after},
+        )
+
+        return OKJsonResponse(status=status.HTTP_201_CREATED)

--- a/src/dashboard/apigateway/apigateway/apis/v2/urls.py
+++ b/src/dashboard/apigateway/apigateway/apis/v2/urls.py
@@ -1,0 +1,35 @@
+# -*- coding: utf-8 -*-
+#
+# TencentBlueKing is pleased to support the open source community by making
+# 蓝鲸智云 - API 网关 (BlueKing - APIGateway) available.
+# Copyright (C) 2017 THL A29 Limited, a Tencent company. All rights reserved.
+# Licensed under the MIT License (the "License"); you may not use this file except
+# in compliance with the License. You may obtain a copy of the License at
+#
+#     http://opensource.org/licenses/MIT
+#
+# Unless required by applicable law or agreed to in writing, software distributed under
+# the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+# either express or implied. See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# We undertake not to change the open source license (MIT license) applicable
+# to the current version of the project delivered to anyone in the future.
+#
+from django.urls import include, path
+
+# NOTE:
+# 1. 新版 http 协议
+# 2. 统一注册到 bk-apigateway 网关，并且 inner api 需要隐藏 + 主动授权 (未来需要下掉 bk-apigateway-inner)
+# 3. 三类 api 即使功能一模一样，也不允许复用代码 (这已经是最上层使用层，现在功能一致不代表随时间推移还会保持一致)
+
+# FIXME: resource.yaml 改成新版格式，并且切换到 openapi3.0 协议，自动生成文档和示例
+
+urlpatterns = [
+    # /api/v2/sync/ 用于 SDK 同步网关; 鉴权：来自于网关+related_apps
+    path("sync/", include("apigateway.apis.v2.sync.urls")),
+    # /api/v2/inner/ 用于 paasv3 内部调用; 鉴权：来自于网关（主动授权）
+    path("inner/", include("apigateway.apis.v2.inner.urls")),
+    # /api/v2/open/ 用于普通开放 api；鉴权：来自于网关
+    path("open/", include("apigateway.apis.v2.open.urls")),
+]

--- a/src/dashboard/apigateway/apigateway/data/apigw-definitions/bk-apigateway-definition.yaml
+++ b/src/dashboard/apigateway/apigateway/data/apigw-definitions/bk-apigateway-definition.yaml
@@ -1,13 +1,16 @@
+spec_version: 1
+
 release:
-  version: 1.2.3
+  version: 1.2.4
   title: 资源同步新增文档生成
   comment: 资源同步新增文档生成
 
 apigateway:
-  description: 蓝鲸 API 网关（BlueKing API Gateway）是一种高性能、高可用的 API 托管服务。网关提供了该服务的基础通用接口，包含网关、资源、环境、版本发布、权限等相关接口。(官方内置网关, 请勿修改!)
+  description: 蓝鲸 API 网关（BlueKing API Gateway）是一种高性能、高可用的 API 托管服务。网关提供了该服务的基础通用接口，包含网关、资源、环境、版本发布、权限等相关接口。(官方内置网关，请勿修改!)
   description_en: BlueKing API Gateway is a high-performance and highly available API hosting service. The gateway provides basic common interfaces for this service, including gateway, resource, stage, version release, permission, and other related interfaces. (Official built-in gateway, do not modify!)
   is_public: true
   api_type: 1
+
 
 stage:
   name: prod
@@ -28,9 +31,26 @@ stage:
             weight: 100
 
 grant_permissions:
-  - bk_app_code: visual-layout
-  - bk_app_code: bk_lesscode
   - bk_app_code: {{ settings.BK_APP_CODE }}
+    grant_dimension: "gateway"
+  # paas v3: TODO: add all inner apis here
+  - bk_app_code: bk_paas3
+    grant_dimension: "resource"
+    resource_names:
+      - v2_inner_list_gateways
+      - v2_inner_get_gateway
+  # bk_lesscode
+  - bk_app_code: bk_lesscode
+    grant_dimension: "resource"
+    resource_names:
+      - get_apigw_public_key
+      - v2_open_get_gateway_public_key
+  # visual-layout
+  - bk_app_code: visual-layout
+    grant_dimension: "resource"
+    resource_names:
+      - get_apigw_public_key
+      - v2_open_get_gateway_public_key
 
 resource_docs:
   basedir: "{{ settings.BASE_DIR }}/data/apidocs/"

--- a/src/dashboard/apigateway/apigateway/data/apigw-definitions/bk-apigateway-definition.yaml
+++ b/src/dashboard/apigateway/apigateway/data/apigw-definitions/bk-apigateway-definition.yaml
@@ -2,8 +2,8 @@ spec_version: 1
 
 release:
   version: 1.2.4
-  title: 资源同步新增文档生成
-  comment: 资源同步新增文档生成
+  title: 增加 api v2 接口
+  comment: 增加 api v2 接口 
 
 apigateway:
   description: 蓝鲸 API 网关（BlueKing API Gateway）是一种高性能、高可用的 API 托管服务。网关提供了该服务的基础通用接口，包含网关、资源、环境、版本发布、权限等相关接口。(官方内置网关，请勿修改!)

--- a/src/dashboard/apigateway/apigateway/data/apigw-definitions/bk-apigateway-resources.yaml
+++ b/src/dashboard/apigateway/apigateway/data/apigw-definitions/bk-apigateway-resources.yaml
@@ -1,529 +1,813 @@
-swagger: '2.0'
-basePath: /
+openapi: 3.0.1
+servers:
+- url: /
 info:
-  version: '0.1'
+  version: '2.0'
   title: API Gateway Resources
   description: ''
-schemes:
-- http
 paths:
   /api/v1/apis/:
     get:
       operationId: get_apis
       description: 查询网关
-      tags: []
+      tags:
+      - v1
       responses:
         default:
           description: ''
+          content:
+            application/json:
+              schema: {}
       x-bk-apigateway-resource:
         isPublic: true
         allowApplyPermission: true
         matchSubpath: false
+        enableWebsocket: false
         backend:
-          type: HTTP
+          name: default
           method: get
           path: /backend/api/v1/apis/
           matchSubpath: false
           timeout: 0
-          upstreams: {}
-          transformHeaders: {}
+        pluginConfigs: []
         authConfig:
           userVerifiedRequired: false
-        disabledStages: []
-        descriptionEn:
+          appVerifiedRequired: true
+          resourcePermissionRequired: true
+        descriptionEn: None
   /api/v1/apis/{api_name}/permissions/apply/:
     post:
       operationId: apply_permissions
       description: 申请网关API访问权限
-      tags: []
+      tags:
+      - v1
       responses:
         default:
           description: ''
+          content:
+            application/json:
+              schema: {}
       x-bk-apigateway-resource:
         isPublic: true
         allowApplyPermission: true
         matchSubpath: false
+        enableWebsocket: false
         backend:
-          type: HTTP
+          name: default
           method: post
           path: /backend/api/v1/apis/{api_name}/permissions/apply/
           matchSubpath: false
           timeout: 0
-          upstreams: {}
-          transformHeaders: {}
+        pluginConfigs: []
         authConfig:
           userVerifiedRequired: false
+          appVerifiedRequired: true
           resourcePermissionRequired: false
-        disabledStages: []
-        descriptionEn:
+        descriptionEn: None
   /api/v1/apis/{api_name}/permissions/grant/:
     post:
       operationId: grant_permissions
       description: 网关为应用主动授权
-      tags: []
+      tags:
+      - v1
       responses:
         default:
           description: ''
+          content:
+            application/json:
+              schema: {}
       x-bk-apigateway-resource:
         isPublic: true
         allowApplyPermission: true
         matchSubpath: false
+        enableWebsocket: false
         backend:
-          type: HTTP
+          name: default
           method: post
           path: /backend/api/v1/apis/{api_name}/permissions/grant/
           matchSubpath: false
           timeout: 0
-          upstreams: {}
-          transformHeaders: {}
+        pluginConfigs: []
         authConfig:
           userVerifiedRequired: false
+          appVerifiedRequired: true
           resourcePermissionRequired: false
-        disabledStages: []
-        descriptionEn:
+        descriptionEn: None
   /api/v1/apis/{api_name}/permissions/revoke/:
     delete:
       operationId: revoke_permissions
       description: 回收应用访问网关 API 的权限
-      tags: []
+      tags:
+      - v1
       responses:
         default:
           description: ''
+          content:
+            application/json:
+              schema: {}
       x-bk-apigateway-resource:
         isPublic: true
         allowApplyPermission: true
         matchSubpath: false
+        enableWebsocket: false
         backend:
-          type: HTTP
+          name: default
           method: delete
           path: /backend/api/v1/apis/{api_name}/permissions/revoke/
           matchSubpath: false
           timeout: 0
-          upstreams: {}
-          transformHeaders: {}
+        pluginConfigs: []
         authConfig:
           userVerifiedRequired: false
+          appVerifiedRequired: true
           resourcePermissionRequired: false
-        disabledStages: []
-        descriptionEn:
+        descriptionEn: None
   /api/v1/apis/{api_name}/public_key/:
     get:
       operationId: get_apigw_public_key
       description: 获取网关公钥
-      tags: []
+      tags:
+      - v1
       responses:
         default:
           description: ''
+          content:
+            application/json:
+              schema: {}
       x-bk-apigateway-resource:
         isPublic: true
         allowApplyPermission: true
         matchSubpath: false
+        enableWebsocket: false
         backend:
           name: core-api
-          type: HTTP
           method: get
           path: /api/v1/open/gateways/{api_name}/public_key/
           matchSubpath: false
           timeout: 0
-          upstreams: {}
-          transformHeaders: {}
+        pluginConfigs: []
         authConfig:
           userVerifiedRequired: false
+          appVerifiedRequired: true
           resourcePermissionRequired: false
-        disabledStages: []
-        descriptionEn:
+        descriptionEn: None
   /api/v1/apis/{api_name}/related-apps/:
     post:
       operationId: add_related_apps
       description: 添加网关关联应用
-      tags: []
+      tags:
+      - v1
       responses:
         default:
           description: ''
+          content:
+            application/json:
+              schema: {}
       x-bk-apigateway-resource:
         isPublic: true
         allowApplyPermission: true
         matchSubpath: false
+        enableWebsocket: false
         backend:
-          type: HTTP
+          name: default
           method: post
           path: /backend/api/v1/apis/{api_name}/related-apps/
           matchSubpath: false
           timeout: 0
-          upstreams: {}
-          transformHeaders: {}
+        pluginConfigs: []
         authConfig:
           userVerifiedRequired: false
+          appVerifiedRequired: true
           resourcePermissionRequired: false
-        disabledStages: []
-        descriptionEn:
+        descriptionEn: None
   /api/v1/apis/{api_name}/released/stages/{stage_name}/resources/:
     get:
       operationId: get_released_resources
       description: 查询已发布资源列表
-      tags: []
+      tags:
+      - v1
       responses:
         default:
           description: ''
+          content:
+            application/json:
+              schema: {}
       x-bk-apigateway-resource:
         isPublic: true
         allowApplyPermission: true
         matchSubpath: false
+        enableWebsocket: false
         backend:
-          type: HTTP
+          name: default
           method: get
           path: /backend/api/v1/apis/{api_name}/released/stages/{stage_name}/resources/
           matchSubpath: false
           timeout: 0
-          upstreams: {}
-          transformHeaders: {}
+        pluginConfigs: []
         authConfig:
           userVerifiedRequired: false
-        disabledStages: []
-        descriptionEn:
-
+          appVerifiedRequired: true
+          resourcePermissionRequired: true
+        descriptionEn: None
   /api/v1/apis/{api_name}/released/stages/{stage_name}/resources/{resource_name}/:
     get:
       operationId: get_released_resource
       description: 查询发布资源详情(包含接口参数)
-      tags: []
+      tags:
+      - v1
       x-bk-apigateway-resource:
         isPublic: true
         allowApplyPermission: true
         matchSubpath: false
+        enableWebsocket: false
         backend:
-          type: HTTP
+          name: default
           method: get
           path: /backend/api/v1/apis/{api_name}/released/stages/{stage_name}/resources/{resource_name}/
           matchSubpath: false
           timeout: 0
-          upstreams: {}
-          transformHeaders: {}
+        pluginConfigs: []
         authConfig:
           userVerifiedRequired: false
-        disabledStages: []
-
-
+          appVerifiedRequired: true
+          resourcePermissionRequired: true
+        descriptionEn:
   /api/v1/apis/{api_name}/resource-docs/import/by-archive/:
     post:
       operationId: import_resource_docs_by_archive
       description: 通过文档归档文件导入资源文档
-      tags: []
+      tags:
+      - v1
       responses:
         default:
           description: ''
+          content:
+            application/json:
+              schema: {}
       x-bk-apigateway-resource:
         isPublic: true
         allowApplyPermission: true
         matchSubpath: false
+        enableWebsocket: false
         backend:
-          type: HTTP
+          name: default
           method: post
           path: /backend/api/v1/apis/{api_name}/resource-docs/import/by-archive/
           matchSubpath: false
           timeout: 0
-          upstreams: {}
-          transformHeaders: {}
+        pluginConfigs: []
         authConfig:
           userVerifiedRequired: false
+          appVerifiedRequired: true
           resourcePermissionRequired: false
-        disabledStages: []
-        descriptionEn:
+        descriptionEn: None
   /api/v1/apis/{api_name}/resource-docs/import/by-swagger/:
     post:
       operationId: import_resource_docs_by_swagger
       description: 通过 Swagger 格式导入文档
-      tags: []
+      tags:
+      - v1
       responses:
         default:
           description: ''
+          content:
+            application/json:
+              schema: {}
       x-bk-apigateway-resource:
         isPublic: true
         allowApplyPermission: true
         matchSubpath: false
+        enableWebsocket: false
         backend:
-          type: HTTP
+          name: default
           method: post
           path: /backend/api/v1/apis/{api_name}/resource-docs/import/by-swagger/
           matchSubpath: false
           timeout: 0
-          upstreams: {}
-          transformHeaders: {}
+        pluginConfigs: []
         authConfig:
           userVerifiedRequired: false
+          appVerifiedRequired: true
           resourcePermissionRequired: false
-        disabledStages: []
-        descriptionEn:
+        descriptionEn: None
   /api/v1/apis/{api_name}/resources/sync/:
     post:
       operationId: sync_resources
       description: 同步资源
-      tags: []
+      tags:
+      - v1
       responses:
         default:
           description: ''
+          content:
+            application/json:
+              schema: {}
       x-bk-apigateway-resource:
         isPublic: true
         allowApplyPermission: true
         matchSubpath: false
+        enableWebsocket: false
         backend:
-          type: HTTP
+          name: default
           method: post
           path: /backend/api/v1/apis/{api_name}/resources/sync/
           matchSubpath: false
           timeout: 0
-          upstreams: {}
-          transformHeaders: {}
+        pluginConfigs: []
         authConfig:
           userVerifiedRequired: false
+          appVerifiedRequired: true
           resourcePermissionRequired: false
-        disabledStages: []
-        descriptionEn:
+        descriptionEn: None
   /api/v1/apis/{api_name}/resource_versions/:
     get:
       operationId: list_resource_versions
       description: 查询资源版本
-      tags: []
+      tags:
+      - v1
       responses:
         default:
           description: ''
+          content:
+            application/json:
+              schema: {}
       x-bk-apigateway-resource:
         isPublic: true
         allowApplyPermission: true
         matchSubpath: false
+        enableWebsocket: false
         backend:
-          type: HTTP
+          name: default
           method: get
           path: /backend/api/v1/apis/{api_name}/resource_versions/
           matchSubpath: false
           timeout: 0
-          upstreams: {}
-          transformHeaders: {}
+        pluginConfigs: []
         authConfig:
           userVerifiedRequired: false
+          appVerifiedRequired: true
           resourcePermissionRequired: false
-        disabledStages: []
         descriptionEn: List resource versions
     post:
       operationId: create_resource_version
       description: 创建资源版本
-      tags: []
+      tags:
+      - v1
       responses:
         default:
           description: ''
+          content:
+            application/json:
+              schema: {}
       x-bk-apigateway-resource:
         isPublic: true
         allowApplyPermission: true
         matchSubpath: false
+        enableWebsocket: false
         backend:
-          type: HTTP
+          name: default
           method: post
           path: /backend/api/v1/apis/{api_name}/resource_versions/
           matchSubpath: false
           timeout: 0
-          upstreams: {}
-          transformHeaders: {}
+        pluginConfigs: []
         authConfig:
           userVerifiedRequired: false
+          appVerifiedRequired: true
           resourcePermissionRequired: false
-        disabledStages: []
-        descriptionEn:
+        descriptionEn: None
   /api/v1/apis/{api_name}/resource_versions/latest/:
     get:
       operationId: get_latest_resource_version
       description: 获取网关最新版本
-      tags: []
+      tags:
+      - v1
       responses:
         default:
           description: ''
+          content:
+            application/json:
+              schema: {}
       x-bk-apigateway-resource:
         isPublic: true
         allowApplyPermission: true
         matchSubpath: false
+        enableWebsocket: false
         backend:
-          type: HTTP
+          name: default
           method: get
           path: /backend/api/v1/apis/{api_name}/resource_versions/latest/
           matchSubpath: false
           timeout: 0
-          upstreams: {}
-          transformHeaders: {}
+        pluginConfigs: []
         authConfig:
           userVerifiedRequired: false
+          appVerifiedRequired: true
           resourcePermissionRequired: false
-        disabledStages: []
-        descriptionEn:
+        descriptionEn: None
   /api/v1/apis/{api_name}/resource_versions/release/:
     post:
       operationId: release
       description: 发布版本
-      tags: []
+      tags:
+      - v1
       responses:
         default:
           description: ''
+          content:
+            application/json:
+              schema: {}
       x-bk-apigateway-resource:
         isPublic: true
         allowApplyPermission: true
         matchSubpath: false
+        enableWebsocket: false
         backend:
-          type: HTTP
+          name: default
           method: post
           path: /backend/api/v1/apis/{api_name}/resource_versions/release/
           matchSubpath: false
           timeout: 0
-          upstreams: {}
-          transformHeaders: {}
+        pluginConfigs: []
         authConfig:
           userVerifiedRequired: false
+          appVerifiedRequired: true
           resourcePermissionRequired: false
-        disabledStages: []
-        descriptionEn:
+        descriptionEn: None
   /api/v1/apis/{api_name}/sdk/:
     post:
       operationId: generate_sdk
       description: 生成 SDK
-      tags: []
+      tags:
+      - v1
       responses:
         default:
           description: ''
+          content:
+            application/json:
+              schema: {}
       x-bk-apigateway-resource:
         isPublic: true
         allowApplyPermission: true
         matchSubpath: false
+        enableWebsocket: false
         backend:
-          type: HTTP
+          name: default
           method: post
           path: /backend/api/v1/apis/{api_name}/sdk/
           matchSubpath: false
           timeout: 0
-          upstreams: {}
-          transformHeaders: {}
+        pluginConfigs: []
         authConfig:
           userVerifiedRequired: false
+          appVerifiedRequired: true
           resourcePermissionRequired: false
-        disabledStages: []
-        descriptionEn:
+        descriptionEn: None
   /api/v1/apis/{api_name}/stages/:
     get:
       operationId: get_stages
       description: 查询环境
-      tags: []
+      tags:
+      - v1
       responses:
         default:
           description: ''
+          content:
+            application/json:
+              schema: {}
       x-bk-apigateway-resource:
         isPublic: true
         allowApplyPermission: true
         matchSubpath: false
+        enableWebsocket: false
         backend:
-          type: HTTP
+          name: default
           method: get
           path: /backend/api/v1/apis/{api_name}/stages/
           matchSubpath: false
           timeout: 0
-          upstreams: {}
-          transformHeaders: {}
+        pluginConfigs: []
         authConfig:
           userVerifiedRequired: false
-        disabledStages: []
-        descriptionEn:
+          appVerifiedRequired: true
+          resourcePermissionRequired: true
+        descriptionEn: None
   /api/v1/apis/{api_name}/stages/sync/:
     post:
       operationId: sync_stage
       description: 同步环境
-      tags: []
+      tags:
+      - v1
       responses:
         default:
           description: ''
+          content:
+            application/json:
+              schema: {}
       x-bk-apigateway-resource:
         isPublic: true
         allowApplyPermission: true
         matchSubpath: false
+        enableWebsocket: false
         backend:
-          type: HTTP
+          name: default
           method: post
           path: /backend/api/v1/apis/{api_name}/stages/sync/
           matchSubpath: false
           timeout: 0
-          upstreams: {}
-          transformHeaders: {}
+        pluginConfigs: []
         authConfig:
           userVerifiedRequired: false
+          appVerifiedRequired: true
           resourcePermissionRequired: false
-        disabledStages: []
-        descriptionEn:
+        descriptionEn: None
   /api/v1/apis/{api_name}/stages/with-resource-version/:
     get:
       operationId: get_stages_with_resource_version
       description: 查询网关环境资源版本
-      tags: []
+      tags:
+      - v1
       responses:
         default:
           description: ''
+          content:
+            application/json:
+              schema: {}
       x-bk-apigateway-resource:
         isPublic: true
         allowApplyPermission: true
         matchSubpath: false
+        enableWebsocket: false
         backend:
-          type: HTTP
+          name: default
           method: get
           path: /backend/api/v1/apis/{api_name}/stages/with-resource-version/
           matchSubpath: false
           timeout: 0
-          upstreams: {}
-          transformHeaders: {}
+        pluginConfigs: []
         authConfig:
           userVerifiedRequired: false
+          appVerifiedRequired: true
           resourcePermissionRequired: false
-        disabledStages: []
         descriptionEn: get stages with resource version
   /api/v1/apis/{api_name}/status/:
     post:
       operationId: update_gateway_status
       description: 修改网关状态
-      tags: []
+      tags:
+      - v1
       responses:
         default:
           description: ''
+          content:
+            application/json:
+              schema: {}
       x-bk-apigateway-resource:
         isPublic: true
         allowApplyPermission: true
         matchSubpath: false
+        enableWebsocket: false
         backend:
-          type: HTTP
+          name: default
           method: post
           path: /backend/api/v1/apis/{api_name}/status/
           matchSubpath: false
           timeout: 0
-          upstreams: {}
-          transformHeaders: {}
+        pluginConfigs: []
         authConfig:
           userVerifiedRequired: false
+          appVerifiedRequired: true
           resourcePermissionRequired: false
-        disabledStages: []
-        descriptionEn:
+        descriptionEn: None
   /api/v1/apis/{api_name}/sync/:
     post:
       operationId: sync_api
       description: 同步网关
-      tags: []
+      tags:
+      - v1
       responses:
         default:
           description: ''
+          content:
+            application/json:
+              schema: {}
       x-bk-apigateway-resource:
         isPublic: true
         allowApplyPermission: true
         matchSubpath: false
+        enableWebsocket: false
         backend:
-          type: HTTP
+          name: default
           method: post
           path: /backend/api/v1/apis/{api_name}/sync/
           matchSubpath: false
           timeout: 0
-          upstreams: {}
-          transformHeaders: {}
+        pluginConfigs: []
         authConfig:
           userVerifiedRequired: false
+          appVerifiedRequired: true
           resourcePermissionRequired: false
-        disabledStages: []
-        descriptionEn:
+        descriptionEn: None
+  /api/v2/open/gateways/:
+    get:
+      operationId: v2_open_list_gateways
+      description: 获取网关列表
+      tags:
+      - v2_open
+      responses:
+        default:
+          description: ''
+          content:
+            application/json:
+              schema: {}
+      x-bk-apigateway-resource:
+        isPublic: true
+        allowApplyPermission: true
+        matchSubpath: false
+        enableWebsocket: false
+        backend:
+          name: default
+          method: get
+          path: /backend/api/v2/open/gateways/
+          matchSubpath: false
+          timeout: 0
+        pluginConfigs: []
+        authConfig:
+          userVerifiedRequired: false
+          appVerifiedRequired: true
+          resourcePermissionRequired: true
+        descriptionEn: None
+  /api/v2/open/gateways/{gateway_name}/:
+    get:
+      operationId: v2_open_get_gateway
+      description: 获取网关
+      tags:
+      - v2_open
+      responses:
+        default:
+          description: ''
+          content:
+            application/json:
+              schema: {}
+      x-bk-apigateway-resource:
+        isPublic: true
+        allowApplyPermission: true
+        matchSubpath: false
+        enableWebsocket: false
+        backend:
+          name: default
+          method: get
+          path: /backend/api/v2/open/gateways/{gateway_name}/
+          matchSubpath: false
+          timeout: 0
+        pluginConfigs: []
+        authConfig:
+          userVerifiedRequired: false
+          appVerifiedRequired: true
+          resourcePermissionRequired: true
+        descriptionEn: None
+  /api/v2/open/gateway/{gateway_name}/public_key/:
+    get:
+      operationId: v2_open_get_gateway_public_key
+      description: 获取网关公钥
+      tags:
+      - v2_open
+      responses:
+        default:
+          description: ''
+          content:
+            application/json:
+              schema: {}
+      x-bk-apigateway-resource:
+        isPublic: true
+        allowApplyPermission: true
+        matchSubpath: false
+        enableWebsocket: false
+        backend:
+          name: core-api
+          method: get
+          path: /api/v1/open/gateways/{gateway_name}/public_key/
+          matchSubpath: false
+          timeout: 0
+        pluginConfigs: []
+        authConfig:
+          userVerifiedRequired: false
+          appVerifiedRequired: true
+          resourcePermissionRequired: false
+        descriptionEn: None
+  /api/v2/sync/gateway/{gateway_name}/public_key/:
+    get:
+      operationId: v2_sync_get_gateway_public_key
+      description: 获取网关公钥
+      tags:
+      - v2_sync
+      responses:
+        default:
+          description: ''
+          content:
+            application/json:
+              schema: {}
+      x-bk-apigateway-resource:
+        isPublic: true
+        allowApplyPermission: false
+        matchSubpath: false
+        enableWebsocket: false
+        backend:
+          name: core-api
+          method: get
+          path: /api/v1/open/gateways/{gateway_name}/public_key/
+          matchSubpath: false
+          timeout: 0
+        pluginConfigs: []
+        authConfig:
+          userVerifiedRequired: false
+          appVerifiedRequired: true
+          resourcePermissionRequired: false
+        descriptionEn: None
+  /api/v2/sync/gateway/{gateway_name}/related-apps/:
+    post:
+      operationId: v2_sync_add_gateway_related_apps
+      description: 添加网关的关联应用
+      tags:
+      - v2_sync
+      responses:
+        default:
+          description: ''
+          content:
+            application/json:
+              schema: {}
+      x-bk-apigateway-resource:
+        isPublic: true
+        allowApplyPermission: false
+        matchSubpath: false
+        enableWebsocket: false
+        backend:
+          name: default
+          method: get
+          path: /backend/api/v2/sync/gateways/{gateway_name}/related-apps/
+          matchSubpath: false
+          timeout: 0
+        pluginConfigs: []
+        authConfig:
+          userVerifiedRequired: false
+          appVerifiedRequired: true
+          resourcePermissionRequired: false
+        descriptionEn: None
+  /api/v2/inner/gateways/:
+    get:
+      operationId: v2_inner_list_gateways
+      description: 获取网关列表
+      tags:
+      - v2_inner
+      responses:
+        default:
+          description: ''
+          content:
+            application/json:
+              schema: {}
+      x-bk-apigateway-resource:
+        isPublic: false
+        allowApplyPermission: false
+        matchSubpath: false
+        enableWebsocket: false
+        backend:
+          name: default
+          method: get
+          path: /backend/api/v2/inner/gateways/
+          matchSubpath: false
+          timeout: 0
+        pluginConfigs: []
+        authConfig:
+          userVerifiedRequired: false
+          appVerifiedRequired: true
+          resourcePermissionRequired: true
+        descriptionEn: None
+  /api/v2/inner/gateways/{gateway_name}/:
+    get:
+      operationId: v2_inner_get_gateway
+      description: 获取网关
+      tags:
+      - v2_inner
+      responses:
+        default:
+          description: ''
+          content:
+            application/json:
+              schema: {}
+      x-bk-apigateway-resource:
+        isPublic: false
+        allowApplyPermission: false
+        matchSubpath: false
+        enableWebsocket: false
+        backend:
+          name: default
+          method: get
+          path: /backend/api/v2/inner/gateways/{gateway_name}/
+          matchSubpath: false
+          timeout: 0
+        pluginConfigs: []
+        authConfig:
+          userVerifiedRequired: false
+          appVerifiedRequired: true
+          resourcePermissionRequired: true
+        descriptionEn: None

--- a/src/dashboard/apigateway/apigateway/tests/apis/v2/__init__.py
+++ b/src/dashboard/apigateway/apigateway/tests/apis/v2/__init__.py
@@ -1,0 +1,17 @@
+#
+# TencentBlueKing is pleased to support the open source community by making
+# 蓝鲸智云 - API 网关(BlueKing - APIGateway) available.
+# Copyright (C) 2017 THL A29 Limited, a Tencent company. All rights reserved.
+# Licensed under the MIT License (the "License"); you may not use this file except
+# in compliance with the License. You may obtain a copy of the License at
+#
+#     http://opensource.org/licenses/MIT
+#
+# Unless required by applicable law or agreed to in writing, software distributed under
+# the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+# either express or implied. See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# We undertake not to change the open source license (MIT license) applicable
+# to the current version of the project delivered to anyone in the future.
+#

--- a/src/dashboard/apigateway/apigateway/tests/apis/v2/inner/__init__.py
+++ b/src/dashboard/apigateway/apigateway/tests/apis/v2/inner/__init__.py
@@ -1,0 +1,17 @@
+#
+# TencentBlueKing is pleased to support the open source community by making
+# 蓝鲸智云 - API 网关(BlueKing - APIGateway) available.
+# Copyright (C) 2017 THL A29 Limited, a Tencent company. All rights reserved.
+# Licensed under the MIT License (the "License"); you may not use this file except
+# in compliance with the License. You may obtain a copy of the License at
+#
+#     http://opensource.org/licenses/MIT
+#
+# Unless required by applicable law or agreed to in writing, software distributed under
+# the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+# either express or implied. See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# We undertake not to change the open source license (MIT license) applicable
+# to the current version of the project delivered to anyone in the future.
+#

--- a/src/dashboard/apigateway/apigateway/tests/apis/v2/inner/test_views.py
+++ b/src/dashboard/apigateway/apigateway/tests/apis/v2/inner/test_views.py
@@ -1,0 +1,65 @@
+# -*- coding: utf-8 -*-
+#
+# TencentBlueKing is pleased to support the open source community by making
+# 蓝鲸智云 - API 网关(BlueKing - APIGateway) available.
+# Copyright (C) 2017 THL A29 Limited, a Tencent company. All rights reserved.
+# Licensed under the MIT License (the "License"); you may not use this file except
+# in compliance with the License. You may obtain a copy of the License at
+#
+#     http://opensource.org/licenses/MIT
+#
+# Unless required by applicable law or agreed to in writing, software distributed under
+# the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+# either express or implied. See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# We undertake not to change the open source license (MIT license) applicable
+# to the current version of the project delivered to anyone in the future.
+#
+from unittest import mock
+
+from django_dynamic_fixture import G
+
+from apigateway.core.constants import GatewayStatusEnum
+from apigateway.core.models import Gateway, Release
+from apigateway.tests.utils.testing import get_response_json
+
+
+class TestGatewayListApi:
+    def test_list(self, request_view, fake_gateway, mocker):
+        g1 = G(Gateway, status=GatewayStatusEnum.ACTIVE.value, is_public=False)
+        G(Release, gateway=g1)
+        g2 = G(Gateway, status=GatewayStatusEnum.INACTIVE.value, is_public=True)
+        G(Release, gateway=g2)
+
+        _ = G(Gateway, status=GatewayStatusEnum.ACTIVE.value, is_public=True)
+
+        # released
+        g4 = G(Gateway, status=GatewayStatusEnum.ACTIVE.value, is_public=True)
+        G(Release, gateway=g4)
+        G(Release, gateway=fake_gateway)
+
+        resp = request_view(
+            method="GET",
+            view_name="openapi.v2.inner.gateway.list",
+            app=mock.MagicMock(app_code="test"),
+        )
+        result = resp.json()
+        assert resp.status_code == 200
+        assert len(result["data"]) == 2
+
+
+class TestGatewayRetrieveApi:
+    def test_retrieve(self, request_to_view, request_factory, fake_gateway):
+        request = request_factory.get("")
+        request.gateway = fake_gateway
+        request.app = mock.MagicMock(app_code="test")
+        response = request_to_view(
+            request,
+            view_name="openapi.v2.inner.gateway.retrieve",
+            path_params={"gateway_name": fake_gateway.name},
+        )
+        result = get_response_json(response)
+
+        assert response.status_code == 200
+        assert result["data"]["name"] == fake_gateway.name

--- a/src/dashboard/apigateway/apigateway/tests/apis/v2/open/__init__.py
+++ b/src/dashboard/apigateway/apigateway/tests/apis/v2/open/__init__.py
@@ -1,0 +1,17 @@
+#
+# TencentBlueKing is pleased to support the open source community by making
+# 蓝鲸智云 - API 网关(BlueKing - APIGateway) available.
+# Copyright (C) 2017 THL A29 Limited, a Tencent company. All rights reserved.
+# Licensed under the MIT License (the "License"); you may not use this file except
+# in compliance with the License. You may obtain a copy of the License at
+#
+#     http://opensource.org/licenses/MIT
+#
+# Unless required by applicable law or agreed to in writing, software distributed under
+# the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+# either express or implied. See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# We undertake not to change the open source license (MIT license) applicable
+# to the current version of the project delivered to anyone in the future.
+#

--- a/src/dashboard/apigateway/apigateway/tests/apis/v2/open/test_views.py
+++ b/src/dashboard/apigateway/apigateway/tests/apis/v2/open/test_views.py
@@ -1,0 +1,65 @@
+# -*- coding: utf-8 -*-
+#
+# TencentBlueKing is pleased to support the open source community by making
+# 蓝鲸智云 - API 网关(BlueKing - APIGateway) available.
+# Copyright (C) 2017 THL A29 Limited, a Tencent company. All rights reserved.
+# Licensed under the MIT License (the "License"); you may not use this file except
+# in compliance with the License. You may obtain a copy of the License at
+#
+#     http://opensource.org/licenses/MIT
+#
+# Unless required by applicable law or agreed to in writing, software distributed under
+# the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+# either express or implied. See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# We undertake not to change the open source license (MIT license) applicable
+# to the current version of the project delivered to anyone in the future.
+#
+from unittest import mock
+
+from django_dynamic_fixture import G
+
+from apigateway.core.constants import GatewayStatusEnum
+from apigateway.core.models import Gateway, Release
+from apigateway.tests.utils.testing import get_response_json
+
+
+class TestGatewayListApi:
+    def test_list(self, request_view, fake_gateway, mocker):
+        g1 = G(Gateway, status=GatewayStatusEnum.ACTIVE.value, is_public=False)
+        G(Release, gateway=g1)
+        g2 = G(Gateway, status=GatewayStatusEnum.INACTIVE.value, is_public=True)
+        G(Release, gateway=g2)
+
+        _ = G(Gateway, status=GatewayStatusEnum.ACTIVE.value, is_public=True)
+
+        # released
+        g4 = G(Gateway, status=GatewayStatusEnum.ACTIVE.value, is_public=True)
+        G(Release, gateway=g4)
+        G(Release, gateway=fake_gateway)
+
+        resp = request_view(
+            method="GET",
+            view_name="openapi.v2.open.gateway.list",
+            app=mock.MagicMock(app_code="test"),
+        )
+        result = resp.json()
+        assert resp.status_code == 200
+        assert len(result["data"]) == 2
+
+
+class TestGatewayRetrieveApi:
+    def test_retrieve(self, request_to_view, request_factory, fake_gateway):
+        request = request_factory.get("")
+        request.gateway = fake_gateway
+        request.app = mock.MagicMock(app_code="test")
+        response = request_to_view(
+            request,
+            view_name="openapi.v2.open.gateway.retrieve",
+            path_params={"gateway_name": fake_gateway.name},
+        )
+        result = get_response_json(response)
+
+        assert response.status_code == 200
+        assert result["data"]["name"] == fake_gateway.name

--- a/src/dashboard/apigateway/apigateway/tests/apis/v2/sync/__init__.py
+++ b/src/dashboard/apigateway/apigateway/tests/apis/v2/sync/__init__.py
@@ -1,0 +1,17 @@
+#
+# TencentBlueKing is pleased to support the open source community by making
+# 蓝鲸智云 - API 网关(BlueKing - APIGateway) available.
+# Copyright (C) 2017 THL A29 Limited, a Tencent company. All rights reserved.
+# Licensed under the MIT License (the "License"); you may not use this file except
+# in compliance with the License. You may obtain a copy of the License at
+#
+#     http://opensource.org/licenses/MIT
+#
+# Unless required by applicable law or agreed to in writing, software distributed under
+# the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+# either express or implied. See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# We undertake not to change the open source license (MIT license) applicable
+# to the current version of the project delivered to anyone in the future.
+#

--- a/src/dashboard/apigateway/apigateway/tests/apis/web/release/test_views.py
+++ b/src/dashboard/apigateway/apigateway/tests/apis/web/release/test_views.py
@@ -95,29 +95,39 @@ class TestReleaseCreateApi:
 class TestReleaseAvailableResourceListApi:
     def test_list(self, request_view, fake_gateway, fake_stage):
         stage_1 = G(Stage, gateway=fake_gateway, name="prod", status=0)
-        resource_version = G(ResourceVersion, gateway=fake_gateway, _data=json.dumps([{
-            "id": 1,
-            "name": "test",
-            "method": "get",
-            "path": "/test/",
-            "description": "test...",
-            "description_en": "",
-            "match_subpath": "",
-            "is_public": True,
-            "allow_apply_permission": True,
-            "disabled_stages": [],
-            "contexts": {
-                "resource_auth": {
-                    "config": json.dumps({
-                        "app_verified_required": True,
-                        "skip_auth_verification": True,
-                        "auth_verified_required": True,
-                        "resource_perm_required": True
-                    })
-                }
-            },
-            "api_labels": "",
-        }]))
+        resource_version = G(
+            ResourceVersion,
+            gateway=fake_gateway,
+            _data=json.dumps(
+                [
+                    {
+                        "id": 1,
+                        "name": "test",
+                        "method": "get",
+                        "path": "/test/",
+                        "description": "test...",
+                        "description_en": "",
+                        "match_subpath": "",
+                        "is_public": True,
+                        "allow_apply_permission": True,
+                        "disabled_stages": [],
+                        "contexts": {
+                            "resource_auth": {
+                                "config": json.dumps(
+                                    {
+                                        "app_verified_required": True,
+                                        "skip_auth_verification": True,
+                                        "auth_verified_required": True,
+                                        "resource_perm_required": True,
+                                    }
+                                )
+                            }
+                        },
+                        "api_labels": "",
+                    }
+                ]
+            ),
+        )
 
         G(Release, gateway=fake_gateway, stage=stage_1, resource_version=resource_version)
 
@@ -130,9 +140,22 @@ class TestReleaseAvailableResourceListApi:
         result = response.json()
 
         assert response.status_code == 200
-        assert result == {'data': [{'id': 1, 'name': 'test', 'description': 'test...', 'method': 'get',
-                                    'path': '/test/', 'verified_user_required': False, 'verified_app_required': True,
-                                    'resource_perm_required': True, 'is_public': True, 'labels': []}]}
+        assert result == {
+            "data": [
+                {
+                    "id": 1,
+                    "name": "test",
+                    "description": "test...",
+                    "method": "get",
+                    "path": "/test/",
+                    "verified_user_required": False,
+                    "verified_app_required": True,
+                    "resource_perm_required": True,
+                    "is_public": True,
+                    "labels": [],
+                }
+            ]
+        }
 
 
 class TestReleaseResourceSchemaRetrieve:

--- a/src/dashboard/apigateway/apigateway/urls.py
+++ b/src/dashboard/apigateway/apigateway/urls.py
@@ -51,6 +51,8 @@ urlpatterns = [
     path("backend/esb/", include("apigateway.apps.esb.urls")),
     # open api
     path("backend/api/v1/", include("apigateway.apis.open.urls")),
+    # open api v2
+    path("backend/api/v2/", include("apigateway.apis.v2.urls")),
     # api-support backend/docs urls
     path("backend/docs/", include("apigateway.apis.web.docs.urls")),
     # web api


### PR DESCRIPTION
### Description

<!-- 关联相关issue Please include a summary of the change and which issue is fixed. -->
<!-- 给出必要的上下文以及review需要的必要信息 Please also include relevant motivation and context. -->

新的 open api
- /api/v2/open/ 普通第三方系统申请，用于查询网关信息，例如网关列表/资源/资源参数等
- /api/v2/sync/ sdk 同步需要的api
- /api/v2/inner/ 用于给内部系统paas v3等调用的内部接口

```
# NOTE:
# 1. 新版 http 协议
# 2. 统一注册到 bk-apigateway 网关，并且 inner api 需要隐藏 + 主动授权 (未来需要下掉 bk-apigateway-inner)
# 3. 三类 api 即使功能一模一样，也不允许复用代码 (这已经是最上层使用层，现在功能一致不代表随时间推移还会保持一致)
```

### Checklist

- [x] 填写 PR 描述及相关 issue (write PR description and related issue)
- [x] 代码风格检查通过 (code style check passed)
- [x] PR 中包含单元测试 (include unit test)
- [x] 单元测试通过 (unit test passed)
- [x] 本地开发联调环境验证通过 (local development environment verification passed)
