### PR TITLE
fix(apps/metrics/prometheus): 修复统计报表非 200 请求 status 条件匹配问题

### DIFF
--- a/src/dashboard/apigateway/apigateway/apps/metrics/prometheus/dimension.py
+++ b/src/dashboard/apigateway/apigateway/apps/metrics/prometheus/dimension.py
@@ -172,7 +172,7 @@ class Non20XStatusMetrics(BaseMetrics):
                 ("api_name", "=", gateway_name),
                 ("stage_name", "=", stage_name),
                 ("resource_name", "=", resource_name),
-                ("status", ">", "299"),
+                ("status", "=~", "3..|4..|5.."),
             ]
         )
         return (

--- a/src/dashboard/apigateway/apigateway/tests/apps/metrics/prometheus/test_dimension.py
+++ b/src/dashboard/apigateway/apigateway/tests/apps/metrics/prometheus/test_dimension.py
@@ -78,7 +78,7 @@ class TestNon20XStatusMetrics:
                 },
                 "expected": (
                     'topk(10, sum(increase(bk_apigateway_apigateway_api_requests_total{api_name="foo", '
-                    'stage_name="prod", resource_name="get_foo", status>"299"}[1m])) by (status))'
+                    'stage_name="prod", resource_name="get_foo", status=~"3..|4..|5.."}[1m])) by (status))'
                 ),
             },
             {
@@ -92,7 +92,7 @@ class TestNon20XStatusMetrics:
                 },
                 "expected": (
                     'topk(10, sum(increase(bk_apigateway_apigateway_api_requests_total{api_name="foo", '
-                    'stage_name="prod", status>"299"}[1m])) by (status))'
+                    'stage_name="prod", status=~"3..|4..|5.."}[1m])) by (status))'
                 ),
             },
         ]


### PR DESCRIPTION
### Description

status 为字符串，改为正则匹配 3xx，4xx，5xx 的 status

<!-- 关联相关issue Please include a summary of the change and which issue is fixed. -->
<!-- 给出必要的上下文以及review需要的必要信息 Please also include relevant motivation and context. -->

Fixes # (issue)

### Checklist

- [ ] 填写 PR 描述及相关 issue (write PR description and related issue)
- [ ] 代码风格检查通过 (code style check passed)
- [ ] PR 中包含单元测试 (include unit test)
- [ ] 单元测试通过 (unit test passed)
- [ ] 本地开发联调环境验证通过 (local development environment verification passed)
