### PR TITLE
fix(apis/web/metrics): 修复统计图表target为空问题

### DIFF
--- a/src/dashboard/apigateway/apigateway/apis/web/metrics/views.py
+++ b/src/dashboard/apigateway/apigateway/apis/web/metrics/views.py
@@ -89,14 +89,17 @@ class QueryRangeApi(generics.ListAPIView):
             step=step,
         )
 
-        if metrics_name in ["ingress", "egress"]:
-            series = data.get("data", {}).get("series", [])
-            ids_data = self.get_series_resource_id_index_map(series)
+        series = [s for s in data.get("data", {}).get("series", []) if s["target"].strip()]
+        if series:
+            data["data"]["series"] = series
 
-            if ids_data:
-                resources = Resource.objects.filter(id__in=ids_data.keys()).values("id", "name")
-                for obj in resources:
-                    series[ids_data[obj["id"]]]["target"] = obj["name"]
+            if metrics_name in ["ingress", "egress"]:
+                ids_data = self.get_series_resource_id_index_map(series)
+
+                if ids_data:
+                    resources = Resource.objects.filter(id__in=ids_data.keys()).values("id", "name")
+                    for obj in resources:
+                        series[ids_data[obj["id"]]]["target"] = obj["name"]
 
         return OKJsonResponse(data=data)
 

--- a/src/dashboard/apigateway/apigateway/tests/apis/web/metrics/test_views.py
+++ b/src/dashboard/apigateway/apigateway/tests/apis/web/metrics/test_views.py
@@ -45,6 +45,14 @@ class TestQueryRangeApi:
                         "dimensions": {"route": "bk-esb.prod.1234"},
                         "datapoints": [],
                     },
+                    {
+                        "alias": "_result_",
+                        "metric_field": "_result_",
+                        "unit": "",
+                        "target": "",
+                        "dimensions": {},
+                        "datapoints": []
+                    },
                 ],
             }
         }
@@ -71,6 +79,7 @@ class TestQueryRangeApi:
         assert response.status_code == 200
         assert result["data"]["data"]["series"][0]["target"] == "testname001"
         assert result["data"]["data"]["series"][1]["target"] == 'route="bk-esb.prod.1234"'
+        assert len(result["data"]["data"]["series"]) == 2
 
         mocker.patch(
             "apigateway.apis.web.metrics.views.MetricsRangeFactory.create_metrics",


### PR DESCRIPTION
### Description

1. 统计图表中排查 metrics=app_requests 的接口数据时，偶尔有些时间段查询出来的数据会有target为空的情况。
2. 其他图表数据也会走这个查询接口，也可能存在target为空的问题。
3. 统一对该接口的查询结果进行target过滤。

Fixes # (issue)

### Checklist

- [ ] 填写 PR 描述及相关 issue (write PR description and related issue)
- [ ] 代码风格检查通过 (code style check passed)
- [ ] PR 中包含单元测试 (include unit test)
- [ ] 单元测试通过 (unit test passed)
- [ ] 本地开发联调环境验证通过 (local development environment verification passed)
