### PR TITLE
fix(tasks/syncing.py): fix rolling update syncing bk_default flag wro…

### DIFF
--- a/src/dashboard/apigateway/apigateway/controller/crds/v1beta1/convertors/service.py
+++ b/src/dashboard/apigateway/apigateway/controller/crds/v1beta1/convertors/service.py
@@ -114,7 +114,7 @@ class ServiceConvertor(BaseConvertor):
             services.append(
                 BkGatewayService(
                     metadata=self._common_metadata(
-                        f"s-{stage_id}-b-{backend_id}",
+                        f"{stage_id}-{backend_id}",
                         labels={
                             "service-type": "stage-backend",
                             "backend-id": str(backend_id),
@@ -122,7 +122,7 @@ class ServiceConvertor(BaseConvertor):
                     ),
                     spec=BkGatewayServiceSpec(
                         name=f"_stage_service_{stage_name}_{backend_id}",
-                        id=f"stage-{stage_id}-backend-{backend_id}",
+                        id=f"{stage_id}-{backend_id}",
                         description=description,
                         upstream=upstream,
                         plugins=plugins,

--- a/src/dashboard/apigateway/apigateway/tests/controller/crds/v1beta1/convertors/test_services.py
+++ b/src/dashboard/apigateway/apigateway/tests/controller/crds/v1beta1/convertors/test_services.py
@@ -52,7 +52,7 @@ class TestServiceConvertor:
         # assert spec
         spec = service.spec
         assert spec.name == f"_stage_service_{stage_name}_{backend_id}"
-        assert spec.id == f"stage-{stage_id}-backend-{backend_id}"
+        assert spec.id == f"{stage_id}-{backend_id}"
         assert spec.description.startswith(f"{stage_name}/{stage_id}" + ": " + edge_gateway_stage.description[:32])
 
         assert spec.upstream.type == UpstreamTypeEnum.ROUNDROBIN


### PR DESCRIPTION
…ng (#1851)### Description

<!-- 关联相关issue Please include a summary of the change and which issue is fixed. -->
<!-- 给出必要的上下文以及review需要的必要信息 Please also include relevant motivation and context. -->


当前规则： `{gateway_name}.{stage_name}.stage-{stage_id}-backend-{backend_id}`
max length:
- gateway_name = 30
- stage_name = 20
- stage_id = 6
- backend_id = 4
- 其他字符： 1 + 7 + 9 = 17

77 个字符会导致超过 64 个字符加载失败


优化 `{gateway_name}.{stage_name}.{stage_id}-{backend_id}`
- 去掉 `stage-`  6
- 去掉 `backend-` 8

63 个字符； 并且短期内没有超过的风险

将在 1.20 版本重新设计 id 规则，规避长度问题

### Checklist

- [x] 填写 PR 描述及相关 issue (write PR description and related issue)
- [x] 代码风格检查通过 (code style check passed)
- [x] PR 中包含单元测试 (include unit test)
- [x] 单元测试通过 (unit test passed)
- [x] 本地开发联调环境验证通过 (local development environment verification passed)
