### PR TITLE
fix(common/plugin): fix response-rewrite plugin

### DIFF
--- a/src/dashboard/apigateway/apigateway/common/plugin/convertor.py
+++ b/src/dashboard/apigateway/apigateway/common/plugin/convertor.py
@@ -173,10 +173,19 @@ class ResponseRewriteConvertor(PluginConvertor):
             config["vars"] = ast.literal_eval(config["vars"])
 
         headers = config["headers"]
-        headers["add"] = [item["key"] for item in headers["add"]]
+        headers["add"] = ["{}:{}".format(item["key"], item["value"]) for item in headers["add"]]
         headers["set"] = {item["key"]: item["value"] for item in headers["set"]}
         headers["remove"] = [item["key"] for item in headers["remove"]]
 
+        new_headers = {}
+        if headers["add"]:
+            new_headers["add"] = headers["add"]
+        if headers["set"]:
+            new_headers["set"] = headers["set"]
+        if headers["remove"]:
+            new_headers["remove"] = headers["remove"]
+
+        config["headers"] = new_headers
         return config
 
 

--- a/src/dashboard/apigateway/apigateway/fixtures/plugins.yaml
+++ b/src/dashboard/apigateway/apigateway/fixtures/plugins.yaml
@@ -2489,19 +2489,25 @@
                       "add": {
                         "description": "添加新的响应头",
                         "items": {
+                          "type": "object",
                           "properties": {
                             "key": {
                               "title": "键",
-                              "description": "您可以添加响应头的键，响应头的键中必须包含冒号（:）。",
+                              "description": "您可以设置响应头的键，响应头的键中不能包含冒号（:）。",
                               "type": "string",
                               "maxLength": 1024,
-                              "pattern": "^[^:]+:[^:]*[^/]$",
-                              "ui:rules": [
-                                "required"
-                              ]
+                              "pattern": "^[\\w-]+$",
+                              "ui:rules": ["required"]
+                            },
+                            "value": {
+                              "title": "值",
+                              "description": "您可以设置响应头的值。",
+                              "type": "string",
+                              "maxLength": 1024,
+                              "pattern": "^[\\s\\S]*$",
+                              "ui:rules": ["required"]
                             }
-                          },
-                          "type": "object"
+                          }
                         },
                         "minItems": 0,
                         "title": "添加",
@@ -2617,19 +2623,25 @@
                       "add": {
                         "description": "add headers",
                         "items": {
+                          "type": "object",
                           "properties": {
                             "key": {
                               "title": "key",
-                              "description": "You can add the key of the response header, but colons (:) must appear in the key of the response header.",
+                              "description": "You can set the key of the response header, but colons (:) cannot appear in the key of the response header.",
                               "type": "string",
                               "maxLength": 1024,
-                              "pattern": "^[^:]+:[^:]*[^/]$",
-                              "ui:rules": [
-                                "required"
-                              ]
+                              "pattern": "^[\\w-]+$",
+                              "ui:rules": ["required"]
+                            },
+                            "value": {
+                              "title": "value",
+                              "description": "You can set the value of the response header.",
+                              "type": "string",
+                              "maxLength": 1024,
+                              "pattern": "^[\\s\\S]*$",
+                              "ui:rules": ["required"]
                             }
-                          },
-                          "type": "object"
+                          }
                         },
                         "minItems": 0,
                         "title": "add",
@@ -2761,7 +2773,7 @@
           "properties": {
               "uri": {
                   "title": "重定向 URI",
-                  "description": "要重定向到的 URI，可以包含 NGINX 变量。例如：/test/index.htm，$uri/index.html，${uri}/index.html，https://example.com/foo/bar。如果你引入了一个不存在的变量，它不会报错，而是将其视为一个空变量。",
+                  "description": "要重定向到的 URI，可以包含 NGINX 变量。例如：/test/index.html，$uri/index.html，${uri}/index.html，https://example.com/foo/bar。如果你引入了一个不存在的变量，它不会报错，而是将其视为一个空变量。",
                   "type": "string",
                   "minLength": 1,
                   "pattern": "^(\\\\\\$[0-9a-zA-Z_]+|\\$\\{[0-9a-zA-Z_]+\\}|\\$[0-9a-zA-Z_]+|\\$|[^$\\\\]+)*$"

--- a/src/dashboard/apigateway/apigateway/tests/common/plugin/test_convertors.py
+++ b/src/dashboard/apigateway/apigateway/tests/common/plugin/test_convertors.py
@@ -235,7 +235,7 @@ class TestResponseRewriteConvertor:
                     "status_code": 200,
                     "body": '{"code":"ok","message":"new json body"}',
                     "headers": {
-                        "add": [{"key": "name:value"}],
+                        "add": [{"key": "name1", "value": "value1"}],
                         "set": [
                             {"key": "key1", "value": "value1"},
                             {"key": "key2", "value": "value2"},
@@ -247,12 +247,28 @@ class TestResponseRewriteConvertor:
                     "status_code": 200,
                     "body": '{"code":"ok","message":"new json body"}',
                     "headers": {
-                        "add": ["name:value"],
+                        "add": ["name1:value1"],
                         "set": {"key1": "value1", "key2": "value2"},
                         "remove": ["key2"],
                     },
                 },
-            )
+            ),
+            (
+                {
+                    "status_code": 200,
+                    "body": '{"code":"ok","message":"new json body"}',
+                    "headers": {
+                        "add": [],
+                        "set": [],
+                        "remove": [],
+                    },
+                },
+                {
+                    "status_code": 200,
+                    "body": '{"code":"ok","message":"new json body"}',
+                    "headers": {},
+                },
+            ),
         ],
     )
     def test_convert(self, data, expected):


### PR DESCRIPTION
### Description

1. 修改插件注释
2. 调整 headers add 格式改为 dict
3. 该配置会导致 apisix 加载失败："headers":{"remove":\[\],"set":{"a":"2"},"add":\["a:1"\]}，原因为 remove/set/add 为空时不可传递该参数，已调整 convertor 方法

<!-- 关联相关issue Please include a summary of the change and which issue is fixed. -->
<!-- 给出必要的上下文以及review需要的必要信息 Please also include relevant motivation and context. -->

Fixes # (issue)

### Checklist

- [ ] 填写 PR 描述及相关 issue (write PR description and related issue)
- [ ] 代码风格检查通过 (code style check passed)
- [ ] PR 中包含单元测试 (include unit test)
- [ ] 单元测试通过 (unit test passed)
- [ ] 本地开发联调环境验证通过 (local development environment verification passed)
