### PR TITLE
fix(apis/web/metrics): 修复统计图表series读取问题

### DIFF
--- a/src/dashboard/apigateway/apigateway/apis/web/metrics/views.py
+++ b/src/dashboard/apigateway/apigateway/apis/web/metrics/views.py
@@ -99,7 +99,7 @@ class QueryRangeApi(generics.ListAPIView):
                 if ids_data:
                     resources = Resource.objects.filter(id__in=ids_data.keys()).values("id", "name")
                     for obj in resources:
-                        series[ids_data[obj["id"]]]["target"] = "name={}".format(obj["name"])
+                        series[ids_data[obj["id"]]]["target"] = 'name="{}"'.format(obj["name"])
 
         return OKJsonResponse(data=data)
 

--- a/src/dashboard/apigateway/apigateway/apis/web/metrics/views.py
+++ b/src/dashboard/apigateway/apigateway/apis/web/metrics/views.py
@@ -89,9 +89,9 @@ class QueryRangeApi(generics.ListAPIView):
             step=step,
         )
 
-        series = [s for s in data.get("data", {}).get("series", []) if s["target"].strip()]
+        series = [s for s in data.get("series", []) if s["target"].strip()]
         if series:
-            data["data"]["series"] = series
+            data["series"] = series
 
             if metrics_name in ["ingress", "egress"]:
                 ids_data = self.get_series_resource_id_index_map(series)
@@ -99,7 +99,7 @@ class QueryRangeApi(generics.ListAPIView):
                 if ids_data:
                     resources = Resource.objects.filter(id__in=ids_data.keys()).values("id", "name")
                     for obj in resources:
-                        series[ids_data[obj["id"]]]["target"] = obj["name"]
+                        series[ids_data[obj["id"]]]["target"] = "name={}".format(obj["name"])
 
         return OKJsonResponse(data=data)
 

--- a/src/dashboard/apigateway/apigateway/tests/apis/web/metrics/test_views.py
+++ b/src/dashboard/apigateway/apigateway/tests/apis/web/metrics/test_views.py
@@ -75,7 +75,7 @@ class TestQueryRangeApi:
         result = response.json()
 
         assert response.status_code == 200
-        assert result["data"]["series"][0]["target"] == "name=testname001"
+        assert result["data"]["series"][0]["target"] == 'name="testname001"'
         assert result["data"]["series"][1]["target"] == 'route="bk-esb.prod.1234"'
         assert len(result["data"]["series"]) == 2
 

--- a/src/dashboard/apigateway/apigateway/tests/apis/web/metrics/test_views.py
+++ b/src/dashboard/apigateway/apigateway/tests/apis/web/metrics/test_views.py
@@ -26,35 +26,33 @@ class TestQueryRangeApi:
         resource_obj = G(Resource, name="testname001", gateway=fake_stage.gateway)
 
         data = {
-            "data": {
-                "metrics": [],
-                "series": [
-                    {
-                        "alias": "_result_",
-                        "metric_field": "_result_",
-                        "unit": "",
-                        "target": 'route="bk-esb.prod.{}"'.format(resource_obj.id),
-                        "dimensions": {"route": "bk-esb.prod.2152"},
-                        "datapoints": [],
-                    },
-                    {
-                        "alias": "_result_",
-                        "metric_field": "_result_",
-                        "unit": "",
-                        "target": 'route="bk-esb.prod.1234"',
-                        "dimensions": {"route": "bk-esb.prod.1234"},
-                        "datapoints": [],
-                    },
-                    {
-                        "alias": "_result_",
-                        "metric_field": "_result_",
-                        "unit": "",
-                        "target": "",
-                        "dimensions": {},
-                        "datapoints": []
-                    },
-                ],
-            }
+            "metrics": [],
+            "series": [
+                {
+                    "alias": "_result_",
+                    "metric_field": "_result_",
+                    "unit": "",
+                    "target": 'route="bk-esb.prod.{}"'.format(resource_obj.id),
+                    "dimensions": {"route": "bk-esb.prod.2152"},
+                    "datapoints": [],
+                },
+                {
+                    "alias": "_result_",
+                    "metric_field": "_result_",
+                    "unit": "",
+                    "target": 'route="bk-esb.prod.1234"',
+                    "dimensions": {"route": "bk-esb.prod.1234"},
+                    "datapoints": [],
+                },
+                {
+                    "alias": "_result_",
+                    "metric_field": "_result_",
+                    "unit": "",
+                    "target": "",
+                    "dimensions": {},
+                    "datapoints": []
+                },
+            ],
         }
 
         mocker.patch(
@@ -77,9 +75,9 @@ class TestQueryRangeApi:
         result = response.json()
 
         assert response.status_code == 200
-        assert result["data"]["data"]["series"][0]["target"] == "testname001"
-        assert result["data"]["data"]["series"][1]["target"] == 'route="bk-esb.prod.1234"'
-        assert len(result["data"]["data"]["series"]) == 2
+        assert result["data"]["series"][0]["target"] == "name=testname001"
+        assert result["data"]["series"][1]["target"] == 'route="bk-esb.prod.1234"'
+        assert len(result["data"]["series"]) == 2
 
         mocker.patch(
             "apigateway.apis.web.metrics.views.MetricsRangeFactory.create_metrics",


### PR DESCRIPTION
### Description

1. 修复读取series层级错误，将 data.data.series 修改为 data.series 。
2. ingress / egress 接口返回的 target 格式调整为 name=xxx ，符合前端 target.split('=')[1] 解析。

<!-- 关联相关issue Please include a summary of the change and which issue is fixed. -->
<!-- 给出必要的上下文以及review需要的必要信息 Please also include relevant motivation and context. -->

Fixes # (issue)

### Checklist

- [ ] 填写 PR 描述及相关 issue (write PR description and related issue)
- [ ] 代码风格检查通过 (code style check passed)
- [ ] PR 中包含单元测试 (include unit test)
- [ ] 单元测试通过 (unit test passed)
- [ ] 本地开发联调环境验证通过 (local development environment verification passed)
