### PR TITLE
fix(apis/web/permission): 修复应用权限的授权维度搜索问题

### DIFF
--- a/src/dashboard/apigateway/apigateway/apis/web/permission/filters.py
+++ b/src/dashboard/apigateway/apigateway/apis/web/permission/filters.py
@@ -26,7 +26,6 @@ from apigateway.apps.permission.models import (
     AppPermissionApply,
     AppPermissionRecord,
     AppResourcePermission,
-    Resource,
 )
 
 
@@ -34,7 +33,7 @@ class AppResourcePermissionFilter(filters.FilterSet):
     bk_app_code = filters.CharFilter()
     keyword = filters.CharFilter(method="query_filter")
     grant_type = filters.ChoiceFilter(choices=GrantTypeEnum.get_choices())
-    resource_id = filters.CharFilter(method="filter_resource")
+    resource_id = filters.NumberFilter()
     order_by = filters.OrderingFilter(
         choices=[(field, field) for field in ["bk_app_code", "-bk_app_code", "expires", "-expires"]]
     )
@@ -51,18 +50,6 @@ class AppResourcePermissionFilter(filters.FilterSet):
 
     def query_filter(self, queryset, name, value):
         return queryset.filter(bk_app_code__icontains=value)
-
-    def filter_resource(self, queryset, name, value):
-        try:
-            resource_id = int(value)
-            return queryset.filter(resource_id=resource_id)
-        except ValueError:
-            resource_ids = list(Resource.objects.filter(
-                id__in=list(queryset.values_list("resource_id", flat=True)),
-                name__icontains=value,
-            ).values_list("id", flat=True))
-
-            return queryset.filter(resource_id__in=resource_ids)
 
 
 class AppPermissionApplyFilter(filters.FilterSet):

--- a/src/dashboard/apigateway/apigateway/apis/web/permission/views.py
+++ b/src/dashboard/apigateway/apigateway/apis/web/permission/views.py
@@ -122,6 +122,19 @@ class AppPermissionQuerySetMixin(AppGatewayPermissionQuerySetMixin, AppResourceP
     ),
 )
 class AppPermissionListApi(AppPermissionQuerySetMixin, generics.ListAPIView):
+
+    def _modify_request_data(self):
+        data = self.request.GET.copy()
+        resource_id = data.get("resource_id")
+        if resource_id:
+            try:
+                int(resource_id)
+            except ValueError:
+                resource_id = -1
+
+            data["resource_id"] = resource_id
+        return data
+
     def get_queryset(self):
         query_params = self.request.query_params
         grant_dimension = query_params.get("grant_dimension")
@@ -138,7 +151,7 @@ class AppPermissionListApi(AppPermissionQuerySetMixin, generics.ListAPIView):
             app_gateway_permissions = []
 
         app_resource_permissions = AppResourcePermissionFilter(
-            self.request.GET, queryset=self.get_resource_queryset()
+            self._modify_request_data(), queryset=self.get_resource_queryset()
         ).qs
         if grant_dimension == GrantDimensionEnum.API.value:
             app_resource_permissions = []

--- a/src/dashboard/apigateway/apigateway/apis/web/permission/views.py
+++ b/src/dashboard/apigateway/apigateway/apis/web/permission/views.py
@@ -124,10 +124,14 @@ class AppPermissionQuerySetMixin(AppGatewayPermissionQuerySetMixin, AppResourceP
 class AppPermissionListApi(AppPermissionQuerySetMixin, generics.ListAPIView):
     def get_queryset(self):
         query_params = self.request.query_params
+        grant_dimension = query_params.get("grant_dimension")
+        if grant_dimension and grant_dimension not in [GrantDimensionEnum.RESOURCE.value, GrantDimensionEnum.API.value]:
+            return []
+
         app_gateway_permissions = AppGatewayPermissionFilter(self.request.GET, queryset=self.get_gateway_queryset()).qs
         # 如果查询维度为资源 或者 授权类型不为 INITIALIZE(网关维度都为INITIALIZE)或者 查询某个资源 都要忽略掉网关维度的
         if (
-            query_params.get("grant_dimension") == GrantDimensionEnum.RESOURCE.value
+            grant_dimension == GrantDimensionEnum.RESOURCE.value
             or (query_params.get("grant_type") and query_params.get("grant_type") != GrantTypeEnum.INITIALIZE.value)
             or query_params.get("resource_id")
         ):
@@ -136,7 +140,7 @@ class AppPermissionListApi(AppPermissionQuerySetMixin, generics.ListAPIView):
         app_resource_permissions = AppResourcePermissionFilter(
             self.request.GET, queryset=self.get_resource_queryset()
         ).qs
-        if query_params.get("grant_dimension") == GrantDimensionEnum.API.value:
+        if grant_dimension == GrantDimensionEnum.API.value:
             app_resource_permissions = []
 
         return self.get_app_permissions(app_gateway_permissions, app_resource_permissions)

--- a/src/dashboard/apigateway/apigateway/apis/web/permission/views.py
+++ b/src/dashboard/apigateway/apigateway/apis/web/permission/views.py
@@ -123,18 +123,6 @@ class AppPermissionQuerySetMixin(AppGatewayPermissionQuerySetMixin, AppResourceP
 )
 class AppPermissionListApi(AppPermissionQuerySetMixin, generics.ListAPIView):
 
-    def _modify_request_data(self):
-        data = self.request.GET.copy()
-        resource_id = data.get("resource_id")
-        if resource_id:
-            try:
-                int(resource_id)
-            except ValueError:
-                resource_id = -1
-
-            data["resource_id"] = resource_id
-        return data
-
     def get_queryset(self):
         query_params = self.request.query_params
         grant_dimension = query_params.get("grant_dimension")
@@ -151,7 +139,7 @@ class AppPermissionListApi(AppPermissionQuerySetMixin, generics.ListAPIView):
             app_gateway_permissions = []
 
         app_resource_permissions = AppResourcePermissionFilter(
-            self._modify_request_data(), queryset=self.get_resource_queryset()
+            self.request.GET, queryset=self.get_resource_queryset()
         ).qs
         if grant_dimension == GrantDimensionEnum.API.value:
             app_resource_permissions = []

--- a/src/dashboard/apigateway/apigateway/tests/apis/web/permission/test_views.py
+++ b/src/dashboard/apigateway/apigateway/tests/apis/web/permission/test_views.py
@@ -80,14 +80,6 @@ class TestAppPermissionViewSet:
             },
             {
                 "params": {
-                    "resource_id": "测试",
-                },
-                "expected": {
-                    "count": 0,
-                },
-            },
-            {
-                "params": {
                     "grant_dimension": "测试",
                 },
                 "expected": {

--- a/src/dashboard/apigateway/apigateway/tests/apis/web/permission/test_views.py
+++ b/src/dashboard/apigateway/apigateway/tests/apis/web/permission/test_views.py
@@ -80,14 +80,6 @@ class TestAppPermissionViewSet:
             },
             {
                 "params": {
-                    "resource_id": "name",
-                },
-                "expected": {
-                    "count": 2,
-                },
-            },
-            {
-                "params": {
                     "resource_id": "测试",
                 },
                 "expected": {

--- a/src/dashboard/apigateway/apigateway/tests/apis/web/permission/test_views.py
+++ b/src/dashboard/apigateway/apigateway/tests/apis/web/permission/test_views.py
@@ -33,21 +33,23 @@ pytestmark = pytest.mark.django_db
 
 
 class TestAppPermissionViewSet:
-    def test_list(self, fake_resource, request_view):
-        fake_gateway = fake_resource.gateway
+    def test_list(self, fake_gateway, request_view):
+
+        fake_resource1 = G(Resource, name="name1", gateway=fake_gateway)
+        fake_resource2 = G(Resource, name="name2", gateway=fake_gateway)
 
         G(
             models.AppResourcePermission,
             gateway=fake_gateway,
             bk_app_code="test",
-            resource_id=fake_resource.id,
+            resource_id=fake_resource1.id,
             grant_type="apply",
         )
         G(
             models.AppResourcePermission,
             gateway=fake_gateway,
             bk_app_code="test-2",
-            resource_id=fake_resource.id,
+            resource_id=fake_resource2.id,
             grant_type="apply",
         )
 
@@ -66,6 +68,38 @@ class TestAppPermissionViewSet:
                 },
                 "expected": {
                     "count": 2,
+                },
+            },
+            {
+                "params": {
+                    "resource_id": fake_resource1.id,
+                },
+                "expected": {
+                    "count": 1,
+                },
+            },
+            {
+                "params": {
+                    "resource_id": "name",
+                },
+                "expected": {
+                    "count": 2,
+                },
+            },
+            {
+                "params": {
+                    "resource_id": "测试",
+                },
+                "expected": {
+                    "count": 0,
+                },
+            },
+            {
+                "params": {
+                    "grant_dimension": "测试",
+                },
+                "expected": {
+                    "count": 0,
                 },
             },
         ]

--- a/src/dashboard/apigateway/apigateway/tests/apis/web/permission/test_views.py
+++ b/src/dashboard/apigateway/apigateway/tests/apis/web/permission/test_views.py
@@ -68,6 +68,7 @@ class TestAppPermissionViewSet:
                 },
                 "expected": {
                     "count": 2,
+                    "status_code": 200,
                 },
             },
             {
@@ -76,6 +77,7 @@ class TestAppPermissionViewSet:
                 },
                 "expected": {
                     "count": 1,
+                    "status_code": 200,
                 },
             },
             {
@@ -84,6 +86,7 @@ class TestAppPermissionViewSet:
                 },
                 "expected": {
                     "count": 0,
+                    "status_code": 400,
                 },
             },
         ]
@@ -98,8 +101,9 @@ class TestAppPermissionViewSet:
             )
 
             result = response.json()
-            assert response.status_code == 200, result
-            assert result["data"]["count"] == test["expected"]["count"]
+            assert response.status_code == test["expected"]["status_code"], result
+            if response.status_code == 200:
+                assert result["data"]["count"] == test["expected"]["count"]
 
 
 class TestAppResourcePermissionViewSet:


### PR DESCRIPTION
### Description
问题1：搜索不存在的授权维度
1.1 校验 grant_dimension 是否在 api/resource 范围内，未在范围内直接返回空。

问题2：搜索不存在的资源名称
2.1 如果 resource_id 为数字，则直接查询对应ID的数据。
2.2 如果 resource_id 为字符串，则模糊匹配资源表中 name 字段，将查询结果的 resource_ids 再反查最终数据。

<!-- 关联相关issue Please include a summary of the change and which issue is fixed. -->
<!-- 给出必要的上下文以及review需要的必要信息 Please also include relevant motivation and context. -->

Fixes # (issue)

### Checklist

- [ ] 填写 PR 描述及相关 issue (write PR description and related issue)
- [ ] 代码风格检查通过 (code style check passed)
- [ ] PR 中包含单元测试 (include unit test)
- [ ] 单元测试通过 (unit test passed)
- [ ] 本地开发联调环境验证通过 (local development environment verification passed)
