### PR TITLE
chore(core-api): upgrade golangci-lint and fix all lint issues

### DIFF
--- a/.github/workflows/core-api.yml
+++ b/.github/workflows/core-api.yml
@@ -17,12 +17,12 @@ jobs:
         os: [ubuntu-latest]
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v6
 
     - name: Set up Go
-      uses: actions/setup-go@v4
+      uses: actions/setup-go@v6
       with:
-        go-version: '1.24'
+        go-version: '1.25'
         cache-dependency-path: src/core-api/go.sum
 
     - name: Build
@@ -32,7 +32,7 @@ jobs:
     - name: Lint
       uses: golangci/golangci-lint-action@v9
       with:
-        version: v2.6
+        version: v2.11
         working-directory: src/core-api
 
     - name: Aqua Security Trivy

--- a/src/core-api/.golangci.yaml
+++ b/src/core-api/.golangci.yaml
@@ -5,17 +5,44 @@ run:
   tests: false
 linters:
   enable:
-    - revive
+    # bug catchers
+    - staticcheck
+    - govet
+    - errcheck
+    - errchkjson
+    - bodyclose
+    - sqlclosecheck
+    - rowserrcheck
+    - nilerr
+    - nilnesserr
+    - ineffassign
+    - unused
+    - durationcheck
+    - errorlint
+    - noctx
+    - forcetypeassert
+    - fatcontext
+    # modernization (Go 1.25.5)
+    - modernize
+    - exptostd
+    - intrange
+    - usestdlibvars
+    # code quality
     - gocritic
     - gocyclo
+    - unconvert
+    - copyloopvar
+    - reassign
+    - mirror
+    - perfsprint
+    # style
+    - revive
     - lll
+    - whitespace
     - misspell
     - nakedret
-    - nilerr
-    - staticcheck
-    - whitespace
-  disable:
-    - errcheck
+    # security
+    - gosec
   settings:
     staticcheck:
       checks:
@@ -38,26 +65,48 @@ linters:
           exclude: []
           arguments:
             - "check-private-receivers"
-            - "disableStutteringCheck"
+            - "disable-stuttering-check"
             - "disable-checks-on-constants"
             - "disable-checks-on-types"
             - "disable-checks-on-variables"
-
     lll:
-      # Max line length, lines longer will be reported.
-      # '\t' is counted as 1 character by default, and can be changed with the tab-width option.
-      # Default: 120.
       line-length: 120
-      # Tab width in spaces.
-      # Default: 1
       tab-width: 1
-
+    errcheck:
+      check-type-assertions: false
+      check-blank: false
+    errorlint:
+      errorf: true
+      errorf-multi: true
+      asserts: true
+      comparison: true
+    modernize:
+      disable:
+        - omitzero
+        - stringsbuilder
+        - waitgroup
+    perfsprint:
+      err-error: false
+      errorf: false
+      int-conversion: false
+    gosec:
+      excludes:
+        - G104
+        - G115
+        - G304
+        - G307
+        - G401
+        - G501
+        - G505
+      confidence: medium
   exclusions:
     generated: lax
-    paths:
-      - third_party$
-      - builtin$
-      - examples$
+    rules:
+      # MCP docs contain embedded long markdown/code blocks by design.
+      - path: pkg/apis/mcp/resources/docs.go
+        linters:
+          - lll
+
 issues:
   uniq-by-line: false
   # Show only new issues: if there are unstaged changes or untracked files,
@@ -68,21 +117,15 @@ issues:
   #
   # Default: false
   new: false
-  # Show only new issues created after the best common ancestor (merge-base against HEAD).
-  # Default: ""
-  new-from-merge-base: master
-  # Show only new issues created after git revision `REV`.
-  # Default: ""
-  new-from-rev: HEAD
-  # Show only new issues created in git patch with set file path.
-  # Default: ""
-  new-from-patch: ""
-  # Show issues in any part of update files (requires new-from-rev or new-from-patch).
-  # Default: false
-  whole-files: true
+  # REMOVED: new-from-merge-base and new-from-rev were hiding all issues
+  # To only check new code, uncomment ONE of these:
+  # new-from-rev: origin/master  # Check only code different from origin/master
+  # new: true                    # Check only unstaged/untracked files or HEAD~
+
   # Fix found issues (if it's supported by the linter).
+  # Keep false so CI lint is non-mutating.
   # Default: false
-  fix: true
+  fix: false
 
 formatters:
   enable:
@@ -90,6 +133,10 @@ formatters:
     - goimports
     - golines
     - gofumpt
+  exclusions:
+    generated: lax
+    paths:
+      - pkg/apis/mcp/resources/docs.go
   settings:
     gofmt:
       # Simplify code: gofmt with `-s` option.
@@ -128,11 +175,3 @@ formatters:
       # Split chained methods on the dots as opposed to the arguments.
       # Default: true
       chain-split-dots: false
-
-  exclusions:
-    warn-unused: true
-    generated: lax
-    paths:
-      - third_party$
-      - builtin$
-      - examples$

--- a/src/core-api/AGENTS.md
+++ b/src/core-api/AGENTS.md
@@ -3,7 +3,7 @@
 Guidance for coding agents working on the core-api service (BlueKing API Gateway).
 
 ## Overview
-- Go service (module `core`, Go 1.24.4) using Gin + Cobra.
+- Go service (module `core`, Go 1.25.5) using Gin + Cobra.
 - Entry: `main.go` -> `cmd/root.go` (`core-api` CLI).
 - Config required via `-c/--config` (see `config.yaml.tpl`).
 
@@ -45,6 +45,15 @@ Support packages: `pkg/server`, `pkg/middleware`, `pkg/config`, `pkg/logging`, `
 - Required fields: `auth.id`, `auth.secret`, and a `databases` entry with id `apigateway`.
 - Key sections: `server`, `auth`, `databases` (supports TLS), `logger`, `tracing`, `sentry`, `debug`.
 
+## Go Version (IMPORTANT — read before running any Go command)
+
+This project requires **Go 1.25.5** (see `go.mod`). The system default `go` is often older.
+
+Before running any `go` command or `make` target, check the repo root for dotfiles that activate the correct Go version (e.g. `.envrc`, `.env`, `.tool-versions`, or similar). Source or apply whichever one is present to get the right `go` on your `PATH`.
+
+Without the correct version, commands will fail with:
+`go: go.mod requires go >= 1.25.5 (running go 1.22.x; GOTOOLCHAIN=local)`
+
 ## Dev commands (Makefile)
 - Setup: `make init`, `make dep`
 - Build/run: `make build`, `make serve`, `make dev-image`
@@ -56,6 +65,12 @@ Support packages: `pkg/server`, `pkg/middleware`, `pkg/config`, `pkg/logging`, `
 - Tests use vendor mode (`-mod=vendor`) and Ginkgo/Gomega.
 - `make mock` runs `go generate ./...` for `mockgen` directives.
 - `make doc` runs `swag init`.
+
+## After Code Changes
+
+Always run `make lint` and `make test` after making code changes and fix any issues before considering the work done.
+
+When asked to "make a PR", create the pull request targeting `upstream/master`.
 
 ## License
 - All non-vendor, non-mock Go files must include the TencentBlueKing license header (checked by `make lint`/`make check-license`).

--- a/src/core-api/Dockerfile
+++ b/src/core-api/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.24.4-bullseye AS builder
+FROM golang:1.25.5-bullseye AS builder
 
 COPY ./ /app
 WORKDIR /app

--- a/src/core-api/Dockerfile
+++ b/src/core-api/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.25.5-bullseye AS builder
+FROM golang:1.25.5 AS builder
 
 COPY ./ /app
 WORKDIR /app

--- a/src/core-api/Makefile
+++ b/src/core-api/Makefile
@@ -6,19 +6,19 @@ init:
 	pip install pre-commit
 	pre-commit install
 	# go get -u github.com/golangci/golangci-lint/cmd/golangci-lint
-	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(shell go env GOPATH)/bin v2.6.0
+	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/HEAD/install.sh | sh -s -- -b $(LOCALBIN) v2.11.2
 	# for ginkgo
-	go install github.com/onsi/ginkgo/v2/ginkgo@latest
+	GOBIN=$(LOCALBIN) go install github.com/onsi/ginkgo/v2/ginkgo@latest
 	# for make mock
-	go install github.com/golang/mock/mockgen@v1.6.0
+	GOBIN=$(LOCALBIN) go install github.com/golang/mock/mockgen@v1.6.0
 	# for gofumpt
-	go install mvdan.cc/gofumpt@latest
+	GOBIN=$(LOCALBIN) go install mvdan.cc/gofumpt@latest
 	# for golines
-	go install github.com/segmentio/golines@latest
+	GOBIN=$(LOCALBIN) go install github.com/segmentio/golines@latest
 	# for goimports
-	go install -v github.com/incu6us/goimports-reviser/v3@latest
+	GOBIN=$(LOCALBIN) go install -v github.com/incu6us/goimports-reviser/v3@latest
 	# for swag
-	go install github.com/swaggo/swag/cmd/swag@latest
+	GOBIN=$(LOCALBIN) go install github.com/swaggo/swag/cmd/swag@latest
 
 .PHONY: dep
 dep:
@@ -26,7 +26,7 @@ dep:
 	go mod vendor
 
 doc:
-	swag init
+	$(SWAG) init
 
 .PHONY: mock
 mock:
@@ -35,7 +35,7 @@ mock:
 .PHONY: lint
 lint:
 	export GOFLAGS=-mod=vendor
-	golangci-lint run
+	$(GOLINTER) run --fix
 	find . -name "*.go" -not -path "./vendor/*" | xargs -n 1 grep -L 'TencentBlueKing is pleased to ' | grep -v '/mock/' | wc -l | xargs -I {} bash -c '[[ {} -eq 0 ]] && exit 0 || exit 1'
 
 .PHONY: check-license
@@ -46,7 +46,7 @@ check-license:
 
 .PHONY: fmt
 fmt:
-	golangci-lint fmt
+	$(GOLINTER) fmt
 
 
 .PHONY: test
@@ -68,3 +68,16 @@ serve: build
 .PHONY: dev-image
 dev-image:
 	docker build --build-arg VERSION=`git describe --tags --abbrev=0` --build-arg COMMIT=`git rev-parse HEAD`  -f  Dockerfile . -t bk-apigateway-core-api:development
+
+
+
+LOCALBIN ?= $(shell pwd)/bin
+$(LOCALBIN):
+	mkdir -p $(LOCALBIN)
+
+## Tool Binaries
+GOLINES ?= $(LOCALBIN)/golines
+GOFUMPT ?= $(LOCALBIN)/gofumpt
+SWAG ?= $(LOCALBIN)/swag
+GOLINTER ?=$(LOCALBIN)/golangci-lint
+GOIMPORTS ?=$(LOCALBIN)/goimports-reviser

--- a/src/core-api/go.mod
+++ b/src/core-api/go.mod
@@ -1,6 +1,6 @@
 module core
 
-go 1.24.4
+go 1.25.5
 
 require (
 	github.com/DATA-DOG/go-sqlmock v1.5.2

--- a/src/core-api/pkg/cacheimpls/app_gateway_permission.go
+++ b/src/core-api/pkg/cacheimpls/app_gateway_permission.go
@@ -43,7 +43,10 @@ func (k AppGatewayPermissionKey) Key() string {
 }
 
 func retrieveAppGatewayPermission(ctx context.Context, k cache.Key) (any, error) {
-	key := k.(AppGatewayPermissionKey)
+	key, ok := k.(AppGatewayPermissionKey)
+	if !ok {
+		return nil, errors.New("invalid key type, expected AppGatewayPermissionKey")
+	}
 
 	manager := dao.NewAppGatewayPermissionManager()
 

--- a/src/core-api/pkg/cacheimpls/app_resource_permission.go
+++ b/src/core-api/pkg/cacheimpls/app_resource_permission.go
@@ -43,7 +43,10 @@ func (k AppResourcePermissionKey) Key() string {
 }
 
 func retrieveAppResourcePermission(ctx context.Context, k cache.Key) (any, error) {
-	key := k.(AppResourcePermissionKey)
+	key, ok := k.(AppResourcePermissionKey)
+	if !ok {
+		return nil, errors.New("invalid key type, expected AppResourcePermissionKey")
+	}
 
 	manager := dao.NewAppResourcePermissionManager()
 

--- a/src/core-api/pkg/cacheimpls/gateway.go
+++ b/src/core-api/pkg/cacheimpls/gateway.go
@@ -38,7 +38,10 @@ func (k GatewayNameKey) Key() string {
 }
 
 func retrieveGatewayByName(ctx context.Context, k cache.Key) (any, error) {
-	key := k.(GatewayNameKey)
+	key, ok := k.(GatewayNameKey)
+	if !ok {
+		return nil, errors.New("invalid key type, expected GatewayNameKey")
+	}
 
 	manager := dao.NewGatewayManager()
 	return manager.GetByName(ctx, key.Name)

--- a/src/core-api/pkg/cacheimpls/init.go
+++ b/src/core-api/pkg/cacheimpls/init.go
@@ -29,7 +29,7 @@ import (
 
 func newRandomDuration(seconds int) backend.RandomExtraExpirationDurationFunc {
 	return func() time.Duration {
-		return time.Duration(rand.Intn(seconds*1000)) * time.Millisecond
+		return time.Duration(rand.Intn(seconds*1000)) * time.Millisecond //nolint:gosec
 	}
 }
 

--- a/src/core-api/pkg/cacheimpls/jwt_public_key.go
+++ b/src/core-api/pkg/cacheimpls/jwt_public_key.go
@@ -39,7 +39,10 @@ func (k JWTPublicKeyCacheKey) Key() string {
 }
 
 func retrieveJWTPublicKey(ctx context.Context, k cache.Key) (any, error) {
-	key := k.(JWTPublicKeyCacheKey)
+	key, ok := k.(JWTPublicKeyCacheKey)
+	if !ok {
+		return nil, errors.New("invalid key type, expected JWTPublicKeyCacheKey")
+	}
 
 	manager := dao.NewJWTManager()
 

--- a/src/core-api/pkg/cacheimpls/release.go
+++ b/src/core-api/pkg/cacheimpls/release.go
@@ -40,7 +40,10 @@ func (k ReleaseKey) Key() string {
 }
 
 func retrieveStageByGatewayIDStageID(ctx context.Context, k cache.Key) (any, error) {
-	key := k.(ReleaseKey)
+	key, ok := k.(ReleaseKey)
+	if !ok {
+		return nil, errors.New("invalid key type, expected ReleaseKey")
+	}
 
 	manager := dao.NewReleaseManager()
 	return manager.Get(ctx, key.GatewayID, key.StageID)

--- a/src/core-api/pkg/cacheimpls/release_history.go
+++ b/src/core-api/pkg/cacheimpls/release_history.go
@@ -39,7 +39,10 @@ func (k ReleaseHistoryCacheKey) Key() string {
 }
 
 func retrieveReleaseHistory(ctx context.Context, k cache.Key) (any, error) {
-	key := k.(ReleaseHistoryCacheKey)
+	key, ok := k.(ReleaseHistoryCacheKey)
+	if !ok {
+		return nil, errors.New("invalid key type, expected ReleaseHistoryCacheKey")
+	}
 
 	manager := dao.NewReleaseHistoryManger()
 

--- a/src/core-api/pkg/cacheimpls/resource_version_mapping.go
+++ b/src/core-api/pkg/cacheimpls/resource_version_mapping.go
@@ -42,7 +42,10 @@ func (k ResourceVersionMappingKey) Key() string {
 }
 
 func retrieveResourceVersionMapping(ctx context.Context, k cache.Key) (any, error) {
-	key := k.(ResourceVersionMappingKey)
+	key, ok := k.(ResourceVersionMappingKey)
+	if !ok {
+		return nil, errors.New("invalid key type, expected ResourceVersionMappingKey")
+	}
 
 	manager := dao.NewResourceVersionManager()
 
@@ -62,14 +65,21 @@ func retrieveResourceVersionMapping(ctx context.Context, k cache.Key) (any, erro
 
 	resourceNameToID := make(map[string]int64, len(releaseResourcesData))
 	for _, d := range releaseResourcesData {
-		valueID := d["id"].(json.Number)
+		valueID, ok := d["id"].(json.Number)
+		if !ok {
+			return nil, errors.New("resource id is not a json.Number")
+		}
 
 		id, err := valueID.Int64()
 		if err != nil {
 			return nil, err
 		}
 
-		resourceNameToID[d["name"].(string)] = id
+		name, ok := d["name"].(string)
+		if !ok {
+			return nil, errors.New("resource name is not a string")
+		}
+		resourceNameToID[name] = id
 	}
 
 	logging.GetLogger().Debugw("retrieveResourceVersionMapping",

--- a/src/core-api/pkg/cacheimpls/stage.go
+++ b/src/core-api/pkg/cacheimpls/stage.go
@@ -40,7 +40,10 @@ func (k StageKey) Key() string {
 }
 
 func retrieveStageByGatewayIDStageName(ctx context.Context, k cache.Key) (any, error) {
-	key := k.(StageKey)
+	key, ok := k.(StageKey)
+	if !ok {
+		return nil, errors.New("invalid key type, expected StageKey")
+	}
 
 	manager := dao.NewStageManager()
 

--- a/src/core-api/pkg/database/dao/publish_event.go
+++ b/src/core-api/pkg/database/dao/publish_event.go
@@ -108,7 +108,8 @@ func (p publishEventManager) Create(ctx context.Context, publishEvent PublishEve
 	result, err := database.SqxExec(ctx, p.DB, query, args...)
 	if err != nil {
 		// make sure err is a mysql.MySQLError.
-		if errMySQL, ok := err.(*mysql.MySQLError); ok {
+		errMySQL := &mysql.MySQLError{}
+		if errors.As(err, &errMySQL) {
 			if errMySQL.Number == database.DuplicateErrCode {
 				return 0, fmt.Errorf("insert event duplicated err: %w", err)
 			}

--- a/src/core-api/pkg/database/dbmock.go
+++ b/src/core-api/pkg/database/dbmock.go
@@ -65,7 +65,7 @@ func NewMockRowsWithoutData(mock sqlmock.Sqlmock, arg any) *sqlmock.Rows {
 		objType = objType.Elem()
 	}
 	var columns []string
-	for i := 0; i < objType.NumField(); i++ {
+	for i := range objType.NumField() {
 		dbTagName := objType.Field(i).Tag.Get("db")
 		if dbTagName != "" {
 			columns = append(columns, dbTagName)
@@ -90,7 +90,7 @@ func NewMockRows(mock sqlmock.Sqlmock, args ...any) *sqlmock.Rows {
 			objValue = objValue.Elem()
 		}
 		values := []driver.Value{}
-		for i := 0; i < objType.NumField(); i++ {
+		for i := range objType.NumField() {
 			dbTagName := objType.Field(i).Tag.Get("db")
 			if dbTagName != "" {
 				values = append(values, objValue.Field(i).Interface())

--- a/src/core-api/pkg/database/mysql.go
+++ b/src/core-api/pkg/database/mysql.go
@@ -19,6 +19,7 @@
 package database
 
 import (
+	"context"
 	"crypto/tls"
 	"crypto/x509"
 	"fmt"
@@ -78,7 +79,9 @@ func (db *DBClient) TestConnection() (err error) {
 		return err
 	}
 
-	conn.Close()
+	if closeErr := conn.Close(); closeErr != nil {
+		logging.GetLogger().Warnf("failed to close test connection: %s", closeErr)
+	}
 	return nil
 }
 
@@ -100,7 +103,7 @@ func (db *DBClient) Connect() error {
 	db.DB.SetMaxIdleConns(db.maxIdleConns)
 	db.DB.SetConnMaxLifetime(db.connMaxLifetime)
 
-	_, err = db.DB.Exec(`SET time_zone = "+00:00";`) // set session time zon to utc
+	_, err = db.DB.ExecContext(context.Background(), `SET time_zone = "+00:00";`) // set session timezone to utc
 	if err != nil {
 		return err
 	}
@@ -119,7 +122,9 @@ func (db *DBClient) SetTraceEnabled(enabled bool) {
 // Close close db connection
 func (db *DBClient) Close() {
 	if db.DB != nil {
-		db.DB.Close()
+		if err := db.DB.Close(); err != nil {
+			logging.GetLogger().Warnf("failed to close database connection: %s", err)
+		}
 	}
 }
 
@@ -210,9 +215,12 @@ func NewDBClient(cfg *config.Database) *DBClient {
 		if cfg.ConnMaxLifetimeSecond >= 60 {
 			connMaxLifetime = time.Duration(cfg.ConnMaxLifetimeSecond) * time.Second
 		} else {
-			logging.GetLogger().Errorf("error config for database %s, connMaxLifetimeSeconds should be greater than 60 seconds"+
-				"use the default [defaultConnMaxLifetime=%s]",
-				cfg.Name, defaultConnMaxLifetime)
+			logging.GetLogger().Errorf(
+				"error config for database %s, connMaxLifetimeSeconds should be greater than 60 seconds"+
+					"use the default [defaultConnMaxLifetime=%s]",
+				cfg.Name,
+				defaultConnMaxLifetime,
+			)
 		}
 	}
 

--- a/src/core-api/pkg/database/utils.go
+++ b/src/core-api/pkg/database/utils.go
@@ -20,6 +20,7 @@ package database
 
 import (
 	"database/sql"
+	"errors"
 	"fmt"
 	"strings"
 	"time"
@@ -42,7 +43,7 @@ const (
 // RollBackWithLog will rollback and log if error
 func RollBackWithLog(tx *sqlx.Tx) {
 	err := tx.Rollback()
-	if err != sql.ErrTxDone && err != nil {
+	if !errors.Is(err, sql.ErrTxDone) && err != nil {
 		logging.GetLogger().Error(err)
 	}
 }

--- a/src/core-api/pkg/sentry/sentry.go
+++ b/src/core-api/pkg/sentry/sentry.go
@@ -43,13 +43,13 @@ func Init(config config.Sentry) error {
 			Dsn: config.DSN,
 		})
 		if err != nil {
-			return fmt.Errorf("init sentry fail: %s", err)
+			return fmt.Errorf("init sentry fail: %w", err)
 		}
 
 		// init gin sentry
 		err = raven.SetDSN(config.DSN)
 		if err != nil {
-			return fmt.Errorf("init gin sentry fail: %s", err)
+			return fmt.Errorf("init gin sentry fail: %w", err)
 		}
 		s.enabled = true
 	}

--- a/src/core-api/pkg/server/router.go
+++ b/src/core-api/pkg/server/router.go
@@ -64,7 +64,6 @@ func NewRouter(cfg *config.Config) *gin.Engine {
 	// healthz
 	router.GET("/healthz", func(c *gin.Context) {
 		for _, dbConfig := range cfg.DatabaseMap {
-			dbConfig := dbConfig
 			// reset the options for check
 			dbConfig.MaxIdleConns = 1
 			dbConfig.MaxOpenConns = 1

--- a/src/core-api/pkg/util/testing.go
+++ b/src/core-api/pkg/util/testing.go
@@ -20,6 +20,7 @@ package util
 
 import (
 	"bytes"
+	"context"
 	"errors"
 	"net/http"
 	"net/http/httptest"
@@ -32,14 +33,14 @@ var TestingContent = []byte("Hello, World!")
 
 // NewRequestResponse ...
 func NewRequestResponse() (*http.Request, *httptest.ResponseRecorder) {
-	r := httptest.NewRequest(http.MethodPost, "/", bytes.NewReader(TestingContent))
+	r := httptest.NewRequestWithContext(context.Background(), http.MethodPost, "/", bytes.NewReader(TestingContent))
 	w := httptest.NewRecorder()
 	return r, w
 }
 
 // NewRequestResponseWithContent ...
 func NewRequestResponseWithContent(content []byte) (*http.Request, *httptest.ResponseRecorder) {
-	r := httptest.NewRequest(http.MethodPost, "/", bytes.NewReader(content))
+	r := httptest.NewRequestWithContext(context.Background(), http.MethodPost, "/", bytes.NewReader(content))
 	w := httptest.NewRecorder()
 	return r, w
 }
@@ -62,7 +63,7 @@ func (errReader) Read(p []byte) (n int, err error) {
 
 // NewRequestErrorResponse ...
 func NewRequestErrorResponse() (*http.Request, *httptest.ResponseRecorder) {
-	r := httptest.NewRequest(http.MethodPost, "/", errReader(0))
+	r := httptest.NewRequestWithContext(context.Background(), http.MethodPost, "/", errReader(0))
 	w := httptest.NewRecorder()
 	return r, w
 }

--- a/src/core-api/pkg/util/validation.go
+++ b/src/core-api/pkg/util/validation.go
@@ -19,6 +19,7 @@
 package util
 
 import (
+	"errors"
 	"fmt"
 	"io"
 
@@ -44,7 +45,7 @@ func (v ValidationFieldError) String() string {
 
 	switch e.Tag() {
 	case "required":
-		return fmt.Sprintf("%s is required", e.Field())
+		return e.Field() + " is required"
 	case "max":
 		return fmt.Sprintf("%s cannot be longer than %s", e.Field(), e.Param())
 	case "min":
@@ -70,11 +71,12 @@ func (v ValidationFieldError) String() string {
 
 // ValidationErrorMessage ...
 func ValidationErrorMessage(err error) string {
-	if err == io.EOF {
+	if errors.Is(err, io.EOF) {
 		return "EOF, json decode fail"
 	}
 
-	validationErrs, ok := err.(validator.ValidationErrors)
+	var validationErrs validator.ValidationErrors
+	ok := errors.As(err, &validationErrs)
 	if !ok {
 		message := fmt.Sprintf("json decode or validate fail, err=%s", err)
 		logging.GetLogger().Info(message)


### PR DESCRIPTION
## Summary

- Upgrade golangci-lint config and bump Go version requirement to 1.25.5
- Fix all lint issues reported by the upgraded linter across `src/core-api`:
  - **errcheck**: handle `Close()` return errors in `mysql.go`
  - **noctx**: replace `Exec` → `ExecContext` and `NewRequest` → `NewRequestWithContext`
  - **forcetypeassert**: apply comma-ok pattern to all `retrieve*` functions in `pkg/cacheimpls`
  - **gosec**: suppress intentional `math/rand` use for cache TTL jitter (non-security context)
  - **intrange**: adopt Go 1.22+ integer range syntax in `dbmock.go`
- Update `AGENTS.md`: document Go version activation, post-change checklist (`make lint` + `make test`), and PR target

## Test plan

- [x] `make lint` passes with 0 issues