### PR TITLE
refactor(mcp_server/tool_name): make it simpler

### DIFF
--- a/src/dashboard/apigateway/apigateway/apis/v2/open/serializers.py
+++ b/src/dashboard/apigateway/apigateway/apis/v2/open/serializers.py
@@ -185,6 +185,7 @@ class MCPServerBaseOutputSLZ(serializers.Serializer):
 
     labels = serializers.ListField(read_only=True, help_text="MCPServer 标签")
     resource_names = serializers.ListField(read_only=True, help_text="MCPServer 资源名称")
+    tool_names = serializers.ListField(read_only=True, help_text="MCPServer 工具名称")
 
     status = serializers.ChoiceField(
         read_only=True, help_text="MCPServer 状态", choices=MCPServerStatusEnum.get_choices()

--- a/src/dashboard/apigateway/apigateway/apis/web/mcp_marketplace/serializers.py
+++ b/src/dashboard/apigateway/apigateway/apis/web/mcp_marketplace/serializers.py
@@ -46,6 +46,7 @@ class MCPServerBaseOutputSLZ(serializers.Serializer):
 
     labels = serializers.ListField(read_only=True, help_text="MCPServer 标签")
     resource_names = serializers.ListField(read_only=True, help_text="MCPServer 资源名称")
+    tool_names = serializers.ListField(read_only=True, help_text="MCPServer 工具名称")
 
     status = serializers.ChoiceField(
         read_only=True, help_text="MCPServer 状态", choices=MCPServerStatusEnum.get_choices()

--- a/src/dashboard/apigateway/apigateway/apis/web/mcp_marketplace/views.py
+++ b/src/dashboard/apigateway/apigateway/apis/web/mcp_marketplace/views.py
@@ -189,10 +189,10 @@ class MCPMarketplaceServerRetrieveApi(generics.RetrieveAPIView):
             }
         }
 
-        tool_resources, labels, tool_name_map = MCPServerHandler.get_tools_resources_and_labels(
+        tool_resources, labels = MCPServerHandler.get_tools_resources_and_labels(
             gateway_id=instance.gateway.id,
             stage_name=instance.stage.name,
-            resource_names=instance.resource_names_raw,
+            resource_names=instance.resource_names,
         )
         instance.tools = tool_resources
 
@@ -212,7 +212,7 @@ class MCPMarketplaceServerRetrieveApi(generics.RetrieveAPIView):
                 "gateways": gateways,
                 "stages": stages,
                 "labels": labels,
-                "tool_name_map": tool_name_map,
+                "tool_name_map": instance.gen_tool_name_map(),
                 "prompts_count_map": prompts_count_map,
                 "prompts": prompts,
                 "user_custom_doc": user_custom_doc,

--- a/src/dashboard/apigateway/apigateway/apis/web/mcp_server/serializers.py
+++ b/src/dashboard/apigateway/apigateway/apis/web/mcp_server/serializers.py
@@ -139,13 +139,20 @@ class MCPServerCreateInputSLZ(serializers.ModelSerializer):
 
     def validate_resource_names(self, resource_names):
         """验证资源名称列表"""
-        if len(resource_names) == 0:
-            raise serializers.ValidationError(_("资源名称列表不能为空"))
+        if resource_names is not None:
+            if len(resource_names) == 0:
+                raise serializers.ValidationError(_("资源名称列表不能为空"))
+            valid_resource_names = self.context["valid_resource_names"]
 
-        if len(resource_names) != len(set(resource_names)):
-            raise serializers.ValidationError(_("资源名称不能重复"))
+            if len(resource_names) != len(set(resource_names)):
+                raise serializers.ValidationError(_("资源名称不能重复"))
 
-        # 返回原始格式，由 model 层处理转换
+            for resource_name in resource_names:
+                if resource_name not in valid_resource_names:
+                    raise serializers.ValidationError(
+                        _("资源名称列表非法，请检查当前环境发布的最新版本中对应资源名称是否存在")
+                        + f"resource_name={resource_name}"
+                    )
         return resource_names
 
     def validate_tool_names(self, tool_names):
@@ -274,13 +281,20 @@ class MCPServerUpdateInputSLZ(serializers.ModelSerializer):
 
     def validate_resource_names(self, resource_names):
         """验证资源名称列表"""
-        if len(resource_names) == 0:
-            raise serializers.ValidationError(_("资源名称列表不能为空"))
+        if resource_names is not None:
+            if len(resource_names) == 0:
+                raise serializers.ValidationError(_("资源名称列表不能为空"))
+            valid_resource_names = self.context["valid_resource_names"]
 
-        if len(resource_names) != len(set(resource_names)):
-            raise serializers.ValidationError(_("资源名称不能重复"))
+            if len(resource_names) != len(set(resource_names)):
+                raise serializers.ValidationError(_("资源名称不能重复"))
 
-        # 返回原始格式，由 model 层处理转换
+            for resource_name in resource_names:
+                if resource_name not in valid_resource_names:
+                    raise serializers.ValidationError(
+                        _("资源名称列表非法，请检查当前环境发布的最新版本中对应资源名称是否存在")
+                        + f"resource_name={resource_name}"
+                    )
         return resource_names
 
     def validate_tool_names(self, tool_names):

--- a/src/dashboard/apigateway/apigateway/apis/web/mcp_server/serializers.py
+++ b/src/dashboard/apigateway/apigateway/apis/web/mcp_server/serializers.py
@@ -139,26 +139,25 @@ class MCPServerCreateInputSLZ(serializers.ModelSerializer):
 
     def validate_resource_names(self, resource_names):
         """验证资源名称列表"""
-        if resource_names is not None:
-            if len(resource_names) == 0:
-                raise serializers.ValidationError(_("资源名称列表不能为空"))
-            valid_resource_names = self.context["valid_resource_names"]
+        if not resource_names:
+            raise serializers.ValidationError(_("资源名称列表不能为空"))
+        valid_resource_names = self.context["valid_resource_names"]
 
-            if len(resource_names) != len(set(resource_names)):
-                raise serializers.ValidationError(_("资源名称不能重复"))
+        if len(resource_names) != len(set(resource_names)):
+            raise serializers.ValidationError(_("资源名称列表中不能存在重复的资源名称"))
 
-            for resource_name in resource_names:
-                if resource_name not in valid_resource_names:
-                    raise serializers.ValidationError(
-                        _("资源名称列表非法，请检查当前环境发布的最新版本中对应资源名称是否存在")
-                        + f"resource_name={resource_name}"
-                    )
+        for resource_name in resource_names:
+            if resource_name not in valid_resource_names:
+                raise serializers.ValidationError(
+                    _("资源名称列表非法，请检查当前环境发布的最新版本中对应资源名称是否存在")
+                    + f"resource_name={resource_name}"
+                )
         return resource_names
 
     def validate_tool_names(self, tool_names):
         """验证工具名称列表"""
         if len(tool_names) == 0:
-            raise serializers.ValidationError(_("资源别名列表不能为空"))
+            raise serializers.ValidationError(_("工具名称列表不能为空"))
 
         if len(tool_names) != len(set(tool_names)):
             raise serializers.ValidationError(_("工具名称不能重复"))
@@ -281,26 +280,25 @@ class MCPServerUpdateInputSLZ(serializers.ModelSerializer):
 
     def validate_resource_names(self, resource_names):
         """验证资源名称列表"""
-        if resource_names is not None:
-            if len(resource_names) == 0:
-                raise serializers.ValidationError(_("资源名称列表不能为空"))
-            valid_resource_names = self.context["valid_resource_names"]
+        if not resource_names:
+            raise serializers.ValidationError(_("资源名称列表不能为空"))
+        valid_resource_names = self.context["valid_resource_names"]
 
-            if len(resource_names) != len(set(resource_names)):
-                raise serializers.ValidationError(_("资源名称不能重复"))
+        if len(resource_names) != len(set(resource_names)):
+            raise serializers.ValidationError(_("资源名称列表中不能存在重复的资源名称"))
 
-            for resource_name in resource_names:
-                if resource_name not in valid_resource_names:
-                    raise serializers.ValidationError(
-                        _("资源名称列表非法，请检查当前环境发布的最新版本中对应资源名称是否存在")
-                        + f"resource_name={resource_name}"
-                    )
+        for resource_name in resource_names:
+            if resource_name not in valid_resource_names:
+                raise serializers.ValidationError(
+                    _("资源名称列表非法，请检查当前环境发布的最新版本中对应资源名称是否存在")
+                    + f"resource_name={resource_name}"
+                )
         return resource_names
 
     def validate_tool_names(self, tool_names):
         """验证工具名称列表"""
         if len(tool_names) == 0:
-            raise serializers.ValidationError(_("资源别名列表不能为空"))
+            raise serializers.ValidationError(_("工具名称列表不能为空"))
 
         if len(tool_names) != len(set(tool_names)):
             raise serializers.ValidationError(_("工具名称不能重复"))
@@ -337,6 +335,9 @@ class MCPServerUpdateInputSLZ(serializers.ModelSerializer):
 
         # 如果传入了 resource_names，使用 model 层方法更新
         if resource_names is not None:
+            if tool_names is None:
+                raise serializers.ValidationError(_("工具名称列表不能为空"))
+
             if len(tool_names) != len(resource_names):
                 raise serializers.ValidationError(_("工具名称列表长度与资源名称列表长度不一致"))
 

--- a/src/dashboard/apigateway/apigateway/apis/web/mcp_server/views.py
+++ b/src/dashboard/apigateway/apigateway/apis/web/mcp_server/views.py
@@ -349,16 +349,16 @@ class MCPServerToolsListApi(generics.ListAPIView):
     def list(self, request, *args, **kwargs):
         instance = self.get_object()
 
-        tool_resources, labels, tool_name_map = MCPServerHandler.get_tools_resources_and_labels(
+        tool_resources, labels = MCPServerHandler.get_tools_resources_and_labels(
             gateway_id=request.gateway.id,
             stage_name=instance.stage.name,
-            resource_names=instance.resource_names_raw,
+            resource_names=instance.resource_names,
         )
 
         slz = MCPServerToolOutputSLZ(
             tool_resources,
             many=True,
-            context={"labels": labels, "tool_name_map": tool_name_map},
+            context={"labels": labels, "tool_name_map": instance.gen_tool_name_map()},
         )
 
         return OKJsonResponse(status=status.HTTP_200_OK, data=slz.data)

--- a/src/dashboard/apigateway/apigateway/apis/web/mcp_server/views.py
+++ b/src/dashboard/apigateway/apigateway/apis/web/mcp_server/views.py
@@ -126,11 +126,15 @@ class MCPServerListCreateApi(generics.ListCreateAPIView):
 
     @transaction.atomic
     def create(self, request, *args, **kwargs):
+        valid_resource_names = MCPServerHandler().get_valid_resource_names(
+            gateway_id=self.request.gateway.id, stage_id=request.data["stage_id"]
+        )
         ctx = {
             "gateway": self.request.gateway,
             "created_by": request.user.username,
             "status": MCPServerStatusEnum.ACTIVE.value,
             "source": CallSourceTypeEnum.Web,
+            "valid_resource_names": valid_resource_names,
         }
         slz = MCPServerCreateInputSLZ(data=request.data, context=ctx)
         slz.is_valid(raise_exception=True)

--- a/src/dashboard/apigateway/apigateway/apps/mcp_server/models.py
+++ b/src/dashboard/apigateway/apigateway/apps/mcp_server/models.py
@@ -85,10 +85,6 @@ class MCPServer(TimestampedModelMixin, OperatorModelMixin):
         self._labels = ";".join(value)
 
     @property
-    def tools_count(self) -> int:
-        return len(self.tool_names)
-
-    @property
     def is_active(self) -> bool:
         return self.status == MCPServerStatusEnum.ACTIVE.value
 
@@ -162,6 +158,10 @@ class MCPServer(TimestampedModelMixin, OperatorModelMixin):
         raise NotImplementedError(
             "Not supported, you should use update_resource_names or delete_resource_names instead"
         )
+
+    @property
+    def tools_count(self) -> int:
+        return len(self.tool_names)
 
     def gen_tool_name_map(self) -> Dict[str, str]:
         """生成工具名称映射"""

--- a/src/dashboard/apigateway/apigateway/apps/mcp_server/models.py
+++ b/src/dashboard/apigateway/apigateway/apps/mcp_server/models.py
@@ -117,16 +117,16 @@ class MCPServer(TimestampedModelMixin, OperatorModelMixin):
             "Not supported, you should use update_resource_names or delete_resource_names instead"
         )
 
-    def delete_resource_names(self, to_deleted_resource_names: set) -> bool:
+    def delete_resource_names(self, deleted_resource_names: set) -> bool:
         """移除已删除的资源
 
         Args:
-            deleted_resource_names: 需要删除的纯资源名称集合
+            to_deleted_resource_names: 需要删除的纯资源名称集合
 
         Returns:
             是否有资源被移除
         """
-        if not to_deleted_resource_names:
+        if not deleted_resource_names:
             return False
 
         current_resource_names = self.resource_names
@@ -134,7 +134,7 @@ class MCPServer(TimestampedModelMixin, OperatorModelMixin):
 
         result = []
         for index, resource_name in enumerate(current_resource_names):
-            if resource_name in to_deleted_resource_names:
+            if resource_name in deleted_resource_names:
                 continue
 
             tool_name = current_tool_names[index]

--- a/src/dashboard/apigateway/apigateway/apps/mcp_server/models.py
+++ b/src/dashboard/apigateway/apigateway/apps/mcp_server/models.py
@@ -16,7 +16,7 @@
 # to the current version of the project delivered to anyone in the future.
 #
 
-from typing import ClassVar, Dict, List, Tuple
+from typing import ClassVar, Dict, List
 
 from django.db import models
 from django.utils.translation import gettext_lazy as _
@@ -37,47 +37,8 @@ from .constants import (
 
 # 工具名分隔符：resource_name@tool_name
 TOOL_NAME_SEPARATOR = "@"
-
-
-def parse_resource_name_with_tool(resource_name_with_tool: str) -> Tuple[str, str]:
-    """解析带有工具名的资源名称
-
-    格式: resource_name 或 resource_name@tool_name
-
-    Args:
-        resource_name_with_tool: 资源名称，可能包含工具名
-
-    Returns:
-        (resource_name, tool_name) 元组，如果没有工具名则 tool_name 为空字符串
-    """
-    if TOOL_NAME_SEPARATOR in resource_name_with_tool:
-        parts = resource_name_with_tool.split(TOOL_NAME_SEPARATOR, 1)
-        return parts[0], parts[1]
-    return resource_name_with_tool, ""
-
-
-def get_pure_resource_names(resource_names: List[str]) -> List[str]:
-    """从资源名称列表中提取纯资源名称（去除工具名部分）
-
-    Args:
-        resource_names: 资源名称列表，可能包含 resource_name@tool_name 格式
-
-    Returns:
-        纯资源名称列表
-    """
-    return [parse_resource_name_with_tool(name)[0] for name in resource_names]
-
-
-def get_resource_name_tool_map(resource_names: List[str]) -> Dict[str, str]:
-    """构建资源名称到工具名的映射
-
-    Args:
-        resource_names: 资源名称列表，可能包含 resource_name@tool_name 格式
-
-    Returns:
-        {resource_name: tool_name} 映射，如果没有工具名则值为空字符串
-    """
-    return dict(parse_resource_name_with_tool(name) for name in resource_names)
+POSITION_RESOURCE_NAME = 0
+POSITION_TOOL_NAME = 1
 
 
 class MCPServer(TimestampedModelMixin, OperatorModelMixin):
@@ -91,6 +52,10 @@ class MCPServer(TimestampedModelMixin, OperatorModelMixin):
     is_public = models.BooleanField(default=False)
 
     _labels = models.CharField(db_column="labels", max_length=1024, blank=True, null=True, default="")
+    # db: resource_name_1;resource_name_2@tool_name_2;resource_name_3@tool_name_3
+    # would parse to resource_names and tool_names, if tool_name is empty, it will be the same as resource_name
+    # resource_names: [resource_name_1, resource_name_2, resource_name_3]
+    # tool_names: [resource_name_1, tool_name_2, tool_name_3]
     _resource_names = models.TextField(db_column="resource_names", blank=True, null=True, default="")
 
     status = models.IntegerField(choices=MCPServerStatusEnum.get_choices())
@@ -120,100 +85,43 @@ class MCPServer(TimestampedModelMixin, OperatorModelMixin):
         self._labels = ";".join(value)
 
     @property
-    def resource_names_raw(self) -> List[str]:
-        """获取原始存储格式的资源名称列表（包含工具名）
+    def tools_count(self) -> int:
+        return len(self.tool_names)
 
-        返回格式: ["xxx@yyy", ...] 或 ["xxx", ...]
+    @property
+    def is_active(self) -> bool:
+        return self.status == MCPServerStatusEnum.ACTIVE.value
+
+    def _parse_resource_names_to_part(self, position: int) -> List[str]:
         """
+        db: resource_name_1;resource_name_2@tool_name_2;resource_name_3@tool_name_3
+        position: 0 is resource_names list: [resource_name_1, resource_name_2, resource_name_3]
+        position: 1 is tool_names list:     [resource_name_1, tool_name_2, tool_name_3]
+        """
+
         if not self._resource_names:
             return []
-        return self._resource_names.split(";")
 
-    @resource_names_raw.setter
-    def resource_names_raw(self, value: List[str]):
-        """设置原始存储格式的资源名称列表
-
-        输入格式: ["xxx@yyy", ...] 或 ["xxx", ...]
-        """
-        self._resource_names = ";".join(value)
+        result = []
+        for i in self._resource_names.split(";"):
+            if TOOL_NAME_SEPARATOR in i:
+                result.append(i.split(TOOL_NAME_SEPARATOR)[position])
+            else:
+                result.append(i)
+        return result
 
     @property
     def resource_names(self) -> List[str]:
-        """获取纯资源名称列表（去除工具名部分）
-
-        返回格式: ["xxx", "yyy", ...]
-        注意：此属性保持向后兼容，只返回纯资源名称
-        """
-        return get_pure_resource_names(self.resource_names_raw)
+        """获取纯资源名称列表（去除工具名部分）"""
+        return self._parse_resource_names_to_part(POSITION_RESOURCE_NAME)
 
     @resource_names.setter
     def resource_names(self, value: List[str]):
-        """设置存储格式的资源名称列表（保持与历史行为兼容）
+        raise NotImplementedError(
+            "Not supported, you should use update_resource_names or delete_resource_names instead"
+        )
 
-        注意：
-        - getter 返回的是"纯资源名"（不包含工具名），例如 ["xxx", "yyy", ...]
-        - setter 接受的是"存储格式"的资源名（可能包含工具名），例如 ["xxx@tool", "yyy", ...]
-
-        为避免歧义，新的代码如果需要直接读写存储格式，建议使用：
-        - `resource_names_raw`（List[str]，如 ["xxx@tool", "yyy", ...]）
-        - 或 `resource_names_with_tool`（List[Dict[str, str]]，如 {"resource_name": "xxx", "tool_name": "tool"}）
-        """
-        self._resource_names = ";".join(value)
-
-    @property
-    def resource_names_with_tool(self) -> List[Dict[str, str]]:
-        """获取带工具名的资源名称列表（前端展示格式）
-
-        返回格式: [{"resource_name": "xxx", "tool_name": "yyy"}, ...]
-        """
-        result = []
-        for name in self.resource_names_raw:
-            resource_name, tool_name = parse_resource_name_with_tool(name)
-            result.append({"resource_name": resource_name, "tool_name": tool_name})
-        return result
-
-    @resource_names_with_tool.setter
-    def resource_names_with_tool(self, value: List[Dict[str, str]]):
-        """设置带工具名的资源名称列表（前端输入格式）
-
-        输入格式: [{"resource_name": "xxx", "tool_name": "yyy"}, ...]
-        """
-        self._resource_names = ";".join(self._to_storage_format(value))
-
-    @property
-    def tool_names(self) -> List[str]:
-        """获取工具名列表（与 resource_names 顺序对应）
-
-        返回格式: ["tool1", "", "tool3", ...]
-        如果资源没有自定义工具名，则对应位置为空字符串
-        """
-        return [parse_resource_name_with_tool(name)[1] for name in self.resource_names_raw]
-
-    @staticmethod
-    def _to_storage_format(resource_names: List[Dict[str, str]]) -> List[str]:
-        """将前端格式转换为存储格式"""
-        result = []
-        for item in resource_names:
-            resource_name = item["resource_name"]
-            tool_name = item.get("tool_name", "")
-            if tool_name:
-                result.append(f"{resource_name}{TOOL_NAME_SEPARATOR}{tool_name}")
-            else:
-                result.append(resource_name)
-        return result
-
-    def update_resource_names(self, resource_names_with_tool: List[Dict[str, str]]) -> None:
-        """更新资源名称列表
-
-        此方法封装了资源名称的更新逻辑，包括格式转换。
-
-        Args:
-            resource_names_with_tool: 前端格式的资源名称列表
-                格式: [{"resource_name": "xxx", "tool_name": "yyy"}, ...]
-        """
-        self._resource_names = ";".join(self._to_storage_format(resource_names_with_tool))
-
-    def remove_deleted_resources(self, deleted_resource_names: set) -> bool:
+    def delete_resource_names(self, to_deleted_resource_names: set) -> bool:
         """移除已删除的资源
 
         Args:
@@ -222,28 +130,60 @@ class MCPServer(TimestampedModelMixin, OperatorModelMixin):
         Returns:
             是否有资源被移除
         """
-        if not deleted_resource_names:
+        if not to_deleted_resource_names:
             return False
 
-        new_resource_names_raw = [
-            name
-            for name in self.resource_names_raw
-            if parse_resource_name_with_tool(name)[0] not in deleted_resource_names
-        ]
+        current_resource_names = self.resource_names
+        current_tool_names = self.tool_names
 
-        if len(new_resource_names_raw) == len(self.resource_names_raw):
-            return False
+        result = []
+        for index, resource_name in enumerate(current_resource_names):
+            if resource_name in to_deleted_resource_names:
+                continue
 
-        self._resource_names = ";".join(new_resource_names_raw)
+            tool_name = current_tool_names[index]
+            if tool_name and tool_name != resource_name:
+                result.append(f"{resource_name}{TOOL_NAME_SEPARATOR}{tool_name}")
+            else:
+                result.append(resource_name)
+
+        self._resource_names = ";".join(result)
         return True
 
     @property
-    def tools_count(self) -> int:
-        return len(self.resource_names_raw)
+    def tool_names(self) -> List[str]:
+        """获取工具名列表（与 resource_names 顺序对应）
+        如果没有设置工具名，使用资源名
+        """
+        return self._parse_resource_names_to_part(POSITION_TOOL_NAME)
 
-    @property
-    def is_active(self) -> bool:
-        return self.status == MCPServerStatusEnum.ACTIVE.value
+    @tool_names.setter
+    def tool_names(self, value: List[str]):
+        raise NotImplementedError(
+            "Not supported, you should use update_resource_names or delete_resource_names instead"
+        )
+
+    def gen_tool_name_map(self) -> Dict[str, str]:
+        """生成工具名称映射"""
+        return dict(zip(self.resource_names, self.tool_names))
+
+    def update_resource_names(self, resource_names: List[str], tool_names: List[str]) -> None:
+        """更新资源名称列表
+
+        Args:
+            resource_names: 资源名称列表
+            tool_names: 工具名称列表
+        """
+        if len(resource_names) != len(tool_names):
+            raise ValueError("resource_names and tool_names length must be the same")
+
+        result = []
+        for resource_name, tool_name in zip(resource_names, tool_names):
+            if tool_name and tool_name != resource_name:
+                result.append(f"{resource_name}{TOOL_NAME_SEPARATOR}{tool_name}")
+            else:
+                result.append(resource_name)
+        self._resource_names = ";".join(result)
 
 
 class MCPServerAppPermission(TimestampedModelMixin, OperatorModelMixin):

--- a/src/dashboard/apigateway/apigateway/biz/mcp_server/mcp_server.py
+++ b/src/dashboard/apigateway/apigateway/biz/mcp_server/mcp_server.py
@@ -35,8 +35,6 @@ from apigateway.apps.mcp_server.models import (
     MCPServerAppPermission,
     MCPServerAppPermissionApply,
     MCPServerExtend,
-    get_pure_resource_names,
-    get_resource_name_tool_map,
 )
 from apigateway.apps.permission.constants import GrantTypeEnum
 from apigateway.apps.permission.models import AppResourcePermission
@@ -61,8 +59,8 @@ class MCPServerHandler:
     @staticmethod
     def get_tools_resources_and_labels(
         gateway_id: int, stage_name: str, resource_names: List[str]
-    ) -> Tuple[List[ReleasedResourceData], Dict[int, List], Dict[str, str]]:
-        """获取工具资源列表、标签和工具名映射
+    ) -> Tuple[List[ReleasedResourceData], Dict[int, List]]:
+        """获取工具资源列表、标签
 
         Args:
             gateway_id: 网关 ID
@@ -70,14 +68,11 @@ class MCPServerHandler:
             resource_names: 资源名称列表，支持 resource_name@tool_name 格式
 
         Returns:
-            (tool_resources, labels, tool_name_map) 元组
+            (tool_resources, labels) 元组
             - tool_resources: 资源数据列表
             - labels: 资源标签映射
-            - tool_name_map: {resource_name: tool_name} 映射
         """
-        # 解析资源名称，提取纯资源名和工具名映射
-        pure_resource_names = set(get_pure_resource_names(resource_names))
-        tool_name_map = get_resource_name_tool_map(resource_names)
+        tool_resource_names = set(resource_names)
 
         stage_released_resources = ReleasedResourceHandler.get_public_released_resource_data_list(
             gateway_id,
@@ -87,13 +82,13 @@ class MCPServerHandler:
 
         # only need the resources in the resource_names
         tool_resources: List[ReleasedResourceData] = [
-            r for r in stage_released_resources if r.name in pure_resource_names
+            r for r in stage_released_resources if r.name in tool_resource_names
         ]
 
         label_ids = list({label_id for resource in tool_resources for label_id in resource.gateway_labels})
         labels = ResourceLabelHandler.get_labels_by_ids(label_ids)
 
-        return tool_resources, labels, tool_name_map
+        return tool_resources, labels
 
     @staticmethod
     def get_valid_resource_names(gateway_id: int, stage_id: int) -> Set[str]:
@@ -198,11 +193,9 @@ class MCPServerHandler:
         if not resource_names:
             logger.debug("no resource_names, skip sync the permissions of the mcp_server %d", mcp_server_id)
             return
-        # 解析资源名称，提取纯资源名（去除工具名部分）
-        pure_resource_names = get_pure_resource_names(resource_names)
-        resource_ids = Resource.objects.filter(
-            gateway_id=mcp_server.gateway_id, name__in=pure_resource_names
-        ).values_list("id", flat=True)
+        resource_ids = Resource.objects.filter(gateway_id=mcp_server.gateway_id, name__in=resource_names).values_list(
+            "id", flat=True
+        )
 
         # 3. sync the permission
         newest_virtual_app_code_resource_id_set = {

--- a/src/dashboard/apigateway/apigateway/biz/validators.py
+++ b/src/dashboard/apigateway/apigateway/biz/validators.py
@@ -25,7 +25,7 @@ from django.db.models import Count
 from django.utils.translation import gettext as _
 from rest_framework import serializers
 
-from apigateway.apps.mcp_server.models import MCPServer, parse_resource_name_with_tool
+from apigateway.apps.mcp_server.models import MCPServer
 from apigateway.apps.plugin.constants import PluginBindingScopeEnum
 from apigateway.apps.plugin.models import PluginBinding
 from apigateway.common.constants import STAGE_VAR_NAME_PATTERN, CallSourceTypeEnum, GatewayAPIDocMaintainerTypeEnum
@@ -568,35 +568,20 @@ class MCPServerValidator(GetGatewayFromContextMixin):
         return MCPServerHandler().get_valid_resource_names(gateway_id=gateway.id, stage_id=stage.id)
 
     def _check_all_resources_valid(self, resource_names: list, valid_names: set[str]):
-        """检查资源是否全部有效
-
-        resource_names 支持两种格式:
-        - 字典格式 (Web): [{"resource_name": "xxx", "tool_name": "yyy"}, ...]
-        - 字符串格式 (OpenAPI): ["resource1@tool", "resource2", ...]
-        """
-        for item in resource_names:
-            # 支持字典格式和字符串格式
-            pure_name = item["resource_name"] if isinstance(item, dict) else parse_resource_name_with_tool(item)[0]
-            if pure_name not in valid_names:
+        """检查资源是否全部有效"""
+        for name in resource_names:
+            if name not in valid_names:
                 raise serializers.ValidationError(
-                    _("资源名称列表非法，请检查当前环境发布的最新版本中对应资源名称是否存在")
-                    + f"resource_name={pure_name}"
+                    _("资源名称列表非法，请检查当前环境发布的最新版本中对应资源名称是否存在") + f"resource_name={name}"
                 )
 
     def _check_resource_schemas_confirmed(self, context: dict, resource_names: list):
-        """检查资源 Schema 是否确认 (仅 OpenAPI 来源需要)
-
-        resource_names 支持两种格式:
-        - 字典格式 (Web): [{"resource_name": "xxx", "tool_name": "yyy"}, ...]
-        - 字符串格式 (OpenAPI): ["resource1@tool", "resource2", ...]
-        """
+        """检查资源 Schema 是否确认 (仅 OpenAPI 来源需要)"""
         schema_map = context.get("resource_name_to_schema", {})
-        for item in resource_names:
-            # 支持字典格式和字符串格式
-            pure_name = item["resource_name"] if isinstance(item, dict) else parse_resource_name_with_tool(item)[0]
-            schema = schema_map.get(pure_name)
+        for name in resource_names:
+            schema = schema_map.get(name)
             if not ResourceOpenAPISchemaHandler.has_openapi_schem(schema):
-                raise serializers.ValidationError(_(f"请检查当前资源:{pure_name}对应的资源请求参数是否已经确认"))
+                raise serializers.ValidationError(_(f"请检查当前资源:{name}对应的资源请求参数是否已经确认"))
 
 
 class UpstreamValidator:

--- a/src/dashboard/apigateway/apigateway/service/mcp/mcp_server.py
+++ b/src/dashboard/apigateway/apigateway/service/mcp/mcp_server.py
@@ -51,11 +51,11 @@ def update_stage_mcp_server_related_resource_names(
     to_update: List[MCPServer] = []
     for mcp_server in mcp_servers:
         # 使用纯资源名称进行比较
-        server_pure_resource_names = set(mcp_server.resource_names)
-        deleted_resource_names = server_pure_resource_names - resource_version_resource_names
+        server_resource_names = set(mcp_server.resource_names)
+        deleted_resource_names = server_resource_names - resource_version_resource_names
 
         # 使用 model 方法移除已删除的资源
-        if mcp_server.remove_deleted_resources(deleted_resource_names):
+        if mcp_server.delete_resource_names(deleted_resource_names):
             to_update.append(mcp_server)
 
     if to_update:

--- a/src/dashboard/apigateway/apigateway/tests/apis/v2/sync/test_views.py
+++ b/src/dashboard/apigateway/apigateway/tests/apis/v2/sync/test_views.py
@@ -84,6 +84,7 @@ class TestSyncApi:
                     "labels": ["tag1", "tag2"],
                     "name": "server1",
                     "resource_names": [fake_resource.name],
+                    "tool_names": [fake_resource.name],
                     "is_public": True,
                     "description": "description",
                     "status": 1,

--- a/src/dashboard/apigateway/apigateway/tests/apis/web/mcp_marketplace/test_views.py
+++ b/src/dashboard/apigateway/apigateway/tests/apis/web/mcp_marketplace/test_views.py
@@ -116,7 +116,7 @@ class TestMCPMarketplaceServerRetrieveApi:
         )
         mocker.patch(
             "apigateway.biz.mcp_server.MCPServerHandler.get_tools_resources_and_labels",
-            return_value=([], {}, {}),
+            return_value=([], {}),
         )
 
         resp = request_view(
@@ -139,7 +139,7 @@ class TestMCPMarketplaceServerRetrieveApi:
         )
         mocker.patch(
             "apigateway.biz.mcp_server.MCPServerHandler.get_tools_resources_and_labels",
-            return_value=([], {}, {}),
+            return_value=([], {}),
         )
 
         # 给 mcp_server 添加 prompts，与 MCPServerPromptItemSLZ 字段一致
@@ -254,7 +254,7 @@ class TestMCPMarketplaceServerRetrieveApi:
         )
         mocker.patch(
             "apigateway.biz.mcp_server.MCPServerHandler.get_tools_resources_and_labels",
-            return_value=([], {}, {}),
+            return_value=([], {}),
         )
 
         # 给 mcp_server 添加用户自定义文档
@@ -285,7 +285,7 @@ class TestMCPMarketplaceServerRetrieveApi:
         )
         mocker.patch(
             "apigateway.biz.mcp_server.MCPServerHandler.get_tools_resources_and_labels",
-            return_value=([], {}, {}),
+            return_value=([], {}),
         )
 
         resp = request_view(

--- a/src/dashboard/apigateway/apigateway/tests/apis/web/mcp_server/test_serializers.py
+++ b/src/dashboard/apigateway/apigateway/tests/apis/web/mcp_server/test_serializers.py
@@ -23,7 +23,6 @@ from ddf import G
 
 from apigateway.apis.web.mcp_server.serializers import (
     MCPServerCreateInputSLZ,
-    MCPServerResourceNameInputItemSLZ,
     MCPServerUpdateInputSLZ,
 )
 from apigateway.apps.mcp_server.constants import MCPServerStatusEnum
@@ -31,36 +30,6 @@ from apigateway.apps.mcp_server.models import MCPServer
 from apigateway.common.constants import CallSourceTypeEnum
 
 pytestmark = pytest.mark.django_db
-
-
-class TestMCPServerResourceNameInputItemSLZ:
-    """测试 MCPServerResourceNameInputItemSLZ 序列化器"""
-
-    def test_valid_with_tool_name(self):
-        """测试带 tool_name 的有效数据"""
-        slz = MCPServerResourceNameInputItemSLZ(data={"resource_name": "test_resource", "tool_name": "custom_tool"})
-        assert slz.is_valid()
-        assert slz.validated_data["resource_name"] == "test_resource"
-        assert slz.validated_data["tool_name"] == "custom_tool"
-
-    def test_valid_without_tool_name(self):
-        """测试不带 tool_name 的有效数据"""
-        slz = MCPServerResourceNameInputItemSLZ(data={"resource_name": "test_resource"})
-        assert slz.is_valid()
-        assert slz.validated_data["resource_name"] == "test_resource"
-        assert slz.validated_data["tool_name"] == ""
-
-    def test_valid_with_empty_tool_name(self):
-        """测试 tool_name 为空字符串的情况"""
-        slz = MCPServerResourceNameInputItemSLZ(data={"resource_name": "test_resource", "tool_name": ""})
-        assert slz.is_valid()
-        assert slz.validated_data["tool_name"] == ""
-
-    def test_invalid_missing_resource_name(self):
-        """测试缺少 resource_name 的情况"""
-        slz = MCPServerResourceNameInputItemSLZ(data={"tool_name": "custom_tool"})
-        assert not slz.is_valid()
-        assert "resource_name" in slz.errors
 
 
 class TestMCPServerCreateInputSLZ:
@@ -89,37 +58,13 @@ class TestMCPServerCreateInputSLZ:
             "description": "Test description",
             "stage_id": fake_stage.id,
             "is_public": True,
-            "resource_names": [
-                {"resource_name": "resource1", "tool_name": "custom_tool"},
-                {"resource_name": "resource2", "tool_name": ""},
-            ],
+            "resource_names": ["resource1", "resource2"],
+            "tool_names": ["custom_tool", "resource2"],
         }
         slz = MCPServerCreateInputSLZ(data=data, context={"gateway": fake_gateway, "source": CallSourceTypeEnum.Web})
         assert slz.is_valid(), slz.errors
-        # 验证返回原始格式（由 model 层处理转换）
-        assert slz.validated_data["resource_names"] == [
-            {"resource_name": "resource1", "tool_name": "custom_tool"},
-            {"resource_name": "resource2", "tool_name": ""},
-        ]
-
-    def test_validate_resource_names_duplicate_tool_name(self, fake_gateway, fake_stage):
-        """测试重复的 tool_name"""
-        data = {
-            "name": "test-mcp-server",
-            "description": "Test description",
-            "stage_id": fake_stage.id,
-            "is_public": True,
-            "resource_names": [
-                {"resource_name": "resource1", "tool_name": "same_tool"},
-                {"resource_name": "resource2", "tool_name": "same_tool"},
-            ],
-        }
-        slz = MCPServerCreateInputSLZ(data=data, context={"gateway": fake_gateway, "source": CallSourceTypeEnum.Web})
-        assert not slz.is_valid()
-        assert "resource_names" in slz.errors
-        # 验证错误信息包含重复提示
-        error_msg = str(slz.errors["resource_names"])
-        assert "重复" in error_msg
+        assert slz.validated_data["resource_names"] == ["resource1", "resource2"]
+        assert slz.validated_data["tool_names"] == ["custom_tool", "resource2"]
 
     def test_validate_resource_names_duplicate_resource_name(self, fake_gateway, fake_stage):
         """测试重复的 resource_name"""
@@ -128,15 +73,30 @@ class TestMCPServerCreateInputSLZ:
             "description": "Test description",
             "stage_id": fake_stage.id,
             "is_public": True,
-            "resource_names": [
-                {"resource_name": "resource1", "tool_name": "tool1"},
-                {"resource_name": "resource1", "tool_name": "tool2"},
-            ],
+            "resource_names": ["resource1", "resource1"],
+            "tool_names": ["tool1", "tool2"],
         }
         slz = MCPServerCreateInputSLZ(data=data, context={"gateway": fake_gateway, "source": CallSourceTypeEnum.Web})
         assert not slz.is_valid()
         assert "resource_names" in slz.errors
         error_msg = str(slz.errors["resource_names"])
+        assert "重复" in error_msg
+
+    def test_validate_resource_names_duplicate_tool_name(self, fake_gateway, fake_stage):
+        """测试重复的 tool_name"""
+        data = {
+            "name": "test-mcp-server",
+            "description": "Test description",
+            "stage_id": fake_stage.id,
+            "is_public": True,
+            "resource_names": ["resource1", "resource2"],
+            "tool_names": ["same_tool", "same_tool"],
+        }
+        slz = MCPServerCreateInputSLZ(data=data, context={"gateway": fake_gateway, "source": CallSourceTypeEnum.Web})
+        assert not slz.is_valid()
+        assert "resource_names" in slz.errors
+        # 验证错误信息包含重复提示
+        error_msg = str(slz.errors["tool_names"])
         assert "重复" in error_msg
 
     @patch("apigateway.biz.validators.MCPServerHandler.get_valid_resource_names")
@@ -149,20 +109,13 @@ class TestMCPServerCreateInputSLZ:
             "description": "Test description",
             "stage_id": fake_stage.id,
             "is_public": True,
-            "resource_names": [
-                {"resource_name": "resource1", "tool_name": ""},
-                {"resource_name": "resource2", "tool_name": ""},
-                {"resource_name": "resource3"},
-            ],
+            "resource_names": ["resource1", "resource2", "resource3"],
+            "tool_names": ["resource1", "resource2", "resource3"],
         }
         slz = MCPServerCreateInputSLZ(data=data, context={"gateway": fake_gateway, "source": CallSourceTypeEnum.Web})
         assert slz.is_valid(), slz.errors
-        # 验证返回原始格式（由 model 层处理转换）
-        assert slz.validated_data["resource_names"] == [
-            {"resource_name": "resource1", "tool_name": ""},
-            {"resource_name": "resource2", "tool_name": ""},
-            {"resource_name": "resource3", "tool_name": ""},
-        ]
+        assert slz.validated_data["resource_names"] == ["resource1", "resource2", "resource3"]
+        assert slz.validated_data["tool_names"] == ["resource1", "resource2", "resource3"]
 
 
 class TestMCPServerUpdateInputSLZ:
@@ -188,9 +141,8 @@ class TestMCPServerUpdateInputSLZ:
         mcp_server = G(MCPServer, gateway=fake_gateway, stage=fake_stage, status=MCPServerStatusEnum.ACTIVE.value)
         data = {
             "description": "Updated description",
-            "resource_names": [
-                {"resource_name": "invalid_resource", "tool_name": ""},
-            ],
+            "resource_names": ["invalid_resource"],
+            "tool_names": ["invalid_tool"],
         }
         slz = MCPServerUpdateInputSLZ(
             instance=mcp_server,
@@ -205,10 +157,8 @@ class TestMCPServerUpdateInputSLZ:
         mcp_server = G(MCPServer, gateway=fake_gateway, stage=fake_stage, status=MCPServerStatusEnum.ACTIVE.value)
         data = {
             "description": "Updated description",
-            "resource_names": [
-                {"resource_name": "resource1", "tool_name": "custom_tool"},
-                {"resource_name": "resource2", "tool_name": ""},
-            ],
+            "resource_names": ["resource1", "resource2"],
+            "tool_names": ["custom_tool", "resource2"],
         }
         slz = MCPServerUpdateInputSLZ(
             instance=mcp_server,
@@ -217,20 +167,16 @@ class TestMCPServerUpdateInputSLZ:
         )
         assert slz.is_valid(), slz.errors
         # 验证返回原始格式（由 model 层处理转换）
-        assert slz.validated_data["resource_names"] == [
-            {"resource_name": "resource1", "tool_name": "custom_tool"},
-            {"resource_name": "resource2", "tool_name": ""},
-        ]
+        assert slz.validated_data["resource_names"] == ["resource1", "resource2"]
+        assert slz.validated_data["tool_names"] == ["custom_tool", "resource2"]
 
     def test_validate_resource_names_duplicate_tool_name(self, fake_gateway, fake_stage):
         """测试重复的 tool_name"""
         mcp_server = G(MCPServer, gateway=fake_gateway, stage=fake_stage, status=MCPServerStatusEnum.ACTIVE.value)
         data = {
             "description": "Updated description",
-            "resource_names": [
-                {"resource_name": "resource1", "tool_name": "same_tool"},
-                {"resource_name": "resource2", "tool_name": "same_tool"},
-            ],
+            "resource_names": ["resource1", "resource2"],
+            "tool_names": ["same_tool", "same_tool"],
         }
         slz = MCPServerUpdateInputSLZ(
             instance=mcp_server,
@@ -239,7 +185,7 @@ class TestMCPServerUpdateInputSLZ:
         )
         assert not slz.is_valid()
         assert "resource_names" in slz.errors
-        error_msg = str(slz.errors["resource_names"])
+        error_msg = str(slz.errors["tool_names"])
         assert "重复" in error_msg
 
     def test_validate_resource_names_duplicate_resource_name(self, fake_gateway, fake_stage):
@@ -247,10 +193,8 @@ class TestMCPServerUpdateInputSLZ:
         mcp_server = G(MCPServer, gateway=fake_gateway, stage=fake_stage, status=MCPServerStatusEnum.ACTIVE.value)
         data = {
             "description": "Updated description",
-            "resource_names": [
-                {"resource_name": "resource1", "tool_name": "tool1"},
-                {"resource_name": "resource1", "tool_name": "tool2"},
-            ],
+            "resource_names": ["resource1", "resource1"],
+            "tool_names": ["tool1", "tool2"],
         }
         slz = MCPServerUpdateInputSLZ(
             instance=mcp_server,
@@ -267,10 +211,8 @@ class TestMCPServerUpdateInputSLZ:
         mcp_server = G(MCPServer, gateway=fake_gateway, stage=fake_stage, status=MCPServerStatusEnum.ACTIVE.value)
         data = {
             "description": "Updated description",
-            "resource_names": [
-                {"resource_name": "resource1", "tool_name": ""},
-                {"resource_name": "resource2"},
-            ],
+            "resource_names": ["resource1", "resource2"],
+            "tool_names": ["resource1", "resource2"],
         }
         slz = MCPServerUpdateInputSLZ(
             instance=mcp_server,
@@ -279,10 +221,8 @@ class TestMCPServerUpdateInputSLZ:
         )
         assert slz.is_valid(), slz.errors
         # 验证返回原始格式（由 model 层处理转换）
-        assert slz.validated_data["resource_names"] == [
-            {"resource_name": "resource1", "tool_name": ""},
-            {"resource_name": "resource2", "tool_name": ""},
-        ]
+        assert slz.validated_data["resource_names"] == ["resource1", "resource2"]
+        assert slz.validated_data["tool_names"] == ["resource1", "resource2"]
 
     def test_validate_resource_names_none(self, fake_gateway, fake_stage):
         """测试 resource_names 为 None（不更新）"""

--- a/src/dashboard/apigateway/apigateway/tests/apis/web/mcp_server/test_serializers.py
+++ b/src/dashboard/apigateway/apigateway/tests/apis/web/mcp_server/test_serializers.py
@@ -44,7 +44,13 @@ class TestMCPServerCreateInputSLZ:
             "is_public": True,
             "resource_names": [],
         }
-        slz = MCPServerCreateInputSLZ(data=data, context={"gateway": fake_gateway, "source": CallSourceTypeEnum.Web})
+        context = {
+            "gateway": fake_gateway,
+            "source": CallSourceTypeEnum.Web,
+            "valid_resource_names": {"resource1", "resource2"},
+        }
+
+        slz = MCPServerCreateInputSLZ(data=data, context=context)
         assert not slz.is_valid()
         assert "resource_names" in slz.errors
 
@@ -61,7 +67,12 @@ class TestMCPServerCreateInputSLZ:
             "resource_names": ["resource1", "resource2"],
             "tool_names": ["custom_tool", "resource2"],
         }
-        slz = MCPServerCreateInputSLZ(data=data, context={"gateway": fake_gateway, "source": CallSourceTypeEnum.Web})
+        context = {
+            "gateway": fake_gateway,
+            "source": CallSourceTypeEnum.Web,
+            "valid_resource_names": {"resource1", "resource2"},
+        }
+        slz = MCPServerCreateInputSLZ(data=data, context=context)
         assert slz.is_valid(), slz.errors
         assert slz.validated_data["resource_names"] == ["resource1", "resource2"]
         assert slz.validated_data["tool_names"] == ["custom_tool", "resource2"]
@@ -76,13 +87,18 @@ class TestMCPServerCreateInputSLZ:
             "resource_names": ["resource1", "resource1"],
             "tool_names": ["tool1", "tool2"],
         }
-        slz = MCPServerCreateInputSLZ(data=data, context={"gateway": fake_gateway, "source": CallSourceTypeEnum.Web})
+        context = {
+            "gateway": fake_gateway,
+            "source": CallSourceTypeEnum.Web,
+            "valid_resource_names": {"resource1", "resource2"},
+        }
+        slz = MCPServerCreateInputSLZ(data=data, context=context)
         assert not slz.is_valid()
         assert "resource_names" in slz.errors
         error_msg = str(slz.errors["resource_names"])
         assert "重复" in error_msg
 
-    def test_validate_resource_names_duplicate_tool_name(self, fake_gateway, fake_stage):
+    def test_validate_tool_names_duplicate_tool_name(self, fake_gateway, fake_stage):
         """测试重复的 tool_name"""
         data = {
             "name": "test-mcp-server",
@@ -92,9 +108,14 @@ class TestMCPServerCreateInputSLZ:
             "resource_names": ["resource1", "resource2"],
             "tool_names": ["same_tool", "same_tool"],
         }
-        slz = MCPServerCreateInputSLZ(data=data, context={"gateway": fake_gateway, "source": CallSourceTypeEnum.Web})
+        context = {
+            "gateway": fake_gateway,
+            "source": CallSourceTypeEnum.Web,
+            "valid_resource_names": {"resource1", "resource2"},
+        }
+        slz = MCPServerCreateInputSLZ(data=data, context=context)
         assert not slz.is_valid()
-        assert "resource_names" in slz.errors
+        assert "tool_names" in slz.errors
         # 验证错误信息包含重复提示
         error_msg = str(slz.errors["tool_names"])
         assert "重复" in error_msg
@@ -112,7 +133,12 @@ class TestMCPServerCreateInputSLZ:
             "resource_names": ["resource1", "resource2", "resource3"],
             "tool_names": ["resource1", "resource2", "resource3"],
         }
-        slz = MCPServerCreateInputSLZ(data=data, context={"gateway": fake_gateway, "source": CallSourceTypeEnum.Web})
+        context = {
+            "gateway": fake_gateway,
+            "source": CallSourceTypeEnum.Web,
+            "valid_resource_names": {"resource1", "resource2", "resource3"},
+        }
+        slz = MCPServerCreateInputSLZ(data=data, context=context)
         assert slz.is_valid(), slz.errors
         assert slz.validated_data["resource_names"] == ["resource1", "resource2", "resource3"]
         assert slz.validated_data["tool_names"] == ["resource1", "resource2", "resource3"]
@@ -142,7 +168,7 @@ class TestMCPServerUpdateInputSLZ:
         data = {
             "description": "Updated description",
             "resource_names": ["invalid_resource"],
-            "tool_names": ["invalid_tool"],
+            "tool_names": ["invalid_resource"],
         }
         slz = MCPServerUpdateInputSLZ(
             instance=mcp_server,
@@ -170,7 +196,7 @@ class TestMCPServerUpdateInputSLZ:
         assert slz.validated_data["resource_names"] == ["resource1", "resource2"]
         assert slz.validated_data["tool_names"] == ["custom_tool", "resource2"]
 
-    def test_validate_resource_names_duplicate_tool_name(self, fake_gateway, fake_stage):
+    def test_validate_tool_names_duplicate_tool_name(self, fake_gateway, fake_stage):
         """测试重复的 tool_name"""
         mcp_server = G(MCPServer, gateway=fake_gateway, stage=fake_stage, status=MCPServerStatusEnum.ACTIVE.value)
         data = {
@@ -184,7 +210,7 @@ class TestMCPServerUpdateInputSLZ:
             context={"valid_resource_names": {"resource1", "resource2"}},
         )
         assert not slz.is_valid()
-        assert "resource_names" in slz.errors
+        assert "tool_names" in slz.errors
         error_msg = str(slz.errors["tool_names"])
         assert "重复" in error_msg
 

--- a/src/dashboard/apigateway/apigateway/tests/apis/web/mcp_server/test_views.py
+++ b/src/dashboard/apigateway/apigateway/tests/apis/web/mcp_server/test_views.py
@@ -128,10 +128,7 @@ class TestMCPServerListCreateApi:
             "stage_id": fake_stage.id,
             "is_public": True,
             "labels": ["test"],
-            "resource_names": [
-                {"resource_name": "resource1", "tool_name": ""},
-                {"resource_name": "resource2", "tool_name": ""},
-            ],
+            "resource_names": ["resource1", "resource2"],
         }
 
         resp = request_view(
@@ -168,10 +165,7 @@ class TestMCPServerListCreateApi:
             "stage_id": fake_stage.id,
             "is_public": True,
             "labels": ["test"],
-            "resource_names": [
-                {"resource_name": "resource1", "tool_name": ""},
-                {"resource_name": "resource2", "tool_name": ""},
-            ],
+            "resource_names": ["resource1", "resource2"],
             "prompts": [
                 {
                     "id": 1,
@@ -238,10 +232,7 @@ class TestMCPServerRetrieveUpdateDestroyApi:
             "description": faker.pystr(),
             "is_public": False,
             "labels": ["new-label"],
-            "resource_names": [
-                {"resource_name": "resource1", "tool_name": ""},
-                {"resource_name": "resource3", "tool_name": ""},
-            ],
+            "resource_names": ["resource1", "resource3"],
         }
 
         resp = request_view(
@@ -324,7 +315,7 @@ class TestMCPServerToolsListApi:
     def test_list(self, mocker, request_view, fake_gateway, fake_mcp_server):
         mocker.patch(
             "apigateway.biz.mcp_server.MCPServerHandler.get_tools_resources_and_labels",
-            return_value=([], {}, {}),
+            return_value=([], {}),
         )
 
         resp = request_view(
@@ -1360,10 +1351,7 @@ class TestMCPServerProtocolType:
             "stage_id": fake_stage.id,
             "is_public": True,
             "labels": ["test"],
-            "resource_names": [
-                {"resource_name": "resource1", "tool_name": ""},
-                {"resource_name": "resource2", "tool_name": ""},
-            ],
+            "resource_names": ["resource1", "resource2"],
         }
 
         resp = request_view(
@@ -1397,10 +1385,7 @@ class TestMCPServerProtocolType:
             "stage_id": fake_stage.id,
             "is_public": True,
             "labels": ["test"],
-            "resource_names": [
-                {"resource_name": "resource1", "tool_name": ""},
-                {"resource_name": "resource2", "tool_name": ""},
-            ],
+            "resource_names": ["resource1", "resource2"],
             "protocol_type": MCPServerProtocolTypeEnum.STREAMABLE_HTTP.value,
         }
 

--- a/src/dashboard/apigateway/apigateway/tests/apis/web/mcp_server/test_views.py
+++ b/src/dashboard/apigateway/apigateway/tests/apis/web/mcp_server/test_views.py
@@ -129,6 +129,7 @@ class TestMCPServerListCreateApi:
             "is_public": True,
             "labels": ["test"],
             "resource_names": ["resource1", "resource2"],
+            "tool_names": ["resource1", "resource2"],
         }
 
         resp = request_view(
@@ -166,6 +167,7 @@ class TestMCPServerListCreateApi:
             "is_public": True,
             "labels": ["test"],
             "resource_names": ["resource1", "resource2"],
+            "tool_names": ["resource1", "resource2"],
             "prompts": [
                 {
                     "id": 1,
@@ -233,6 +235,7 @@ class TestMCPServerRetrieveUpdateDestroyApi:
             "is_public": False,
             "labels": ["new-label"],
             "resource_names": ["resource1", "resource3"],
+            "tool_names": ["tool1", "tool3"],
         }
 
         resp = request_view(
@@ -1352,6 +1355,7 @@ class TestMCPServerProtocolType:
             "is_public": True,
             "labels": ["test"],
             "resource_names": ["resource1", "resource2"],
+            "tool_names": ["tool1", "tool2"],
         }
 
         resp = request_view(
@@ -1386,6 +1390,7 @@ class TestMCPServerProtocolType:
             "is_public": True,
             "labels": ["test"],
             "resource_names": ["resource1", "resource2"],
+            "tool_names": ["tool1", "tool2"],
             "protocol_type": MCPServerProtocolTypeEnum.STREAMABLE_HTTP.value,
         }
 

--- a/src/dashboard/apigateway/apigateway/tests/apps/mcp_server/test_models.py
+++ b/src/dashboard/apigateway/apigateway/tests/apps/mcp_server/test_models.py
@@ -22,104 +22,7 @@ from apigateway.apps.mcp_server.constants import MCPServerStatusEnum
 from apigateway.apps.mcp_server.models import (
     TOOL_NAME_SEPARATOR,
     MCPServer,
-    get_pure_resource_names,
-    get_resource_name_tool_map,
-    parse_resource_name_with_tool,
 )
-
-
-class TestParseResourceNameWithTool:
-    """测试 parse_resource_name_with_tool 函数"""
-
-    def test_without_tool_name(self):
-        """测试不带工具名的资源名称"""
-        resource_name, tool_name = parse_resource_name_with_tool("resource1")
-        assert resource_name == "resource1"
-        assert tool_name == ""
-
-    def test_with_tool_name(self):
-        """测试带工具名的资源名称"""
-        resource_name, tool_name = parse_resource_name_with_tool("resource1@custom_tool")
-        assert resource_name == "resource1"
-        assert tool_name == "custom_tool"
-
-    def test_with_multiple_separators(self):
-        """测试包含多个分隔符的情况（只分割第一个）"""
-        resource_name, tool_name = parse_resource_name_with_tool("resource1@tool@extra")
-        assert resource_name == "resource1"
-        assert tool_name == "tool@extra"
-
-    def test_empty_string(self):
-        """测试空字符串"""
-        resource_name, tool_name = parse_resource_name_with_tool("")
-        assert resource_name == ""
-        assert tool_name == ""
-
-    def test_only_separator(self):
-        """测试只有分隔符"""
-        resource_name, tool_name = parse_resource_name_with_tool("@")
-        assert resource_name == ""
-        assert tool_name == ""
-
-    def test_separator_at_end(self):
-        """测试分隔符在末尾"""
-        resource_name, tool_name = parse_resource_name_with_tool("resource1@")
-        assert resource_name == "resource1"
-        assert tool_name == ""
-
-
-class TestGetPureResourceNames:
-    """测试 get_pure_resource_names 函数"""
-
-    def test_without_tool_name(self):
-        """测试不带工具名的资源名称"""
-        resource_names = ["resource1", "resource2"]
-        result = get_pure_resource_names(resource_names)
-        assert result == ["resource1", "resource2"]
-
-    def test_with_tool_name(self):
-        """测试带工具名的资源名称"""
-        resource_names = ["resource1@custom_tool1", "resource2@custom_tool2"]
-        result = get_pure_resource_names(resource_names)
-        assert result == ["resource1", "resource2"]
-
-    def test_mixed(self):
-        """测试混合情况"""
-        resource_names = ["resource1@custom_tool", "resource2", "resource3@tool3"]
-        result = get_pure_resource_names(resource_names)
-        assert result == ["resource1", "resource2", "resource3"]
-
-    def test_empty_list(self):
-        """测试空列表"""
-        result = get_pure_resource_names([])
-        assert result == []
-
-
-class TestGetResourceNameToolMap:
-    """测试 get_resource_name_tool_map 函数"""
-
-    def test_without_tool_name(self):
-        """测试不带工具名的资源名称"""
-        resource_names = ["resource1", "resource2"]
-        result = get_resource_name_tool_map(resource_names)
-        assert result == {"resource1": "", "resource2": ""}
-
-    def test_with_tool_name(self):
-        """测试带工具名的资源名称"""
-        resource_names = ["resource1@custom_tool1", "resource2@custom_tool2"]
-        result = get_resource_name_tool_map(resource_names)
-        assert result == {"resource1": "custom_tool1", "resource2": "custom_tool2"}
-
-    def test_mixed(self):
-        """测试混合情况"""
-        resource_names = ["resource1@custom_tool", "resource2", "resource3@tool3"]
-        result = get_resource_name_tool_map(resource_names)
-        assert result == {"resource1": "custom_tool", "resource2": "", "resource3": "tool3"}
-
-    def test_empty_list(self):
-        """测试空列表"""
-        result = get_resource_name_tool_map([])
-        assert result == {}
 
 
 class TestToolNameSeparator:
@@ -138,49 +41,11 @@ class TestMCPServer:
         mcp_server.labels = ["label1", "label2"]
         assert mcp_server.labels == ["label1", "label2"]
 
-    def test_resource_names_without_tool(self):
-        """测试不带工具名的 resource_names"""
+    def test_resource_names(self):
         mcp_server = G(MCPServer)
         assert mcp_server.resource_names == []
 
-        mcp_server.resource_names = ["resource1", "resource2"]
-        assert mcp_server.resource_names == ["resource1", "resource2"]
-
-    def test_resource_names_with_tool(self):
-        """测试带工具名的 resource_names（返回纯资源名称）"""
-        mcp_server = G(MCPServer)
-        mcp_server.resource_names = ["resource1@custom_tool", "resource2"]
-
-        # resource_names 返回纯资源名称
-        assert mcp_server.resource_names == ["resource1", "resource2"]
-
-    def test_resource_names_raw(self):
-        """测试 resource_names_raw 属性"""
-        mcp_server = G(MCPServer)
-        assert mcp_server.resource_names_raw == []
-
-        mcp_server.resource_names_raw = ["resource1@custom_tool", "resource2"]
-        assert mcp_server.resource_names_raw == ["resource1@custom_tool", "resource2"]
-
-    def test_resource_names_with_tool_property(self):
-        """测试 resource_names_with_tool 属性"""
-        mcp_server = G(MCPServer)
-        mcp_server.resource_names_raw = ["resource1@custom_tool", "resource2"]
-
-        assert mcp_server.resource_names_with_tool == [
-            {"resource_name": "resource1", "tool_name": "custom_tool"},
-            {"resource_name": "resource2", "tool_name": ""},
-        ]
-
-    def test_resource_names_with_tool_setter(self):
-        """测试 resource_names_with_tool setter"""
-        mcp_server = G(MCPServer)
-        mcp_server.resource_names_with_tool = [
-            {"resource_name": "resource1", "tool_name": "custom_tool"},
-            {"resource_name": "resource2", "tool_name": ""},
-        ]
-
-        assert mcp_server.resource_names_raw == ["resource1@custom_tool", "resource2"]
+        mcp_server._resource_names = "resource1;resource2"
         assert mcp_server.resource_names == ["resource1", "resource2"]
 
     def test_is_active(self):
@@ -190,95 +55,10 @@ class TestMCPServer:
         mcp_server.status = MCPServerStatusEnum.ACTIVE.value
         assert mcp_server.is_active is True
 
-    def test_tools_count_without_tool_name(self):
+    def test_tools_count(self):
         """测试不带工具名的 tools_count"""
         mcp_server = G(MCPServer)
         assert mcp_server.tools_count == 0
 
-        mcp_server.resource_names = ["resource1", "resource2"]
+        mcp_server._resource_names = "resource1;resource2"
         assert mcp_server.tools_count == 2
-
-    def test_tools_count_with_tool_name(self):
-        """测试带工具名的 tools_count"""
-        mcp_server = G(MCPServer)
-        mcp_server.resource_names_raw = ["resource1@custom_tool", "resource2"]
-        assert mcp_server.tools_count == 2
-
-    def test_empty_resource_names(self):
-        """测试空资源名称的各种属性"""
-        mcp_server = G(MCPServer)
-        mcp_server._resource_names = ""
-
-        assert mcp_server.resource_names == []
-        assert mcp_server.resource_names_raw == []
-        assert mcp_server.resource_names_with_tool == []
-        assert mcp_server.tools_count == 0
-
-    def test_tool_names_property(self):
-        """测试 tool_names 属性"""
-        mcp_server = G(MCPServer)
-        mcp_server.resource_names_raw = ["resource1@custom_tool", "resource2", "resource3@tool3"]
-
-        assert mcp_server.tool_names == ["custom_tool", "", "tool3"]
-
-    def test_tool_names_empty(self):
-        """测试空资源时的 tool_names"""
-        mcp_server = G(MCPServer)
-        mcp_server._resource_names = ""
-
-        assert mcp_server.tool_names == []
-
-    def test_update_resource_names(self):
-        """测试 update_resource_names 方法"""
-        mcp_server = G(MCPServer)
-        mcp_server.update_resource_names(
-            [
-                {"resource_name": "resource1", "tool_name": "custom_tool"},
-                {"resource_name": "resource2", "tool_name": ""},
-            ]
-        )
-
-        assert mcp_server.resource_names_raw == ["resource1@custom_tool", "resource2"]
-        assert mcp_server.resource_names == ["resource1", "resource2"]
-
-    def test_remove_deleted_resources_some_deleted(self):
-        """测试 remove_deleted_resources 方法 - 部分删除"""
-        mcp_server = G(MCPServer)
-        mcp_server.resource_names_raw = ["resource1@custom_tool", "resource2", "resource3@tool3"]
-
-        result = mcp_server.remove_deleted_resources({"resource2"})
-
-        assert result is True
-        assert mcp_server.resource_names_raw == ["resource1@custom_tool", "resource3@tool3"]
-        assert mcp_server.resource_names == ["resource1", "resource3"]
-
-    def test_remove_deleted_resources_all_deleted(self):
-        """测试 remove_deleted_resources 方法 - 全部删除"""
-        mcp_server = G(MCPServer)
-        mcp_server.resource_names_raw = ["resource1@custom_tool", "resource2"]
-
-        result = mcp_server.remove_deleted_resources({"resource1", "resource2"})
-
-        assert result is True
-        assert mcp_server.resource_names_raw == []
-        assert mcp_server.resource_names == []
-
-    def test_remove_deleted_resources_none_deleted(self):
-        """测试 remove_deleted_resources 方法 - 无删除"""
-        mcp_server = G(MCPServer)
-        mcp_server.resource_names_raw = ["resource1@custom_tool", "resource2"]
-
-        result = mcp_server.remove_deleted_resources({"resource3", "resource4"})
-
-        assert result is False
-        assert mcp_server.resource_names_raw == ["resource1@custom_tool", "resource2"]
-
-    def test_remove_deleted_resources_empty_set(self):
-        """测试 remove_deleted_resources 方法 - 空集合"""
-        mcp_server = G(MCPServer)
-        mcp_server.resource_names_raw = ["resource1@custom_tool", "resource2"]
-
-        result = mcp_server.remove_deleted_resources(set())
-
-        assert result is False
-        assert mcp_server.resource_names_raw == ["resource1@custom_tool", "resource2"]

--- a/src/dashboard/apigateway/apigateway/tests/apps/mcp_server/test_models.py
+++ b/src/dashboard/apigateway/apigateway/tests/apps/mcp_server/test_models.py
@@ -93,6 +93,16 @@ class TestMCPServer:
         assert mcp_server.delete_resource_names({"resource1", "resource3"})
         assert mcp_server.resource_names == ["resource2"]
 
+        # Test edge case: trying to delete nonexistent resources should return False
+        mcp_server._resource_names = "resource1;resource2;resource3"
+        assert mcp_server.delete_resource_names({"nonexistent_resource"})
+        assert mcp_server.resource_names == ["resource1", "resource2", "resource3"]
+
+        # Test edge case: trying to delete nonexistent resources with tool names should return False
+        mcp_server._resource_names = "resource1@tool1;resource2@tool2"
+        assert mcp_server.delete_resource_names({"resource_x", "resource_y"})
+        assert mcp_server.resource_names == ["resource1", "resource2"]
+
     def test_tool_names(self):
         mcp_server = G(MCPServer)
         assert mcp_server.tool_names == []

--- a/src/dashboard/apigateway/apigateway/tests/apps/mcp_server/test_models.py
+++ b/src/dashboard/apigateway/apigateway/tests/apps/mcp_server/test_models.py
@@ -16,6 +16,7 @@
 # to the current version of the project delivered to anyone in the future.
 #
 
+import pytest
 from ddf import G
 
 from apigateway.apps.mcp_server.constants import MCPServerStatusEnum
@@ -41,6 +42,30 @@ class TestMCPServer:
         mcp_server.labels = ["label1", "label2"]
         assert mcp_server.labels == ["label1", "label2"]
 
+    def test_is_active(self):
+        mcp_server = G(MCPServer)
+        assert mcp_server.is_active is False
+
+        mcp_server.status = MCPServerStatusEnum.ACTIVE.value
+        assert mcp_server.is_active is True
+
+    def test_parse_resource_names_to_part(self):
+        mcp_server = G(MCPServer)
+        assert mcp_server._parse_resource_names_to_part(0) == []
+        assert mcp_server._parse_resource_names_to_part(1) == []
+
+        mcp_server._resource_names = "resource1;resource2;resource3"
+        assert mcp_server._parse_resource_names_to_part(0) == ["resource1", "resource2", "resource3"]
+        assert mcp_server._parse_resource_names_to_part(1) == ["resource1", "resource2", "resource3"]
+
+        mcp_server._resource_names = "resource1@tool1;resource2@tool2;resource3@tool3"
+        assert mcp_server._parse_resource_names_to_part(0) == ["resource1", "resource2", "resource3"]
+        assert mcp_server._parse_resource_names_to_part(1) == ["tool1", "tool2", "tool3"]
+
+        mcp_server._resource_names = "resource1@tool1;resource2@tool2;resource3"
+        assert mcp_server._parse_resource_names_to_part(0) == ["resource1", "resource2", "resource3"]
+        assert mcp_server._parse_resource_names_to_part(1) == ["tool1", "tool2", "resource3"]
+
     def test_resource_names(self):
         mcp_server = G(MCPServer)
         assert mcp_server.resource_names == []
@@ -48,12 +73,43 @@ class TestMCPServer:
         mcp_server._resource_names = "resource1;resource2"
         assert mcp_server.resource_names == ["resource1", "resource2"]
 
-    def test_is_active(self):
-        mcp_server = G(MCPServer)
-        assert mcp_server.is_active is False
+        mcp_server._resource_names = "resource1@tool1;resource2@tool2;resource3"
+        assert mcp_server.resource_names == ["resource1", "resource2", "resource3"]
 
-        mcp_server.status = MCPServerStatusEnum.ACTIVE.value
-        assert mcp_server.is_active is True
+    def test_resource_names_setter(self):
+        mcp_server = G(MCPServer)
+        with pytest.raises(NotImplementedError):
+            mcp_server.resource_names = ["resource1", "resource2"]
+
+    def test_delete_resource_names(self):
+        mcp_server = G(MCPServer)
+        assert not mcp_server.delete_resource_names(set())
+
+        mcp_server._resource_names = "resource1;resource2;resource3"
+        assert mcp_server.delete_resource_names({"resource1", "resource2"})
+        assert mcp_server.resource_names == ["resource3"]
+
+        mcp_server._resource_names = "resource1@tool1;resource2@tool2;resource3@tool3"
+        assert mcp_server.delete_resource_names({"resource1", "resource3"})
+        assert mcp_server.resource_names == ["resource2"]
+
+    def test_tool_names(self):
+        mcp_server = G(MCPServer)
+        assert mcp_server.tool_names == []
+
+        mcp_server._resource_names = "resource1;resource2"
+        assert mcp_server.tool_names == ["resource1", "resource2"]
+
+        mcp_server._resource_names = "resource1@tool1;resource2@tool2;resource3@tool3"
+        assert mcp_server.tool_names == ["tool1", "tool2", "tool3"]
+
+        mcp_server._resource_names = "resource1@tool1;resource2@tool2;resource3"
+        assert mcp_server.tool_names == ["tool1", "tool2", "resource3"]
+
+    def test_tool_names_setter(self):
+        mcp_server = G(MCPServer)
+        with pytest.raises(NotImplementedError):
+            mcp_server.tool_names = ["tool1", "tool2"]
 
     def test_tools_count(self):
         """测试不带工具名的 tools_count"""
@@ -62,3 +118,28 @@ class TestMCPServer:
 
         mcp_server._resource_names = "resource1;resource2"
         assert mcp_server.tools_count == 2
+
+        mcp_server._resource_names = "resource1@tool1;resource2@tool2;resource3@tool3"
+        assert mcp_server.tools_count == 3
+
+    def test_update_resource_names(self):
+        mcp_server = G(MCPServer)
+        with pytest.raises(ValueError):
+            mcp_server.update_resource_names(["resource1", "resource2"], ["tool1"])
+
+        mcp_server._resource_names = "resource1;resource2;resource3"
+        mcp_server.update_resource_names(["resource1", "resource2", "resource4"], ["tool1", "tool2", "tool4"])
+        assert mcp_server.resource_names == ["resource1", "resource2", "resource4"]
+        assert mcp_server.tool_names == ["tool1", "tool2", "tool4"]
+
+        mcp_server._resource_names = "resource1@tool1;resource2@tool2;resource3@tool3"
+        mcp_server.update_resource_names(["resource1", "resource2", "resource4"], ["tool11", "tool22", "tool44"])
+        assert mcp_server.resource_names == ["resource1", "resource2", "resource4"]
+        assert mcp_server.tool_names == ["tool11", "tool22", "tool44"]
+
+        mcp_server._resource_names = "resource1@tool1;resource2@tool2;resource3"
+        mcp_server.update_resource_names(
+            ["resource1", "resource2", "resource4"], ["resource1", "resource2", "resource4"]
+        )
+        assert mcp_server.resource_names == ["resource1", "resource2", "resource4"]
+        assert mcp_server.tool_names == ["resource1", "resource2", "resource4"]

--- a/src/dashboard/apigateway/apigateway/tests/biz/mcp_server/test_mcp_server.py
+++ b/src/dashboard/apigateway/apigateway/tests/biz/mcp_server/test_mcp_server.py
@@ -91,7 +91,7 @@ class TestMCPServerHandler:
         """Test sync_permissions when no resource names exist - should return early"""
         # Create MCP server with app permissions but no resource names
         mcp_server = G(MCPServer, gateway=fake_gateway, stage=fake_stage)
-        mcp_server.resource_names = []  # No resource names
+        mcp_server._resource_names = ""  # No resource names
         mcp_server.save()
 
         # Create app permission
@@ -111,7 +111,7 @@ class TestMCPServerHandler:
 
         # Create MCP server with resource names
         mcp_server = G(MCPServer, gateway=fake_gateway, stage=fake_stage)
-        mcp_server.resource_names = ["resource1", "resource2"]
+        mcp_server._resource_names = "resource1;resource2"
         mcp_server.save()
 
         # Create app permissions
@@ -166,7 +166,7 @@ class TestMCPServerHandler:
 
         # Create MCP server with resource names
         mcp_server = G(MCPServer, gateway=fake_gateway, stage=fake_stage)
-        mcp_server.resource_names = ["resource1", "resource2"]
+        mcp_server._resource_names = "resource1;resource2"
         mcp_server.save()
 
         # Create app permissions
@@ -198,7 +198,7 @@ class TestMCPServerHandler:
 
         # Create MCP server with only one resource name
         mcp_server = G(MCPServer, gateway=fake_gateway, stage=fake_stage)
-        mcp_server.resource_names = ["resource1"]  # Only resource1
+        mcp_server._resource_names = "resource1"  # Only resource1
         mcp_server.save()
 
         # Create app permission for only one app
@@ -245,7 +245,7 @@ class TestMCPServerHandler:
 
         # Create MCP server with resource names
         mcp_server = G(MCPServer, gateway=fake_gateway, stage=fake_stage)
-        mcp_server.resource_names = ["resource2", "resource3"]  # Changed from resource1 to resource2,3
+        mcp_server._resource_names = "resource2;resource3"  # Changed from resource1 to resource2,3
         mcp_server.save()
 
         # Create app permissions

--- a/src/dashboard/apigateway/apigateway/tests/biz/mcp_server/test_permission.py
+++ b/src/dashboard/apigateway/apigateway/tests/biz/mcp_server/test_permission.py
@@ -48,7 +48,7 @@ class TestMCPServerPermissionHandler:
         """Test sync_permissions when no resource names exist - should return early"""
         # Create MCP server with app permissions but no resource names
         mcp_server = G(MCPServer, gateway=fake_gateway, stage=fake_stage)
-        mcp_server.resource_names = []  # No resource names
+        mcp_server._resource_names = ""  # No resource names
         mcp_server.save()
 
         # Create app permission
@@ -68,7 +68,7 @@ class TestMCPServerPermissionHandler:
 
         # Create MCP server with resource names
         mcp_server = G(MCPServer, gateway=fake_gateway, stage=fake_stage)
-        mcp_server.resource_names = ["resource1", "resource2"]
+        mcp_server._resource_names = "resource1;resource2"
         mcp_server.save()
 
         # Create app permissions
@@ -123,7 +123,7 @@ class TestMCPServerPermissionHandler:
 
         # Create MCP server with resource names
         mcp_server = G(MCPServer, gateway=fake_gateway, stage=fake_stage)
-        mcp_server.resource_names = ["resource1", "resource2"]
+        mcp_server._resource_names = "resource1;resource2"
         mcp_server.save()
 
         # Create app permissions
@@ -155,7 +155,7 @@ class TestMCPServerPermissionHandler:
 
         # Create MCP server with only one resource name
         mcp_server = G(MCPServer, gateway=fake_gateway, stage=fake_stage)
-        mcp_server.resource_names = ["resource1"]  # Only resource1
+        mcp_server._resource_names = "resource1"  # Only resource1
         mcp_server.save()
 
         # Create app permission for only one app
@@ -202,7 +202,7 @@ class TestMCPServerPermissionHandler:
 
         # Create MCP server with resource names
         mcp_server = G(MCPServer, gateway=fake_gateway, stage=fake_stage)
-        mcp_server.resource_names = ["resource2", "resource3"]  # Changed from resource1 to resource2,3
+        mcp_server._resource_names = "resource2;resource3"  # Changed from resource1 to resource2,3
         mcp_server.save()
 
         # Create app permissions

--- a/src/dashboard/apigateway/apigateway/tests/service/mcp/test_mcp_server.py
+++ b/src/dashboard/apigateway/apigateway/tests/service/mcp/test_mcp_server.py
@@ -103,7 +103,7 @@ class TestUpdateStageMcpServerRelatedResourceNames:
             gateway=stage.gateway,
             status=MCPServerStatusEnum.ACTIVE.value,
         )
-        mcp_server.resource_names = ["resource1", "resource2"]
+        mcp_server._resource_names = "resource1;resource2"
         mcp_server.save()
 
         original_resource_names = mcp_server.resource_names.copy()
@@ -124,7 +124,7 @@ class TestUpdateStageMcpServerRelatedResourceNames:
             gateway=stage.gateway,
             status=MCPServerStatusEnum.ACTIVE.value,
         )
-        mcp_server.resource_names = ["resource1", "deleted_resource1", "resource2", "deleted_resource2"]
+        mcp_server._resource_names = "resource1;deleted_resource1;resource2;deleted_resource2"
         mcp_server.save()
 
         # Call the function
@@ -143,7 +143,7 @@ class TestUpdateStageMcpServerRelatedResourceNames:
             gateway=stage.gateway,
             status=MCPServerStatusEnum.ACTIVE.value,
         )
-        mcp_server.resource_names = ["deleted_resource1", "deleted_resource2", "deleted_resource3"]
+        mcp_server._resource_names = "deleted_resource1;deleted_resource2;deleted_resource3"
         mcp_server.save()
 
         # Call the function
@@ -208,103 +208,6 @@ class TestUpdateStageMcpServerRelatedResourceNames:
         assert set(mcp_server2.resource_names) == {"resource1", "resource3"}  # unchanged
         assert mcp_server3.resource_names == []
         assert mcp_server4.resource_names == []  # unchanged
-
-    def test_with_tool_names_some_deleted(self, stage, resource_version):
-        """Test resources with tool names when some are deleted"""
-        mcp_server = G(
-            MCPServer,
-            stage=stage,
-            gateway=stage.gateway,
-            status=MCPServerStatusEnum.ACTIVE.value,
-        )
-        # 设置带工具名的资源
-        mcp_server.resource_names_raw = [
-            "resource1@custom_tool1",
-            "deleted_resource@custom_tool2",
-            "resource2",
-        ]
-        mcp_server.save()
-
-        # Call the function
-        update_stage_mcp_server_related_resource_names(stage.id, resource_version.id)
-
-        # Check results - tool names should be preserved
-        mcp_server.refresh_from_db()
-        assert set(mcp_server.resource_names_raw) == {"resource1@custom_tool1", "resource2"}
-        assert set(mcp_server.resource_names) == {"resource1", "resource2"}
-
-    def test_with_tool_names_all_preserved(self, stage, resource_version):
-        """Test resources with tool names when all are preserved"""
-        mcp_server = G(
-            MCPServer,
-            stage=stage,
-            gateway=stage.gateway,
-            status=MCPServerStatusEnum.ACTIVE.value,
-        )
-        # 设置带工具名的资源（全部存在于 resource_version 中）
-        mcp_server.resource_names_raw = [
-            "resource1@custom_tool1",
-            "resource2@custom_tool2",
-            "resource3",
-        ]
-        mcp_server.save()
-
-        original_resource_names_raw = mcp_server.resource_names_raw.copy()
-
-        # Call the function
-        update_stage_mcp_server_related_resource_names(stage.id, resource_version.id)
-
-        # Check results - should remain unchanged
-        mcp_server.refresh_from_db()
-        assert mcp_server.resource_names_raw == original_resource_names_raw
-
-    def test_with_tool_names_all_deleted(self, stage, resource_version):
-        """Test resources with tool names when all are deleted"""
-        mcp_server = G(
-            MCPServer,
-            stage=stage,
-            gateway=stage.gateway,
-            status=MCPServerStatusEnum.ACTIVE.value,
-        )
-        # 设置带工具名的资源（全部不存在于 resource_version 中）
-        mcp_server.resource_names_raw = [
-            "deleted1@custom_tool1",
-            "deleted2@custom_tool2",
-        ]
-        mcp_server.save()
-
-        # Call the function
-        update_stage_mcp_server_related_resource_names(stage.id, resource_version.id)
-
-        # Check results - all should be removed
-        mcp_server.refresh_from_db()
-        assert mcp_server.resource_names_raw == []
-        assert mcp_server.resource_names == []
-
-    def test_mixed_with_and_without_tool_names(self, stage, resource_version):
-        """Test mixed resources with and without tool names"""
-        mcp_server = G(
-            MCPServer,
-            stage=stage,
-            gateway=stage.gateway,
-            status=MCPServerStatusEnum.ACTIVE.value,
-        )
-        # 混合设置
-        mcp_server.resource_names_raw = [
-            "resource1@custom_tool",  # 存在，带工具名
-            "resource2",  # 存在，不带工具名
-            "deleted1@tool1",  # 不存在，带工具名
-            "deleted2",  # 不存在，不带工具名
-        ]
-        mcp_server.save()
-
-        # Call the function
-        update_stage_mcp_server_related_resource_names(stage.id, resource_version.id)
-
-        # Check results
-        mcp_server.refresh_from_db()
-        assert set(mcp_server.resource_names_raw) == {"resource1@custom_tool", "resource2"}
-        assert set(mcp_server.resource_names) == {"resource1", "resource2"}
 
 
 class TestBuildMCPServerURL:

--- a/src/dashboard/apigateway/apigateway/tests/service/mcp/test_mcp_server.py
+++ b/src/dashboard/apigateway/apigateway/tests/service/mcp/test_mcp_server.py
@@ -72,7 +72,7 @@ class TestUpdateStageMcpServerRelatedResourceNames:
             gateway=stage.gateway,
             status=MCPServerStatusEnum.ACTIVE.value,
         )
-        mcp_server1.resource_names = ["resource1", "resource2", "old_resource"]
+        mcp_server1._resource_names = "resource1;resource2;old_resource"
         mcp_server1.save()
 
         mcp_server2 = G(
@@ -81,7 +81,7 @@ class TestUpdateStageMcpServerRelatedResourceNames:
             gateway=stage.gateway,
             status=MCPServerStatusEnum.ACTIVE.value,
         )
-        mcp_server2.resource_names = ["resource3", "another_old_resource"]
+        mcp_server2._resource_names = "resource3;another_old_resource"
         mcp_server2.save()
 
         # Call function with non-existent resource version ID
@@ -162,7 +162,7 @@ class TestUpdateStageMcpServerRelatedResourceNames:
             gateway=stage.gateway,
             status=MCPServerStatusEnum.ACTIVE.value,
         )
-        mcp_server1.resource_names = ["resource1", "deleted_resource1", "resource2"]
+        mcp_server1._resource_names = "resource1;deleted_resource1;resource2"
         mcp_server1.save()
 
         # MCP server 2: has no deleted resources
@@ -172,7 +172,7 @@ class TestUpdateStageMcpServerRelatedResourceNames:
             gateway=stage.gateway,
             status=MCPServerStatusEnum.ACTIVE.value,
         )
-        mcp_server2.resource_names = ["resource1", "resource3"]
+        mcp_server2._resource_names = "resource1;resource3"
         mcp_server2.save()
 
         # MCP server 3: has all deleted resources
@@ -182,7 +182,7 @@ class TestUpdateStageMcpServerRelatedResourceNames:
             gateway=stage.gateway,
             status=MCPServerStatusEnum.ACTIVE.value,
         )
-        mcp_server3.resource_names = ["deleted_resource1", "deleted_resource2"]
+        mcp_server3._resource_names = "deleted_resource1;deleted_resource2"
         mcp_server3.save()
 
         # MCP server 4: has no resources
@@ -192,7 +192,7 @@ class TestUpdateStageMcpServerRelatedResourceNames:
             gateway=stage.gateway,
             status=MCPServerStatusEnum.ACTIVE.value,
         )
-        mcp_server4.resource_names = []
+        mcp_server4._resource_names = ""
         mcp_server4.save()
 
         # Call the function


### PR DESCRIPTION
### Description

<!-- 关联相关issue Please include a summary of the change and which issue is fixed. -->
<!-- 给出必要的上下文以及review需要的必要信息 Please also include relevant motivation and context. -->

mcp server 工具别名重构, 降低复杂度(refactor #2324)

- 字段拼接规则完全下沉，只有model知道规则
- model 之上，只知道 resource_names / tool_names 以及一个 update方法
- 废弃无用 property 以及 helper方法
- 回滚部分代码，相关位置只关注 resource_names
- 前端：只知道 resource_names 和 tool_names【都能拿到值，都是完整列表】， 别名变更的话，只更新tool_names

其他：
- web api: 读取可同时拿到 resource_names 和 tool_names， 创建/更新必须同时提交 rsource_names和tool_names
- open api: tool_names非必填，可以不传，默认等于 resource_names

TODO:

- [x] - 修复单测
- [x] - 补充models层单测

### Checklist

- [x] 填写 PR 描述及相关 issue (write PR description and related issue)
- [x] 代码风格检查通过 (code style check passed)
- [x] PR 中包含单元测试 (include unit test)
- [x] 单元测试通过 (unit test passed)
- [x] 本地开发联调环境验证通过 (local development environment verification passed)
