### PR TITLE
fix(api/web/metrics): 修复历史请求统计缺少调用方接口

### DIFF
--- a/src/dashboard/apigateway/apigateway/apis/web/metrics/serializers.py
+++ b/src/dashboard/apigateway/apigateway/apis/web/metrics/serializers.py
@@ -76,3 +76,18 @@ class MetricsQuerySummaryInputSLZ(serializers.Serializer):
         if data["time_start"] < time_interval:
             raise serializers.ValidationError(_("查询时间范围不可超过半年"))
         return data
+
+
+class MetricsQuerySummaryCallerListInputSLZ(serializers.Serializer):
+    stage_id = serializers.IntegerField(required=True, help_text="环境 id")
+    time_start = serializers.IntegerField(required=False, min_value=0, help_text="开始时间")
+    time_end = serializers.IntegerField(required=False, min_value=0, help_text="结束时间")
+
+    def validate(self, data):
+        if not (data.get("time_start") and data.get("time_end")):
+            raise serializers.ValidationError(_("参数 time_start+time_end 必须同时有效。"))
+
+        time_interval = int((timezone.now() - relativedelta(months=6)).timestamp())
+        if data["time_start"] < time_interval:
+            raise serializers.ValidationError(_("查询时间范围不可超过半年"))
+        return data

--- a/src/dashboard/apigateway/apigateway/apis/web/metrics/views.py
+++ b/src/dashboard/apigateway/apigateway/apis/web/metrics/views.py
@@ -238,13 +238,13 @@ class QuerySummaryCallerListApi(generics.ListAPIView):
             raise Http404
 
         app_codes = sorted(
-            set(
-                StatisticsAppRequestByDay.objects.filter(
-                    stage_name=stage_name,
-                    start_time__gte=timezone.datetime.fromtimestamp(data["time_start"]),
-                    end_time__lte=timezone.datetime.fromtimestamp(data["time_end"]),
-                ).values_list("bk_app_code", flat=True)
+            StatisticsAppRequestByDay.objects.filter(
+                stage_name=stage_name,
+                start_time__gte=timezone.datetime.fromtimestamp(data["time_start"]),
+                end_time__lte=timezone.datetime.fromtimestamp(data["time_end"]),
             )
+            .values_list("bk_app_code", flat=True)
+            .distinct()
         )
 
         return OKJsonResponse(data={"app_codes": app_codes})

--- a/src/dashboard/apigateway/apigateway/apps/metrics/admin.py
+++ b/src/dashboard/apigateway/apigateway/apps/metrics/admin.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # TencentBlueKing is pleased to support the open source community by making
 # 蓝鲸智云 - API 网关(BlueKing - APIGateway) available.
@@ -16,21 +15,22 @@
 # We undertake not to change the open source license (MIT license) applicable
 # to the current version of the project delivered to anyone in the future.
 #
-from django.urls import include, path
+from django.contrib import admin
+from djangoql.admin import DjangoQLSearchMixin
 
-from .views import QueryInstantApi, QueryRangeApi, QuerySummaryApi, QuerySummaryCallerListApi, QuerySummaryExportApi
+# Register your models here.
+from apigateway.apps.metrics.models import StatisticsAppRequestByDay, StatisticsGatewayRequestByDay
 
-urlpatterns = [
-    path("query-range/", QueryRangeApi.as_view(), name="metrics.query_range"),
-    path("query-instant/", QueryInstantApi.as_view(), name="metrics.query_instant"),
-    path(
-        "query-summary/",
-        include(
-            [
-                path("", QuerySummaryApi.as_view(), name="metrics.query_summary"),
-                path("caller/", QuerySummaryCallerListApi.as_view(), name="metrics.query_summary_caller"),
-                path("export/", QuerySummaryExportApi.as_view(), name="metrics.query_summary_export"),
-            ]
-        ),
-    ),
-]
+
+class StatisticsGatewayRequestByDayAdmin(DjangoQLSearchMixin, admin.ModelAdmin):
+    djangoql_completion_enabled_by_default = False
+    list_display = ["gateway_id", "stage_name", "total_count", "failed_count", "start_time", "end_time"]
+
+
+class StatisticsAppRequestByDayAdmin(DjangoQLSearchMixin, admin.ModelAdmin):
+    djangoql_completion_enabled_by_default = False
+    list_display = ["gateway_id", "stage_name", "bk_app_code", "total_count", "failed_count", "start_time", "end_time"]
+
+
+admin.site.register(StatisticsGatewayRequestByDay, StatisticsGatewayRequestByDayAdmin)
+admin.site.register(StatisticsAppRequestByDay, StatisticsAppRequestByDayAdmin)

--- a/src/dashboard/apigateway/apigateway/apps/metrics/management/__init__.py
+++ b/src/dashboard/apigateway/apigateway/apps/metrics/management/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # TencentBlueKing is pleased to support the open source community by making
 # 蓝鲸智云 - API 网关(BlueKing - APIGateway) available.
@@ -16,21 +15,3 @@
 # We undertake not to change the open source license (MIT license) applicable
 # to the current version of the project delivered to anyone in the future.
 #
-from django.urls import include, path
-
-from .views import QueryInstantApi, QueryRangeApi, QuerySummaryApi, QuerySummaryCallerListApi, QuerySummaryExportApi
-
-urlpatterns = [
-    path("query-range/", QueryRangeApi.as_view(), name="metrics.query_range"),
-    path("query-instant/", QueryInstantApi.as_view(), name="metrics.query_instant"),
-    path(
-        "query-summary/",
-        include(
-            [
-                path("", QuerySummaryApi.as_view(), name="metrics.query_summary"),
-                path("caller/", QuerySummaryCallerListApi.as_view(), name="metrics.query_summary_caller"),
-                path("export/", QuerySummaryExportApi.as_view(), name="metrics.query_summary_export"),
-            ]
-        ),
-    ),
-]

--- a/src/dashboard/apigateway/apigateway/apps/metrics/management/commands/__init__.py
+++ b/src/dashboard/apigateway/apigateway/apps/metrics/management/commands/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # TencentBlueKing is pleased to support the open source community by making
 # 蓝鲸智云 - API 网关(BlueKing - APIGateway) available.
@@ -16,21 +15,3 @@
 # We undertake not to change the open source license (MIT license) applicable
 # to the current version of the project delivered to anyone in the future.
 #
-from django.urls import include, path
-
-from .views import QueryInstantApi, QueryRangeApi, QuerySummaryApi, QuerySummaryCallerListApi, QuerySummaryExportApi
-
-urlpatterns = [
-    path("query-range/", QueryRangeApi.as_view(), name="metrics.query_range"),
-    path("query-instant/", QueryInstantApi.as_view(), name="metrics.query_instant"),
-    path(
-        "query-summary/",
-        include(
-            [
-                path("", QuerySummaryApi.as_view(), name="metrics.query_summary"),
-                path("caller/", QuerySummaryCallerListApi.as_view(), name="metrics.query_summary_caller"),
-                path("export/", QuerySummaryExportApi.as_view(), name="metrics.query_summary_export"),
-            ]
-        ),
-    ),
-]

--- a/src/dashboard/apigateway/apigateway/apps/metrics/management/commands/fake_stats.py
+++ b/src/dashboard/apigateway/apigateway/apps/metrics/management/commands/fake_stats.py
@@ -1,0 +1,84 @@
+# -*- coding: utf-8 -*-
+#
+# TencentBlueKing is pleased to support the open source community by making
+# 蓝鲸智云 - API 网关(BlueKing - APIGateway) available.
+# Copyright (C) 2017 THL A29 Limited, a Tencent company. All rights reserved.
+# Licensed under the MIT License (the "License"); you may not use this file except
+# in compliance with the License. You may obtain a copy of the License at
+#
+#     http://opensource.org/licenses/MIT
+#
+# Unless required by applicable law or agreed to in writing, software distributed under
+# the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+# either express or implied. See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# We undertake not to change the open source license (MIT license) applicable
+# to the current version of the project delivered to anyone in the future.
+#
+import random
+from datetime import datetime, timedelta
+
+from django.core.management.base import BaseCommand
+
+from apigateway.apps.metrics.models import StatisticsAppRequestByDay, StatisticsGatewayRequestByDay
+from apigateway.core.models import Gateway, Resource, Stage
+from apigateway.utils.time import utctime
+
+
+class Command(BaseCommand):
+    def handle(self, *args, **options):
+        dates = self._get_dates()
+        gateways = Gateway.objects.all()
+        total = gateways.count()
+
+        self.stdout.write(f"开始为{total}个网关生成假数据...")
+
+        for idx, gateway in enumerate(gateways, 1):
+            self.stdout.write(f"\r处理进度: {idx}/{total}", ending="")
+            self.stdout.flush()
+
+            gateway_request_data = []
+            app_request_data = []
+
+            resource_ids = Resource.objects.filter(gateway=gateway).values_list("id", flat=True)
+            if not resource_ids:
+                continue
+
+            for date in dates:
+                for stage in Stage.objects.filter(gateway=gateway):
+                    gateway_request_data.append(
+                        StatisticsGatewayRequestByDay(
+                            gateway_id=gateway.id,
+                            stage_name=stage.name,
+                            resource_id=random.choice(resource_ids),
+                            total_count=random.randint(0, 1000),
+                            failed_count=random.randint(0, 100),
+                            total_msecs=random.randint(60, 600),
+                            start_time=date,
+                            end_time=date,
+                        )
+                    )
+
+                    app_request_data.append(
+                        StatisticsAppRequestByDay(
+                            gateway_id=gateway.id,
+                            stage_name=stage.name,
+                            resource_id=random.choice(resource_ids),
+                            bk_app_code=random.choice(["app1", "app2", "app3"]),
+                            total_count=random.randint(0, 1000),
+                            failed_count=random.randint(0, 100),
+                            total_msecs=random.randint(60, 600),
+                            start_time=date,
+                            end_time=date,
+                        )
+                    )
+
+            StatisticsGatewayRequestByDay.objects.bulk_create(gateway_request_data, batch_size=100)
+            StatisticsAppRequestByDay.objects.bulk_create(app_request_data, batch_size=100)
+
+        self.stdout.write("\n假数据生成完成!")
+
+    def _get_dates(self):
+        now = datetime.now()
+        return [utctime(int((now - timedelta(days=i)).timestamp())).datetime for i in range(30)]

--- a/src/dashboard/apigateway/apigateway/tests/apis/web/metrics/test_serializers.py
+++ b/src/dashboard/apigateway/apigateway/tests/apis/web/metrics/test_serializers.py
@@ -127,3 +127,25 @@ class TestMetricsQuerySummaryInputSLZ(TestCase):
             slz = serializers.MetricsQuerySummaryInputSLZ(data=test["data"])
             slz.is_valid(raise_exception=True)
             self.assertEqual(slz.validated_data, test["expected"])
+
+
+class TestMetricsQuerySummaryCallerListInputSLZ(TestCase):
+    def test_validate(self):
+        data = [
+            {
+                "data": {
+                    "stage_id": 1,
+                    "time_start": int(time.time()),
+                    "time_end": int(time.time()),
+                },
+                "expected": {
+                    "stage_id": 1,
+                    "time_start": int(time.time()),
+                    "time_end": int(time.time()),
+                },
+            }
+        ]
+        for test in data:
+            slz = serializers.MetricsQuerySummaryCallerListInputSLZ(data=test["data"])
+            slz.is_valid(raise_exception=True)
+            self.assertEqual(slz.validated_data, test["expected"])

--- a/src/dashboard/apigateway/apigateway/tests/apis/web/metrics/test_views.py
+++ b/src/dashboard/apigateway/apigateway/tests/apis/web/metrics/test_views.py
@@ -379,6 +379,18 @@ class TestQuerySummaryCallerListApi:
             gateway_id=fake_stage.gateway.id,
             stage_name=fake_stage.name,
             resource_id=resource_obj.id,
+            bk_app_code="app1",
+            total_count=150,
+            failed_count=15,
+            total_msecs=660,
+            start_time=utctime(int(time.time())).datetime,
+            end_time=utctime(int(time.time())).datetime,
+        )
+        G(
+            StatisticsAppRequestByDay,
+            gateway_id=fake_stage.gateway.id,
+            stage_name=fake_stage.name,
+            resource_id=resource_obj.id,
             bk_app_code="app2",
             total_count=200,
             failed_count=20,


### PR DESCRIPTION
### Description

1. 增加历史请求统计缺少调用方接口
2. 增加批量生成30天的假统计数据的 command
3. 调整请求总量接口的返回数据格式："series": {"datapoints": datapoints}  -> "series": [{"datapoints": datapoints}]

<!-- 关联相关issue Please include a summary of the change and which issue is fixed. -->
<!-- 给出必要的上下文以及review需要的必要信息 Please also include relevant motivation and context. -->

Fixes # (issue)

### Checklist

- [ ] 填写 PR 描述及相关 issue (write PR description and related issue)
- [ ] 代码风格检查通过 (code style check passed)
- [ ] PR 中包含单元测试 (include unit test)
- [ ] 单元测试通过 (unit test passed)
- [ ] 本地开发联调环境验证通过 (local development environment verification passed)
