### PR TITLE
feat(open-api): add OAuth Protected Resource Metadata endpoint

### DIFF
--- a/src/dashboard/apigateway/apigateway/apis/v2/open/serializers.py
+++ b/src/dashboard/apigateway/apigateway/apis/v2/open/serializers.py
@@ -506,7 +506,7 @@ class LogSearchByRequestIdOutputSLZ(serializers.Serializer):
 
 
 class OAuthProtectedResourceInputSLZ(serializers.Serializer):
-    resource = serializers.CharField(required=True, help_text="The resource URL")
+    resource = serializers.URLField(required=True, allow_blank=False, help_text="The resource URL")
 
     class Meta:
         ref_name = "apigateway.apis.v2.open.serializers.OAuthProtectedResourceInputSLZ"

--- a/src/dashboard/apigateway/apigateway/apis/v2/open/serializers.py
+++ b/src/dashboard/apigateway/apigateway/apis/v2/open/serializers.py
@@ -503,3 +503,10 @@ class LogSearchByRequestIdOutputSLZ(serializers.Serializer):
 
     class Meta:
         ref_name = "apigateway.apis.v2.open.serializers.LogSearchByRequestIdOutputSLZ"
+
+
+class OAuthProtectedResourceInputSLZ(serializers.Serializer):
+    resource = serializers.CharField(required=True, help_text="The resource URL")
+
+    class Meta:
+        ref_name = "apigateway.apis.v2.open.serializers.OAuthProtectedResourceInputSLZ"

--- a/src/dashboard/apigateway/apigateway/apis/v2/open/urls.py
+++ b/src/dashboard/apigateway/apigateway/apis/v2/open/urls.py
@@ -159,4 +159,18 @@ urlpatterns = [
             ]
         ),
     ),
+    # .well-known endpoints
+    path(
+        ".well-known/",
+        include(
+            [
+                # GET /api/v2/open/.well-known/oauth-protected-resource
+                path(
+                    "oauth-protected-resource",
+                    views.OAuthProtectedResourceApi.as_view(),
+                    name="openapi.v2.open.well_known.oauth_protected_resource",
+                ),
+            ]
+        ),
+    ),
 ]

--- a/src/dashboard/apigateway/apigateway/apis/v2/open/views.py
+++ b/src/dashboard/apigateway/apigateway/apis/v2/open/views.py
@@ -828,7 +828,7 @@ class OAuthProtectedResourceApi(generics.RetrieveAPIView):
         return JsonResponse(
             {
                 "resource": resource,
-                "authorization_servers": [settings.BK_AUTH_URL],
+                "authorization_servers": [settings.BK_AUTH_SERVER_URL],
                 "bearer_methods_supported": ["header"],
             }
         )

--- a/src/dashboard/apigateway/apigateway/apps/plugin/constants.py
+++ b/src/dashboard/apigateway/apigateway/apps/plugin/constants.py
@@ -45,6 +45,10 @@ class PluginTypeCodeEnum(StructuredEnum):
     AI_PROXY = EnumField("ai-proxy", label=_("AI 代理"))
     AI_RATE_LIMITING = EnumField("ai-rate-limiting", label=_("AI 速率限制"))
 
+    BK_OAUTH2_PROTECTED_RESOURCE = EnumField("bk-oauth2-protected-resource", label=_("OAuth2 保护资源"))
+    BK_OAUTH2_VERIFY = EnumField("bk-oauth2-verify", label=_("OAuth2 验证"))
+    BK_OAUTH2_AUDIENCE_VALIDATE = EnumField("bk-oauth2-audience-validate", label=_("OAuth2 受众验证"))
+
 
 class PluginTypeScopeEnum(StructuredEnum):
     STAGE = EnumField(ScopeTypeEnum.STAGE.value, label=_("环境"))

--- a/src/dashboard/apigateway/apigateway/conf/default.py
+++ b/src/dashboard/apigateway/apigateway/conf/default.py
@@ -532,7 +532,7 @@ BK_APIGATEWAY_API_URL = env.str("BK_APIGATEWAY_API_URL", "")
 
 BK_AUTH_API_URL = env.str("BK_AUTH_API_URL", "")
 # BKAuth 站点地址 用于 OAuth2 跳转
-BK_AUTH_URL = env.str("BK_AUTH_URL", "")
+BK_AUTH_SERVER_URL = env.str("BK_AUTH_SERVER_URL", "")
 BK_MCP_SERVER_PERMISSION_APPROVAL_URL_TMPL = (
     env.str("DASHBOARD_FE_URL", "").rstrip("/") + "/{gateway_id}/mcp/permission?serverId={mcp_server_id}"
 )

--- a/src/dashboard/apigateway/apigateway/conf/default.py
+++ b/src/dashboard/apigateway/apigateway/conf/default.py
@@ -531,6 +531,8 @@ BK_PAAS3_API_TIMEOUT = env.int("BK_PAAS3_API_TIMEOUT", 30)
 BK_APIGATEWAY_API_URL = env.str("BK_APIGATEWAY_API_URL", "")
 
 BK_AUTH_API_URL = env.str("BK_AUTH_API_URL", "")
+# BKAuth 站点地址 用于 OAuth2 跳转
+BK_AUTH_URL = env.str("BK_AUTH_URL", "")
 BK_MCP_SERVER_PERMISSION_APPROVAL_URL_TMPL = (
     env.str("DASHBOARD_FE_URL", "").rstrip("/") + "/{gateway_id}/mcp/permission?serverId={mcp_server_id}"
 )

--- a/src/dashboard/apigateway/apigateway/data/apigw-definitions/bk-apigateway-definition.yaml
+++ b/src/dashboard/apigateway/apigateway/data/apigw-definitions/bk-apigateway-definition.yaml
@@ -1,9 +1,9 @@
 spec_version: 1
 
 release:
-  version: 1.3.8
-  title: v2 inner api 新增网关停用和删除接口
-  comment:  v2 inner api 新增网关停用和删除接口
+  version: 1.4.0
+  title: v2 open api 新增 OAuth2 保护资源元数据接口
+  comment:  v2 open api 新增 OAuth2 保护资源元数据接口
 
 apigateway:
   description: 蓝鲸 API 网关（BlueKing API Gateway）是一种高性能、高可用的 API 托管服务。网关提供了该服务的基础通用接口，包含网关、资源、环境、版本发布、权限等相关接口。(官方内置网关，请勿修改!)

--- a/src/dashboard/apigateway/apigateway/data/apigw-definitions/bk-apigateway-resources.yaml
+++ b/src/dashboard/apigateway/apigateway/data/apigw-definitions/bk-apigateway-resources.yaml
@@ -175,7 +175,13 @@ paths:
           path: /{mcp_server_name}/sse
           matchSubpath: false
           timeout: 0
-        pluginConfigs: [ ]
+        pluginConfigs:
+        - type: bk-oauth2-protected-resource
+          yaml: '{}'
+        - type: bk-oauth2-verify
+          yaml: '{}'
+        - type: bk-oauth2-audience-validate
+          yaml: '{}'
         authConfig:
           userVerifiedRequired: true
           appVerifiedRequired: true
@@ -204,7 +210,13 @@ paths:
           path: /{mcp_server_name}/sse/message
           matchSubpath: false
           timeout: 0
-        pluginConfigs: [ ]
+        pluginConfigs:
+        - type: bk-oauth2-protected-resource
+          yaml: '{}'
+        - type: bk-oauth2-verify
+          yaml: '{}'
+        - type: bk-oauth2-audience-validate
+          yaml: '{}'
         authConfig:
           userVerifiedRequired: true
           appVerifiedRequired: true
@@ -289,7 +301,13 @@ paths:
           path: /{mcp_server_name}/mcp
           matchSubpath: false
           timeout: 0
-        pluginConfigs: [ ]
+        pluginConfigs:
+        - type: bk-oauth2-protected-resource
+          yaml: '{}'
+        - type: bk-oauth2-verify
+          yaml: '{}'
+        - type: bk-oauth2-audience-validate
+          yaml: '{}'
         authConfig:
           userVerifiedRequired: true
           appVerifiedRequired: true
@@ -317,7 +335,13 @@ paths:
           path: /{mcp_server_name}/mcp
           matchSubpath: false
           timeout: 0
-        pluginConfigs: [ ]
+        pluginConfigs:
+        - type: bk-oauth2-protected-resource
+          yaml: '{}'
+        - type: bk-oauth2-verify
+          yaml: '{}'
+        - type: bk-oauth2-audience-validate
+          yaml: '{}'
         authConfig:
           userVerifiedRequired: true
           appVerifiedRequired: true

--- a/src/dashboard/apigateway/apigateway/data/apigw-definitions/bk-apigateway-resources.yaml
+++ b/src/dashboard/apigateway/apigateway/data/apigw-definitions/bk-apigateway-resources.yaml
@@ -1524,6 +1524,42 @@ paths:
           appVerifiedRequired: true
           resourcePermissionRequired: false
         descriptionEn: None
+  /api/v2/open/.well-known/oauth-protected-resource:
+    get:
+      operationId: v2_open_oauth_protected_resource
+      description: 获取 OAuth 保护资源元数据
+      tags:
+        - v2_open
+      responses:
+        default:
+          description: ''
+          content:
+            application/json:
+              schema: {}
+      parameters:
+        - in: query
+          name: resource
+          schema:
+            type: string
+          required: true
+          description: The resource URL
+      x-bk-apigateway-resource:
+        isPublic: false
+        allowApplyPermission: false
+        matchSubpath: false
+        enableWebsocket: false
+        backend:
+          name: default
+          method: get
+          path: /backend/api/v2/open/.well-known/oauth-protected-resource
+          matchSubpath: false
+          timeout: 0
+        pluginConfigs: []
+        authConfig:
+          userVerifiedRequired: false
+          appVerifiedRequired: false
+          resourcePermissionRequired: false
+        descriptionEn: Get OAuth Protected Resource Metadata
   /api/v2/sync/gateways/{gateway_name}/public_key/:
     get:
       operationId: v2_sync_get_gateway_public_key_new

--- a/src/dashboard/apigateway/apigateway/fixtures/plugins.yaml
+++ b/src/dashboard/apigateway/apigateway/fixtures/plugins.yaml
@@ -1322,6 +1322,81 @@
         "formData": {},
         "rules": {}
       }
+- model: plugin.plugintype
+  fields:
+    code: bk-oauth2-protected-resource
+    name: OAuth2 受保护资源
+    name_en: OAuth2 Protected Resource
+    is_public: false
+    scope: resource
+    priority: 18740
+    _tags: "认证,Authentication"
+    schema: null
+- model: plugin.pluginform
+  fields:
+    language: ''
+    type:
+      - bk-oauth2-protected-resource
+    notes: OAuth2 protected resource plugin
+    style: dynamic
+    default_value: ''
+    config: |-
+      {
+        "schema": {},
+        "layout": [],
+        "formData": {},
+        "rules": {}
+      }
+- model: plugin.plugintype
+  fields:
+    code: bk-oauth2-verify
+    name: OAuth2 验证
+    name_en: OAuth2 Verify
+    is_public: false
+    scope: resource
+    priority: 18732
+    _tags: "认证,Authentication"
+    schema: null
+- model: plugin.pluginform
+  fields:
+    language: ''
+    type:
+      - bk-oauth2-verify
+    notes: OAuth2 verify plugin
+    style: dynamic
+    default_value: ''
+    config: |-
+      {
+        "schema": {},
+        "layout": [],
+        "formData": {},
+        "rules": {}
+      }
+- model: plugin.plugintype
+  fields:
+    code: bk-oauth2-audience-validate
+    name: OAuth2 Audience 校验
+    name_en: OAuth2 Audience Validate
+    is_public: false
+    scope: resource
+    priority: 17678
+    _tags: "认证,Authentication"
+    schema: null
+- model: plugin.pluginform
+  fields:
+    language: ''
+    type:
+      - bk-oauth2-audience-validate
+    notes: OAuth2 audience validate plugin
+    style: dynamic
+    default_value: ''
+    config: |-
+      {
+        "schema": {},
+        "layout": [],
+        "formData": {},
+        "rules": {}
+      }
 - model: schema.schema
   fields:
     created_time: 2023-02-02 14:54:21.010753+00:00

--- a/src/dashboard/apigateway/apigateway/tests/apis/v2/open/test_views.py
+++ b/src/dashboard/apigateway/apigateway/tests/apis/v2/open/test_views.py
@@ -325,7 +325,7 @@ class TestParseDatetimeStrToTimestampApi:
 class TestOAuthProtectedResourceApi:
     def test_get_oauth_protected_resource_success(self, request_view, settings):
         """测试成功获取 OAuth 保护资源元数据"""
-        settings.BK_AUTH_URL = "https://bkauth.example.com"
+        settings.BK_AUTH_SERVER_URL = "https://bkauth.example.com"
         resource_url = "https://api.example.com/resource"
 
         resp = request_view(
@@ -341,8 +341,8 @@ class TestOAuthProtectedResourceApi:
         assert result["bearer_methods_supported"] == ["header"]
 
     def test_get_oauth_protected_resource_returns_settings_auth_url(self, request_view, settings):
-        """测试返回的 authorization_servers 使用 settings.BK_AUTH_URL"""
-        settings.BK_AUTH_URL = "https://custom-auth.example.com"
+        """测试返回的 authorization_servers 使用 settings.BK_AUTH_SERVER_URL"""
+        settings.BK_AUTH_SERVER_URL = "https://custom-auth.example.com"
         resource_url = "https://api.example.com/another-resource"
 
         resp = request_view(
@@ -357,7 +357,7 @@ class TestOAuthProtectedResourceApi:
 
     def test_get_oauth_protected_resource_missing_resource_param(self, request_view, settings):
         """测试缺少 resource 参数时返回错误"""
-        settings.BK_AUTH_URL = "https://bkauth.example.com"
+        settings.BK_AUTH_SERVER_URL = "https://bkauth.example.com"
 
         resp = request_view(
             method="GET",
@@ -369,7 +369,7 @@ class TestOAuthProtectedResourceApi:
 
     def test_get_oauth_protected_resource_empty_resource_param(self, request_view, settings):
         """测试 resource 参数为空时返回错误"""
-        settings.BK_AUTH_URL = "https://bkauth.example.com"
+        settings.BK_AUTH_SERVER_URL = "https://bkauth.example.com"
 
         resp = request_view(
             method="GET",


### PR DESCRIPTION
## Summary

- Add new `.well-known/oauth-protected-resource` endpoint (RFC 9728) under `/api/v2/open/`
- Enable OAuth clients to discover the authorization server for the API gateway
- Returns JSON response with `resource`, `authorization_servers`, and `bearer_methods_supported`

## Changes

- Added `OAuthProtectedResourceInputSLZ` serializer for the `resource` query parameter
- Created `OAuthProtectedResourceApi` view with no permission checks (public metadata endpoint)
- Added URL route at `/api/v2/open/.well-known/oauth-protected-resource`
- Added `BK_AUTH_URL` setting for configuring authorization server URL
- Added API resource definition in `bk-apigateway-resources.yaml`
- Added unit tests for the new endpoint

Made with [Cursor](https://cursor.com)