### PR TITLE
feat(default.py): add ENABLE_MULTI_TENANT_MODE

### DIFF
--- a/src/dashboard/apigateway/apigateway/apis/open/urls.py
+++ b/src/dashboard/apigateway/apigateway/apis/open/urls.py
@@ -16,6 +16,7 @@
 # We undertake not to change the open source license (MIT license) applicable
 # to the current version of the project delivered to anyone in the future.
 #
+from django.conf import settings
 from django.urls import include, path
 
 from apigateway.apis.open.esb.permission import views as esb_permission_views
@@ -87,27 +88,29 @@ urlpatterns = [
     path("", include("apigateway.apis.open.monitor.urls")),
 ]
 
-urlpatterns += [
-    path("esb/systems/", include("apigateway.apis.open.esb.system.urls")),
-    path("esb/systems/<int:system_id>/permissions/", include("apigateway.apis.open.esb.permission.urls")),
-    path(
-        "esb/systems/permissions/renew/",
-        esb_permission_views.AppPermissionRenewAPIView.as_view({"post": "renew"}),
-        name="openapi.esb.permission.renew",
-    ),
-    path(
-        "esb/systems/permissions/app-permissions/",
-        esb_permission_views.AppPermissionViewSet.as_view({"get": "list"}),
-        name="openapi.esb.permission.app-permissions",
-    ),
-    path(
-        "esb/systems/permissions/apply-records/",
-        esb_permission_views.AppPermissionApplyRecordViewSet.as_view({"get": "list"}),
-        name="openapi.esb.permission.app-records",
-    ),
-    path(
-        "esb/systems/permissions/apply-records/<int:record_id>/",
-        esb_permission_views.AppPermissionApplyRecordViewSet.as_view({"get": "retrieve"}),
-        name="openapi.esb.permission.app-record-detail",
-    ),
-]
+# 非多租户模式才会有 esb 相关的接口
+if not settings.ENABLE_MULTI_TENANT_MODE:
+    urlpatterns += [
+        path("esb/systems/", include("apigateway.apis.open.esb.system.urls")),
+        path("esb/systems/<int:system_id>/permissions/", include("apigateway.apis.open.esb.permission.urls")),
+        path(
+            "esb/systems/permissions/renew/",
+            esb_permission_views.AppPermissionRenewAPIView.as_view({"post": "renew"}),
+            name="openapi.esb.permission.renew",
+        ),
+        path(
+            "esb/systems/permissions/app-permissions/",
+            esb_permission_views.AppPermissionViewSet.as_view({"get": "list"}),
+            name="openapi.esb.permission.app-permissions",
+        ),
+        path(
+            "esb/systems/permissions/apply-records/",
+            esb_permission_views.AppPermissionApplyRecordViewSet.as_view({"get": "list"}),
+            name="openapi.esb.permission.app-records",
+        ),
+        path(
+            "esb/systems/permissions/apply-records/<int:record_id>/",
+            esb_permission_views.AppPermissionApplyRecordViewSet.as_view({"get": "retrieve"}),
+            name="openapi.esb.permission.app-record-detail",
+        ),
+    ]

--- a/src/dashboard/apigateway/apigateway/apis/web/docs/urls.py
+++ b/src/dashboard/apigateway/apigateway/apis/web/docs/urls.py
@@ -15,6 +15,7 @@
 # We undertake not to change the open source license (MIT license) applicable
 # to the current version of the project delivered to anyone in the future.
 #
+from django.conf import settings
 from django.urls import include, path
 
 urlpatterns = [
@@ -26,11 +27,17 @@ urlpatterns = [
     path("gateways/<slug:gateway_name>/resources/", include("apigateway.apis.web.docs.gateway.resource.urls")),
     path("gateways/<slug:gateway_name>/stages/", include("apigateway.apis.web.docs.gateway.stage.urls")),
     path("gateways/<slug:gateway_name>/sdks/", include("apigateway.apis.web.docs.gateway.gateway_sdk.urls")),
-    # esb
-    path("esb/boards/<slug:board>/systems/", include("apigateway.apis.web.docs.esb.system.urls")),
-    path(
-        "esb/boards/<slug:board>/systems/<slug:system_name>/components/",
-        include("apigateway.apis.web.docs.esb.component.urls"),
-    ),
-    path("esb/boards/<slug:board>/sdks/", include("apigateway.apis.web.docs.esb.sdk.urls")),
 ]
+
+
+# 非多租户模式才会有 esb 相关的接口
+if not settings.ENABLE_MULTI_TENANT_MODE:
+    urlpatterns += [
+        # esb
+        path("esb/boards/<slug:board>/systems/", include("apigateway.apis.web.docs.esb.system.urls")),
+        path(
+            "esb/boards/<slug:board>/systems/<slug:system_name>/components/",
+            include("apigateway.apis.web.docs.esb.component.urls"),
+        ),
+        path("esb/boards/<slug:board>/sdks/", include("apigateway.apis.web.docs.esb.sdk.urls")),
+    ]

--- a/src/dashboard/apigateway/apigateway/biz/access_log/constants.py
+++ b/src/dashboard/apigateway/apigateway/biz/access_log/constants.py
@@ -17,6 +17,7 @@
 #
 import re
 
+from django.conf import settings
 from django.utils.translation import gettext_lazy as _
 
 ES_LOG_FIELDS = [
@@ -152,6 +153,17 @@ ES_LOG_FIELDS = [
     },
 ]
 
+
+# insert into the 3rd position of ES_LOG_FIELDS
+if settings.ENABLE_MULTI_TENANT_MODE:
+    ES_LOG_FIELDS.insert(
+        2,
+        {
+            "label": _("请求租户"),
+            "field": "bk_tenant_id",
+            "is_filter": True,
+        },
+    )
 
 # ES_QUERY_FIELDS = [field["field"] for field in ES_LOG_FIELDS if field["is_filter"]]
 

--- a/src/dashboard/apigateway/apigateway/components/bk_log.py
+++ b/src/dashboard/apigateway/apigateway/components/bk_log.py
@@ -23,8 +23,7 @@ from bkapi_client_core.apigateway import OperationGroup
 from bkapi_client_core.apigateway.django_helper import get_client_by_username as get_client_by_username_for_apigateway
 from django.conf import settings
 
-from apigateway.components.bkapi_client.log_search import Client as LogSearchClient
-from apigateway.components.esb_components import get_client_by_username as get_client_by_username_for_esb
+from apigateway.components.bkapi_client.log_search import new_client_cls
 from apigateway.components.handler import RequestAPIHandler
 from apigateway.components.utils import inject_accept_language
 
@@ -46,15 +45,15 @@ class BKLogComponent:
         return self._request_handler.parse_api_result(api_result, response, {"result": True}, itemgetter("data"))
 
     def _get_api_client(self) -> OperationGroup:
-        # use gateway: log-search
-        if settings.USE_BKAPI_BK_LOG:
-            apigw_client = get_client_by_username_for_apigateway(LogSearchClient, username="admin")
-            apigw_client.session.register_hook("request", inject_accept_language)
-            return apigw_client.api
+        # use gateway: log-search(te) / bk-log-search(ee)
+        gateway_name = "bk-log-search"
+        if settings.EDITION == "te":
+            gateway_name = "log-search"
 
-        esb_client = get_client_by_username_for_esb("admin")
-        esb_client.session.register_hook("request", inject_accept_language)
-        return esb_client.bk_log
+        client_cls = new_client_cls(gateway_name)
+        apigw_client = get_client_by_username_for_apigateway(client_cls, username="admin")
+        apigw_client.session.register_hook("request", inject_accept_language)
+        return apigw_client.api
 
 
 bk_log_component = BKLogComponent()

--- a/src/dashboard/apigateway/apigateway/components/bkapi_client/bkmonitorv3.py
+++ b/src/dashboard/apigateway/apigateway/components/bkapi_client/bkmonitorv3.py
@@ -34,3 +34,11 @@ class Client(APIGatewayClient):
     _api_name = "bkmonitorv3"
 
     api = bind_property(Group, name="api")
+
+
+def new_client_cls(api_name: str):
+    class Client(APIGatewayClient):
+        _api_name = api_name
+        api = bind_property(Group, name="api")
+
+    return Client

--- a/src/dashboard/apigateway/apigateway/components/bkapi_client/log_search.py
+++ b/src/dashboard/apigateway/apigateway/components/bkapi_client/log_search.py
@@ -34,3 +34,11 @@ class Client(APIGatewayClient):
     _api_name = "log-search"
 
     api = bind_property(Group, name="api")
+
+
+def new_client_cls(api_name: str):
+    class Client(APIGatewayClient):
+        _api_name = api_name
+        api = bind_property(Group, name="api")
+
+    return Client

--- a/src/dashboard/apigateway/apigateway/components/prometheus.py
+++ b/src/dashboard/apigateway/apigateway/components/prometheus.py
@@ -21,10 +21,8 @@ from typing import Any, Dict
 
 from bkapi_client_core.apigateway import OperationGroup
 from bkapi_client_core.apigateway.django_helper import get_client_by_username as get_client_by_username_for_apigateway
-from django.conf import settings
 
-from apigateway.components.bkapi_client.bkmonitorv3 import Client as BkMonitorV3Client
-from apigateway.components.esb_components import get_client_by_username as get_client_by_username_for_esb
+from apigateway.components.bkapi_client.bkmonitorv3 import new_client_cls
 from apigateway.components.handler import RequestAPIHandler
 
 
@@ -85,13 +83,9 @@ class PrometheusComponent:
 
     def _get_api_client(self) -> OperationGroup:
         # use gateway: bkmonitorv3
-        if settings.USE_BKAPI_BKMONITORV3:
-            apigw_client = get_client_by_username_for_apigateway(BkMonitorV3Client, username="admin")
-            return apigw_client.api
-
-        # use esb api
-        esb_client = get_client_by_username_for_esb("admin")
-        return esb_client.monitor_v3
+        client_cls = new_client_cls("bkmonitorv3")
+        apigw_client = get_client_by_username_for_apigateway(client_cls, username="admin")
+        return apigw_client.api
 
 
 prometheus_component = PrometheusComponent()

--- a/src/dashboard/apigateway/apigateway/conf/celery_conf.py
+++ b/src/dashboard/apigateway/apigateway/conf/celery_conf.py
@@ -16,6 +16,8 @@
 # We undertake not to change the open source license (MIT license) applicable
 # to the current version of the project delivered to anyone in the future.
 #
+import os
+
 from celery.schedules import crontab
 
 # celery configuration
@@ -28,13 +30,15 @@ CELERY_WORKER_HIJACK_ROOT_LOGGER = False
 
 CELERY_BEAT_SCHEDULER = "django_celery_beat.schedulers:DatabaseScheduler"
 
-CELERY_IMPORTS = (
+CELERY_IMPORTS = [
     "apigateway.apps.monitor.tasks",
     "apigateway.apps.metrics.tasks",
     "apigateway.apps.permission.tasks",
-    "apigateway.apps.esb.component.tasks",
     "apigateway.controller.tasks",
-)
+]
+
+if os.getenv("ENABLE_MULTI_TENANT_MODE", "False").lower() not in ("true", "on", "ok", "y", "yes", "1"):
+    CELERY_IMPORTS.append("apigateway.apps.esb.component.tasks")
 
 CELERY_BEAT_SCHEDULE = {
     # "add-every-minute": {

--- a/src/dashboard/apigateway/apigateway/conf/default.py
+++ b/src/dashboard/apigateway/apigateway/conf/default.py
@@ -68,6 +68,9 @@ DEBUG = env.bool("DEBUG", False)
 # 是否为本地开发环境
 IS_LOCAL = env.bool("DASHBOARD_IS_LOCAL", default=False)
 
+# 是否开启多租户模式
+ENABLE_MULTI_TENANT_MODE = env.bool("ENABLE_MULTI_TENANT_MODE", default=False)
+
 ALLOWED_HOSTS = ["*"]
 
 # Application definition

--- a/src/dashboard/apigateway/apigateway/conf/default.py
+++ b/src/dashboard/apigateway/apigateway/conf/default.py
@@ -68,6 +68,9 @@ DEBUG = env.bool("DEBUG", False)
 # 是否为本地开发环境
 IS_LOCAL = env.bool("DASHBOARD_IS_LOCAL", default=False)
 
+# te 还是 ee
+EDITION = env.str("EDITION", "ee")
+
 # 是否开启多租户模式
 ENABLE_MULTI_TENANT_MODE = env.bool("ENABLE_MULTI_TENANT_MODE", default=False)
 
@@ -103,9 +106,7 @@ INSTALLED_APPS = [
     "bkpaas_auth",
     "apigateway.account",
     "apigateway.apps.feature",
-    "apigateway.apps.esb",
     "apigateway.apps.docs",
-    "apigateway.apps.esb.bkcore",
     "apigateway.apps.api_debug",
     "apigw_manager.apigw",
     "apigateway.controller",
@@ -113,6 +114,13 @@ INSTALLED_APPS = [
     # 蓝鲸通知中心
     "bk_notice_sdk",
 ]
+
+# 非多租户模式才会有 esb 相关的模型
+if not ENABLE_MULTI_TENANT_MODE:
+    INSTALLED_APPS += [
+        "apigateway.apps.esb",
+        "apigateway.apps.esb.bkcore",
+    ]
 
 MIDDLEWARE = [
     # 这个必须在最前
@@ -262,7 +270,11 @@ DATABASES = {
             "isolation_level": env.str("BK_APIGW_DATABASE_ISOLATION_LEVEL", "READ COMMITTED"),
         },
     },
-    "bkcore": {
+}
+
+# 非多租户模式才会有 esb 相关的模型
+if not ENABLE_MULTI_TENANT_MODE:
+    DATABASES["bkcore"] = {
         "ENGINE": env.str("BK_ESB_DATABASE_ENGINE", "django.db.backends.mysql"),
         "NAME": env.str("BK_ESB_DATABASE_NAME", "bk_esb"),
         "USER": env.str("BK_ESB_DATABASE_USER", BK_APP_CODE),
@@ -272,8 +284,7 @@ DATABASES = {
         "OPTIONS": {
             "isolation_level": env.str("BK_ESB_DATABASE_ISOLATION_LEVEL", "READ COMMITTED"),
         },
-    },
-}
+    }
 
 # ==============================================================================
 # redis 配置
@@ -636,10 +647,6 @@ BK_ESB_ACCESS_LOG_CONFIG = {
     "es_index": env.str("BK_ESB_API_LOG_ES_INDEX", "2_bklog_bkapigateway_esb_container*"),
 }
 
-# 使用 bkmonitorv3 网关 API，还是 monitor_v3 组件 API
-USE_BKAPI_BKMONITORV3 = env.bool("USE_BKAPI_BKMONITORV3", False)
-# 是否使用 bklog 网关 API
-USE_BKAPI_BK_LOG = env.bool("USE_BKAPI_BK_LOG", False)
 
 # ==============================================================================
 # prometheus 配置
@@ -806,6 +813,8 @@ DEFAULT_FEATURE_FLAG = {
     # ----------------------------------------------------------------------------
     # 是否展示蓝鲸通知中心组件
     "ENABLE_BK_NOTICE": ENABLE_BK_NOTICE,
+    # 是否开启多租户模式
+    "ENABLE_MULTI_TENANT_MODE": ENABLE_MULTI_TENANT_MODE,
 }
 
 # 用户功能开关，将与 DEFAULT_FEATURE_FLAG 合并

--- a/src/dashboard/apigateway/apigateway/conf/default.py
+++ b/src/dashboard/apigateway/apigateway/conf/default.py
@@ -707,6 +707,7 @@ PLUGIN_METADATA_CONFIG = {
             "x_request_id": "$x_request_id",
             "request_duration": "$bk_log_request_duration",
             "bk_username": "$bk_username",
+            "bk_tenant_id": "$bk_tenant_id",
             # 网关信息
             "api_id": "$bk_gateway_id",
             "api_name": "$bk_gateway_name",

--- a/src/dashboard/apigateway/apigateway/controller/crds/v1beta1/convertors/stage.py
+++ b/src/dashboard/apigateway/apigateway/controller/crds/v1beta1/convertors/stage.py
@@ -71,7 +71,7 @@ class StageConvertor(BaseConvertor):
 
     def _get_default_stage_plugins(self) -> List[PluginConfig]:
         """Get the default plugins for stage, which is shared by all resources in the stage"""
-        return [
+        default_stage_plugins = [
             # 2024-08-19 disable the bk-opentelemetry plugin, we should let each gateway set their own opentelemetry
             # PluginConfig(name="bk-opentelemetry"),
             PluginConfig(name="prometheus"),
@@ -106,6 +106,14 @@ class StageConvertor(BaseConvertor):
                 },
             ),
         ]
+
+        # 多租户模式
+        if settings.ENABLE_MULTI_TENANT_MODE:
+            default_stage_plugins.append(PluginConfig(name="bk-tenant-verify"))
+        else:
+            default_stage_plugins.append(PluginConfig(name="bk-default-tenant"))
+
+        return default_stage_plugins
 
     def _get_stage_plugins(self) -> List[PluginConfig]:
         return [

--- a/src/dashboard/apigateway/apigateway/urls.py
+++ b/src/dashboard/apigateway/apigateway/urls.py
@@ -31,6 +31,7 @@ Including another URLconf
     2. Add a URL to urlpatterns:  path('blog/', include('blog.urls'))
 """
 
+from django.conf import settings
 from django.contrib import admin
 from django.urls import include, path, re_path
 from django.views.i18n import set_language
@@ -47,8 +48,6 @@ urlpatterns = [
     path("backend/admin42/", admin.site.urls),
     # /userinfo
     path("backend/accounts/", include("apigateway.account.urls")),
-    # esb
-    path("backend/esb/", include("apigateway.apps.esb.urls")),
     # open api
     path("backend/api/v1/", include("apigateway.apis.open.urls")),
     # open api v2
@@ -85,6 +84,12 @@ urlpatterns = [
     path("backend/notice/", include(("bk_notice_sdk.urls", "notice"), namespace="notice")),
 ]
 
+# 非多租户模式才会有 esb 相关的接口
+if not settings.ENABLE_MULTI_TENANT_MODE:
+    urlpatterns += [
+        # esb
+        path("backend/esb/", include("apigateway.apps.esb.urls")),
+    ]
 
 # backend/docs/
 urlpatterns += [

--- a/src/dashboard/bin/on_migrate
+++ b/src/dashboard/bin/on_migrate
@@ -37,13 +37,16 @@ python manage.py sync_default_micro_gateway \
 --secret "${DEFAULT_MICRO_GATEWAY_SECRET}" \
 --http-url "${DEFAULT_MICRO_GATEWAY_HTTP_URL}"
 
-# ESB 相关
-python manage.py create_esb_jwt_key
-python manage.py create_esb_gateway
-python manage.py sync_esb_jwt_key_to_gateway
-python manage.py update_esb_user_verified_unrequired_apps ${esb_verified_user_exempted_apps}
-python manage.py sync_esb_verified_user_exempted_apps_to_gateway
-python manage.py add_plugin_error_status_code_200
+# only init esb when ENABLE_MULTI_TENANT_MODE != true/True
+if [ "${ENABLE_MULTI_TENANT_MODE}" != "true" ] && [ "${ENABLE_MULTI_TENANT_MODE}" != "True" ]; then
+    # ESB 相关
+    python manage.py create_esb_jwt_key
+    python manage.py create_esb_gateway
+    python manage.py sync_esb_jwt_key_to_gateway
+    python manage.py update_esb_user_verified_unrequired_apps ${esb_verified_user_exempted_apps}
+    python manage.py sync_esb_verified_user_exempted_apps_to_gateway
+    python manage.py add_plugin_error_status_code_200
+fi
 
 # 蓝鲸通知中心
 python manage.py register_to_bk_notice

--- a/src/dashboard/bin/post_migrate
+++ b/src/dashboard/bin/post_migrate
@@ -65,7 +65,12 @@ sync_bk_default() {
 # 默认共享网关实例挂在 bk-default 这个网关中，所以 sync_bk_default 必须在第一位
 sync_bk_default
 sync_bk_apigateway
-sync_bk_esb
+
+# only init esb when ENABLE_MULTI_TENANT_MODE != true/True
+if [ "${ENABLE_MULTI_TENANT_MODE}" != "true" ] && [ "${ENABLE_MULTI_TENANT_MODE}" != "True" ]; then
+    sync_bk_esb
+fi
+
 sync_bk_apigateway_inner
 
 # delete abandoned celery tasks in 1.14(remove below code in 1.15)


### PR DESCRIPTION
### Description

<!-- 关联相关issue Please include a summary of the change and which issue is fixed. -->
<!-- 给出必要的上下文以及review需要的必要信息 Please also include relevant motivation and context. -->

变更点：
- default.py: 增加 ENABLE_MULTI_TENANT_MODE 变量，从环境变量中获取，默认False
- 多租户模式下，所有 esb 相关的模型/url 不注册
- 返回 feature_flag: ENABLE_MULTI_TENANT_MODE 给到前端 【用户展示差异化的开关】
- bin脚本
  - bin/on_migrate: ENABLE_MULTI_TENANT_MODE 开启则不初始化 bk-esb
  - bin/post_migrate: ENABLE_MULTI_TENANT_MODE 开启则不初始化 bk-esb
- 多租户模式环境默认插件: bk-tenant-verify， 否则环境默认插件: bk-default-tenant
- 增加 EDITION 环境变量用于区分内外部版（后续逐步合并内外部版代码文件差异）
  - bk-monitor 和 bk-log 内外部版使用不同的网关名
- 多租户版本：不再兼容非标准化调用 【直接 allow_auth_from_params 默认值强制设置为 False】
- 多租户版本： 禁用掉免用户认证应用白名单  【直接在slz校验时强校验报错，不允许绑定该插件】
- 多租户版本：日志增加 bk_tenant_id 字段

### Checklist

- [x] 填写 PR 描述及相关 issue (write PR description and related issue)
- [x] 代码风格检查通过 (code style check passed)
- [ ] PR 中包含单元测试 (include unit test)
- [ ] 单元测试通过 (unit test passed)
- [ ] 本地开发联调环境验证通过 (local development environment verification passed)
