### PR TITLE
feat(mcp): add observability for MCP Server with log search and metrics

### DIFF
--- a/src/dashboard/apigateway/apigateway/apis/web/mcp_server/serializers.py
+++ b/src/dashboard/apigateway/apigateway/apis/web/mcp_server/serializers.py
@@ -857,7 +857,6 @@ class MCPServerAppPermissionAppCodeListOutputSLZ(serializers.Serializer):
 
     bk_app_codes = serializers.ListField(
         child=serializers.CharField(),
-        read_only=True,
         help_text="有权限的应用 bk_app_code 列表",
     )
 

--- a/src/dashboard/apigateway/apigateway/apis/web/mcp_server/serializers.py
+++ b/src/dashboard/apigateway/apigateway/apis/web/mcp_server/serializers.py
@@ -838,3 +838,28 @@ class MCPServerConfigListOutputSLZ(serializers.Serializer):
 
     class Meta:
         ref_name = "apigateway.apis.web.mcp_server.serializers.MCPServerConfigListOutputSLZ"
+
+
+class MCPServerAppPermissionAppCodeListInputSLZ(serializers.Serializer):
+    """MCPServer 已授权应用 bk_app_code 列表输入序列化器"""
+
+    mcp_server_id = serializers.IntegerField(
+        required=False,
+        help_text="MCPServer ID，传入则只查询该 MCPServer 的授权应用",
+    )
+
+    class Meta:
+        ref_name = "apigateway.apis.web.mcp_server.serializers.MCPServerAppPermissionAppCodeListInputSLZ"
+
+
+class MCPServerAppPermissionAppCodeListOutputSLZ(serializers.Serializer):
+    """MCPServer 已授权应用 bk_app_code 列表输出序列化器"""
+
+    bk_app_codes = serializers.ListField(
+        child=serializers.CharField(),
+        read_only=True,
+        help_text="有权限的应用 bk_app_code 列表",
+    )
+
+    class Meta:
+        ref_name = "apigateway.apis.web.mcp_server.serializers.MCPServerAppPermissionAppCodeListOutputSLZ"

--- a/src/dashboard/apigateway/apigateway/apis/web/mcp_server/urls.py
+++ b/src/dashboard/apigateway/apigateway/apis/web/mcp_server/urls.py
@@ -19,6 +19,7 @@
 from django.urls import include, path
 
 from .views import (
+    MCPServerAppPermissionAppCodeListApi,
     MCPServerAppPermissionApplyApplicantListApi,
     MCPServerAppPermissionApplyListApi,
     MCPServerAppPermissionApplyUpdateStatusApi,
@@ -44,6 +45,12 @@ urlpatterns = [
     path("", MCPServerListCreateApi.as_view(), name="mcp_server.list_create"),
     path("-/categories/", MCPServerCategoriesListApi.as_view(), name="mcp_server.categories_list"),
     path("-/filter-options/", MCPServerFilterOptionsApi.as_view(), name="mcp_server.filter_options"),
+    # 有权限的 bk_app_code 列表（网关级别）
+    path(
+        "-/app-permission-app-codes/",
+        MCPServerAppPermissionAppCodeListApi.as_view(),
+        name="mcp_server.app-permission.app_code_list",
+    ),
     # 授权审批列表（网关级别，支持按 mcp_server_id 筛选）
     path(
         "-/app-permission-apply/",

--- a/src/dashboard/apigateway/apigateway/apis/web/mcp_server/views.py
+++ b/src/dashboard/apigateway/apigateway/apis/web/mcp_server/views.py
@@ -1011,4 +1011,6 @@ class MCPServerAppPermissionAppCodeListApi(generics.ListAPIView):
         # 获取唯一的 bk_app_code 列表
         bk_app_codes = queryset.values_list("bk_app_code", flat=True).distinct().order_by("bk_app_code")
 
-        return OKJsonResponse(data={"bk_app_codes": list(bk_app_codes)})
+        output_slz = MCPServerAppPermissionAppCodeListOutputSLZ(data={"bk_app_codes": list(bk_app_codes)})
+        output_slz.is_valid(raise_exception=True)
+        return OKJsonResponse(data=output_slz.data)

--- a/src/dashboard/apigateway/apigateway/apis/web/mcp_server/views.py
+++ b/src/dashboard/apigateway/apigateway/apis/web/mcp_server/views.py
@@ -55,6 +55,8 @@ from apigateway.utils.responses import OKJsonResponse
 from apigateway.utils.time import now_datetime
 
 from .serializers import (
+    MCPServerAppPermissionAppCodeListInputSLZ,
+    MCPServerAppPermissionAppCodeListOutputSLZ,
     MCPServerAppPermissionApplyListInputSLZ,
     MCPServerAppPermissionApplyListOutputSLZ,
     MCPServerAppPermissionApplyUpdateInputSLZ,
@@ -979,3 +981,34 @@ class MCPServerFilterOptionsApi(generics.ListAPIView):
                 "categories": categories,
             }
         )
+
+
+@method_decorator(
+    name="get",
+    decorator=swagger_auto_schema(
+        operation_description="获取有 MCPServer 调用权限的 bk_app_code 列表（网关级别），用于前端下拉列表",
+        query_serializer=MCPServerAppPermissionAppCodeListInputSLZ,
+        responses={status.HTTP_200_OK: MCPServerAppPermissionAppCodeListOutputSLZ()},
+        tags=["WebAPI.MCPServer"],
+    ),
+)
+class MCPServerAppPermissionAppCodeListApi(generics.ListAPIView):
+    """获取有 MCPServer 调用权限的 bk_app_code 列表（网关级别）"""
+
+    def list(self, request, *args, **kwargs):
+        slz = MCPServerAppPermissionAppCodeListInputSLZ(data=request.query_params)
+        slz.is_valid(raise_exception=True)
+
+        mcp_server_id = slz.validated_data.get("mcp_server_id")
+
+        # 构建查询条件
+        queryset = MCPServerAppPermission.objects.filter(mcp_server__gateway=request.gateway)
+
+        # 如果传入了 mcp_server_id，则只查询该 MCPServer 的授权应用
+        if mcp_server_id:
+            queryset = queryset.filter(mcp_server_id=mcp_server_id)
+
+        # 获取唯一的 bk_app_code 列表
+        bk_app_codes = queryset.values_list("bk_app_code", flat=True).distinct().order_by("bk_app_code")
+
+        return OKJsonResponse(data={"bk_app_codes": list(bk_app_codes)})

--- a/src/dashboard/apigateway/apigateway/apis/web/mcp_server_log/__init__.py
+++ b/src/dashboard/apigateway/apigateway/apis/web/mcp_server_log/__init__.py
@@ -1,0 +1,17 @@
+#
+# TencentBlueKing is pleased to support the open source community by making
+# 蓝鲸智云 - API 网关(BlueKing - APIGateway) available.
+# Copyright (C) 2025 Tencent. All rights reserved.
+# Licensed under the MIT License (the "License"); you may not use this file except
+# in compliance with the License. You may obtain a copy of the License at
+#
+#     http://opensource.org/licenses/MIT
+#
+# Unless required by applicable law or agreed to in writing, software distributed under
+# the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+# either express or implied. See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# We undertake not to change the open source license (MIT license) applicable
+# to the current version of the project delivered to anyone in the future.
+#

--- a/src/dashboard/apigateway/apigateway/apis/web/mcp_server_log/serializers.py
+++ b/src/dashboard/apigateway/apigateway/apis/web/mcp_server_log/serializers.py
@@ -1,0 +1,240 @@
+# -*- coding: utf-8 -*-
+#
+# TencentBlueKing is pleased to support the open source community by making
+# 蓝鲸智云 - API 网关(BlueKing - APIGateway) available.
+# Copyright (C) 2025 Tencent. All rights reserved.
+# Licensed under the MIT License (the "License"); you may not use this file except
+# in compliance with the License. You may obtain a copy of the License at
+#
+#     http://opensource.org/licenses/MIT
+#
+# Unless required by applicable law or agreed to in writing, software distributed under
+# the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+# either express or implied. See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# We undertake not to change the open source license (MIT license) applicable
+# to the current version of the project delivered to anyone in the future.
+#
+from typing import List, Tuple
+
+from django.utils.translation import gettext as _
+from rest_framework import serializers
+
+
+class MCPServerLogQueryInputSLZ(serializers.Serializer):
+    """MCP Server 日志查询输入"""
+
+    mcp_server_name = serializers.CharField(allow_blank=True, required=False, help_text="MCP Server 名称")
+    mcp_method = serializers.CharField(
+        allow_blank=True, required=False, help_text="MCP 方法 (initialize, tools/call, tools/list, prompts/get, etc.)"
+    )
+    tool_name = serializers.CharField(allow_blank=True, required=False, help_text="工具名称")
+    prompt_name = serializers.CharField(allow_blank=True, required=False, help_text="Prompt 名称")
+    status = serializers.CharField(allow_blank=True, required=False, help_text="请求状态 (success/failed)")
+    app_code = serializers.CharField(allow_blank=True, required=False, help_text="蓝鲸应用编码")
+    request_id = serializers.CharField(allow_blank=True, required=False, help_text="请求 ID")
+    x_request_id = serializers.CharField(allow_blank=True, required=False, help_text="全链路请求 ID")
+    session_id = serializers.CharField(allow_blank=True, required=False, help_text="会话 ID")
+    query = serializers.CharField(
+        label="查询条件", required=False, allow_blank=True, help_text="ES query_string 查询条件"
+    )
+    # ?include=xxx:yyy&include=aaa:bbb
+    include = serializers.ListField(child=serializers.CharField(), required=False, help_text="包含条件")
+    # ?exclude=xxx:yyy&exclude=aaa:bbb
+    exclude = serializers.ListField(child=serializers.CharField(), required=False, help_text="排除条件")
+    time_range = serializers.IntegerField(label="时间范围", required=False, min_value=0, help_text="时间范围（秒）")
+    time_start = serializers.IntegerField(
+        label="起始时间", required=False, min_value=0, help_text="起始时间（时间戳）"
+    )
+    time_end = serializers.IntegerField(label="结束时间", required=False, min_value=0, help_text="结束时间（时间戳）")
+    offset = serializers.IntegerField(label="偏移量", required=False, min_value=0, default=0, help_text="偏移量")
+    limit = serializers.IntegerField(label="限制条数", required=False, min_value=1, default=10, help_text="限制条数")
+
+    class Meta:
+        ref_name = "apigateway.apis.web.mcp_server_log.serializers.MCPServerLogQueryInputSLZ"
+
+    def validate(self, data):
+        if not (data.get("time_start") and data.get("time_end") or data.get("time_range")):
+            raise serializers.ValidationError(_("参数 time_start+time_end, time_range 必须一组有效。"))
+        return data
+
+    def to_internal_value(self, data):
+        data = super().to_internal_value(data)
+
+        include_conditions: List[Tuple[str, str]] = []
+        if data.get("include"):
+            for expr in data["include"]:
+                if ":" not in expr:
+                    continue
+                k, v = expr.split(":", 1)
+                include_conditions.append((k, v))
+
+        if include_conditions:
+            data["include_conditions"] = include_conditions
+
+        exclude_conditions: List[Tuple[str, str]] = []
+        if data.get("exclude"):
+            for expr in data["exclude"]:
+                if ":" not in expr:
+                    continue
+                k, v = expr.split(":", 1)
+                exclude_conditions.append((k, v))
+
+        if exclude_conditions:
+            data["exclude_conditions"] = exclude_conditions
+
+        return data
+
+
+class MCPServerLogTimeChartOutputSLZ(serializers.Serializer):
+    """时间分布图输出"""
+
+    series = serializers.ListField(child=serializers.IntegerField(), help_text="时间序列数据")
+    timeline = serializers.ListField(child=serializers.IntegerField(), help_text="时间轴")
+
+    class Meta:
+        ref_name = "apigateway.apis.web.mcp_server_log.serializers.MCPServerLogTimeChartOutputSLZ"
+
+
+class MCPServerLogOutputSLZ(serializers.Serializer):
+    """MCP Server 日志输出"""
+
+    request_id = serializers.CharField(required=False, allow_null=True, allow_blank=True, help_text="请求 ID")
+    x_request_id = serializers.CharField(required=False, allow_null=True, allow_blank=True, help_text="全链路请求 ID")
+    timestamp = serializers.IntegerField(required=False, allow_null=True, help_text="请求时间戳")
+    gateway_name = serializers.CharField(required=False, allow_null=True, allow_blank=True, help_text="网关名称")
+    mcp_server_name = serializers.CharField(
+        required=False, allow_null=True, allow_blank=True, help_text="MCP Server 名称"
+    )
+    mcp_method = serializers.CharField(required=False, allow_null=True, allow_blank=True, help_text="MCP 方法")
+    tool_name = serializers.CharField(required=False, allow_null=True, allow_blank=True, help_text="工具名称")
+    prompt_name = serializers.CharField(required=False, allow_null=True, allow_blank=True, help_text="Prompt 名称")
+    app_code = serializers.CharField(required=False, allow_null=True, allow_blank=True, help_text="蓝鲸应用编码")
+    bk_username = serializers.CharField(required=False, allow_null=True, allow_blank=True, help_text="蓝鲸用户")
+    client_ip = serializers.CharField(required=False, allow_null=True, allow_blank=True, help_text="客户端 IP")
+    client_id = serializers.CharField(required=False, allow_null=True, allow_blank=True, help_text="客户端 ID")
+    session_id = serializers.CharField(required=False, allow_null=True, allow_blank=True, help_text="会话 ID")
+    params = serializers.CharField(required=False, allow_null=True, allow_blank=True, help_text="请求参数")
+    response = serializers.CharField(required=False, allow_null=True, allow_blank=True, help_text="响应内容")
+    request_body_size = serializers.IntegerField(required=False, allow_null=True, help_text="请求体大小")
+    response_body_size = serializers.IntegerField(required=False, allow_null=True, help_text="响应体大小")
+    latency = serializers.CharField(required=False, allow_null=True, allow_blank=True, help_text="耗时")
+    trace_id = serializers.CharField(required=False, allow_null=True, allow_blank=True, help_text="Trace ID")
+    status = serializers.CharField(
+        required=False, allow_null=True, allow_blank=True, help_text="请求状态 (success/failed)"
+    )
+    error = serializers.CharField(required=False, allow_null=True, allow_blank=True, help_text="错误信息")
+
+    class Meta:
+        ref_name = "apigateway.apis.web.mcp_server_log.serializers.MCPServerLogOutputSLZ"
+
+
+class SpanDetailOutputSLZ(serializers.Serializer):
+    """Span 详情输出"""
+
+    class Meta:
+        ref_name = "apigateway.apis.web.mcp_server_log.serializers.SpanDetailOutputSLZ"
+
+    def to_representation(self, instance):
+        # detail 是动态字典，直接返回
+        return instance
+
+
+class SpanOutputSLZ(serializers.Serializer):
+    """调用链路 Span 输出"""
+
+    span_id = serializers.CharField(help_text="Span ID")
+    parent_span_id = serializers.CharField(allow_null=True, help_text="父 Span ID")
+    layer = serializers.CharField(help_text="日志层级: http / mcp")
+    service = serializers.CharField(help_text="服务名称")
+    upstream = serializers.CharField(allow_blank=True, allow_null=True, help_text="上游服务名称（调用的目标服务）")
+    operation = serializers.CharField(help_text="操作名称")
+    latency = serializers.CharField(allow_null=True, allow_blank=True, help_text="耗时(原始字符串)")
+    latency_ms = serializers.FloatField(allow_null=True, help_text="耗时(毫秒)")
+    start_offset_ms = serializers.FloatField(help_text="相对于入口请求开始的偏移量(毫秒)")
+    status = serializers.IntegerField(allow_null=True, help_text="HTTP 状态码(仅 HTTP 层)")
+    detail = SpanDetailOutputSLZ(help_text="Span 详情")
+    children = serializers.SerializerMethodField(help_text="子 Span 列表")
+
+    class Meta:
+        ref_name = "apigateway.apis.web.mcp_server_log.serializers.SpanOutputSLZ"
+
+    def get_children(self, obj):
+        children = obj.get("children", [])
+        if not children:
+            return []
+        return SpanOutputSLZ(children, many=True).data
+
+
+class GatewayLogOutputSLZ(serializers.Serializer):
+    """上游网关日志输出"""
+
+    layer = serializers.CharField(help_text="日志层级")
+    service = serializers.CharField(help_text="服务名称")
+    timestamp = serializers.IntegerField(required=False, allow_null=True, help_text="请求时间戳")
+    request_id = serializers.CharField(required=False, allow_null=True, allow_blank=True, help_text="请求 ID")
+    method = serializers.CharField(required=False, allow_null=True, allow_blank=True, help_text="请求方法")
+    http_host = serializers.CharField(required=False, allow_null=True, allow_blank=True, help_text="请求域名")
+    http_path = serializers.CharField(required=False, allow_null=True, allow_blank=True, help_text="请求路径")
+    status = serializers.IntegerField(required=False, allow_null=True, help_text="响应状态码")
+    request_duration = serializers.IntegerField(required=False, allow_null=True, help_text="请求总耗时(ms)")
+    backend_duration = serializers.IntegerField(required=False, allow_null=True, help_text="后端请求耗时(ms)")
+    stage = serializers.CharField(required=False, allow_null=True, allow_blank=True, help_text="环境")
+    resource_name = serializers.CharField(required=False, allow_null=True, allow_blank=True, help_text="资源名称")
+    backend_host = serializers.CharField(required=False, allow_null=True, allow_blank=True, help_text="后端域名")
+    backend_path = serializers.CharField(required=False, allow_null=True, allow_blank=True, help_text="后端路径")
+    backend_method = serializers.CharField(required=False, allow_null=True, allow_blank=True, help_text="后端请求方法")
+    backend_scheme = serializers.CharField(required=False, allow_null=True, allow_blank=True, help_text="后端请求协议")
+    app_code = serializers.CharField(required=False, allow_null=True, allow_blank=True, help_text="蓝鲸应用编码")
+    client_ip = serializers.CharField(required=False, allow_null=True, allow_blank=True, help_text="客户端 IP")
+    error = serializers.CharField(required=False, allow_null=True, allow_blank=True, help_text="错误信息")
+    code_name = serializers.CharField(required=False, allow_null=True, allow_blank=True, help_text="错误编码名称")
+
+    class Meta:
+        ref_name = "apigateway.apis.web.mcp_server_log.serializers.GatewayLogOutputSLZ"
+
+
+class MCPServerLogChainOutputSLZ(serializers.Serializer):
+    """MCP Server 调用链路输出"""
+
+    request_id = serializers.CharField(help_text="请求 ID (X-Bkapi-Request-ID)")
+    x_request_id = serializers.CharField(allow_blank=True, help_text="全链路请求 ID (X-Request-Id)")
+    timestamp = serializers.IntegerField(allow_null=True, help_text="产生时间(时间戳)")
+    total_latency_ms = serializers.FloatField(help_text="总耗时(毫秒)")
+    # 汇总统计信息
+    span_count = serializers.IntegerField(help_text="Span 总数")
+    service_count = serializers.IntegerField(help_text="服务总数")
+    status = serializers.CharField(allow_blank=True, help_text="请求状态 (success/failed)")
+    # 耗时分布：各服务的耗时列表
+    latency_distribution = serializers.ListField(child=serializers.DictField(), help_text="耗时分布（各服务耗时统计）")
+    # 调用链路数据
+    spans = SpanOutputSLZ(many=True, help_text="调用链路 Span 列表")
+    upstream_gateway_log = GatewayLogOutputSLZ(allow_null=True, help_text="上游网关 (bk-apigateway) 日志")
+    downstream_gateway_log = GatewayLogOutputSLZ(allow_null=True, help_text="下游网关 (biz-gateway) 日志")
+
+    class Meta:
+        ref_name = "apigateway.apis.web.mcp_server_log.serializers.MCPServerLogChainOutputSLZ"
+
+
+class MCPServerLogQuerySummaryOutputSLZ(serializers.Serializer):
+    """工具箱 MCP Server 调用链汇总输出"""
+
+    request_id = serializers.CharField(help_text="请求 ID (X-Bkapi-Request-ID)")
+    x_request_id = serializers.CharField(allow_blank=True, help_text="全链路请求 ID (X-Request-Id)")
+    timestamp = serializers.IntegerField(allow_null=True, help_text="产生时间(时间戳)")
+    total_latency_ms = serializers.FloatField(help_text="总耗时(毫秒)")
+    service_count = serializers.IntegerField(help_text="服务数")
+    span_count = serializers.IntegerField(help_text="Span 总数")
+    status = serializers.CharField(allow_blank=True, help_text="请求状态 (success/failed)")
+    mcp_server_name = serializers.CharField(allow_blank=True, help_text="MCP Server 名称")
+    mcp_method = serializers.CharField(allow_blank=True, help_text="MCP 方法")
+    tool_name = serializers.CharField(allow_blank=True, help_text="工具名称")
+    app_code = serializers.CharField(allow_blank=True, help_text="蓝鲸应用编码")
+    client_ip = serializers.CharField(allow_blank=True, help_text="客户端 IP")
+    error = serializers.CharField(allow_blank=True, help_text="错误信息")
+    # 耗时分布
+    latency_distribution = serializers.ListField(child=serializers.DictField(), help_text="耗时分布（各服务耗时统计）")
+
+    class Meta:
+        ref_name = "apigateway.apis.web.mcp_server_log.serializers.MCPServerLogQuerySummaryOutputSLZ"

--- a/src/dashboard/apigateway/apigateway/apis/web/mcp_server_log/urls.py
+++ b/src/dashboard/apigateway/apigateway/apis/web/mcp_server_log/urls.py
@@ -1,0 +1,44 @@
+# -*- coding: utf-8 -*-
+#
+# TencentBlueKing is pleased to support the open source community by making
+# 蓝鲸智云 - API 网关(BlueKing - APIGateway) available.
+# Copyright (C) 2025 Tencent. All rights reserved.
+# Licensed under the MIT License (the "License"); you may not use this file except
+# in compliance with the License. You may obtain a copy of the License at
+#
+#     http://opensource.org/licenses/MIT
+#
+# Unless required by applicable law or agreed to in writing, software distributed under
+# the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+# either express or implied. See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# We undertake not to change the open source license (MIT license) applicable
+# to the current version of the project delivered to anyone in the future.
+#
+from django.urls import include, path
+
+from .views import (
+    MCPServerLogChainApi,
+    MCPServerLogDetailApi,
+    MCPServerLogExportApi,
+    MCPServerLogTimeChartRetrieveApi,
+    MCPServerLogTraceApi,
+    MCPServerSearchLogListApi,
+)
+
+urlpatterns = [
+    path("", MCPServerSearchLogListApi.as_view(), name="mcp_server_log.logs"),
+    path("export/", MCPServerLogExportApi.as_view(), name="mcp_server_log.export"),
+    path("timechart/", MCPServerLogTimeChartRetrieveApi.as_view(), name="mcp_server_log.logs.time_chart"),
+    path(
+        "<slug:request_id>/",
+        include(
+            [
+                path("", MCPServerLogDetailApi.as_view(), name="mcp_server_log.logs.detail"),
+                path("chain/", MCPServerLogChainApi.as_view(), name="mcp_server_log.logs.chain"),
+            ]
+        ),
+    ),
+    path("trace/<slug:x_request_id>/", MCPServerLogTraceApi.as_view(), name="mcp_server_log.logs.trace"),
+]

--- a/src/dashboard/apigateway/apigateway/apis/web/mcp_server_log/views.py
+++ b/src/dashboard/apigateway/apigateway/apis/web/mcp_server_log/views.py
@@ -35,8 +35,6 @@ from apigateway.biz.mcp_server_log.constants import MCP_SERVER_LOG_FIELDS
 from apigateway.biz.mcp_server_log.utils import build_mcp_server_log_client
 from apigateway.utils.paginator import LimitOffsetPaginator
 from apigateway.utils.responses import DownloadableResponse, OKJsonResponse
-
-logger = logging.getLogger(__name__)
 from apigateway.utils.time import SmartTimeRange
 
 from .serializers import (
@@ -46,6 +44,8 @@ from .serializers import (
     MCPServerLogQuerySummaryOutputSLZ,
     MCPServerLogTimeChartOutputSLZ,
 )
+
+logger = logging.getLogger(__name__)
 
 
 @method_decorator(

--- a/src/dashboard/apigateway/apigateway/apis/web/mcp_server_log/views.py
+++ b/src/dashboard/apigateway/apigateway/apis/web/mcp_server_log/views.py
@@ -24,13 +24,12 @@ from django.utils.decorators import method_decorator
 from drf_yasg.utils import swagger_auto_schema
 from rest_framework import generics, status
 
-from apigateway.biz.mcp_server_log.chain_helpers import (
-    build_chain_summary,
-    build_latency_distribution,
-    enrich_chain_data,
-    flatten_spans_to_logs,
+from apigateway.biz.mcp_server_log.chain_query import (
+    search_chain_logs_by_any_id,
+    search_chain_logs_with_gateway_by_any_id,
+    search_chain_summary_by_any_id,
+    search_chain_with_summary_by_any_id,
 )
-from apigateway.biz.mcp_server_log.chain_search import MCPServerLogChainSearchClient
 from apigateway.biz.mcp_server_log.constants import MCP_SERVER_LOG_FIELDS
 from apigateway.biz.mcp_server_log.utils import build_mcp_server_log_client
 from apigateway.utils.paginator import LimitOffsetPaginator
@@ -173,32 +172,8 @@ class MCPServerLogDetailApi(generics.RetrieveAPIView):
     """
 
     def retrieve(self, request, request_id, *args, **kwargs):
-        # 使用 MCPServerLogChainSearchClient 查询所有层级的日志
-        # 因为它不强制过滤 mcp_method，可以查到 HTTP 层和审计日志
-        client = MCPServerLogChainSearchClient(request_id=request_id)
-        chain_data = client.search_chain()
-
-        # 如果没找到数据，尝试作为 x_request_id 查询
-        if not chain_data.get("spans"):
-            client = MCPServerLogChainSearchClient(x_request_id=request_id)
-            chain_data = client.search_chain_by_x_request_id()
-
-        # 如果还是没找到数据，尝试作为 upstream_request_id 查询
-        # upstream_request_id 是上游 API 返回的 request_id，存储在 MCP 层日志中
-        if not chain_data.get("spans"):
-            client = MCPServerLogChainSearchClient(upstream_request_id=request_id)
-            chain_data = client.search_chain_by_upstream_request_id()
-
-        # 将 spans 扁平化为日志列表
-        logs = flatten_spans_to_logs(chain_data)
-
-        total_count = len(logs)
-        paginator = LimitOffsetPaginator(total_count, 0, total_count)
-
-        results = paginator.get_paginated_data(logs)
-        results["fields"] = MCP_SERVER_LOG_FIELDS
-
-        return OKJsonResponse(data=results)
+        result = search_chain_logs_by_any_id(request_id)
+        return OKJsonResponse(data=result)
 
 
 @method_decorator(
@@ -220,32 +195,8 @@ class MCPServerLogTraceApi(generics.RetrieveAPIView):
     """
 
     def retrieve(self, request, x_request_id, *args, **kwargs):
-        # 使用 MCPServerLogChainSearchClient 查询所有层级的日志
-        # 因为它不强制过滤 mcp_method，可以查到 HTTP 层和审计日志
-        client = MCPServerLogChainSearchClient(request_id="", x_request_id=x_request_id)
-        chain_data = client.search_chain_by_x_request_id()
-
-        # 将 spans 扁平化为日志列表
-        logs = flatten_spans_to_logs(chain_data)
-
-        # 添加网关日志到列表开头（如果有）
-        if chain_data.get("upstream_gateway_log"):
-            upstream_log = chain_data["upstream_gateway_log"]
-            upstream_log["layer"] = "gateway_upstream"
-            logs.insert(0, upstream_log)
-
-        if chain_data.get("downstream_gateway_log"):
-            downstream_log = chain_data["downstream_gateway_log"]
-            downstream_log["layer"] = "gateway_downstream"
-            logs.insert(0, downstream_log)
-
-        total_count = len(logs)
-        paginator = LimitOffsetPaginator(total_count, 0, total_count)
-
-        results = paginator.get_paginated_data(logs)
-        results["fields"] = MCP_SERVER_LOG_FIELDS
-
-        return OKJsonResponse(data=results)
+        result = search_chain_logs_with_gateway_by_any_id(x_request_id)
+        return OKJsonResponse(data=result)
 
 
 @method_decorator(
@@ -274,22 +225,7 @@ class MCPServerLogChainApi(generics.RetrieveAPIView):
     """
 
     def retrieve(self, request, request_id, *args, **kwargs):
-        client = MCPServerLogChainSearchClient(request_id=request_id)
-        chain_data = client.search_chain()
-
-        # 如果没找到数据，尝试作为 x_request_id 查询
-        if not chain_data.get("spans"):
-            client = MCPServerLogChainSearchClient(x_request_id=request_id)
-            chain_data = client.search_chain_by_x_request_id()
-
-        # 如果还是没找到数据，尝试作为 upstream_request_id 查询
-        if not chain_data.get("spans"):
-            client = MCPServerLogChainSearchClient(upstream_request_id=request_id)
-            chain_data = client.search_chain_by_upstream_request_id()
-
-        # 添加汇总统计信息
-        chain_data = enrich_chain_data(chain_data)
-
+        chain_data = search_chain_with_summary_by_any_id(request_id)
         slz = MCPServerLogChainOutputSLZ(instance=chain_data)
         return OKJsonResponse(data=slz.data)
 
@@ -318,46 +254,8 @@ class MCPServerLogQueryApi(generics.RetrieveAPIView):
     gateway_permission_exempt = True
 
     def retrieve(self, request, request_id, *args, **kwargs):
-        # 使用 MCPServerLogChainSearchClient 查询所有层级的日志
-        # 因为它不强制过滤 mcp_method，可以查到 HTTP 层和审计日志
-
-        # 尝试作为 request_id 查询
-        client = MCPServerLogChainSearchClient(request_id=request_id)
-        chain_data = client.search_chain()
-
-        # 如果没找到数据，尝试作为 x_request_id 查询
-        if not chain_data.get("spans"):
-            client = MCPServerLogChainSearchClient(x_request_id=request_id)
-            chain_data = client.search_chain_by_x_request_id()
-
-        # 如果还是没找到数据，尝试作为 upstream_request_id 查询
-        # upstream_request_id 是上游 API 返回的 request_id，存储在 MCP 层日志中
-        if not chain_data.get("spans"):
-            client = MCPServerLogChainSearchClient(upstream_request_id=request_id)
-            chain_data = client.search_chain_by_upstream_request_id()
-
-        # 将 spans 扁平化为日志列表
-        logs = flatten_spans_to_logs(chain_data)
-
-        # 添加网关日志到列表开头（如果有）
-        # 注意：不同查询方式返回的网关日志字段名可能不同
-        if chain_data.get("upstream_gateway_log"):
-            upstream_log = chain_data["upstream_gateway_log"]
-            upstream_log["layer"] = "gateway_upstream"
-            logs.insert(0, upstream_log)
-
-        if chain_data.get("downstream_gateway_log"):
-            downstream_log = chain_data["downstream_gateway_log"]
-            downstream_log["layer"] = "gateway_downstream"
-            logs.insert(0, downstream_log)
-
-        total_count = len(logs)
-        paginator = LimitOffsetPaginator(total_count, 0, total_count)
-
-        results = paginator.get_paginated_data(logs)
-        results["fields"] = MCP_SERVER_LOG_FIELDS
-
-        return OKJsonResponse(data=results)
+        result = search_chain_logs_with_gateway_by_any_id(request_id)
+        return OKJsonResponse(data=result)
 
 
 @method_decorator(
@@ -381,24 +279,7 @@ class MCPServerLogQuerySummaryApi(generics.RetrieveAPIView):
     gateway_permission_exempt = True
 
     def retrieve(self, request, request_id, *args, **kwargs):
-        # 尝试作为 request_id 查询
-        client = MCPServerLogChainSearchClient(request_id=request_id)
-        chain_data = client.search_chain()
-
-        # 如果没找到数据，尝试作为 x_request_id 查询
-        if not chain_data.get("spans"):
-            client = MCPServerLogChainSearchClient(x_request_id=request_id)
-            chain_data = client.search_chain_by_x_request_id()
-
-        # 如果还是没找到数据，尝试作为 upstream_request_id 查询
-        if not chain_data.get("spans"):
-            client = MCPServerLogChainSearchClient(upstream_request_id=request_id)
-            chain_data = client.search_chain_by_upstream_request_id()
-
-        # 构建汇总信息
-        summary = build_chain_summary(chain_data)
-        summary["latency_distribution"] = build_latency_distribution(chain_data)
-
+        summary = search_chain_summary_by_any_id(request_id)
         slz = MCPServerLogQuerySummaryOutputSLZ(instance=summary)
         return OKJsonResponse(data=slz.data)
 
@@ -430,22 +311,6 @@ class MCPServerLogQueryChainApi(generics.RetrieveAPIView):
     gateway_permission_exempt = True
 
     def retrieve(self, request, request_id, *args, **kwargs):
-        # 尝试作为 request_id 查询
-        client = MCPServerLogChainSearchClient(request_id=request_id)
-        chain_data = client.search_chain()
-
-        # 如果没找到数据，尝试作为 x_request_id 查询
-        if not chain_data.get("spans"):
-            client = MCPServerLogChainSearchClient(x_request_id=request_id)
-            chain_data = client.search_chain_by_x_request_id()
-
-        # 如果还是没找到数据，尝试作为 upstream_request_id 查询
-        if not chain_data.get("spans"):
-            client = MCPServerLogChainSearchClient(upstream_request_id=request_id)
-            chain_data = client.search_chain_by_upstream_request_id()
-
-        # 添加汇总统计信息
-        chain_data = enrich_chain_data(chain_data)
-
+        chain_data = search_chain_with_summary_by_any_id(request_id)
         slz = MCPServerLogChainOutputSLZ(instance=chain_data)
         return OKJsonResponse(data=slz.data)

--- a/src/dashboard/apigateway/apigateway/apis/web/mcp_server_log/views.py
+++ b/src/dashboard/apigateway/apigateway/apis/web/mcp_server_log/views.py
@@ -17,6 +17,7 @@
 # to the current version of the project delivered to anyone in the future.
 #
 import csv
+import logging
 from datetime import datetime
 from io import StringIO
 
@@ -34,6 +35,8 @@ from apigateway.biz.mcp_server_log.constants import MCP_SERVER_LOG_FIELDS
 from apigateway.biz.mcp_server_log.utils import build_mcp_server_log_client
 from apigateway.utils.paginator import LimitOffsetPaginator
 from apigateway.utils.responses import DownloadableResponse, OKJsonResponse
+
+logger = logging.getLogger(__name__)
 from apigateway.utils.time import SmartTimeRange
 
 from .serializers import (
@@ -120,6 +123,12 @@ class MCPServerLogExportApi(generics.RetrieveAPIView):
             offset=0,
             limit=limit,
         )
+
+        if total_count > limit:
+            logger.warning(
+                "MCP log export truncated: total_count=%s exceeds limit=%s, gateway=%s",
+                total_count, limit, request.gateway.name,
+            )
 
         gateway = request.gateway
 

--- a/src/dashboard/apigateway/apigateway/apis/web/mcp_server_log/views.py
+++ b/src/dashboard/apigateway/apigateway/apis/web/mcp_server_log/views.py
@@ -24,9 +24,15 @@ from django.utils.decorators import method_decorator
 from drf_yasg.utils import swagger_auto_schema
 from rest_framework import generics, status
 
+from apigateway.biz.mcp_server_log.chain_helpers import (
+    build_chain_summary,
+    build_latency_distribution,
+    enrich_chain_data,
+    flatten_spans_to_logs,
+)
 from apigateway.biz.mcp_server_log.chain_search import MCPServerLogChainSearchClient
 from apigateway.biz.mcp_server_log.constants import MCP_SERVER_LOG_FIELDS
-from apigateway.biz.mcp_server_log.log_search import MCPServerLogSearchClient
+from apigateway.biz.mcp_server_log.utils import build_mcp_server_log_client
 from apigateway.utils.paginator import LimitOffsetPaginator
 from apigateway.utils.responses import DownloadableResponse, OKJsonResponse
 from apigateway.utils.time import SmartTimeRange
@@ -38,42 +44,6 @@ from .serializers import (
     MCPServerLogQuerySummaryOutputSLZ,
     MCPServerLogTimeChartOutputSLZ,
 )
-
-
-def _span_to_log(span: dict) -> dict:
-    """将 span 转换为日志格式"""
-    detail = span.get("detail", {})
-    return {
-        "layer": span.get("layer"),
-        "service": span.get("service"),
-        "operation": span.get("operation"),
-        "latency": span.get("latency"),
-        "latency_ms": span.get("latency_ms"),
-        "status": span.get("status"),
-        **detail,
-    }
-
-
-def _build_mcp_server_log_client(request, data) -> MCPServerLogSearchClient:
-    """根据请求参数构建 MCP Server 日志搜索客户端"""
-    return MCPServerLogSearchClient(
-        gateway_name=request.gateway.name,
-        mcp_server_name=data.get("mcp_server_name"),
-        mcp_method=data.get("mcp_method"),
-        tool_name=data.get("tool_name"),
-        prompt_name=data.get("prompt_name"),
-        app_code=data.get("app_code"),
-        request_id=data.get("request_id"),
-        x_request_id=data.get("x_request_id"),
-        session_id=data.get("session_id"),
-        status=data.get("status"),
-        query=data.get("query"),
-        include_conditions=data.get("include_conditions"),
-        exclude_conditions=data.get("exclude_conditions"),
-        time_start=data.get("time_start"),
-        time_end=data.get("time_end"),
-        time_range=data.get("time_range"),
-    )
 
 
 @method_decorator(
@@ -93,7 +63,7 @@ class MCPServerLogTimeChartRetrieveApi(generics.RetrieveAPIView):
         slz.is_valid(raise_exception=True)
         data = slz.validated_data
 
-        client = _build_mcp_server_log_client(request, data)
+        client = build_mcp_server_log_client(request.gateway.name, data)
         slz = MCPServerLogTimeChartOutputSLZ(instance=client.get_time_chart())
         return OKJsonResponse(data=slz.data)
 
@@ -114,7 +84,7 @@ class MCPServerSearchLogListApi(generics.ListAPIView):
         slz.is_valid(raise_exception=True)
         data = slz.validated_data
 
-        client = _build_mcp_server_log_client(request, data)
+        client = build_mcp_server_log_client(request.gateway.name, data)
         total_count, logs = client.search_logs(
             offset=data["offset"],
             limit=data["limit"],
@@ -146,7 +116,7 @@ class MCPServerLogExportApi(generics.RetrieveAPIView):
         slz.is_valid(raise_exception=True)
         data = slz.validated_data
 
-        client = _build_mcp_server_log_client(request, data)
+        client = build_mcp_server_log_client(request.gateway.name, data)
         total_count, logs = client.search_logs(
             offset=0,
             limit=limit,
@@ -220,10 +190,7 @@ class MCPServerLogDetailApi(generics.RetrieveAPIView):
             chain_data = client.search_chain_by_upstream_request_id()
 
         # 将 spans 扁平化为日志列表
-        logs = []
-        for span in chain_data.get("spans", []):
-            logs.append(_span_to_log(span))
-            logs.extend(_span_to_log(child) for child in span.get("children", []))
+        logs = flatten_spans_to_logs(chain_data)
 
         total_count = len(logs)
         paginator = LimitOffsetPaginator(total_count, 0, total_count)
@@ -259,10 +226,7 @@ class MCPServerLogTraceApi(generics.RetrieveAPIView):
         chain_data = client.search_chain_by_x_request_id()
 
         # 将 spans 扁平化为日志列表
-        logs = []
-        for span in chain_data.get("spans", []):
-            logs.append(_span_to_log(span))
-            logs.extend(_span_to_log(child) for child in span.get("children", []))
+        logs = flatten_spans_to_logs(chain_data)
 
         # 添加网关日志到列表开头（如果有）
         if chain_data.get("upstream_gateway_log"):
@@ -324,7 +288,7 @@ class MCPServerLogChainApi(generics.RetrieveAPIView):
             chain_data = client.search_chain_by_upstream_request_id()
 
         # 添加汇总统计信息
-        chain_data = _enrich_chain_data(chain_data)
+        chain_data = enrich_chain_data(chain_data)
 
         slz = MCPServerLogChainOutputSLZ(instance=chain_data)
         return OKJsonResponse(data=slz.data)
@@ -373,10 +337,7 @@ class MCPServerLogQueryApi(generics.RetrieveAPIView):
             chain_data = client.search_chain_by_upstream_request_id()
 
         # 将 spans 扁平化为日志列表
-        logs = []
-        for span in chain_data.get("spans", []):
-            logs.append(_span_to_log(span))
-            logs.extend(_span_to_log(child) for child in span.get("children", []))
+        logs = flatten_spans_to_logs(chain_data)
 
         # 添加网关日志到列表开头（如果有）
         # 注意：不同查询方式返回的网关日志字段名可能不同
@@ -397,122 +358,6 @@ class MCPServerLogQueryApi(generics.RetrieveAPIView):
         results["fields"] = MCP_SERVER_LOG_FIELDS
 
         return OKJsonResponse(data=results)
-
-
-def _build_chain_summary(chain_data: dict) -> dict:
-    """从调用链数据构建汇总信息"""
-    spans = chain_data.get("spans", [])
-
-    # 计算服务数（去重）
-    services = set()
-    span_count = 0
-
-    def count_spans(span_list):
-        nonlocal span_count
-        for span in span_list:
-            span_count += 1
-            if span.get("service"):
-                services.add(span["service"])
-            count_spans(span.get("children", []))
-
-    count_spans(spans)
-
-    # 计算状态：如果有任何 error 则为 failed
-    status = "success"
-    for span in spans:
-        if span.get("detail", {}).get("error"):
-            status = "failed"
-            break
-
-    # 从 HTTP 入口 span 提取公共信息，从第一个 MCP 子 span 提取 MCP 特有信息
-    first_span = spans[0] if spans else {}
-    first_detail = first_span.get("detail", {})
-
-    # 递归查找第一个 MCP 层 span（含 mcp_method / tool_name）
-    def find_first_mcp_span(span_list):
-        for span in span_list:
-            if span.get("layer") == "mcp":
-                return span
-            result = find_first_mcp_span(span.get("children", []))
-            if result:
-                return result
-        return None
-
-    mcp_span = find_first_mcp_span(spans)
-    mcp_detail = mcp_span.get("detail", {}) if mcp_span else {}
-
-    # 获取 timestamp（从 chain_data 中获取）
-    timestamp = chain_data.get("timestamp")
-
-    return {
-        "request_id": chain_data.get("request_id", ""),
-        "x_request_id": chain_data.get("x_request_id", ""),
-        "timestamp": timestamp,
-        "total_latency_ms": chain_data.get("total_latency_ms", 0),
-        "service_count": len(services),
-        "span_count": span_count,
-        "status": status,
-        "mcp_server_name": mcp_detail.get("mcp_server_name", "") or first_detail.get("mcp_server_name", ""),
-        "mcp_method": mcp_detail.get("mcp_method", ""),
-        "tool_name": mcp_detail.get("tool_name", ""),
-        "app_code": mcp_detail.get("app_code", "") or first_detail.get("app_code", ""),
-        "client_ip": mcp_detail.get("client_ip", "") or first_detail.get("client_ip", ""),
-        "error": mcp_detail.get("error", "") or first_detail.get("error", ""),
-    }
-
-
-def _build_latency_distribution(chain_data: dict) -> list:
-    """从调用链数据构建耗时分布
-
-    返回各服务的耗时统计列表，按 start_offset_ms 排序
-    """
-    spans = chain_data.get("spans", [])
-    total_latency_ms = chain_data.get("total_latency_ms", 0) or 0
-    latency_distribution = []
-
-    def collect_latencies(span_list):
-        for span in span_list:
-            service = span.get("service", "")
-            latency_ms = span.get("latency_ms", 0) or 0
-            start_offset_ms = span.get("start_offset_ms", 0) or 0
-            layer = span.get("layer", "")
-            operation = span.get("operation", "")
-
-            if service:
-                percentage = (latency_ms / total_latency_ms * 100) if total_latency_ms > 0 else 0
-                latency_distribution.append(
-                    {
-                        "service": service,
-                        "upstream": span.get("upstream", ""),
-                        "layer": layer,
-                        "operation": operation,
-                        "latency_ms": round(latency_ms, 2),
-                        "start_offset_ms": round(start_offset_ms, 2),
-                        "percentage": round(percentage, 1),
-                    }
-                )
-
-            collect_latencies(span.get("children", []))
-
-    collect_latencies(spans)
-
-    # 按 start_offset_ms 排序
-    latency_distribution.sort(key=lambda x: x.get("start_offset_ms", 0))
-
-    return latency_distribution
-
-
-def _enrich_chain_data(chain_data: dict) -> dict:
-    """为调用链数据添加汇总统计信息"""
-    summary = _build_chain_summary(chain_data)
-    latency_distribution = _build_latency_distribution(chain_data)
-
-    chain_data["span_count"] = summary["span_count"]
-    chain_data["service_count"] = summary["service_count"]
-    chain_data["status"] = summary["status"]
-    chain_data["latency_distribution"] = latency_distribution
-
-    return chain_data
 
 
 @method_decorator(
@@ -551,8 +396,8 @@ class MCPServerLogQuerySummaryApi(generics.RetrieveAPIView):
             chain_data = client.search_chain_by_upstream_request_id()
 
         # 构建汇总信息
-        summary = _build_chain_summary(chain_data)
-        summary["latency_distribution"] = _build_latency_distribution(chain_data)
+        summary = build_chain_summary(chain_data)
+        summary["latency_distribution"] = build_latency_distribution(chain_data)
 
         slz = MCPServerLogQuerySummaryOutputSLZ(instance=summary)
         return OKJsonResponse(data=slz.data)
@@ -600,7 +445,7 @@ class MCPServerLogQueryChainApi(generics.RetrieveAPIView):
             chain_data = client.search_chain_by_upstream_request_id()
 
         # 添加汇总统计信息
-        chain_data = _enrich_chain_data(chain_data)
+        chain_data = enrich_chain_data(chain_data)
 
         slz = MCPServerLogChainOutputSLZ(instance=chain_data)
         return OKJsonResponse(data=slz.data)

--- a/src/dashboard/apigateway/apigateway/apis/web/mcp_server_log/views.py
+++ b/src/dashboard/apigateway/apigateway/apis/web/mcp_server_log/views.py
@@ -1,0 +1,585 @@
+# -*- coding: utf-8 -*-
+#
+# TencentBlueKing is pleased to support the open source community by making
+# 蓝鲸智云 - API 网关(BlueKing - APIGateway) available.
+# Copyright (C) 2025 Tencent. All rights reserved.
+# Licensed under the MIT License (the "License"); you may not use this file except
+# in compliance with the License. You may obtain a copy of the License at
+#
+#     http://opensource.org/licenses/MIT
+#
+# Unless required by applicable law or agreed to in writing, software distributed under
+# the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+# either express or implied. See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# We undertake not to change the open source license (MIT license) applicable
+# to the current version of the project delivered to anyone in the future.
+#
+import csv
+from datetime import datetime
+from io import StringIO
+
+from django.utils.decorators import method_decorator
+from drf_yasg.utils import swagger_auto_schema
+from rest_framework import generics, status
+
+from apigateway.biz.mcp_server_log.chain_search import MCPServerLogChainSearchClient
+from apigateway.biz.mcp_server_log.constants import MCP_SERVER_LOG_FIELDS
+from apigateway.biz.mcp_server_log.log_search import MCPServerLogSearchClient
+from apigateway.utils.paginator import LimitOffsetPaginator
+from apigateway.utils.responses import DownloadableResponse, OKJsonResponse
+from apigateway.utils.time import SmartTimeRange
+
+from .serializers import (
+    MCPServerLogChainOutputSLZ,
+    MCPServerLogOutputSLZ,
+    MCPServerLogQueryInputSLZ,
+    MCPServerLogQuerySummaryOutputSLZ,
+    MCPServerLogTimeChartOutputSLZ,
+)
+
+
+def _span_to_log(span: dict) -> dict:
+    """将 span 转换为日志格式"""
+    detail = span.get("detail", {})
+    return {
+        "layer": span.get("layer"),
+        "service": span.get("service"),
+        "operation": span.get("operation"),
+        "latency": span.get("latency"),
+        "latency_ms": span.get("latency_ms"),
+        "status": span.get("status"),
+        **detail,
+    }
+
+
+def _build_mcp_server_log_client(request, data) -> MCPServerLogSearchClient:
+    """根据请求参数构建 MCP Server 日志搜索客户端"""
+    return MCPServerLogSearchClient(
+        gateway_name=request.gateway.name,
+        mcp_server_name=data.get("mcp_server_name"),
+        mcp_method=data.get("mcp_method"),
+        tool_name=data.get("tool_name"),
+        prompt_name=data.get("prompt_name"),
+        app_code=data.get("app_code"),
+        request_id=data.get("request_id"),
+        x_request_id=data.get("x_request_id"),
+        session_id=data.get("session_id"),
+        status=data.get("status"),
+        query=data.get("query"),
+        include_conditions=data.get("include_conditions"),
+        exclude_conditions=data.get("exclude_conditions"),
+        time_start=data.get("time_start"),
+        time_end=data.get("time_end"),
+        time_range=data.get("time_range"),
+    )
+
+
+@method_decorator(
+    name="get",
+    decorator=swagger_auto_schema(
+        query_serializer=MCPServerLogQueryInputSLZ,
+        responses={status.HTTP_200_OK: MCPServerLogTimeChartOutputSLZ()},
+        operation_description="查询 MCP Server 日志时间分布图",
+        tags=["WebAPI.MCPServer.Log"],
+    ),
+)
+class MCPServerLogTimeChartRetrieveApi(generics.RetrieveAPIView):
+    """MCP Server 日志时间分布图"""
+
+    def retrieve(self, request, *args, **kwargs):
+        slz = MCPServerLogQueryInputSLZ(data=request.query_params)
+        slz.is_valid(raise_exception=True)
+        data = slz.validated_data
+
+        client = _build_mcp_server_log_client(request, data)
+        slz = MCPServerLogTimeChartOutputSLZ(instance=client.get_time_chart())
+        return OKJsonResponse(data=slz.data)
+
+
+@method_decorator(
+    name="get",
+    decorator=swagger_auto_schema(
+        responses={status.HTTP_200_OK: MCPServerLogOutputSLZ(many=True)},
+        operation_description="查询 MCP Server 日志列表",
+        tags=["WebAPI.MCPServer.Log"],
+    ),
+)
+class MCPServerSearchLogListApi(generics.ListAPIView):
+    """MCP Server 日志列表"""
+
+    def list(self, request, *args, **kwargs):
+        slz = MCPServerLogQueryInputSLZ(data=request.query_params)
+        slz.is_valid(raise_exception=True)
+        data = slz.validated_data
+
+        client = _build_mcp_server_log_client(request, data)
+        total_count, logs = client.search_logs(
+            offset=data["offset"],
+            limit=data["limit"],
+        )
+
+        paginator = LimitOffsetPaginator(total_count, data["offset"], data["limit"])
+
+        results = paginator.get_paginated_data(logs)
+        results["fields"] = MCP_SERVER_LOG_FIELDS
+
+        return OKJsonResponse(data=results)
+
+
+@method_decorator(
+    name="get",
+    decorator=swagger_auto_schema(
+        query_serializer=MCPServerLogQueryInputSLZ,
+        responses={status.HTTP_200_OK: "file/csv"},
+        operation_description="导出 MCP Server 日志",
+        tags=["WebAPI.MCPServer.Log"],
+    ),
+)
+class MCPServerLogExportApi(generics.RetrieveAPIView):
+    """MCP Server 日志导出"""
+
+    def get(self, request, *args, **kwargs):
+        limit = 10000
+        slz = MCPServerLogQueryInputSLZ(data=request.query_params)
+        slz.is_valid(raise_exception=True)
+        data = slz.validated_data
+
+        client = _build_mcp_server_log_client(request, data)
+        total_count, logs = client.search_logs(
+            offset=0,
+            limit=limit,
+        )
+
+        gateway = request.gateway
+
+        # Handle both time_start+time_end and time_range scenarios
+        smart_time_range = SmartTimeRange(
+            time_start=data.get("time_start"),
+            time_end=data.get("time_end"),
+            time_range=data.get("time_range"),
+        )
+        time_start, time_end = smart_time_range.get_head_and_tail()
+        time_start_dt = datetime.fromtimestamp(time_start)
+        time_end_dt = datetime.fromtimestamp(time_end)
+
+        formatted_time_start = time_start_dt.strftime("%Y%m%d%H%M%S")
+        formatted_time_end = time_end_dt.strftime("%Y%m%d%H%M%S")
+
+        output = StringIO()
+        writer = csv.writer(output)
+
+        writer.writerow(field_dict["field"] for field_dict in MCP_SERVER_LOG_FIELDS)
+        for log in logs:
+            writer.writerow([log.get(field_dict["field"]) for field_dict in MCP_SERVER_LOG_FIELDS])
+
+        content = output.getvalue()
+        output.close()
+
+        response = DownloadableResponse(
+            content, filename=f"{gateway.name}-mcp-server-{formatted_time_start}-{formatted_time_end}-logs.csv"
+        )
+        response.charset = "utf-8-sig" if "windows" in request.headers.get("User-Agent", "").lower() else "utf-8"
+        return response
+
+
+@method_decorator(
+    name="get",
+    decorator=swagger_auto_schema(
+        responses={status.HTTP_200_OK: MCPServerLogOutputSLZ(many=True)},
+        operation_description="根据 request_id 获取 MCP Server 日志详情",
+        tags=["WebAPI.MCPServer.Log"],
+    ),
+)
+class MCPServerLogDetailApi(generics.RetrieveAPIView):
+    """根据 request_id 获取 MCP Server 日志详情
+
+    支持通过 request_id 查询完整的 MCP 请求日志。
+    如需通过 x_request_id 关联查询全链路日志，请使用 MCPServerLogTraceApi。
+
+    注意：此接口查询所有层级的日志（HTTP 层、MCP 协议层、审计日志），
+    不强制要求 mcp_method 字段存在。
+    """
+
+    def retrieve(self, request, request_id, *args, **kwargs):
+        # 使用 MCPServerLogChainSearchClient 查询所有层级的日志
+        # 因为它不强制过滤 mcp_method，可以查到 HTTP 层和审计日志
+        client = MCPServerLogChainSearchClient(request_id=request_id)
+        chain_data = client.search_chain()
+
+        # 将 spans 扁平化为日志列表
+        logs = []
+        for span in chain_data.get("spans", []):
+            logs.append(_span_to_log(span))
+            logs.extend(_span_to_log(child) for child in span.get("children", []))
+
+        total_count = len(logs)
+        paginator = LimitOffsetPaginator(total_count, 0, total_count)
+
+        results = paginator.get_paginated_data(logs)
+        results["fields"] = MCP_SERVER_LOG_FIELDS
+
+        return OKJsonResponse(data=results)
+
+
+@method_decorator(
+    name="get",
+    decorator=swagger_auto_schema(
+        responses={status.HTTP_200_OK: MCPServerLogOutputSLZ(many=True)},
+        operation_description="根据 x_request_id 查询全链路关联日志",
+        tags=["WebAPI.MCPServer.Log"],
+    ),
+)
+class MCPServerLogTraceApi(generics.RetrieveAPIView):
+    """根据 x_request_id（全链路请求 ID）查询关联日志
+
+    可以关联 MCP Proxy 的请求日志与上下游网关的日志，
+    实现跨服务的请求追踪。
+
+    注意：此接口查询所有层级的日志（HTTP 层、MCP 协议层、审计日志），
+    不强制要求 mcp_method 字段存在。
+    """
+
+    def retrieve(self, request, x_request_id, *args, **kwargs):
+        # 使用 MCPServerLogChainSearchClient 查询所有层级的日志
+        # 因为它不强制过滤 mcp_method，可以查到 HTTP 层和审计日志
+        client = MCPServerLogChainSearchClient(request_id="", x_request_id=x_request_id)
+        chain_data = client.search_chain_by_x_request_id()
+
+        # 将 spans 扁平化为日志列表
+        logs = []
+        for span in chain_data.get("spans", []):
+            logs.append(_span_to_log(span))
+            logs.extend(_span_to_log(child) for child in span.get("children", []))
+
+        # 添加网关日志到列表开头（如果有）
+        if chain_data.get("upstream_gateway_log"):
+            upstream_log = chain_data["upstream_gateway_log"]
+            upstream_log["layer"] = "gateway_upstream"
+            logs.insert(0, upstream_log)
+
+        if chain_data.get("downstream_gateway_log"):
+            downstream_log = chain_data["downstream_gateway_log"]
+            downstream_log["layer"] = "gateway_downstream"
+            logs.insert(0, downstream_log)
+
+        total_count = len(logs)
+        paginator = LimitOffsetPaginator(total_count, 0, total_count)
+
+        results = paginator.get_paginated_data(logs)
+        results["fields"] = MCP_SERVER_LOG_FIELDS
+
+        return OKJsonResponse(data=results)
+
+
+@method_decorator(
+    name="get",
+    decorator=swagger_auto_schema(
+        responses={status.HTTP_200_OK: MCPServerLogChainOutputSLZ()},
+        operation_description="根据 request_id 查询 MCP Server 调用链路（瀑布图数据）",
+        tags=["WebAPI.MCPServer.Log"],
+    ),
+)
+class MCPServerLogChainApi(generics.RetrieveAPIView):
+    """MCP Server 调用链路查询
+
+    通过 request_id 查询同一请求的所有层级日志（HTTP 层、MCP 协议层），
+    并关联上游 bk-apigateway 和下游 biz-gateway 的日志，组装成调用链路树结构，
+    用于前端瀑布图展示各环节耗时。
+
+    返回结构包含:
+    - spans: 按层级组织的调用链路 span 列表（含 latency_ms、start_offset_ms 等瀑布图绘制所需数据）
+    - upstream_gateway_log: 上游 bk-apigateway 的日志详情（如果能关联到）
+    - downstream_gateway_log: 下游 biz-gateway 的日志详情（如果能关联到）
+    - span_count: Span 总数
+    - service_count: 服务总数
+    - status: 请求状态 (success/failed)
+    - latency_distribution: 耗时分布（各服务耗时统计）
+    """
+
+    def retrieve(self, request, request_id, *args, **kwargs):
+        client = MCPServerLogChainSearchClient(request_id=request_id)
+        chain_data = client.search_chain()
+
+        # 添加汇总统计信息
+        chain_data = _enrich_chain_data(chain_data)
+
+        slz = MCPServerLogChainOutputSLZ(instance=chain_data)
+        return OKJsonResponse(data=slz.data)
+
+
+@method_decorator(
+    name="get",
+    decorator=swagger_auto_schema(
+        responses={status.HTTP_200_OK: MCPServerLogOutputSLZ(many=True)},
+        operation_description="根据 request_id 或 x_request_id 查询 MCP Server 日志（工具箱，无需网关权限）",
+        tags=["WebAPI.MCPServer.Log"],
+    ),
+)
+class MCPServerLogQueryApi(generics.RetrieveAPIView):
+    """工具箱中根据 request_id 或 x_request_id 查询 MCP Server 日志
+
+    该接口注册在不带 gateway_id 的顶层路径，供平台工具箱使用。
+    仅需登录认证，跳过网关权限校验（与 LogDetailInfoApi 对齐）。
+
+    支持通过 request_id（X-Bkapi-Request-ID）或 x_request_id（X-Request-Id）查询。
+    接口会自动识别传入的 ID 类型并进行相应查询。
+
+    注意：此接口查询所有层级的日志（HTTP 层、MCP 协议层、审计日志），
+    不强制要求 mcp_method 字段存在。
+    """
+
+    gateway_permission_exempt = True
+
+    def retrieve(self, request, request_id, *args, **kwargs):
+        # 使用 MCPServerLogChainSearchClient 查询所有层级的日志
+        # 因为它不强制过滤 mcp_method，可以查到 HTTP 层和审计日志
+
+        # 尝试作为 request_id 查询
+        client = MCPServerLogChainSearchClient(request_id=request_id)
+        chain_data = client.search_chain()
+
+        # 如果没找到数据，尝试作为 x_request_id 查询
+        if not chain_data.get("spans"):
+            client = MCPServerLogChainSearchClient(x_request_id=request_id)
+            chain_data = client.search_chain_by_x_request_id()
+
+        # 如果还是没找到数据，尝试作为 upstream_request_id 查询
+        # upstream_request_id 是上游 API 返回的 request_id，存储在 MCP 层日志中
+        if not chain_data.get("spans"):
+            client = MCPServerLogChainSearchClient(upstream_request_id=request_id)
+            chain_data = client.search_chain_by_upstream_request_id()
+
+        # 将 spans 扁平化为日志列表
+        logs = []
+        for span in chain_data.get("spans", []):
+            logs.append(_span_to_log(span))
+            logs.extend(_span_to_log(child) for child in span.get("children", []))
+
+        # 添加网关日志到列表开头（如果有）
+        # 注意：不同查询方式返回的网关日志字段名可能不同
+        if chain_data.get("upstream_gateway_log"):
+            upstream_log = chain_data["upstream_gateway_log"]
+            upstream_log["layer"] = "gateway_upstream"
+            logs.insert(0, upstream_log)
+
+        if chain_data.get("downstream_gateway_log"):
+            downstream_log = chain_data["downstream_gateway_log"]
+            downstream_log["layer"] = "gateway_downstream"
+            logs.insert(0, downstream_log)
+
+        total_count = len(logs)
+        paginator = LimitOffsetPaginator(total_count, 0, total_count)
+
+        results = paginator.get_paginated_data(logs)
+        results["fields"] = MCP_SERVER_LOG_FIELDS
+
+        return OKJsonResponse(data=results)
+
+
+def _build_chain_summary(chain_data: dict) -> dict:
+    """从调用链数据构建汇总信息"""
+    spans = chain_data.get("spans", [])
+
+    # 计算服务数（去重）
+    services = set()
+    span_count = 0
+
+    def count_spans(span_list):
+        nonlocal span_count
+        for span in span_list:
+            span_count += 1
+            if span.get("service"):
+                services.add(span["service"])
+            count_spans(span.get("children", []))
+
+    count_spans(spans)
+
+    # 计算状态：如果有任何 error 则为 failed
+    status = "success"
+    for span in spans:
+        if span.get("detail", {}).get("error"):
+            status = "failed"
+            break
+
+    # 从 HTTP 入口 span 提取公共信息，从第一个 MCP 子 span 提取 MCP 特有信息
+    first_span = spans[0] if spans else {}
+    first_detail = first_span.get("detail", {})
+
+    # 递归查找第一个 MCP 层 span（含 mcp_method / tool_name）
+    def find_first_mcp_span(span_list):
+        for span in span_list:
+            if span.get("layer") == "mcp":
+                return span
+            result = find_first_mcp_span(span.get("children", []))
+            if result:
+                return result
+        return None
+
+    mcp_span = find_first_mcp_span(spans)
+    mcp_detail = mcp_span.get("detail", {}) if mcp_span else {}
+
+    # 获取 timestamp（从 chain_data 中获取）
+    timestamp = chain_data.get("timestamp")
+
+    return {
+        "request_id": chain_data.get("request_id", ""),
+        "x_request_id": chain_data.get("x_request_id", ""),
+        "timestamp": timestamp,
+        "total_latency_ms": chain_data.get("total_latency_ms", 0),
+        "service_count": len(services),
+        "span_count": span_count,
+        "status": status,
+        "mcp_server_name": mcp_detail.get("mcp_server_name", "") or first_detail.get("mcp_server_name", ""),
+        "mcp_method": mcp_detail.get("mcp_method", ""),
+        "tool_name": mcp_detail.get("tool_name", ""),
+        "app_code": mcp_detail.get("app_code", "") or first_detail.get("app_code", ""),
+        "client_ip": mcp_detail.get("client_ip", "") or first_detail.get("client_ip", ""),
+        "error": mcp_detail.get("error", "") or first_detail.get("error", ""),
+    }
+
+
+def _build_latency_distribution(chain_data: dict) -> list:
+    """从调用链数据构建耗时分布
+
+    返回各服务的耗时统计列表，按 start_offset_ms 排序
+    """
+    spans = chain_data.get("spans", [])
+    total_latency_ms = chain_data.get("total_latency_ms", 0) or 0
+    latency_distribution = []
+
+    def collect_latencies(span_list):
+        for span in span_list:
+            service = span.get("service", "")
+            latency_ms = span.get("latency_ms", 0) or 0
+            start_offset_ms = span.get("start_offset_ms", 0) or 0
+            layer = span.get("layer", "")
+            operation = span.get("operation", "")
+
+            if service:
+                percentage = (latency_ms / total_latency_ms * 100) if total_latency_ms > 0 else 0
+                latency_distribution.append(
+                    {
+                        "service": service,
+                        "upstream": span.get("upstream", ""),
+                        "layer": layer,
+                        "operation": operation,
+                        "latency_ms": round(latency_ms, 2),
+                        "start_offset_ms": round(start_offset_ms, 2),
+                        "percentage": round(percentage, 1),
+                    }
+                )
+
+            collect_latencies(span.get("children", []))
+
+    collect_latencies(spans)
+
+    # 按 start_offset_ms 排序
+    latency_distribution.sort(key=lambda x: x.get("start_offset_ms", 0))
+
+    return latency_distribution
+
+
+def _enrich_chain_data(chain_data: dict) -> dict:
+    """为调用链数据添加汇总统计信息"""
+    summary = _build_chain_summary(chain_data)
+    latency_distribution = _build_latency_distribution(chain_data)
+
+    chain_data["span_count"] = summary["span_count"]
+    chain_data["service_count"] = summary["service_count"]
+    chain_data["status"] = summary["status"]
+    chain_data["latency_distribution"] = latency_distribution
+
+    return chain_data
+
+
+@method_decorator(
+    name="get",
+    decorator=swagger_auto_schema(
+        responses={status.HTTP_200_OK: MCPServerLogQuerySummaryOutputSLZ()},
+        operation_description="根据 request_id 或 x_request_id 查询 MCP Server 调用链汇总信息（工具箱，无需网关权限）",
+        tags=["WebAPI.MCPServer.Log"],
+    ),
+)
+class MCPServerLogQuerySummaryApi(generics.RetrieveAPIView):
+    """工具箱中根据 request_id 或 x_request_id 查询 MCP Server 调用链汇总信息
+
+    该接口注册在不带 gateway_id 的顶层路径，供平台工具箱使用。
+    仅需登录认证，跳过网关权限校验。
+
+    返回调用链的汇总信息，包括：
+    - 产生时间、总耗时、服务数、Span 总数、状态等
+    """
+
+    gateway_permission_exempt = True
+
+    def retrieve(self, request, request_id, *args, **kwargs):
+        # 尝试作为 request_id 查询
+        client = MCPServerLogChainSearchClient(request_id=request_id)
+        chain_data = client.search_chain()
+
+        # 如果没找到数据，尝试作为 x_request_id 查询
+        if not chain_data.get("spans"):
+            client = MCPServerLogChainSearchClient(x_request_id=request_id)
+            chain_data = client.search_chain_by_x_request_id()
+
+        # 如果还是没找到数据，尝试作为 upstream_request_id 查询
+        if not chain_data.get("spans"):
+            client = MCPServerLogChainSearchClient(upstream_request_id=request_id)
+            chain_data = client.search_chain_by_upstream_request_id()
+
+        # 构建汇总信息
+        summary = _build_chain_summary(chain_data)
+        summary["latency_distribution"] = _build_latency_distribution(chain_data)
+
+        slz = MCPServerLogQuerySummaryOutputSLZ(instance=summary)
+        return OKJsonResponse(data=slz.data)
+
+
+@method_decorator(
+    name="get",
+    decorator=swagger_auto_schema(
+        responses={status.HTTP_200_OK: MCPServerLogChainOutputSLZ()},
+        operation_description="根据 request_id 或 x_request_id 查询 MCP Server 调用链路详情（工具箱，无需网关权限）",
+        tags=["WebAPI.MCPServer.Log"],
+    ),
+)
+class MCPServerLogQueryChainApi(generics.RetrieveAPIView):
+    """工具箱中根据 request_id 或 x_request_id 查询 MCP Server 调用链路详情
+
+    该接口注册在不带 gateway_id 的顶层路径，供平台工具箱使用。
+    仅需登录认证，跳过网关权限校验。
+
+    返回完整的调用链路数据，包括：
+    - spans: 调用链路 Span 列表（含 latency_ms、start_offset_ms 等瀑布图绘制所需数据）
+    - upstream_gateway_log: 上游网关日志（如果能关联到）
+    - downstream_gateway_log: 下游网关日志（如果能关联到）
+    - span_count: Span 总数
+    - service_count: 服务总数
+    - status: 请求状态 (success/failed)
+    - latency_distribution: 耗时分布（各服务耗时统计）
+    """
+
+    gateway_permission_exempt = True
+
+    def retrieve(self, request, request_id, *args, **kwargs):
+        # 尝试作为 request_id 查询
+        client = MCPServerLogChainSearchClient(request_id=request_id)
+        chain_data = client.search_chain()
+
+        # 如果没找到数据，尝试作为 x_request_id 查询
+        if not chain_data.get("spans"):
+            client = MCPServerLogChainSearchClient(x_request_id=request_id)
+            chain_data = client.search_chain_by_x_request_id()
+
+        # 如果还是没找到数据，尝试作为 upstream_request_id 查询
+        if not chain_data.get("spans"):
+            client = MCPServerLogChainSearchClient(upstream_request_id=request_id)
+            chain_data = client.search_chain_by_upstream_request_id()
+
+        # 添加汇总统计信息
+        chain_data = _enrich_chain_data(chain_data)
+
+        slz = MCPServerLogChainOutputSLZ(instance=chain_data)
+        return OKJsonResponse(data=slz.data)

--- a/src/dashboard/apigateway/apigateway/apis/web/mcp_server_log/views.py
+++ b/src/dashboard/apigateway/apigateway/apis/web/mcp_server_log/views.py
@@ -65,7 +65,7 @@ class MCPServerLogTimeChartRetrieveApi(generics.RetrieveAPIView):
         slz.is_valid(raise_exception=True)
         data = slz.validated_data
 
-        client = build_mcp_server_log_client(request.gateway.name, data)
+        client = build_mcp_server_log_client(request.gateway.name, data, gateway_id=request.gateway.id)
         slz = MCPServerLogTimeChartOutputSLZ(instance=client.get_time_chart())
         return OKJsonResponse(data=slz.data)
 
@@ -86,7 +86,7 @@ class MCPServerSearchLogListApi(generics.ListAPIView):
         slz.is_valid(raise_exception=True)
         data = slz.validated_data
 
-        client = build_mcp_server_log_client(request.gateway.name, data)
+        client = build_mcp_server_log_client(request.gateway.name, data, gateway_id=request.gateway.id)
         total_count, logs = client.search_logs(
             offset=data["offset"],
             limit=data["limit"],
@@ -118,7 +118,7 @@ class MCPServerLogExportApi(generics.RetrieveAPIView):
         slz.is_valid(raise_exception=True)
         data = slz.validated_data
 
-        client = build_mcp_server_log_client(request.gateway.name, data)
+        client = build_mcp_server_log_client(request.gateway.name, data, gateway_id=request.gateway.id)
         total_count, logs = client.search_logs(
             offset=0,
             limit=limit,
@@ -127,7 +127,9 @@ class MCPServerLogExportApi(generics.RetrieveAPIView):
         if total_count > limit:
             logger.warning(
                 "MCP log export truncated: total_count=%s exceeds limit=%s, gateway=%s",
-                total_count, limit, request.gateway.name,
+                total_count,
+                limit,
+                request.gateway.name,
             )
 
         gateway = request.gateway

--- a/src/dashboard/apigateway/apigateway/apis/web/mcp_server_log/views.py
+++ b/src/dashboard/apigateway/apigateway/apis/web/mcp_server_log/views.py
@@ -208,6 +208,17 @@ class MCPServerLogDetailApi(generics.RetrieveAPIView):
         client = MCPServerLogChainSearchClient(request_id=request_id)
         chain_data = client.search_chain()
 
+        # 如果没找到数据，尝试作为 x_request_id 查询
+        if not chain_data.get("spans"):
+            client = MCPServerLogChainSearchClient(x_request_id=request_id)
+            chain_data = client.search_chain_by_x_request_id()
+
+        # 如果还是没找到数据，尝试作为 upstream_request_id 查询
+        # upstream_request_id 是上游 API 返回的 request_id，存储在 MCP 层日志中
+        if not chain_data.get("spans"):
+            client = MCPServerLogChainSearchClient(upstream_request_id=request_id)
+            chain_data = client.search_chain_by_upstream_request_id()
+
         # 将 spans 扁平化为日志列表
         logs = []
         for span in chain_data.get("spans", []):
@@ -301,6 +312,16 @@ class MCPServerLogChainApi(generics.RetrieveAPIView):
     def retrieve(self, request, request_id, *args, **kwargs):
         client = MCPServerLogChainSearchClient(request_id=request_id)
         chain_data = client.search_chain()
+
+        # 如果没找到数据，尝试作为 x_request_id 查询
+        if not chain_data.get("spans"):
+            client = MCPServerLogChainSearchClient(x_request_id=request_id)
+            chain_data = client.search_chain_by_x_request_id()
+
+        # 如果还是没找到数据，尝试作为 upstream_request_id 查询
+        if not chain_data.get("spans"):
+            client = MCPServerLogChainSearchClient(upstream_request_id=request_id)
+            chain_data = client.search_chain_by_upstream_request_id()
 
         # 添加汇总统计信息
         chain_data = _enrich_chain_data(chain_data)

--- a/src/dashboard/apigateway/apigateway/apis/web/mcp_server_metrics/serializers.py
+++ b/src/dashboard/apigateway/apigateway/apis/web/mcp_server_metrics/serializers.py
@@ -1,0 +1,61 @@
+# -*- coding: utf-8 -*-
+#
+# TencentBlueKing is pleased to support the open source community by making
+# 蓝鲸智云 - API 网关(BlueKing - APIGateway) available.
+# Copyright (C) 2025 Tencent. All rights reserved.
+# Licensed under the MIT License (the "License"); you may not use this file except
+# in compliance with the License. You may obtain a copy of the License at
+#
+#     http://opensource.org/licenses/MIT
+#
+# Unless required by applicable law or agreed to in writing, software distributed under
+# the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+# either express or implied. See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# We undertake not to change the open source license (MIT license) applicable
+# to the current version of the project delivered to anyone in the future.
+#
+from django.utils.translation import gettext as _
+from rest_framework import serializers
+
+from apigateway.apps.mcp_server.metrics_constants import (
+    MCPServerMetricsInstantEnum,
+    MCPServerMetricsRangeEnum,
+)
+from apigateway.apps.metrics.constants import MetricsStepEnum
+
+
+class MCPServerMetricsQueryRangeInputSLZ(serializers.Serializer):
+    mcp_server_name = serializers.CharField(allow_blank=True, required=False, help_text="MCP Server 名称")
+    app_code = serializers.CharField(allow_blank=True, required=False, help_text="调用方应用编码")
+    metrics = serializers.ChoiceField(choices=MCPServerMetricsRangeEnum.get_choices(), help_text="metric 类型")
+    time_range = serializers.IntegerField(required=False, min_value=0, help_text="时间范围（秒）")
+    time_start = serializers.IntegerField(required=False, min_value=0, help_text="开始时间（时间戳）")
+    time_end = serializers.IntegerField(required=False, min_value=0, help_text="结束时间（时间戳）")
+    step = serializers.ChoiceField(choices=MetricsStepEnum.get_choices(), required=False, help_text="精度")
+
+    class Meta:
+        ref_name = "apigateway.apis.web.mcp_server_metrics.serializers.MCPServerMetricsQueryRangeInputSLZ"
+
+    def validate(self, data):
+        if not (data.get("time_start") and data.get("time_end") or data.get("time_range")):
+            raise serializers.ValidationError(_("参数 time_start+time_end, time_range 必须一组有效。"))
+        return data
+
+
+class MCPServerMetricsQueryInstantInputSLZ(serializers.Serializer):
+    mcp_server_name = serializers.CharField(allow_blank=True, required=False, help_text="MCP Server 名称")
+    app_code = serializers.CharField(allow_blank=True, required=False, help_text="调用方应用编码")
+    metrics = serializers.ChoiceField(choices=MCPServerMetricsInstantEnum.get_choices(), help_text="metric 类型")
+    time_range = serializers.IntegerField(required=False, min_value=0, help_text="时间范围（秒）")
+    time_start = serializers.IntegerField(required=False, min_value=0, help_text="开始时间（时间戳）")
+    time_end = serializers.IntegerField(required=False, min_value=0, help_text="结束时间（时间戳）")
+
+    class Meta:
+        ref_name = "apigateway.apis.web.mcp_server_metrics.serializers.MCPServerMetricsQueryInstantInputSLZ"
+
+    def validate(self, data):
+        if not (data.get("time_start") and data.get("time_end") or data.get("time_range")):
+            raise serializers.ValidationError(_("参数 time_start+time_end, time_range 必须一组有效。"))
+        return data

--- a/src/dashboard/apigateway/apigateway/apis/web/mcp_server_metrics/urls.py
+++ b/src/dashboard/apigateway/apigateway/apis/web/mcp_server_metrics/urls.py
@@ -1,0 +1,26 @@
+# -*- coding: utf-8 -*-
+#
+# TencentBlueKing is pleased to support the open source community by making
+# 蓝鲸智云 - API 网关(BlueKing - APIGateway) available.
+# Copyright (C) 2025 Tencent. All rights reserved.
+# Licensed under the MIT License (the "License"); you may not use this file except
+# in compliance with the License. You may obtain a copy of the License at
+#
+#     http://opensource.org/licenses/MIT
+#
+# Unless required by applicable law or agreed to in writing, software distributed under
+# the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+# either express or implied. See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# We undertake not to change the open source license (MIT license) applicable
+# to the current version of the project delivered to anyone in the future.
+#
+from django.urls import path
+
+from .views import MCPServerQueryInstantApi, MCPServerQueryRangeApi
+
+urlpatterns = [
+    path("query-range/", MCPServerQueryRangeApi.as_view(), name="mcp_server_metrics.query_range"),
+    path("query-instant/", MCPServerQueryInstantApi.as_view(), name="mcp_server_metrics.query_instant"),
+]

--- a/src/dashboard/apigateway/apigateway/apis/web/mcp_server_metrics/views.py
+++ b/src/dashboard/apigateway/apigateway/apis/web/mcp_server_metrics/views.py
@@ -1,0 +1,130 @@
+# -*- coding: utf-8 -*-
+#
+# TencentBlueKing is pleased to support the open source community by making
+# 蓝鲸智云 - API 网关(BlueKing - APIGateway) available.
+# Copyright (C) 2025 Tencent. All rights reserved.
+# Licensed under the MIT License (the "License"); you may not use this file except
+# in compliance with the License. You may obtain a copy of the License at
+#
+#     http://opensource.org/licenses/MIT
+#
+# Unless required by applicable law or agreed to in writing, software distributed under
+# the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+# either express or implied. See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# We undertake not to change the open source license (MIT license) applicable
+# to the current version of the project delivered to anyone in the future.
+#
+from drf_yasg.utils import swagger_auto_schema
+from rest_framework import generics, status
+
+from apigateway.apps.mcp_server.metrics_constants import (
+    MCPServerMetricsInstantEnum,
+    MCPServerMetricsRangeEnum,
+)
+from apigateway.apps.metrics.constants import MetricsStepEnum
+from apigateway.service.prometheus.mcp_server_dimension import (
+    MCPServerMetricsInstantFactory,
+    MCPServerMetricsRangeFactory,
+)
+from apigateway.utils.responses import OKJsonResponse
+from apigateway.utils.time import MetricsSmartTimeRange
+
+from .serializers import (
+    MCPServerMetricsQueryInstantInputSLZ,
+    MCPServerMetricsQueryRangeInputSLZ,
+)
+
+
+class MCPServerQueryRangeApi(generics.ListAPIView):
+    """MCP Server 时序图指标查询 API
+
+    支持的 metrics 类型:
+    - requests: 请求总量趋势
+    - requests_2xx: 2XX 状态码请求趋势
+    - non_2xx_status: 非 2XX 状态码请求趋势（按 error_code 分组）
+    - app_requests: 按 app_code 分组的请求趋势
+    - tool_requests: 按 tool_name 分组的请求趋势
+    - response_time_95th: P95 响应时间分布
+    - method_requests: 按 MCP 方法分组的请求趋势
+    """
+
+    @swagger_auto_schema(
+        query_serializer=MCPServerMetricsQueryRangeInputSLZ(),
+        responses={status.HTTP_200_OK: ""},
+        operation_description="查询 MCP Server 时序图 metrics",
+        tags=["WebAPI.MCPServer.Metrics"],
+    )
+    def get(self, request, *args, **kwargs):
+        slz = MCPServerMetricsQueryRangeInputSLZ(data=request.query_params)
+        slz.is_valid(raise_exception=True)
+        data = slz.validated_data
+
+        smart_time_range = MetricsSmartTimeRange(
+            data.get("time_start"),
+            data.get("time_end"),
+            data.get("time_range"),
+        )
+        time_start, time_end = smart_time_range.get_head_and_tail()
+        if data.get("step", MetricsStepEnum.AUTO.value) == MetricsStepEnum.AUTO.value:
+            step = smart_time_range.get_interval()
+        else:
+            step = data.get("step")
+
+        metrics = MCPServerMetricsRangeFactory.create_metrics(MCPServerMetricsRangeEnum(data["metrics"]))
+        result = metrics.query_range(
+            gateway_name=request.gateway.name,
+            mcp_server_name=data.get("mcp_server_name"),
+            app_code=data.get("app_code"),
+            start=time_start,
+            end=time_end,
+            step=step,
+        )
+
+        # Filter out empty series targets
+        series = [s for s in result.get("series", []) if s["target"].strip()]
+        if series:
+            result["series"] = series
+
+        return OKJsonResponse(data=result)
+
+
+class MCPServerQueryInstantApi(generics.ListAPIView):
+    """MCP Server 瞬时值指标查询 API
+
+    支持的 metrics 类型:
+    - requests_total: 总请求数
+    - non_2xx_total: 非 2XX 请求数
+    """
+
+    @swagger_auto_schema(
+        query_serializer=MCPServerMetricsQueryInstantInputSLZ(),
+        responses={status.HTTP_200_OK: ""},
+        operation_description="查询 MCP Server 瞬时值 metrics",
+        tags=["WebAPI.MCPServer.Metrics"],
+    )
+    def get(self, request, *args, **kwargs):
+        slz = MCPServerMetricsQueryInstantInputSLZ(data=request.query_params)
+        slz.is_valid(raise_exception=True)
+        data = slz.validated_data
+
+        smart_time_range = MetricsSmartTimeRange(
+            data.get("time_start"),
+            data.get("time_end"),
+            data.get("time_range"),
+        )
+        time_start, time_end = smart_time_range.get_head_and_tail()
+        step = smart_time_range.get_interval()
+
+        metrics = MCPServerMetricsInstantFactory.create_metrics(MCPServerMetricsInstantEnum(data["metrics"]))
+        result = metrics.query_instant(
+            gateway_name=request.gateway.name,
+            mcp_server_name=data.get("mcp_server_name"),
+            app_code=data.get("app_code"),
+            start=time_start,
+            end=time_end,
+            step=step,
+        )
+
+        return OKJsonResponse(data=result)

--- a/src/dashboard/apigateway/apigateway/apps/mcp_server/metrics_constants.py
+++ b/src/dashboard/apigateway/apigateway/apps/mcp_server/metrics_constants.py
@@ -1,0 +1,57 @@
+# -*- coding: utf-8 -*-
+#
+# TencentBlueKing is pleased to support the open source community by making
+# 蓝鲸智云 - API 网关(BlueKing - APIGateway) available.
+# Copyright (C) 2025 Tencent. All rights reserved.
+# Licensed under the MIT License (the "License"); you may not use this file except
+# in compliance with the License. You may obtain a copy of the License at
+#
+#     http://opensource.org/licenses/MIT
+#
+# Unless required by applicable law or agreed to in writing, software distributed under
+# the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+# either express or implied. See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# We undertake not to change the open source license (MIT license) applicable
+# to the current version of the project delivered to anyone in the future.
+#
+from blue_krill.data_types.enum import EnumField, StructuredEnum
+
+
+class MCPServerMetricsRangeEnum(StructuredEnum):
+    """MCP Server 时序图指标类型"""
+
+    # 请求总量趋势
+    REQUESTS = EnumField("requests")
+    # 2XX 状态码请求趋势
+    REQUESTS_2XX = EnumField("requests_2xx")
+    # 非 2XX 状态码请求趋势（按 status 分组）
+    NON_2XX_STATUS = EnumField("non_2xx_status")
+    # 按 app_code 分组的请求趋势
+    APP_REQUESTS = EnumField("app_requests")
+    # 按 resource_name/tool_name 分组的请求趋势
+    TOOL_REQUESTS = EnumField("tool_requests")
+    # 网关到后端响应时间 P50
+    RESPONSE_TIME_50TH = EnumField("response_time_50th")
+    # 网关到后端响应时间 P95
+    RESPONSE_TIME_95TH = EnumField("response_time_95th")
+    # 网关到后端响应时间 P99
+    RESPONSE_TIME_99TH = EnumField("response_time_99th")
+    # 按 method（MCP 方法）分组的请求趋势
+    METHOD_REQUESTS = EnumField("method_requests")
+    # 请求体大小趋势
+    REQUEST_BODY_SIZE = EnumField("request_body_size")
+    # 响应体大小趋势
+    RESPONSE_BODY_SIZE = EnumField("response_body_size")
+
+
+class MCPServerMetricsInstantEnum(StructuredEnum):
+    """MCP Server 瞬时值指标类型"""
+
+    # 总请求数
+    REQUESTS_TOTAL = EnumField("requests_total")
+    # 非 2XX 请求数
+    NON_2XX_TOTAL = EnumField("non_2xx_total")
+    # 健康率
+    HEALTH_RATE = EnumField("health_rate")

--- a/src/dashboard/apigateway/apigateway/biz/mcp_server_log/__init__.py
+++ b/src/dashboard/apigateway/apigateway/biz/mcp_server_log/__init__.py
@@ -1,0 +1,17 @@
+#
+# TencentBlueKing is pleased to support the open source community by making
+# 蓝鲸智云 - API 网关(BlueKing - APIGateway) available.
+# Copyright (C) 2025 Tencent. All rights reserved.
+# Licensed under the MIT License (the "License"); you may not use this file except
+# in compliance with the License. You may obtain a copy of the License at
+#
+#     http://opensource.org/licenses/MIT
+#
+# Unless required by applicable law or agreed to in writing, software distributed under
+# the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+# either express or implied. See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# We undertake not to change the open source license (MIT license) applicable
+# to the current version of the project delivered to anyone in the future.
+#

--- a/src/dashboard/apigateway/apigateway/biz/mcp_server_log/chain_helpers.py
+++ b/src/dashboard/apigateway/apigateway/biz/mcp_server_log/chain_helpers.py
@@ -1,0 +1,164 @@
+#
+# TencentBlueKing is pleased to support the open source community by making
+# 蓝鲸智云 - API 网关(BlueKing - APIGateway) available.
+# Copyright (C) 2025 Tencent. All rights reserved.
+# Licensed under the MIT License (the "License"); you may not use this file except
+# in compliance with the License. You may obtain a copy of the License at
+#
+#     http://opensource.org/licenses/MIT
+#
+# Unless required by applicable law or agreed to in writing, software distributed under
+# the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+# either express or implied. See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# We undertake not to change the open source license (MIT license) applicable
+# to the current version of the project delivered to anyone in the future.
+#
+from typing import Dict, List, Optional
+
+from apigateway.biz.mcp_server_log.constants import MCP_SERVER_LOG_FIELDS
+
+
+def span_to_log(span: dict) -> dict:
+    """将 span 转换为日志格式"""
+    detail = span.get("detail", {})
+    return {
+        "layer": span.get("layer"),
+        "service": span.get("service"),
+        "operation": span.get("operation"),
+        "latency": span.get("latency"),
+        "latency_ms": span.get("latency_ms"),
+        "status": span.get("status"),
+        **detail,
+    }
+
+
+def build_chain_summary(chain_data: dict) -> dict:
+    """从调用链数据构建汇总信息"""
+    spans = chain_data.get("spans", [])
+
+    # 计算服务数（去重）
+    services = set()
+    span_count = 0
+
+    def count_spans(span_list: List[Dict]) -> None:
+        nonlocal span_count
+        for span in span_list:
+            span_count += 1
+            if span.get("service"):
+                services.add(span["service"])
+            count_spans(span.get("children", []))
+
+    count_spans(spans)
+
+    # 计算状态：如果有任何 error 则为 failed
+    status = "success"
+    for span in spans:
+        if span.get("detail", {}).get("error"):
+            status = "failed"
+            break
+
+    # 从 HTTP 入口 span 提取公共信息，从第一个 MCP 子 span 提取 MCP 特有信息
+    first_span = spans[0] if spans else {}
+    first_detail = first_span.get("detail", {})
+
+    # 递归查找第一个 MCP 层 span（含 mcp_method / tool_name）
+    def find_first_mcp_span(span_list: List[Dict]) -> Optional[Dict]:
+        for span in span_list:
+            if span.get("layer") == "mcp":
+                return span
+            result = find_first_mcp_span(span.get("children", []))
+            if result:
+                return result
+        return None
+
+    mcp_span = find_first_mcp_span(spans)
+    mcp_detail = mcp_span.get("detail", {}) if mcp_span else {}
+
+    # 获取 timestamp（从 chain_data 中获取）
+    timestamp = chain_data.get("timestamp")
+
+    return {
+        "request_id": chain_data.get("request_id", ""),
+        "x_request_id": chain_data.get("x_request_id", ""),
+        "timestamp": timestamp,
+        "total_latency_ms": chain_data.get("total_latency_ms", 0),
+        "service_count": len(services),
+        "span_count": span_count,
+        "status": status,
+        "mcp_server_name": mcp_detail.get("mcp_server_name", "") or first_detail.get("mcp_server_name", ""),
+        "mcp_method": mcp_detail.get("mcp_method", ""),
+        "tool_name": mcp_detail.get("tool_name", ""),
+        "app_code": mcp_detail.get("app_code", "") or first_detail.get("app_code", ""),
+        "client_ip": mcp_detail.get("client_ip", "") or first_detail.get("client_ip", ""),
+        "error": mcp_detail.get("error", "") or first_detail.get("error", ""),
+    }
+
+
+def build_latency_distribution(chain_data: dict) -> list:
+    """从调用链数据构建耗时分布
+
+    返回各服务的耗时统计列表，按 start_offset_ms 排序
+    """
+    spans = chain_data.get("spans", [])
+    total_latency_ms = chain_data.get("total_latency_ms", 0) or 0
+    latency_distribution = []
+
+    def collect_latencies(span_list: List[Dict]) -> None:
+        for span in span_list:
+            service = span.get("service", "")
+            latency_ms = span.get("latency_ms", 0) or 0
+            start_offset_ms = span.get("start_offset_ms", 0) or 0
+            layer = span.get("layer", "")
+            operation = span.get("operation", "")
+
+            if service:
+                percentage = (latency_ms / total_latency_ms * 100) if total_latency_ms > 0 else 0
+                latency_distribution.append(
+                    {
+                        "service": service,
+                        "upstream": span.get("upstream", ""),
+                        "layer": layer,
+                        "operation": operation,
+                        "latency_ms": round(latency_ms, 2),
+                        "start_offset_ms": round(start_offset_ms, 2),
+                        "percentage": round(percentage, 1),
+                    }
+                )
+
+            collect_latencies(span.get("children", []))
+
+    collect_latencies(spans)
+
+    # 按 start_offset_ms 排序
+    latency_distribution.sort(key=lambda x: x.get("start_offset_ms", 0))
+
+    return latency_distribution
+
+
+def enrich_chain_data(chain_data: dict) -> dict:
+    """为调用链数据添加汇总统计信息"""
+    summary = build_chain_summary(chain_data)
+    latency_distribution = build_latency_distribution(chain_data)
+
+    chain_data["span_count"] = summary["span_count"]
+    chain_data["service_count"] = summary["service_count"]
+    chain_data["status"] = summary["status"]
+    chain_data["latency_distribution"] = latency_distribution
+
+    return chain_data
+
+
+def flatten_spans_to_logs(chain_data: dict) -> List[Dict]:
+    """将调用链数据中的 spans 扁平化为日志列表"""
+    logs = []
+    for span in chain_data.get("spans", []):
+        logs.append(span_to_log(span))
+        logs.extend(span_to_log(child) for child in span.get("children", []))
+    return logs
+
+
+def get_log_fields() -> List[Dict]:
+    """获取日志字段定义"""
+    return MCP_SERVER_LOG_FIELDS

--- a/src/dashboard/apigateway/apigateway/biz/mcp_server_log/chain_helpers.py
+++ b/src/dashboard/apigateway/apigateway/biz/mcp_server_log/chain_helpers.py
@@ -15,7 +15,7 @@
 # We undertake not to change the open source license (MIT license) applicable
 # to the current version of the project delivered to anyone in the future.
 #
-from typing import Dict, List, Optional
+from typing import Dict, List, Optional, Set
 
 from apigateway.biz.mcp_server_log.constants import MCP_SERVER_LOG_FIELDS
 
@@ -34,23 +34,68 @@ def span_to_log(span: dict) -> dict:
     }
 
 
+def _count_spans(span_list: List[Dict]) -> int:
+    """递归统计 span 数量"""
+    count = 0
+    for span in span_list:
+        count += 1
+        count += _count_spans(span.get("children", []))
+    return count
+
+
+def _collect_services(span_list: List[Dict], services: Set[str]) -> None:
+    """递归收集所有 service 名称"""
+    for span in span_list:
+        if span.get("service"):
+            services.add(span["service"])
+        _collect_services(span.get("children", []), services)
+
+
+def _find_first_mcp_span(span_list: List[Dict]) -> Optional[Dict]:
+    """递归查找第一个 MCP 层 span（含 mcp_method / tool_name）"""
+    for span in span_list:
+        if span.get("layer") == "mcp":
+            return span
+        result = _find_first_mcp_span(span.get("children", []))
+        if result:
+            return result
+    return None
+
+
+def _collect_latencies(span_list: List[Dict], total_latency_ms: float, latency_distribution: list) -> None:
+    """递归收集各服务的耗时信息"""
+    for span in span_list:
+        service = span.get("service", "")
+        latency_ms = span.get("latency_ms", 0) or 0
+        start_offset_ms = span.get("start_offset_ms", 0) or 0
+        layer = span.get("layer", "")
+        operation = span.get("operation", "")
+
+        if service:
+            percentage = (latency_ms / total_latency_ms * 100) if total_latency_ms > 0 else 0
+            latency_distribution.append(
+                {
+                    "service": service,
+                    "upstream": span.get("upstream", ""),
+                    "layer": layer,
+                    "operation": operation,
+                    "latency_ms": round(latency_ms, 2),
+                    "start_offset_ms": round(start_offset_ms, 2),
+                    "percentage": round(percentage, 1),
+                }
+            )
+
+        _collect_latencies(span.get("children", []), total_latency_ms, latency_distribution)
+
+
 def build_chain_summary(chain_data: dict) -> dict:
     """从调用链数据构建汇总信息"""
     spans = chain_data.get("spans", [])
 
-    # 计算服务数（去重）
-    services = set()
-    span_count = 0
-
-    def count_spans(span_list: List[Dict]) -> None:
-        nonlocal span_count
-        for span in span_list:
-            span_count += 1
-            if span.get("service"):
-                services.add(span["service"])
-            count_spans(span.get("children", []))
-
-    count_spans(spans)
+    # 计算服务数（去重）和 span 总数
+    services: Set[str] = set()
+    _collect_services(spans, services)
+    span_count = _count_spans(spans)
 
     # 计算状态：如果有任何 error 则为 failed
     status = "success"
@@ -63,17 +108,7 @@ def build_chain_summary(chain_data: dict) -> dict:
     first_span = spans[0] if spans else {}
     first_detail = first_span.get("detail", {})
 
-    # 递归查找第一个 MCP 层 span（含 mcp_method / tool_name）
-    def find_first_mcp_span(span_list: List[Dict]) -> Optional[Dict]:
-        for span in span_list:
-            if span.get("layer") == "mcp":
-                return span
-            result = find_first_mcp_span(span.get("children", []))
-            if result:
-                return result
-        return None
-
-    mcp_span = find_first_mcp_span(spans)
+    mcp_span = _find_first_mcp_span(spans)
     mcp_detail = mcp_span.get("detail", {}) if mcp_span else {}
 
     # 获取 timestamp（从 chain_data 中获取）
@@ -101,35 +136,10 @@ def build_latency_distribution(chain_data: dict) -> list:
 
     返回各服务的耗时统计列表，按 start_offset_ms 排序
     """
-    spans = chain_data.get("spans", [])
     total_latency_ms = chain_data.get("total_latency_ms", 0) or 0
-    latency_distribution = []
+    latency_distribution: list[dict] = []
 
-    def collect_latencies(span_list: List[Dict]) -> None:
-        for span in span_list:
-            service = span.get("service", "")
-            latency_ms = span.get("latency_ms", 0) or 0
-            start_offset_ms = span.get("start_offset_ms", 0) or 0
-            layer = span.get("layer", "")
-            operation = span.get("operation", "")
-
-            if service:
-                percentage = (latency_ms / total_latency_ms * 100) if total_latency_ms > 0 else 0
-                latency_distribution.append(
-                    {
-                        "service": service,
-                        "upstream": span.get("upstream", ""),
-                        "layer": layer,
-                        "operation": operation,
-                        "latency_ms": round(latency_ms, 2),
-                        "start_offset_ms": round(start_offset_ms, 2),
-                        "percentage": round(percentage, 1),
-                    }
-                )
-
-            collect_latencies(span.get("children", []))
-
-    collect_latencies(spans)
+    _collect_latencies(chain_data.get("spans", []), total_latency_ms, latency_distribution)
 
     # 按 start_offset_ms 排序
     latency_distribution.sort(key=lambda x: x.get("start_offset_ms", 0))

--- a/src/dashboard/apigateway/apigateway/biz/mcp_server_log/chain_query.py
+++ b/src/dashboard/apigateway/apigateway/biz/mcp_server_log/chain_query.py
@@ -1,0 +1,130 @@
+#
+# TencentBlueKing is pleased to support the open source community by making
+# 蓝鲸智云 - API 网关(BlueKing - APIGateway) available.
+# Copyright (C) 2025 Tencent. All rights reserved.
+# Licensed under the MIT License (the "License"); you may not use this file except
+# in compliance with the License. You may obtain a copy of the License at
+#
+#     http://opensource.org/licenses/MIT
+#
+# Unless required by applicable law or agreed to in writing, software distributed under
+# the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+# either express or implied. See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# We undertake not to change the open source license (MIT license) applicable
+# to the current version of the project delivered to anyone in the future.
+#
+from typing import Dict, List
+
+from apigateway.biz.mcp_server_log.chain_helpers import (
+    build_chain_summary,
+    build_latency_distribution,
+    enrich_chain_data,
+    flatten_spans_to_logs,
+)
+from apigateway.biz.mcp_server_log.chain_search import MCPServerLogChainSearchClient
+from apigateway.biz.mcp_server_log.constants import MCP_SERVER_LOG_FIELDS
+
+
+def search_chain_by_any_id(request_id: str = "") -> Dict:
+    """通过 request_id 查询调用链路，自动尝试多种 ID 类型
+
+    按优先级依次尝试：
+    1. request_id 查询
+    2. x_request_id 查询
+    3. upstream_request_id 查询
+
+    Args:
+        request_id: 用户传入的请求 ID，可能是任意类型
+    """
+    client = MCPServerLogChainSearchClient(request_id=request_id)
+    chain_data = client.search_chain()
+
+    if not chain_data.get("spans"):
+        client = MCPServerLogChainSearchClient(x_request_id=request_id)
+        chain_data = client.search_chain_by_x_request_id()
+
+    if not chain_data.get("spans"):
+        client = MCPServerLogChainSearchClient(upstream_request_id=request_id)
+        chain_data = client.search_chain_by_upstream_request_id()
+
+    return chain_data
+
+
+def search_chain_logs_by_any_id(request_id: str = "") -> Dict:
+    """通过 request_id 查询调用链路并扁平化为日志列表
+
+    适用于日志详情查询场景（MCPServerLogDetailApi / MCPServerLogQueryApi），
+    自动尝试多种 ID 类型查询。
+
+    Args:
+        request_id: 用户传入的请求 ID
+    """
+    chain_data = search_chain_by_any_id(request_id)
+    logs = flatten_spans_to_logs(chain_data)
+    return _build_paginated_log_result(logs, chain_data)
+
+
+def search_chain_logs_with_gateway_by_any_id(request_id: str = "") -> Dict:
+    """通过 request_id 查询调用链路并扁平化为日志列表，同时附加网关日志
+
+    适用于链路追踪场景（MCPServerLogTraceApi / MCPServerLogQueryApi），
+    自动尝试多种 ID 类型查询，并添加上下游网关日志。
+
+    Args:
+        request_id: 用户传入的请求 ID
+    """
+    chain_data = search_chain_by_any_id(request_id)
+    logs = flatten_spans_to_logs(chain_data)
+
+    # 添加网关日志到列表开头
+    if chain_data.get("upstream_gateway_log"):
+        upstream_log = chain_data["upstream_gateway_log"]
+        upstream_log["layer"] = "gateway_upstream"
+        logs.insert(0, upstream_log)
+
+    if chain_data.get("downstream_gateway_log"):
+        downstream_log = chain_data["downstream_gateway_log"]
+        downstream_log["layer"] = "gateway_downstream"
+        logs.insert(0, downstream_log)
+
+    return _build_paginated_log_result(logs, chain_data)
+
+
+def search_chain_with_summary_by_any_id(request_id: str = "") -> Dict:
+    """通过 request_id 查询调用链路并添加汇总统计信息
+
+    适用于瀑布图场景（MCPServerLogChainApi / MCPServerLogQueryChainApi）。
+
+    Args:
+        request_id: 用户传入的请求 ID
+    """
+    chain_data = search_chain_by_any_id(request_id)
+    return enrich_chain_data(chain_data)
+
+
+def search_chain_summary_by_any_id(request_id: str = "") -> Dict:
+    """通过 request_id 查询调用链路并构建汇总信息
+
+    适用于工具箱汇总查询场景（MCPServerLogQuerySummaryApi）。
+
+    Args:
+        request_id: 用户传入的请求 ID
+    """
+    chain_data = search_chain_by_any_id(request_id)
+    summary = build_chain_summary(chain_data)
+    summary["latency_distribution"] = build_latency_distribution(chain_data)
+    return summary
+
+
+def _build_paginated_log_result(logs: List[Dict], chain_data: Dict) -> Dict:
+    """构建分页日志结果"""
+    total_count = len(logs)
+    return {
+        "count": total_count,
+        "has_next": False,
+        "has_previous": False,
+        "results": logs,
+        "fields": MCP_SERVER_LOG_FIELDS,
+    }

--- a/src/dashboard/apigateway/apigateway/biz/mcp_server_log/chain_search.py
+++ b/src/dashboard/apigateway/apigateway/biz/mcp_server_log/chain_search.py
@@ -1,0 +1,929 @@
+#
+# TencentBlueKing is pleased to support the open source community by making
+# 蓝鲸智云 - API 网关(BlueKing - APIGateway) available.
+# Copyright (C) 2025 Tencent. All rights reserved.
+# Licensed under the MIT License (the "License"); you may not use this file except
+# in compliance with the License. You may obtain a copy of the License at
+#
+#     http://opensource.org/licenses/MIT
+#
+# Unless required by applicable law or agreed to in writing, software distributed under
+# the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+# either express or implied. See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# We undertake not to change the open source license (MIT license) applicable
+# to the current version of the project delivered to anyone in the future.
+#
+import logging
+import re
+from typing import Any, Dict, List, Optional
+
+from django.conf import settings
+from elasticsearch_dsl import Search
+
+from apigateway.biz.access_log.log_search import LogSearchClient
+from apigateway.common.error_codes import error_codes
+from apigateway.service.es.clients import BKLogESClient
+from apigateway.utils import time as time_utils
+from apigateway.utils.time import SmartTimeRange
+
+logger = logging.getLogger(__name__)
+
+# latency 字符串(如 "37.36ms", "1.2s", "500µs") 转换为毫秒
+_LATENCY_PATTERN = re.compile(r"^([\d.]+)(µs|us|ms|s|m|h)$")
+
+_UNIT_TO_MS = {
+    "µs": 0.001,
+    "us": 0.001,
+    "ms": 1.0,
+    "s": 1000.0,
+    "m": 60_000.0,
+    "h": 3_600_000.0,
+}
+
+
+def _parse_latency_ms(latency_str: str) -> Optional[float]:
+    """将 Go 的 duration 字符串转换为毫秒数值"""
+    if not latency_str:
+        return None
+    m = _LATENCY_PATTERN.match(latency_str.strip())
+    if not m:
+        return None
+    value = float(m.group(1))
+    unit = m.group(2)
+    return round(value * _UNIT_TO_MS.get(unit, 1.0), 3)
+
+
+# MCP Proxy 的 ES 日志中，所有层共有的字段
+_CHAIN_OUTPUT_FIELDS = [
+    # 链路标识
+    "request_id",
+    "x_request_id",
+    "session_id",
+    # 网关信息
+    "gateway_id",
+    "gateway_name",
+    "mcp_server_name",
+    "mcp_server_id",
+    # HTTP 层字段（注意：ES 中 method/path/status 在 __ext_json 中）
+    "method",
+    "path",
+    "status",
+    # Filebeat 提取的字段
+    "__ext_json",
+    # MCP 协议层字段
+    "mcp_method",
+    "tool_name",
+    "prompt_name",  # prompt 名称
+    "tool",  # audit 日志中的原始 tool 配置字符串
+    "params",
+    "request",  # audit 日志使用 request 字段存储请求参数
+    "response",
+    "request_body_size",
+    "response_body_size",
+    "upstream_request_id",  # 上游 API 返回的 request_id
+    # 调用方信息
+    "app_code",
+    "bk_username",
+    "client_ip",
+    "client_id",
+    # 性能
+    "latency",
+    # trace
+    "trace_id",
+    # 错误
+    "error",
+]
+
+
+class MCPServerLogChainSearchClient:
+    """MCP Server 调用链路搜索客户端
+
+    通过 request_id 或 x_request_id 从 mcp-proxy 的 ES 日志中查询同一请求的所有层级日志，
+    并将它们组装成调用链路树结构，用于前端瀑布图展示。
+
+    日志层级：
+    - HTTP 层 (APILogger): 整个 HTTP 请求的入口日志，无 mcp_method 字段
+    - MCP 协议层 (LoggingMiddleware): MCP 方法调用日志，有 mcp_method 字段
+    """
+
+    _es_index: str = settings.MCP_SERVER_ACCESS_LOG_CONFIG["es_index"]
+    _es_time_field_name: str = settings.MCP_SERVER_ACCESS_LOG_CONFIG["es_time_field_name"]
+
+    def __init__(self, request_id: str = "", x_request_id: str = "", upstream_request_id: str = ""):
+        self._request_id = request_id
+        self._x_request_id = x_request_id
+        self._upstream_request_id = upstream_request_id
+        self._es_client = BKLogESClient(self._es_index)
+
+    def search_chain(self) -> Dict[str, Any]:
+        """查询调用链路
+
+        返回结构:
+        {
+            "request_id": "xxx",
+            "x_request_id": "yyy",
+            "total_latency_ms": 905.0,
+            "spans": [
+                {
+                    "span_id": "http_entry",
+                    "parent_span_id": null,
+                    "layer": "http",
+                    "service": "mcp-proxy",
+                    "operation": "POST /mcp/xxx/sse/message",
+                    "latency": "905ms",
+                    "latency_ms": 905.0,
+                    "start_offset_ms": 0,
+                    "status": 200,
+                    "detail": { ... },
+                    "children": [
+                        {
+                            "span_id": "mcp_0",
+                            "parent_span_id": "http_entry",
+                            "layer": "mcp",
+                            "service": "mcp-server-name",
+                            "operation": "tools/call search_host",
+                            ...
+                        }
+                    ]
+                }
+            ]
+        }
+        """
+        # 1. 从 mcp-proxy ES 查询同一 request_id 的所有日志(不限 mcp_method exists)
+        logs = self._search_all_layers()
+
+        if not logs:
+            return {
+                "request_id": self._request_id,
+                "x_request_id": "",
+                "total_latency_ms": 0,
+                "spans": [],
+                "gateway_log": None,
+            }
+
+        # 2. 分类：HTTP 层 vs MCP 协议层
+        http_logs = []
+        mcp_logs = []
+        for log in logs:
+            if log.get("mcp_method"):
+                mcp_logs.append(log)
+            else:
+                http_logs.append(log)
+
+        # 3. 合并同一 request_id + mcp_method + tool_name 的多条 MCP 日志
+        # "call tool" (无 latency) 和 "call tool complete" (有 latency) 需要合并
+        mcp_logs = self._merge_mcp_logs(mcp_logs)
+
+        # 4. 组装调用链路
+        spans = self._build_spans(http_logs, mcp_logs)
+
+        # 5. 提取全链路 ID
+        x_request_id = ""
+        for log in logs:
+            if log.get("x_request_id"):
+                x_request_id = log["x_request_id"]
+                break
+
+        # 5.1 计算总耗时：所有 span 的最大结束时间
+        # 结束时间 = start_offset_ms + latency_ms
+        def calc_max_end_time(span_list, max_end=0):
+            for span in span_list:
+                start = span.get("start_offset_ms", 0) or 0
+                latency = span.get("latency_ms", 0) or 0
+                end_time = start + latency
+                max_end = max(max_end, end_time)
+                # 递归计算子 span
+                max_end = calc_max_end_time(span.get("children", []), max_end)
+            return max_end
+
+        total_latency_ms = calc_max_end_time(spans)
+
+        # 5.2 提取产生时间（从 HTTP 层日志或第一条日志）
+        timestamp = None
+        if http_logs and http_logs[0].get("timestamp"):
+            timestamp = http_logs[0]["timestamp"]
+        elif logs and logs[0].get("timestamp"):
+            timestamp = logs[0]["timestamp"]
+
+        # 6. 从 MCP 日志中提取 upstream_request_id（下游网关的 request_id）
+        upstream_request_id = ""
+        for log in mcp_logs:
+            if log.get("upstream_request_id"):
+                upstream_request_id = log["upstream_request_id"]
+                break
+        logger.info(
+            "extracted upstream_request_id=%s from mcp_logs, self._request_id=%s",
+            upstream_request_id,
+            self._request_id,
+        )
+
+        # 7. 查询上游网关 (bk-apigateway) 的日志
+        # 使用 request_id 查询，因为 bk-apigateway 的 request_id 对应 mcp-proxy 的 request_id
+        upstream_gateway_log = (
+            self._search_gateway_log(self._request_id, gateway_type="upstream") if self._request_id else None
+        )
+        logger.info(
+            "upstream_gateway_log search result: request_id=%s, found=%s",
+            self._request_id,
+            upstream_gateway_log is not None,
+        )
+
+        # 8. 查询下游网关 (biz-gateway) 的日志
+        # 使用 upstream_request_id 查询，这是 API 响应中返回的 request_id
+        # 注意：如果 biz-gateway 的日志不在 bk-apigateway 的 ES 索引中，将无法查询到
+        downstream_gateway_log = (
+            self._search_gateway_log(upstream_request_id, gateway_type="downstream") if upstream_request_id else None
+        )
+        logger.info(
+            "downstream_gateway_log search result: upstream_request_id=%s, found=%s",
+            upstream_request_id,
+            downstream_gateway_log is not None,
+        )
+
+        return {
+            "request_id": self._request_id,
+            "x_request_id": x_request_id,
+            "timestamp": timestamp,
+            "total_latency_ms": total_latency_ms,
+            "spans": spans,
+            "upstream_gateway_log": upstream_gateway_log,
+            "downstream_gateway_log": downstream_gateway_log,
+        }
+
+    def search_chain_by_x_request_id(self) -> Dict[str, Any]:
+        """通过 x_request_id 查询调用链路
+
+        用于 MCPServerLogTraceApi，支持通过全链路 ID 查询所有层级的日志。
+        """
+        # 1. 从 mcp-proxy ES 查询同一 x_request_id 的所有日志
+        logs = self._search_all_layers()
+
+        if not logs:
+            return {
+                "request_id": "",
+                "x_request_id": self._x_request_id,
+                "total_latency_ms": 0,
+                "spans": [],
+                "gateway_log": None,
+            }
+
+        # 2. 分类：HTTP 层 vs MCP 协议层
+        http_logs = []
+        mcp_logs = []
+        for log in logs:
+            if log.get("mcp_method"):
+                mcp_logs.append(log)
+            else:
+                http_logs.append(log)
+
+        # 3. 合并同一 request_id + mcp_method + tool_name 的多条 MCP 日志
+        mcp_logs = self._merge_mcp_logs(mcp_logs)
+
+        # 4. 组装调用链路
+        spans = self._build_spans(http_logs, mcp_logs)
+
+        # 5. 提取 request_id（从 HTTP 层或 MCP 层）
+        request_id = ""
+        for log in logs:
+            if log.get("request_id"):
+                request_id = log["request_id"]
+                break
+
+        # 5.1 计算总耗时：所有 span 的最大结束时间
+        def calc_max_end_time_x(span_list, max_end=0):
+            for span in span_list:
+                start = span.get("start_offset_ms", 0) or 0
+                latency = span.get("latency_ms", 0) or 0
+                end_time = start + latency
+                max_end = max(max_end, end_time)
+                max_end = calc_max_end_time_x(span.get("children", []), max_end)
+            return max_end
+
+        total_latency_ms = calc_max_end_time_x(spans)
+
+        # 5.2 提取产生时间（从 HTTP 层日志或第一条日志）
+        timestamp = None
+        if http_logs and http_logs[0].get("timestamp"):
+            timestamp = http_logs[0]["timestamp"]
+        elif logs and logs[0].get("timestamp"):
+            timestamp = logs[0]["timestamp"]
+
+        # 6. 从 MCP 日志中提取 upstream_request_id（下游网关的 request_id）
+        upstream_request_id = ""
+        for log in mcp_logs:
+            if log.get("upstream_request_id"):
+                upstream_request_id = log["upstream_request_id"]
+                break
+        logger.info(
+            "[x_request_id] extracted upstream_request_id=%s from mcp_logs, request_id=%s",
+            upstream_request_id,
+            request_id,
+        )
+
+        # 7. 查询上游网关 (bk-apigateway) 的日志
+        # 使用 request_id 查询，因为 bk-apigateway 的 request_id 对应 mcp-proxy 的 request_id
+        upstream_gateway_log = self._search_gateway_log(request_id, gateway_type="upstream") if request_id else None
+        logger.info(
+            "[x_request_id] upstream_gateway_log search result: request_id=%s, found=%s",
+            request_id,
+            upstream_gateway_log is not None,
+        )
+
+        # 8. 查询下游网关 (biz-gateway) 的日志
+        # 使用 upstream_request_id 查询，这是 API 响应中返回的 request_id
+        # 注意：如果 biz-gateway 的日志不在 bk-apigateway 的 ES 索引中，将无法查询到
+        downstream_gateway_log = (
+            self._search_gateway_log(upstream_request_id, gateway_type="downstream") if upstream_request_id else None
+        )
+        logger.info(
+            "[x_request_id] downstream_gateway_log search result: upstream_request_id=%s, found=%s",
+            upstream_request_id,
+            downstream_gateway_log is not None,
+        )
+
+        return {
+            "request_id": request_id,
+            "x_request_id": self._x_request_id,
+            "timestamp": timestamp,
+            "total_latency_ms": total_latency_ms,
+            "spans": spans,
+            "upstream_gateway_log": upstream_gateway_log,
+            "downstream_gateway_log": downstream_gateway_log,
+        }
+
+    def search_chain_by_upstream_request_id(self) -> Dict[str, Any]:
+        """通过 upstream_request_id（上游 API 返回的 request_id）查询调用链路
+
+        用于工具箱接口，当用户通过上游 API 返回的 request_id 查询时使用。
+        mcp-proxy 的 tools/call 日志中存储了 upstream_request_id 字段，
+        直接用该字段在 mcp-proxy ES 中搜索，获取 mcp-proxy 的 request_id 后，
+        再用 request_id 查询完整链路（包含 HTTP 入口日志）。
+        """
+        if not self._upstream_request_id:
+            return {
+                "request_id": "",
+                "x_request_id": "",
+                "total_latency_ms": 0,
+                "spans": [],
+                "upstream_gateway_log": None,
+                "downstream_gateway_log": None,
+            }
+
+        # 1. 查询下游网关日志（upstream_request_id 对应下游网关的 request_id）
+        downstream_gateway_log = self._search_gateway_log(self._upstream_request_id, gateway_type="downstream")
+
+        # 2. 用 upstream_request_id 字段在 mcp-proxy ES 中搜索，获取 mcp-proxy 的 request_id
+        mcp_logs = self._search_by_upstream_request_id()
+        if not mcp_logs:
+            return {
+                "request_id": "",
+                "x_request_id": "",
+                "total_latency_ms": 0,
+                "spans": [],
+                "upstream_gateway_log": None,
+                "downstream_gateway_log": downstream_gateway_log,
+            }
+
+        # 3. 从查到的日志中提取 mcp-proxy 的 request_id
+        # upstream_request_id 查到的日志都是 MCP 协议层日志（有 upstream_request_id 字段），
+        # 需要用 mcp-proxy 的 request_id 查完整链路（包含 HTTP 入口日志）
+        mcp_request_id = ""
+        for log in mcp_logs:
+            if log.get("request_id"):
+                mcp_request_id = log["request_id"]
+                break
+
+        if mcp_request_id:
+            # 4. 使用 mcp-proxy 的 request_id 查询完整链路
+            self._request_id = mcp_request_id
+            result = self.search_chain()
+            result["downstream_gateway_log"] = downstream_gateway_log
+            return result
+
+        # 5. 如果没有 request_id，直接使用查到的日志构建结果
+        merged_mcp_logs = self._merge_mcp_logs([log for log in mcp_logs if log.get("mcp_method")])
+        spans = self._build_spans([], merged_mcp_logs)
+
+        x_request_id = ""
+        for log in mcp_logs:
+            if log.get("x_request_id"):
+                x_request_id = log["x_request_id"]
+                break
+
+        # 计算总耗时：所有 span 的最大结束时间
+        def calc_max_end_time_upstream(span_list, max_end=0):
+            for span in span_list:
+                start = span.get("start_offset_ms", 0) or 0
+                latency = span.get("latency_ms", 0) or 0
+                end_time = start + latency
+                max_end = max(max_end, end_time)
+                max_end = calc_max_end_time_upstream(span.get("children", []), max_end)
+            return max_end
+
+        total_latency_ms = calc_max_end_time_upstream(spans)
+
+        timestamp = None
+        if mcp_logs and mcp_logs[0].get("timestamp"):
+            timestamp = mcp_logs[0]["timestamp"]
+
+        return {
+            "request_id": "",
+            "x_request_id": x_request_id,
+            "timestamp": timestamp,
+            "total_latency_ms": total_latency_ms,
+            "spans": spans,
+            "upstream_gateway_log": None,
+            "downstream_gateway_log": downstream_gateway_log,
+        }
+
+    def _search_all_layers(self) -> List[Dict]:  # noqa: C901, PLR0912
+        """从 ES 中查询同一 request_id 或 x_request_id 的所有层级日志"""
+        s = Search()
+
+        # 根据传入的参数决定查询条件
+        if self._request_id:
+            s = s.filter("term", request_id=self._request_id)
+        elif self._x_request_id:
+            s = s.filter("term", x_request_id=self._x_request_id)
+        else:
+            return []
+
+        # 添加默认时间范围（最近7天），避免ES查询超时或返回过多数据
+        # 由于request_id/x_request_id是唯一的，时间范围不会影响结果准确性
+        time_range = SmartTimeRange(time_range=7 * 24 * 60 * 60)  # 7天
+        time_start, time_end = time_range.get_head_and_tail()
+        s = s.filter(
+            "range",
+            **{
+                self._es_time_field_name: {
+                    "gte": time_utils.convert_second_to_epoch_millisecond(time_start),
+                    "lte": time_utils.convert_second_to_epoch_millisecond(time_end),
+                }
+            },
+        )
+
+        s = s.source(fields=_CHAIN_OUTPUT_FIELDS)
+        s = s.sort({self._es_time_field_name: {"order": "asc"}})
+        s = s[:100]  # 限制最多 100 条
+
+        try:
+            data = self._es_client.execute_search(s.to_dict())
+        except Exception as e:
+            logger.exception(
+                "failed to search mcp server chain logs for request_id=%s, x_request_id=%s",
+                self._request_id,
+                self._x_request_id,
+            )
+            # 重新抛出异常，让上层处理
+            raise error_codes.INTERNAL.format(message=f"ES query failed: {str(e)}")
+
+        hits = data.get("hits", {}).get("hits", [])
+        logger.info(
+            "search mcp server chain logs success, request_id=%s, x_request_id=%s, hits=%s",
+            self._request_id,
+            self._x_request_id,
+            len(hits),
+        )
+        # 调试：记录每个 hit 的关键字段
+        for i, hit in enumerate(hits):
+            src = hit.get("_source", {})
+            logger.info(
+                "hit[%s]: request_id=%s, mcp_method=%s, has_latency=%s, latency=%s, "
+                "has_params=%s, has_response=%s, has_tool=%s",
+                i,
+                src.get("request_id"),
+                src.get("mcp_method"),
+                bool(src.get("latency")),
+                src.get("latency"),
+                bool(src.get("params")),
+                bool(src.get("response")),
+                bool(src.get("tool")),
+            )
+        result = []
+        for hit in hits:
+            log = hit["_source"]
+            # 调试日志：检查 sort 字段
+            sort = hit.get("sort")
+            logger.info(
+                "hit sort field: hit_id=%s, sort=%s, is_list=%s, len=%s",
+                hit.get("_id"),
+                sort,
+                isinstance(sort, list),
+                len(sort) if isinstance(sort, list) else "N/A",
+            )
+            if sort and len(sort) > 0:
+                log["timestamp"] = time_utils.convert_epoch_millisecond_to_second(sort[0])
+                log["timestamp_ms"] = sort[0]
+                logger.info("added timestamp=%s to log", log.get("timestamp"))
+            else:
+                logger.warning("sort field is missing or empty for hit_id=%s", hit.get("_id"))
+
+            # 合并 __ext_json 中的字段到顶层（Filebeat 提取的字段）
+            # Filebeat 可能将某些字段提取到 __ext_json 中，需要合并到顶层
+            ext_json = log.get("__ext_json", {}) or {}
+            if ext_json:
+                # 合并所有 __ext_json 中的字段到顶层（优先使用 __ext_json 中的值）
+                # 这解决了 Filebeat 字段提取位置不一致的问题
+                for key, value in ext_json.items():
+                    # 只在顶层字段为空或不存在时，才用 __ext_json 中的值覆盖
+                    if (
+                        value is not None
+                        and value != ""
+                        and (key not in log or log.get(key) is None or log.get(key) == "")
+                    ):
+                        log[key] = value
+
+            # 排除文件访问日志：如果 __ext_json.method 为空，说明是文件访问日志
+            # 真正的 HTTP 请求日志有 __ext_json.method 字段
+            # 但 MCP 协议层日志（audit 日志）没有 __ext_json，通过 mcp_method 字段识别
+            if not ext_json.get("method") and not log.get("mcp_method"):
+                continue
+
+            # 排除健康检查请求
+            path = log.get("path", "")
+            if "/health" in path and path.split("?")[0].split("/")[-1] == "/health":
+                continue
+
+            result.append(log)
+        return result
+
+    def _search_by_upstream_request_id(self) -> List[Dict]:
+        """从 ES 中查询 upstream_request_id 匹配的日志
+
+        当用户通过上游 API 返回的 request_id（即 biz-gateway 的 request_id）查询时使用。
+        mcp-proxy 的 tools/call 日志中存储了 upstream_request_id 字段，
+        该值是下游 API 响应中返回的 request_id。
+        """
+        if not self._upstream_request_id:
+            return []
+
+        s = Search()
+        s = s.filter("term", upstream_request_id=self._upstream_request_id)
+
+        # 添加默认时间范围（最近7天）
+        time_range = SmartTimeRange(time_range=7 * 24 * 60 * 60)  # 7天
+        time_start, time_end = time_range.get_head_and_tail()
+        s = s.filter(
+            "range",
+            **{
+                self._es_time_field_name: {
+                    "gte": time_utils.convert_second_to_epoch_millisecond(time_start),
+                    "lte": time_utils.convert_second_to_epoch_millisecond(time_end),
+                }
+            },
+        )
+
+        s = s.source(fields=_CHAIN_OUTPUT_FIELDS)
+        s = s.sort({self._es_time_field_name: {"order": "asc"}})
+        s = s[:100]  # 同一 upstream_request_id 可能关联多条日志
+
+        try:
+            data = self._es_client.execute_search(s.to_dict())
+        except Exception:
+            logger.exception(
+                "failed to search mcp server logs by upstream_request_id=%s",
+                self._upstream_request_id,
+            )
+            return []
+
+        hits = data.get("hits", {}).get("hits", [])
+        logger.info(
+            "search mcp server logs by upstream_request_id=%s, hits=%s",
+            self._upstream_request_id,
+            len(hits),
+        )
+        result = []
+        for hit in hits:
+            log = hit["_source"]
+            # 调试日志：检查 sort 字段
+            sort = hit.get("sort")
+            logger.info(
+                "[upstream_request_id] hit sort field: hit_id=%s, sort=%s, is_list=%s, len=%s",
+                hit.get("_id"),
+                sort,
+                isinstance(sort, list),
+                len(sort) if isinstance(sort, list) else "N/A",
+            )
+            if sort and len(sort) > 0:
+                log["timestamp"] = time_utils.convert_epoch_millisecond_to_second(sort[0])
+                log["timestamp_ms"] = sort[0]
+                logger.info("[upstream_request_id] added timestamp=%s to log", log.get("timestamp"))
+            else:
+                logger.warning("[upstream_request_id] sort field is missing or empty for hit_id=%s", hit.get("_id"))
+
+            # 合并 __ext_json 中的字段到顶层（Filebeat 提取的字段）
+            ext_json = log.get("__ext_json", {}) or {}
+            if ext_json:
+                for key, value in ext_json.items():
+                    if (
+                        value is not None
+                        and value != ""
+                        and (key not in log or log.get(key) is None or log.get(key) == "")
+                    ):
+                        log[key] = value
+
+            # 排除文件访问日志
+            if not ext_json.get("method") and not log.get("mcp_method"):
+                continue
+
+            # 排除健康检查请求
+            path = log.get("path", "")
+            if "/health" in path and path.split("?")[0].split("/")[-1] == "/health":
+                continue
+
+            result.append(log)
+        return result
+
+    def _build_spans(self, http_logs: List[Dict], mcp_logs: List[Dict]) -> List[Dict]:
+        """将日志构建为 span 树结构"""
+        spans = []
+
+        # HTTP 入口 span (如果存在)
+        http_entry = None
+        if http_logs:
+            log = http_logs[0]
+            latency_ms = _parse_latency_ms(log.get("latency", ""))
+            http_entry = {
+                "span_id": "http_entry",
+                "parent_span_id": None,
+                "layer": "http",
+                "service": "mcp-proxy",
+                "upstream": log.get("mcp_server_name", "") or "",
+                "operation": f"{log.get('method', '')} {log.get('path', '')}",
+                "latency": log.get("latency", ""),
+                "latency_ms": latency_ms,
+                "start_offset_ms": 0,
+                "status": log.get("status"),
+                "detail": {
+                    "timestamp": log.get("timestamp"),
+                    "method": log.get("method"),
+                    "path": log.get("path"),
+                    "status": log.get("status"),
+                    "client_ip": log.get("client_ip"),
+                    "app_code": log.get("app_code"),
+                    "gateway_name": log.get("gateway_name"),
+                    "mcp_server_name": log.get("mcp_server_name"),
+                    "request_id": log.get("request_id"),
+                    "x_request_id": log.get("x_request_id"),
+                },
+                "children": [],
+            }
+            spans.append(http_entry)
+
+        # MCP 协议层 span
+        # 计算 base timestamp 用于 start_offset_ms
+        base_ts_ms = None
+        if http_entry and http_logs and http_logs[0].get("timestamp_ms"):
+            # HTTP 入口的 timestamp 是请求完成后记录的，所以 MCP span 的偏移需要用 HTTP 开始时间
+            # 近似用 HTTP 完成时间 - HTTP 耗时
+            http_latency_ms = http_entry.get("latency_ms") or 0
+            base_ts_ms = http_logs[0]["timestamp_ms"] - http_latency_ms
+        elif mcp_logs and mcp_logs[0].get("timestamp_ms"):
+            base_ts_ms = mcp_logs[0]["timestamp_ms"]
+
+        for i, log in enumerate(mcp_logs):
+            latency_ms = _parse_latency_ms(log.get("latency", ""))
+            mcp_method = log.get("mcp_method", "")
+
+            # Audit 日志中 tool 字段存储工具配置字符串，需要提取工具名
+            # 格式: "tool:[name:xxx,url:xxx, method:GET]"
+            tool_str = log.get("tool", "")
+            tool_name = log.get("tool_name", "")
+            if not tool_name and tool_str:
+                # 从 tool 字符串中提取工具名
+                match = re.search(r"name:([^,]+)", tool_str)
+                if match:
+                    tool_name = match.group(1).strip()
+
+            operation = mcp_method
+            if tool_name:
+                operation = f"{mcp_method} {tool_name}"
+
+            # 计算 start_offset_ms: MCP 日志的 timestamp 是完成时间，
+            # 所以 start = 完成时间 - 耗时 - base_ts
+            start_offset_ms = 0
+            if base_ts_ms is not None and log.get("timestamp_ms"):
+                log_start_ms = log["timestamp_ms"] - (latency_ms or 0)
+                start_offset_ms = max(0, round(log_start_ms - base_ts_ms, 3))
+
+            # Audit 日志中的 request 字段存储请求参数
+            params = log.get("params") or log.get("request")
+
+            span = {
+                "span_id": f"mcp_{i}",
+                "parent_span_id": "http_entry" if http_entry else None,
+                "layer": "mcp",
+                "service": log.get("mcp_server_name") or log.get("gateway_name", ""),
+                "upstream": log.get("gateway_name", "") or "",
+                "operation": operation,
+                "latency": log.get("latency", ""),
+                "latency_ms": latency_ms,
+                "start_offset_ms": start_offset_ms,
+                "status": None,
+                "detail": {
+                    "timestamp": log.get("timestamp"),
+                    "mcp_method": mcp_method,
+                    "tool_name": tool_name,
+                    "prompt_name": log.get("prompt_name"),
+                    "tool": tool_str,  # 保留原始 tool 字符串
+                    "params": params,
+                    "response": log.get("response"),
+                    "request_body_size": log.get("request_body_size"),
+                    "response_body_size": log.get("response_body_size"),
+                    "app_code": log.get("app_code"),
+                    "bk_username": log.get("bk_username"),
+                    "client_ip": log.get("client_ip"),
+                    "client_id": log.get("client_id"),
+                    "session_id": log.get("session_id"),
+                    "request_id": log.get("request_id"),
+                    "x_request_id": log.get("x_request_id"),
+                    "trace_id": log.get("trace_id"),
+                    "error": log.get("error"),
+                },
+                "children": [],
+            }
+
+            if http_entry:
+                http_entry["children"].append(span)
+            else:
+                spans.append(span)
+
+        return spans
+
+    def _merge_mcp_logs(self, mcp_logs: List[Dict]) -> List[Dict]:  # noqa: C901, PLR0912
+        """合并同一 request_id + mcp_method + tool_name 的多条 MCP 日志
+
+        mcp-proxy 会输出多份 MCP 层日志：
+        - "call tool": 开始调用时记录，只有 request 字段
+        - "call tool request params": 请求参数信息，包含 header, query, path, body
+        - "call tool complete": 函数返回时记录，有完整的 params, response, latency 等字段
+        - api log: 包含完整字段（但如果 filebeat 过滤可能不存在）
+
+        需要合并这些日志，优先使用有 latency 字段的日志（即 "call tool complete"）。
+        如果某些日志缺少 mcp_method，则按 request_id + tool_name 分组。
+        """
+        if not mcp_logs:
+            return []
+
+        # 按 (request_id, mcp_method, tool_name) 分组
+        # 如果 mcp_method 缺失，则使用 tool_name 作为分组键的一部分
+        log_groups: Dict[tuple, List[Dict]] = {}
+        for idx, log in enumerate(mcp_logs):
+            # 确保 tool_name 存在
+            tool_name = log.get("tool_name", "")
+            if not tool_name:
+                # 尝试从 tool 字段提取
+                tool_str = log.get("tool", "")
+                if tool_str:
+                    match = re.search(r"name:([^,]+)", tool_str)
+                    if match:
+                        tool_name = match.group(1).strip()
+
+            # 如果 mcp_method 缺失，使用 tool_name 作为分组键
+            mcp_method = log.get("mcp_method", "") or "tools/call"  # 默认值
+            key = (
+                log.get("request_id", ""),
+                mcp_method,
+                tool_name,
+            )
+            logger.info(
+                "_merge_mcp_logs: log[%s] key=%s, has_latency=%s, has_params=%s, has_response=%s",
+                idx,
+                key,
+                bool(log.get("latency")),
+                bool(log.get("params")),
+                bool(log.get("response")),
+            )
+            if key not in log_groups:
+                log_groups[key] = []
+            log_groups[key].append(log)
+
+        logger.info("_merge_mcp_logs: total groups=%s, group_keys=%s", len(log_groups), list(log_groups.keys()))
+
+        # 合并每组日志：优先使用有 latency 的日志（"call tool complete"）
+        merged_logs = []
+        for key, logs in log_groups.items():
+            logger.info(
+                "merging group %s: log_count=%s",
+                key,
+                len(logs),
+            )
+            if len(logs) == 1:
+                merged_logs.append(logs[0])
+                continue
+
+            # 找到有 latency 的日志（通常是 "call tool complete"）
+            complete_log = None
+            for log in logs:
+                if log.get("latency"):
+                    complete_log = log
+                    break
+
+            if complete_log:
+                # 使用 complete_log 作为基础，但补充其他日志中的非空字段
+                merged = dict(complete_log)
+                for log in logs:
+                    if log is complete_log:
+                        continue
+                    for field_name, value in log.items():
+                        if (
+                            value is not None
+                            and value != ""
+                            and (field_name not in merged or merged[field_name] is None or merged[field_name] == "")
+                        ):
+                            merged[field_name] = value
+                merged_logs.append(merged)
+                logger.info(
+                    "merged with complete_log: has_latency=%s, has_params=%s, has_response=%s",
+                    bool(merged.get("latency")),
+                    bool(merged.get("params")),
+                    bool(merged.get("response")),
+                )
+            else:
+                # 如果没有 complete log，使用第一个日志并合并其他字段
+                merged = dict(logs[0])
+                for log in logs[1:]:
+                    for field_name, value in log.items():
+                        if (
+                            value is not None
+                            and value != ""
+                            and (field_name not in merged or merged[field_name] is None or merged[field_name] == "")
+                        ):
+                            merged[field_name] = value
+                merged_logs.append(merged)
+                logger.info("merged without complete_log")
+
+        return merged_logs
+
+    def _search_gateway_log(self, request_id: str, gateway_type: str = "upstream") -> Optional[Dict]:
+        """通过 request_id 查询网关日志
+
+        bk-apigateway 的 access_log ES 中，request_id 字段对应的是 X-Bkapi-Request-ID，
+        而这个值就是 mcp-proxy 日志中的 request_id 字段（从上游传入的）。
+
+        Args:
+            request_id: 网关的请求 ID
+            gateway_type: 网关类型，"upstream" 或 "downstream"
+        """
+        if not request_id:
+            logger.warning("search_gateway_log called with empty request_id, gateway_type=%s", gateway_type)
+            return None
+
+        try:
+            # 使用已有的 access_log LogSearchClient 查询
+            # 注意：这里查询的是 bk-apigateway 的日志索引
+            # 对于 upstream（bk-apigateway），request_id 是直接对应的
+            # 对于 downstream（biz-gateway），如果它的日志也在同一个 ES 索引中，才能查询到
+            logger.info(
+                "searching %s gateway log with request_id=%s",
+                gateway_type,
+                request_id,
+            )
+            client = LogSearchClient(request_id=request_id, time_range=7 * 24 * 60 * 60)  # 7天
+            total_count, logs = client.search_logs(offset=0, limit=1)
+            logger.info(
+                "%s gateway log search result: request_id=%s, total_count=%s, has_logs=%s",
+                gateway_type,
+                request_id,
+                total_count,
+                bool(logs),
+            )
+            if logs:
+                log = logs[0]
+                return {
+                    "layer": "gateway",
+                    "service": "bk-apigateway" if gateway_type == "upstream" else "biz-gateway",
+                    "timestamp": log.get("timestamp"),
+                    "request_id": log.get("request_id"),
+                    "method": log.get("method"),
+                    "http_host": log.get("http_host"),
+                    "http_path": log.get("http_path"),
+                    "status": log.get("status"),
+                    "request_duration": log.get("request_duration"),
+                    "backend_duration": log.get("backend_duration"),
+                    "stage": log.get("stage"),
+                    "resource_name": log.get("resource_name"),
+                    "backend_host": log.get("backend_host"),
+                    "backend_path": log.get("backend_path"),
+                    "backend_method": log.get("backend_method"),
+                    "backend_scheme": log.get("backend_scheme"),
+                    "app_code": log.get("app_code"),
+                    "client_ip": log.get("client_ip"),
+                    "error": log.get("error"),
+                    "code_name": log.get("code_name"),
+                }
+            logger.warning(
+                "no %s gateway log found for request_id=%s, may be out of time range or not indexed",
+                gateway_type,
+                request_id,
+            )
+        except Exception:
+            logger.exception(
+                "failed to search %s gateway log for request_id=%s",
+                gateway_type,
+                request_id,
+            )
+
+        return None

--- a/src/dashboard/apigateway/apigateway/biz/mcp_server_log/chain_search.py
+++ b/src/dashboard/apigateway/apigateway/biz/mcp_server_log/chain_search.py
@@ -16,19 +16,15 @@
 # to the current version of the project delivered to anyone in the future.
 #
 import logging
-import re
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List
 
 from django.conf import settings
-from elasticsearch_dsl import Search
 
-from apigateway.biz.access_log.log_search import LogSearchClient
-from apigateway.biz.mcp_server_log.constants import CHAIN_OUTPUT_FIELDS
-from apigateway.biz.mcp_server_log.utils import calc_max_end_time, parse_latency_ms
-from apigateway.common.error_codes import error_codes
+from apigateway.biz.mcp_server_log.es_query import search_all_layers, search_by_upstream_request_id
+from apigateway.biz.mcp_server_log.gateway_log import search_gateway_log
+from apigateway.biz.mcp_server_log.span_builder import build_spans, merge_mcp_logs
+from apigateway.biz.mcp_server_log.utils import calc_max_end_time
 from apigateway.service.es.clients import BKLogESClient
-from apigateway.utils import time as time_utils
-from apigateway.utils.time import SmartTimeRange
 
 logger = logging.getLogger(__name__)
 
@@ -88,7 +84,11 @@ class MCPServerLogChainSearchClient:
         }
         """
         # 1. 从 mcp-proxy ES 查询同一 request_id 的所有日志(不限 mcp_method exists)
-        logs = self._search_all_layers()
+        logs = search_all_layers(
+            self._es_client,
+            self._es_time_field_name,
+            request_id=self._request_id,
+        )
 
         if not logs:
             return {
@@ -100,44 +100,25 @@ class MCPServerLogChainSearchClient:
             }
 
         # 2. 分类：HTTP 层 vs MCP 协议层
-        http_logs = []
-        mcp_logs = []
-        for log in logs:
-            if log.get("mcp_method"):
-                mcp_logs.append(log)
-            else:
-                http_logs.append(log)
+        http_logs, mcp_logs = _classify_logs(logs)
 
         # 3. 合并同一 request_id + mcp_method + tool_name 的多条 MCP 日志
-        # "call tool" (无 latency) 和 "call tool complete" (有 latency) 需要合并
-        mcp_logs = self._merge_mcp_logs(mcp_logs)
+        mcp_logs = merge_mcp_logs(mcp_logs)
 
         # 4. 组装调用链路
-        spans = self._build_spans(http_logs, mcp_logs)
+        spans = build_spans(http_logs, mcp_logs)
 
         # 5. 提取全链路 ID
-        x_request_id = ""
-        for log in logs:
-            if log.get("x_request_id"):
-                x_request_id = log["x_request_id"]
-                break
+        x_request_id = _extract_field(logs, "x_request_id")
 
         # 5.1 计算总耗时：所有 span 的最大结束时间
         total_latency_ms = calc_max_end_time(spans)
 
         # 5.2 提取产生时间（从 HTTP 层日志或第一条日志）
-        timestamp = None
-        if http_logs and http_logs[0].get("timestamp"):
-            timestamp = http_logs[0]["timestamp"]
-        elif logs and logs[0].get("timestamp"):
-            timestamp = logs[0]["timestamp"]
+        timestamp = _extract_timestamp(http_logs, logs)
 
         # 6. 从 MCP 日志中提取 upstream_request_id（下游网关的 request_id）
-        upstream_request_id = ""
-        for log in mcp_logs:
-            if log.get("upstream_request_id"):
-                upstream_request_id = log["upstream_request_id"]
-                break
+        upstream_request_id = _extract_field(mcp_logs, "upstream_request_id")
         logger.debug(
             "extracted upstream_request_id=%s from mcp_logs, self._request_id=%s",
             upstream_request_id,
@@ -145,9 +126,8 @@ class MCPServerLogChainSearchClient:
         )
 
         # 7. 查询上游网关 (bk-apigateway) 的日志
-        # 使用 request_id 查询，因为 bk-apigateway 的 request_id 对应 mcp-proxy 的 request_id
         upstream_gateway_log = (
-            self._search_gateway_log(self._request_id, gateway_type="upstream") if self._request_id else None
+            search_gateway_log(self._request_id, gateway_type="upstream") if self._request_id else None
         )
         logger.debug(
             "upstream_gateway_log search result: request_id=%s, found=%s",
@@ -156,10 +136,8 @@ class MCPServerLogChainSearchClient:
         )
 
         # 8. 查询下游网关 (biz-gateway) 的日志
-        # 使用 upstream_request_id 查询，这是 API 响应中返回的 request_id
-        # 注意：如果 biz-gateway 的日志不在 bk-apigateway 的 ES 索引中，将无法查询到
         downstream_gateway_log = (
-            self._search_gateway_log(upstream_request_id, gateway_type="downstream") if upstream_request_id else None
+            search_gateway_log(upstream_request_id, gateway_type="downstream") if upstream_request_id else None
         )
         logger.debug(
             "downstream_gateway_log search result: upstream_request_id=%s, found=%s",
@@ -183,7 +161,11 @@ class MCPServerLogChainSearchClient:
         用于 MCPServerLogTraceApi，支持通过全链路 ID 查询所有层级的日志。
         """
         # 1. 从 mcp-proxy ES 查询同一 x_request_id 的所有日志
-        logs = self._search_all_layers()
+        logs = search_all_layers(
+            self._es_client,
+            self._es_time_field_name,
+            x_request_id=self._x_request_id,
+        )
 
         if not logs:
             return {
@@ -195,43 +177,25 @@ class MCPServerLogChainSearchClient:
             }
 
         # 2. 分类：HTTP 层 vs MCP 协议层
-        http_logs = []
-        mcp_logs = []
-        for log in logs:
-            if log.get("mcp_method"):
-                mcp_logs.append(log)
-            else:
-                http_logs.append(log)
+        http_logs, mcp_logs = _classify_logs(logs)
 
         # 3. 合并同一 request_id + mcp_method + tool_name 的多条 MCP 日志
-        mcp_logs = self._merge_mcp_logs(mcp_logs)
+        mcp_logs = merge_mcp_logs(mcp_logs)
 
         # 4. 组装调用链路
-        spans = self._build_spans(http_logs, mcp_logs)
+        spans = build_spans(http_logs, mcp_logs)
 
         # 5. 提取 request_id（从 HTTP 层或 MCP 层）
-        request_id = ""
-        for log in logs:
-            if log.get("request_id"):
-                request_id = log["request_id"]
-                break
+        request_id = _extract_field(logs, "request_id")
 
         # 5.1 计算总耗时：所有 span 的最大结束时间
         total_latency_ms = calc_max_end_time(spans)
 
         # 5.2 提取产生时间（从 HTTP 层日志或第一条日志）
-        timestamp = None
-        if http_logs and http_logs[0].get("timestamp"):
-            timestamp = http_logs[0]["timestamp"]
-        elif logs and logs[0].get("timestamp"):
-            timestamp = logs[0]["timestamp"]
+        timestamp = _extract_timestamp(http_logs, logs)
 
         # 6. 从 MCP 日志中提取 upstream_request_id（下游网关的 request_id）
-        upstream_request_id = ""
-        for log in mcp_logs:
-            if log.get("upstream_request_id"):
-                upstream_request_id = log["upstream_request_id"]
-                break
+        upstream_request_id = _extract_field(mcp_logs, "upstream_request_id")
         logger.debug(
             "[x_request_id] extracted upstream_request_id=%s from mcp_logs, request_id=%s",
             upstream_request_id,
@@ -239,8 +203,7 @@ class MCPServerLogChainSearchClient:
         )
 
         # 7. 查询上游网关 (bk-apigateway) 的日志
-        # 使用 request_id 查询，因为 bk-apigateway 的 request_id 对应 mcp-proxy 的 request_id
-        upstream_gateway_log = self._search_gateway_log(request_id, gateway_type="upstream") if request_id else None
+        upstream_gateway_log = search_gateway_log(request_id, gateway_type="upstream") if request_id else None
         logger.debug(
             "[x_request_id] upstream_gateway_log search result: request_id=%s, found=%s",
             request_id,
@@ -248,10 +211,8 @@ class MCPServerLogChainSearchClient:
         )
 
         # 8. 查询下游网关 (biz-gateway) 的日志
-        # 使用 upstream_request_id 查询，这是 API 响应中返回的 request_id
-        # 注意：如果 biz-gateway 的日志不在 bk-apigateway 的 ES 索引中，将无法查询到
         downstream_gateway_log = (
-            self._search_gateway_log(upstream_request_id, gateway_type="downstream") if upstream_request_id else None
+            search_gateway_log(upstream_request_id, gateway_type="downstream") if upstream_request_id else None
         )
         logger.debug(
             "[x_request_id] downstream_gateway_log search result: upstream_request_id=%s, found=%s",
@@ -288,10 +249,14 @@ class MCPServerLogChainSearchClient:
             }
 
         # 1. 查询下游网关日志（upstream_request_id 对应下游网关的 request_id）
-        downstream_gateway_log = self._search_gateway_log(self._upstream_request_id, gateway_type="downstream")
+        downstream_gateway_log = search_gateway_log(self._upstream_request_id, gateway_type="downstream")
 
         # 2. 用 upstream_request_id 字段在 mcp-proxy ES 中搜索，获取 mcp-proxy 的 request_id
-        mcp_logs = self._search_by_upstream_request_id()
+        mcp_logs = search_by_upstream_request_id(
+            self._es_client,
+            self._es_time_field_name,
+            self._upstream_request_id,
+        )
         if not mcp_logs:
             return {
                 "request_id": "",
@@ -303,13 +268,7 @@ class MCPServerLogChainSearchClient:
             }
 
         # 3. 从查到的日志中提取 mcp-proxy 的 request_id
-        # upstream_request_id 查到的日志都是 MCP 协议层日志（有 upstream_request_id 字段），
-        # 需要用 mcp-proxy 的 request_id 查完整链路（包含 HTTP 入口日志）
-        mcp_request_id = ""
-        for log in mcp_logs:
-            if log.get("request_id"):
-                mcp_request_id = log["request_id"]
-                break
+        mcp_request_id = _extract_field(mcp_logs, "request_id")
 
         if mcp_request_id:
             # 4. 使用 mcp-proxy 的 request_id 查询完整链路
@@ -319,16 +278,12 @@ class MCPServerLogChainSearchClient:
             return result
 
         # 5. 如果没有 request_id，直接使用查到的日志构建结果
-        merged_mcp_logs = self._merge_mcp_logs([log for log in mcp_logs if log.get("mcp_method")])
-        spans = self._build_spans([], merged_mcp_logs)
+        merged_mcp_logs = merge_mcp_logs([log for log in mcp_logs if log.get("mcp_method")])
+        spans = build_spans([], merged_mcp_logs)
 
-        x_request_id = ""
-        for log in mcp_logs:
-            if log.get("x_request_id"):
-                x_request_id = log["x_request_id"]
-                break
+        x_request_id = _extract_field(mcp_logs, "x_request_id")
 
-        # 计算总耗时：所有 span 的最大结束时间
+        # 计算总耗时
         total_latency_ms = calc_max_end_time(spans)
 
         timestamp = None
@@ -345,492 +300,31 @@ class MCPServerLogChainSearchClient:
             "downstream_gateway_log": downstream_gateway_log,
         }
 
-    def _search_all_layers(self) -> List[Dict]:  # noqa: C901, PLR0912
-        """从 ES 中查询同一 request_id 或 x_request_id 的所有层级日志"""
-        s = Search()
 
-        # 根据传入的参数决定查询条件
-        if self._request_id:
-            s = s.filter("term", request_id=self._request_id)
-        elif self._x_request_id:
-            s = s.filter("term", x_request_id=self._x_request_id)
+def _classify_logs(logs: List[Dict]) -> tuple:
+    """分类日志为 HTTP 层和 MCP 协议层"""
+    http_logs = []
+    mcp_logs = []
+    for log in logs:
+        if log.get("mcp_method"):
+            mcp_logs.append(log)
         else:
-            return []
+            http_logs.append(log)
+    return http_logs, mcp_logs
 
-        # 添加默认时间范围（最近7天），避免ES查询超时或返回过多数据
-        # 由于request_id/x_request_id是唯一的，时间范围不会影响结果准确性
-        time_range = SmartTimeRange(time_range=7 * 24 * 60 * 60)  # 7天
-        time_start, time_end = time_range.get_head_and_tail()
-        s = s.filter(
-            "range",
-            **{
-                self._es_time_field_name: {
-                    "gte": time_utils.convert_second_to_epoch_millisecond(time_start),
-                    "lte": time_utils.convert_second_to_epoch_millisecond(time_end),
-                }
-            },
-        )
 
-        s = s.source(fields=CHAIN_OUTPUT_FIELDS)
-        s = s.sort({self._es_time_field_name: {"order": "asc"}})
-        s = s[:100]  # 限制最多 100 条
+def _extract_field(logs: List[Dict], field_name: str) -> str:
+    """从日志列表中提取第一个非空的指定字段值"""
+    for log in logs:
+        if log.get(field_name):
+            return log[field_name]
+    return ""
 
-        try:
-            data = self._es_client.execute_search(s.to_dict())
-        except Exception as e:
-            logger.exception(
-                "failed to search mcp server chain logs for request_id=%s, x_request_id=%s",
-                self._request_id,
-                self._x_request_id,
-            )
-            # 重新抛出异常，让上层处理
-            raise error_codes.INTERNAL.format(message=f"ES query failed: {str(e)}")
 
-        hits = data.get("hits", {}).get("hits", [])
-        logger.debug(
-            "search mcp server chain logs success, request_id=%s, x_request_id=%s, hits=%s",
-            self._request_id,
-            self._x_request_id,
-            len(hits),
-        )
-        # 调试：记录每个 hit 的关键字段
-        for i, hit in enumerate(hits):
-            src = hit.get("_source", {})
-            logger.debug(
-                "hit[%s]: request_id=%s, mcp_method=%s, has_latency=%s, latency=%s, "
-                "has_params=%s, has_response=%s, has_tool=%s",
-                i,
-                src.get("request_id"),
-                src.get("mcp_method"),
-                bool(src.get("latency")),
-                src.get("latency"),
-                bool(src.get("params")),
-                bool(src.get("response")),
-                bool(src.get("tool")),
-            )
-        result = []
-        for hit in hits:
-            log = hit["_source"]
-            # 调试日志：检查 sort 字段
-            sort = hit.get("sort")
-            logger.debug(
-                "hit sort field: hit_id=%s, sort=%s, is_list=%s, len=%s",
-                hit.get("_id"),
-                sort,
-                isinstance(sort, list),
-                len(sort) if isinstance(sort, list) else "N/A",
-            )
-            if sort and len(sort) > 0:
-                log["timestamp"] = time_utils.convert_epoch_millisecond_to_second(sort[0])
-                log["timestamp_ms"] = sort[0]
-                logger.debug("added timestamp=%s to log", log.get("timestamp"))
-            else:
-                logger.warning("sort field is missing or empty for hit_id=%s", hit.get("_id"))
-
-            # 合并 __ext_json 中的字段到顶层（Filebeat 提取的字段）
-            # Filebeat 可能将某些字段提取到 __ext_json 中，需要合并到顶层
-            ext_json = log.get("__ext_json", {}) or {}
-            if ext_json:
-                # 合并所有 __ext_json 中的字段到顶层（优先使用 __ext_json 中的值）
-                # 这解决了 Filebeat 字段提取位置不一致的问题
-                for key, value in ext_json.items():
-                    # 只在顶层字段为空或不存在时，才用 __ext_json 中的值覆盖
-                    if (
-                        value is not None
-                        and value != ""
-                        and (key not in log or log.get(key) is None or log.get(key) == "")
-                    ):
-                        log[key] = value
-
-            # 排除文件访问日志：如果 __ext_json.method 为空，说明是文件访问日志
-            # 真正的 HTTP 请求日志有 __ext_json.method 字段
-            # 但 MCP 协议层日志（audit 日志）没有 __ext_json，通过 mcp_method 字段识别
-            if not ext_json.get("method") and not log.get("mcp_method"):
-                continue
-
-            # 排除健康检查请求
-            path = log.get("path", "")
-            if "/health" in path and path.split("?")[0].split("/")[-1] == "/health":
-                continue
-
-            result.append(log)
-        return result
-
-    def _search_by_upstream_request_id(self) -> List[Dict]:
-        """从 ES 中查询 upstream_request_id 匹配的日志
-
-        当用户通过上游 API 返回的 request_id（即 biz-gateway 的 request_id）查询时使用。
-        mcp-proxy 的 tools/call 日志中存储了 upstream_request_id 字段，
-        该值是下游 API 响应中返回的 request_id。
-        """
-        if not self._upstream_request_id:
-            return []
-
-        s = Search()
-        s = s.filter("term", upstream_request_id=self._upstream_request_id)
-
-        # 添加默认时间范围（最近7天）
-        time_range = SmartTimeRange(time_range=7 * 24 * 60 * 60)  # 7天
-        time_start, time_end = time_range.get_head_and_tail()
-        s = s.filter(
-            "range",
-            **{
-                self._es_time_field_name: {
-                    "gte": time_utils.convert_second_to_epoch_millisecond(time_start),
-                    "lte": time_utils.convert_second_to_epoch_millisecond(time_end),
-                }
-            },
-        )
-
-        s = s.source(fields=CHAIN_OUTPUT_FIELDS)
-        s = s.sort({self._es_time_field_name: {"order": "asc"}})
-        s = s[:100]  # 同一 upstream_request_id 可能关联多条日志
-
-        try:
-            data = self._es_client.execute_search(s.to_dict())
-        except Exception:
-            logger.exception(
-                "failed to search mcp server logs by upstream_request_id=%s",
-                self._upstream_request_id,
-            )
-            return []
-
-        hits = data.get("hits", {}).get("hits", [])
-        logger.debug(
-            "search mcp server logs by upstream_request_id=%s, hits=%s",
-            self._upstream_request_id,
-            len(hits),
-        )
-        result = []
-        for hit in hits:
-            log = hit["_source"]
-            # 调试日志：检查 sort 字段
-            sort = hit.get("sort")
-            logger.debug(
-                "[upstream_request_id] hit sort field: hit_id=%s, sort=%s, is_list=%s, len=%s",
-                hit.get("_id"),
-                sort,
-                isinstance(sort, list),
-                len(sort) if isinstance(sort, list) else "N/A",
-            )
-            if sort and len(sort) > 0:
-                log["timestamp"] = time_utils.convert_epoch_millisecond_to_second(sort[0])
-                log["timestamp_ms"] = sort[0]
-                logger.debug("[upstream_request_id] added timestamp=%s to log", log.get("timestamp"))
-            else:
-                logger.warning("[upstream_request_id] sort field is missing or empty for hit_id=%s", hit.get("_id"))
-
-            # 合并 __ext_json 中的字段到顶层（Filebeat 提取的字段）
-            ext_json = log.get("__ext_json", {}) or {}
-            if ext_json:
-                for key, value in ext_json.items():
-                    if (
-                        value is not None
-                        and value != ""
-                        and (key not in log or log.get(key) is None or log.get(key) == "")
-                    ):
-                        log[key] = value
-
-            # 排除文件访问日志
-            if not ext_json.get("method") and not log.get("mcp_method"):
-                continue
-
-            # 排除健康检查请求
-            path = log.get("path", "")
-            if "/health" in path and path.split("?")[0].split("/")[-1] == "/health":
-                continue
-
-            result.append(log)
-        return result
-
-    def _build_spans(self, http_logs: List[Dict], mcp_logs: List[Dict]) -> List[Dict]:
-        """将日志构建为 span 树结构"""
-        spans = []
-
-        # HTTP 入口 span (如果存在)
-        http_entry = None
-        if http_logs:
-            log = http_logs[0]
-            latency_ms = parse_latency_ms(log.get("latency", ""))
-            http_entry = {
-                "span_id": "http_entry",
-                "parent_span_id": None,
-                "layer": "http",
-                "service": "mcp-proxy",
-                "upstream": log.get("mcp_server_name", "") or "",
-                "operation": f"{log.get('method', '')} {log.get('path', '')}",
-                "latency": log.get("latency", ""),
-                "latency_ms": latency_ms,
-                "start_offset_ms": 0,
-                "status": log.get("status"),
-                "detail": {
-                    "timestamp": log.get("timestamp"),
-                    "method": log.get("method"),
-                    "path": log.get("path"),
-                    "status": log.get("status"),
-                    "client_ip": log.get("client_ip"),
-                    "app_code": log.get("app_code"),
-                    "gateway_name": log.get("gateway_name"),
-                    "mcp_server_name": log.get("mcp_server_name"),
-                    "request_id": log.get("request_id"),
-                    "x_request_id": log.get("x_request_id"),
-                },
-                "children": [],
-            }
-            spans.append(http_entry)
-
-        # MCP 协议层 span
-        # 计算 base timestamp 用于 start_offset_ms
-        base_ts_ms = None
-        if http_entry and http_logs and http_logs[0].get("timestamp_ms"):
-            # HTTP 入口的 timestamp 是请求完成后记录的，所以 MCP span 的偏移需要用 HTTP 开始时间
-            # 近似用 HTTP 完成时间 - HTTP 耗时
-            http_latency_ms = http_entry.get("latency_ms") or 0
-            base_ts_ms = http_logs[0]["timestamp_ms"] - http_latency_ms
-        elif mcp_logs and mcp_logs[0].get("timestamp_ms"):
-            base_ts_ms = mcp_logs[0]["timestamp_ms"]
-
-        for i, log in enumerate(mcp_logs):
-            latency_ms = parse_latency_ms(log.get("latency", ""))
-            mcp_method = log.get("mcp_method", "")
-
-            # Audit 日志中 tool 字段存储工具配置字符串，需要提取工具名
-            # 格式: "tool:[name:xxx,url:xxx, method:GET]"
-            tool_str = log.get("tool", "")
-            tool_name = log.get("tool_name", "")
-            if not tool_name and tool_str:
-                # 从 tool 字符串中提取工具名
-                match = re.search(r"name:([^,]+)", tool_str)
-                if match:
-                    tool_name = match.group(1).strip()
-
-            operation = mcp_method
-            if tool_name:
-                operation = f"{mcp_method} {tool_name}"
-
-            # 计算 start_offset_ms: MCP 日志的 timestamp 是完成时间，
-            # 所以 start = 完成时间 - 耗时 - base_ts
-            start_offset_ms = 0
-            if base_ts_ms is not None and log.get("timestamp_ms"):
-                log_start_ms = log["timestamp_ms"] - (latency_ms or 0)
-                start_offset_ms = max(0, round(log_start_ms - base_ts_ms, 3))
-
-            # Audit 日志中的 request 字段存储请求参数
-            params = log.get("params") or log.get("request")
-
-            span = {
-                "span_id": f"mcp_{i}",
-                "parent_span_id": "http_entry" if http_entry else None,
-                "layer": "mcp",
-                "service": log.get("mcp_server_name") or log.get("gateway_name", ""),
-                "upstream": log.get("gateway_name", "") or "",
-                "operation": operation,
-                "latency": log.get("latency", ""),
-                "latency_ms": latency_ms,
-                "start_offset_ms": start_offset_ms,
-                "status": None,
-                "detail": {
-                    "timestamp": log.get("timestamp"),
-                    "mcp_method": mcp_method,
-                    "tool_name": tool_name,
-                    "prompt_name": log.get("prompt_name"),
-                    "tool": tool_str,  # 保留原始 tool 字符串
-                    "params": params,
-                    "response": log.get("response"),
-                    "request_body_size": log.get("request_body_size"),
-                    "response_body_size": log.get("response_body_size"),
-                    "app_code": log.get("app_code"),
-                    "bk_username": log.get("bk_username"),
-                    "client_ip": log.get("client_ip"),
-                    "client_id": log.get("client_id"),
-                    "session_id": log.get("session_id"),
-                    "request_id": log.get("request_id"),
-                    "x_request_id": log.get("x_request_id"),
-                    "trace_id": log.get("trace_id"),
-                    "error": log.get("error"),
-                },
-                "children": [],
-            }
-
-            if http_entry:
-                http_entry["children"].append(span)
-            else:
-                spans.append(span)
-
-        return spans
-
-    def _merge_mcp_logs(self, mcp_logs: List[Dict]) -> List[Dict]:  # noqa: C901, PLR0912
-        """合并同一 request_id + mcp_method + tool_name 的多条 MCP 日志
-
-        mcp-proxy 会输出多份 MCP 层日志：
-        - "call tool": 开始调用时记录，只有 request 字段
-        - "call tool request params": 请求参数信息，包含 header, query, path, body
-        - "call tool complete": 函数返回时记录，有完整的 params, response, latency 等字段
-        - api log: 包含完整字段（但如果 filebeat 过滤可能不存在）
-
-        需要合并这些日志，优先使用有 latency 字段的日志（即 "call tool complete"）。
-        如果某些日志缺少 mcp_method，则按 request_id + tool_name 分组。
-        """
-        if not mcp_logs:
-            return []
-
-        # 按 (request_id, mcp_method, tool_name) 分组
-        # 如果 mcp_method 缺失，则使用 tool_name 作为分组键的一部分
-        log_groups: Dict[tuple, List[Dict]] = {}
-        for idx, log in enumerate(mcp_logs):
-            # 确保 tool_name 存在
-            tool_name = log.get("tool_name", "")
-            if not tool_name:
-                # 尝试从 tool 字段提取
-                tool_str = log.get("tool", "")
-                if tool_str:
-                    match = re.search(r"name:([^,]+)", tool_str)
-                    if match:
-                        tool_name = match.group(1).strip()
-
-            # 如果 mcp_method 缺失，使用 tool_name 作为分组键
-            mcp_method = log.get("mcp_method", "") or "tools/call"  # 默认值
-            key = (
-                log.get("request_id", ""),
-                mcp_method,
-                tool_name,
-            )
-            logger.debug(
-                "_merge_mcp_logs: log[%s] key=%s, has_latency=%s, has_params=%s, has_response=%s",
-                idx,
-                key,
-                bool(log.get("latency")),
-                bool(log.get("params")),
-                bool(log.get("response")),
-            )
-            if key not in log_groups:
-                log_groups[key] = []
-            log_groups[key].append(log)
-
-        logger.debug("_merge_mcp_logs: total groups=%s, group_keys=%s", len(log_groups), list(log_groups.keys()))
-
-        # 合并每组日志：优先使用有 latency 的日志（"call tool complete"）
-        merged_logs = []
-        for key, logs in log_groups.items():
-            logger.debug(
-                "merging group %s: log_count=%s",
-                key,
-                len(logs),
-            )
-            if len(logs) == 1:
-                merged_logs.append(logs[0])
-                continue
-
-            # 找到有 latency 的日志（通常是 "call tool complete"）
-            complete_log = None
-            for log in logs:
-                if log.get("latency"):
-                    complete_log = log
-                    break
-
-            if complete_log:
-                # 使用 complete_log 作为基础，但补充其他日志中的非空字段
-                merged = dict(complete_log)
-                for log in logs:
-                    if log is complete_log:
-                        continue
-                    for field_name, value in log.items():
-                        if (
-                            value is not None
-                            and value != ""
-                            and (field_name not in merged or merged[field_name] is None or merged[field_name] == "")
-                        ):
-                            merged[field_name] = value
-                merged_logs.append(merged)
-                logger.debug(
-                    "merged with complete_log: has_latency=%s, has_params=%s, has_response=%s",
-                    bool(merged.get("latency")),
-                    bool(merged.get("params")),
-                    bool(merged.get("response")),
-                )
-            else:
-                # 如果没有 complete log，使用第一个日志并合并其他字段
-                merged = dict(logs[0])
-                for log in logs[1:]:
-                    for field_name, value in log.items():
-                        if (
-                            value is not None
-                            and value != ""
-                            and (field_name not in merged or merged[field_name] is None or merged[field_name] == "")
-                        ):
-                            merged[field_name] = value
-                merged_logs.append(merged)
-                logger.debug("merged without complete_log")
-
-        return merged_logs
-
-    def _search_gateway_log(self, request_id: str, gateway_type: str = "upstream") -> Optional[Dict]:
-        """通过 request_id 查询网关日志
-
-        bk-apigateway 的 access_log ES 中，request_id 字段对应的是 X-Bkapi-Request-ID，
-        而这个值就是 mcp-proxy 日志中的 request_id 字段（从上游传入的）。
-
-        Args:
-            request_id: 网关的请求 ID
-            gateway_type: 网关类型，"upstream" 或 "downstream"
-        """
-        if not request_id:
-            logger.warning("search_gateway_log called with empty request_id, gateway_type=%s", gateway_type)
-            return None
-
-        try:
-            # 使用已有的 access_log LogSearchClient 查询
-            # 注意：这里查询的是 bk-apigateway 的日志索引
-            # 对于 upstream（bk-apigateway），request_id 是直接对应的
-            # 对于 downstream（biz-gateway），如果它的日志也在同一个 ES 索引中，才能查询到
-            logger.debug(
-                "searching %s gateway log with request_id=%s",
-                gateway_type,
-                request_id,
-            )
-            client = LogSearchClient(request_id=request_id, time_range=7 * 24 * 60 * 60)  # 7天
-            total_count, logs = client.search_logs(offset=0, limit=1)
-            logger.debug(
-                "%s gateway log search result: request_id=%s, total_count=%s, has_logs=%s",
-                gateway_type,
-                request_id,
-                total_count,
-                bool(logs),
-            )
-            if logs:
-                log = logs[0]
-                return {
-                    "layer": "gateway",
-                    "service": "bk-apigateway" if gateway_type == "upstream" else "biz-gateway",
-                    "timestamp": log.get("timestamp"),
-                    "request_id": log.get("request_id"),
-                    "method": log.get("method"),
-                    "http_host": log.get("http_host"),
-                    "http_path": log.get("http_path"),
-                    "status": log.get("status"),
-                    "request_duration": log.get("request_duration"),
-                    "backend_duration": log.get("backend_duration"),
-                    "stage": log.get("stage"),
-                    "resource_name": log.get("resource_name"),
-                    "backend_host": log.get("backend_host"),
-                    "backend_path": log.get("backend_path"),
-                    "backend_method": log.get("backend_method"),
-                    "backend_scheme": log.get("backend_scheme"),
-                    "app_code": log.get("app_code"),
-                    "client_ip": log.get("client_ip"),
-                    "error": log.get("error"),
-                    "code_name": log.get("code_name"),
-                }
-            logger.warning(
-                "no %s gateway log found for request_id=%s, may be out of time range or not indexed",
-                gateway_type,
-                request_id,
-            )
-        except Exception:
-            logger.exception(
-                "failed to search %s gateway log for request_id=%s",
-                gateway_type,
-                request_id,
-            )
-
-        return None
+def _extract_timestamp(http_logs: List[Dict], all_logs: List[Dict]):
+    """提取产生时间（从 HTTP 层日志或第一条日志）"""
+    if http_logs and http_logs[0].get("timestamp"):
+        return http_logs[0]["timestamp"]
+    if all_logs and all_logs[0].get("timestamp"):
+        return all_logs[0]["timestamp"]
+    return None

--- a/src/dashboard/apigateway/apigateway/biz/mcp_server_log/chain_search.py
+++ b/src/dashboard/apigateway/apigateway/biz/mcp_server_log/chain_search.py
@@ -23,78 +23,14 @@ from django.conf import settings
 from elasticsearch_dsl import Search
 
 from apigateway.biz.access_log.log_search import LogSearchClient
+from apigateway.biz.mcp_server_log.constants import CHAIN_OUTPUT_FIELDS
+from apigateway.biz.mcp_server_log.utils import calc_max_end_time, parse_latency_ms
 from apigateway.common.error_codes import error_codes
 from apigateway.service.es.clients import BKLogESClient
 from apigateway.utils import time as time_utils
 from apigateway.utils.time import SmartTimeRange
 
 logger = logging.getLogger(__name__)
-
-# latency 字符串(如 "37.36ms", "1.2s", "500µs") 转换为毫秒
-_LATENCY_PATTERN = re.compile(r"^([\d.]+)(µs|us|ms|s|m|h)$")
-
-_UNIT_TO_MS = {
-    "µs": 0.001,
-    "us": 0.001,
-    "ms": 1.0,
-    "s": 1000.0,
-    "m": 60_000.0,
-    "h": 3_600_000.0,
-}
-
-
-def _parse_latency_ms(latency_str: str) -> Optional[float]:
-    """将 Go 的 duration 字符串转换为毫秒数值"""
-    if not latency_str:
-        return None
-    m = _LATENCY_PATTERN.match(latency_str.strip())
-    if not m:
-        return None
-    value = float(m.group(1))
-    unit = m.group(2)
-    return round(value * _UNIT_TO_MS.get(unit, 1.0), 3)
-
-
-# MCP Proxy 的 ES 日志中，所有层共有的字段
-_CHAIN_OUTPUT_FIELDS = [
-    # 链路标识
-    "request_id",
-    "x_request_id",
-    "session_id",
-    # 网关信息
-    "gateway_id",
-    "gateway_name",
-    "mcp_server_name",
-    "mcp_server_id",
-    # HTTP 层字段（注意：ES 中 method/path/status 在 __ext_json 中）
-    "method",
-    "path",
-    "status",
-    # Filebeat 提取的字段
-    "__ext_json",
-    # MCP 协议层字段
-    "mcp_method",
-    "tool_name",
-    "prompt_name",  # prompt 名称
-    "tool",  # audit 日志中的原始 tool 配置字符串
-    "params",
-    "request",  # audit 日志使用 request 字段存储请求参数
-    "response",
-    "request_body_size",
-    "response_body_size",
-    "upstream_request_id",  # 上游 API 返回的 request_id
-    # 调用方信息
-    "app_code",
-    "bk_username",
-    "client_ip",
-    "client_id",
-    # 性能
-    "latency",
-    # trace
-    "trace_id",
-    # 错误
-    "error",
-]
 
 
 class MCPServerLogChainSearchClient:
@@ -187,17 +123,6 @@ class MCPServerLogChainSearchClient:
                 break
 
         # 5.1 计算总耗时：所有 span 的最大结束时间
-        # 结束时间 = start_offset_ms + latency_ms
-        def calc_max_end_time(span_list, max_end=0):
-            for span in span_list:
-                start = span.get("start_offset_ms", 0) or 0
-                latency = span.get("latency_ms", 0) or 0
-                end_time = start + latency
-                max_end = max(max_end, end_time)
-                # 递归计算子 span
-                max_end = calc_max_end_time(span.get("children", []), max_end)
-            return max_end
-
         total_latency_ms = calc_max_end_time(spans)
 
         # 5.2 提取产生时间（从 HTTP 层日志或第一条日志）
@@ -213,7 +138,7 @@ class MCPServerLogChainSearchClient:
             if log.get("upstream_request_id"):
                 upstream_request_id = log["upstream_request_id"]
                 break
-        logger.info(
+        logger.debug(
             "extracted upstream_request_id=%s from mcp_logs, self._request_id=%s",
             upstream_request_id,
             self._request_id,
@@ -224,7 +149,7 @@ class MCPServerLogChainSearchClient:
         upstream_gateway_log = (
             self._search_gateway_log(self._request_id, gateway_type="upstream") if self._request_id else None
         )
-        logger.info(
+        logger.debug(
             "upstream_gateway_log search result: request_id=%s, found=%s",
             self._request_id,
             upstream_gateway_log is not None,
@@ -236,7 +161,7 @@ class MCPServerLogChainSearchClient:
         downstream_gateway_log = (
             self._search_gateway_log(upstream_request_id, gateway_type="downstream") if upstream_request_id else None
         )
-        logger.info(
+        logger.debug(
             "downstream_gateway_log search result: upstream_request_id=%s, found=%s",
             upstream_request_id,
             downstream_gateway_log is not None,
@@ -292,16 +217,7 @@ class MCPServerLogChainSearchClient:
                 break
 
         # 5.1 计算总耗时：所有 span 的最大结束时间
-        def calc_max_end_time_x(span_list, max_end=0):
-            for span in span_list:
-                start = span.get("start_offset_ms", 0) or 0
-                latency = span.get("latency_ms", 0) or 0
-                end_time = start + latency
-                max_end = max(max_end, end_time)
-                max_end = calc_max_end_time_x(span.get("children", []), max_end)
-            return max_end
-
-        total_latency_ms = calc_max_end_time_x(spans)
+        total_latency_ms = calc_max_end_time(spans)
 
         # 5.2 提取产生时间（从 HTTP 层日志或第一条日志）
         timestamp = None
@@ -316,7 +232,7 @@ class MCPServerLogChainSearchClient:
             if log.get("upstream_request_id"):
                 upstream_request_id = log["upstream_request_id"]
                 break
-        logger.info(
+        logger.debug(
             "[x_request_id] extracted upstream_request_id=%s from mcp_logs, request_id=%s",
             upstream_request_id,
             request_id,
@@ -325,7 +241,7 @@ class MCPServerLogChainSearchClient:
         # 7. 查询上游网关 (bk-apigateway) 的日志
         # 使用 request_id 查询，因为 bk-apigateway 的 request_id 对应 mcp-proxy 的 request_id
         upstream_gateway_log = self._search_gateway_log(request_id, gateway_type="upstream") if request_id else None
-        logger.info(
+        logger.debug(
             "[x_request_id] upstream_gateway_log search result: request_id=%s, found=%s",
             request_id,
             upstream_gateway_log is not None,
@@ -337,7 +253,7 @@ class MCPServerLogChainSearchClient:
         downstream_gateway_log = (
             self._search_gateway_log(upstream_request_id, gateway_type="downstream") if upstream_request_id else None
         )
-        logger.info(
+        logger.debug(
             "[x_request_id] downstream_gateway_log search result: upstream_request_id=%s, found=%s",
             upstream_request_id,
             downstream_gateway_log is not None,
@@ -413,16 +329,7 @@ class MCPServerLogChainSearchClient:
                 break
 
         # 计算总耗时：所有 span 的最大结束时间
-        def calc_max_end_time_upstream(span_list, max_end=0):
-            for span in span_list:
-                start = span.get("start_offset_ms", 0) or 0
-                latency = span.get("latency_ms", 0) or 0
-                end_time = start + latency
-                max_end = max(max_end, end_time)
-                max_end = calc_max_end_time_upstream(span.get("children", []), max_end)
-            return max_end
-
-        total_latency_ms = calc_max_end_time_upstream(spans)
+        total_latency_ms = calc_max_end_time(spans)
 
         timestamp = None
         if mcp_logs and mcp_logs[0].get("timestamp"):
@@ -464,7 +371,7 @@ class MCPServerLogChainSearchClient:
             },
         )
 
-        s = s.source(fields=_CHAIN_OUTPUT_FIELDS)
+        s = s.source(fields=CHAIN_OUTPUT_FIELDS)
         s = s.sort({self._es_time_field_name: {"order": "asc"}})
         s = s[:100]  # 限制最多 100 条
 
@@ -480,7 +387,7 @@ class MCPServerLogChainSearchClient:
             raise error_codes.INTERNAL.format(message=f"ES query failed: {str(e)}")
 
         hits = data.get("hits", {}).get("hits", [])
-        logger.info(
+        logger.debug(
             "search mcp server chain logs success, request_id=%s, x_request_id=%s, hits=%s",
             self._request_id,
             self._x_request_id,
@@ -489,7 +396,7 @@ class MCPServerLogChainSearchClient:
         # 调试：记录每个 hit 的关键字段
         for i, hit in enumerate(hits):
             src = hit.get("_source", {})
-            logger.info(
+            logger.debug(
                 "hit[%s]: request_id=%s, mcp_method=%s, has_latency=%s, latency=%s, "
                 "has_params=%s, has_response=%s, has_tool=%s",
                 i,
@@ -506,7 +413,7 @@ class MCPServerLogChainSearchClient:
             log = hit["_source"]
             # 调试日志：检查 sort 字段
             sort = hit.get("sort")
-            logger.info(
+            logger.debug(
                 "hit sort field: hit_id=%s, sort=%s, is_list=%s, len=%s",
                 hit.get("_id"),
                 sort,
@@ -516,7 +423,7 @@ class MCPServerLogChainSearchClient:
             if sort and len(sort) > 0:
                 log["timestamp"] = time_utils.convert_epoch_millisecond_to_second(sort[0])
                 log["timestamp_ms"] = sort[0]
-                logger.info("added timestamp=%s to log", log.get("timestamp"))
+                logger.debug("added timestamp=%s to log", log.get("timestamp"))
             else:
                 logger.warning("sort field is missing or empty for hit_id=%s", hit.get("_id"))
 
@@ -575,7 +482,7 @@ class MCPServerLogChainSearchClient:
             },
         )
 
-        s = s.source(fields=_CHAIN_OUTPUT_FIELDS)
+        s = s.source(fields=CHAIN_OUTPUT_FIELDS)
         s = s.sort({self._es_time_field_name: {"order": "asc"}})
         s = s[:100]  # 同一 upstream_request_id 可能关联多条日志
 
@@ -589,7 +496,7 @@ class MCPServerLogChainSearchClient:
             return []
 
         hits = data.get("hits", {}).get("hits", [])
-        logger.info(
+        logger.debug(
             "search mcp server logs by upstream_request_id=%s, hits=%s",
             self._upstream_request_id,
             len(hits),
@@ -599,7 +506,7 @@ class MCPServerLogChainSearchClient:
             log = hit["_source"]
             # 调试日志：检查 sort 字段
             sort = hit.get("sort")
-            logger.info(
+            logger.debug(
                 "[upstream_request_id] hit sort field: hit_id=%s, sort=%s, is_list=%s, len=%s",
                 hit.get("_id"),
                 sort,
@@ -609,7 +516,7 @@ class MCPServerLogChainSearchClient:
             if sort and len(sort) > 0:
                 log["timestamp"] = time_utils.convert_epoch_millisecond_to_second(sort[0])
                 log["timestamp_ms"] = sort[0]
-                logger.info("[upstream_request_id] added timestamp=%s to log", log.get("timestamp"))
+                logger.debug("[upstream_request_id] added timestamp=%s to log", log.get("timestamp"))
             else:
                 logger.warning("[upstream_request_id] sort field is missing or empty for hit_id=%s", hit.get("_id"))
 
@@ -644,7 +551,7 @@ class MCPServerLogChainSearchClient:
         http_entry = None
         if http_logs:
             log = http_logs[0]
-            latency_ms = _parse_latency_ms(log.get("latency", ""))
+            latency_ms = parse_latency_ms(log.get("latency", ""))
             http_entry = {
                 "span_id": "http_entry",
                 "parent_span_id": None,
@@ -684,7 +591,7 @@ class MCPServerLogChainSearchClient:
             base_ts_ms = mcp_logs[0]["timestamp_ms"]
 
         for i, log in enumerate(mcp_logs):
-            latency_ms = _parse_latency_ms(log.get("latency", ""))
+            latency_ms = parse_latency_ms(log.get("latency", ""))
             mcp_method = log.get("mcp_method", "")
 
             # Audit 日志中 tool 字段存储工具配置字符串，需要提取工具名
@@ -788,7 +695,7 @@ class MCPServerLogChainSearchClient:
                 mcp_method,
                 tool_name,
             )
-            logger.info(
+            logger.debug(
                 "_merge_mcp_logs: log[%s] key=%s, has_latency=%s, has_params=%s, has_response=%s",
                 idx,
                 key,
@@ -800,12 +707,12 @@ class MCPServerLogChainSearchClient:
                 log_groups[key] = []
             log_groups[key].append(log)
 
-        logger.info("_merge_mcp_logs: total groups=%s, group_keys=%s", len(log_groups), list(log_groups.keys()))
+        logger.debug("_merge_mcp_logs: total groups=%s, group_keys=%s", len(log_groups), list(log_groups.keys()))
 
         # 合并每组日志：优先使用有 latency 的日志（"call tool complete"）
         merged_logs = []
         for key, logs in log_groups.items():
-            logger.info(
+            logger.debug(
                 "merging group %s: log_count=%s",
                 key,
                 len(logs),
@@ -835,7 +742,7 @@ class MCPServerLogChainSearchClient:
                         ):
                             merged[field_name] = value
                 merged_logs.append(merged)
-                logger.info(
+                logger.debug(
                     "merged with complete_log: has_latency=%s, has_params=%s, has_response=%s",
                     bool(merged.get("latency")),
                     bool(merged.get("params")),
@@ -853,7 +760,7 @@ class MCPServerLogChainSearchClient:
                         ):
                             merged[field_name] = value
                 merged_logs.append(merged)
-                logger.info("merged without complete_log")
+                logger.debug("merged without complete_log")
 
         return merged_logs
 
@@ -876,14 +783,14 @@ class MCPServerLogChainSearchClient:
             # 注意：这里查询的是 bk-apigateway 的日志索引
             # 对于 upstream（bk-apigateway），request_id 是直接对应的
             # 对于 downstream（biz-gateway），如果它的日志也在同一个 ES 索引中，才能查询到
-            logger.info(
+            logger.debug(
                 "searching %s gateway log with request_id=%s",
                 gateway_type,
                 request_id,
             )
             client = LogSearchClient(request_id=request_id, time_range=7 * 24 * 60 * 60)  # 7天
             total_count, logs = client.search_logs(offset=0, limit=1)
-            logger.info(
+            logger.debug(
                 "%s gateway log search result: request_id=%s, total_count=%s, has_logs=%s",
                 gateway_type,
                 request_id,

--- a/src/dashboard/apigateway/apigateway/biz/mcp_server_log/chain_search.py
+++ b/src/dashboard/apigateway/apigateway/biz/mcp_server_log/chain_search.py
@@ -94,9 +94,11 @@ class MCPServerLogChainSearchClient:
             return {
                 "request_id": self._request_id,
                 "x_request_id": "",
+                "timestamp": None,
                 "total_latency_ms": 0,
                 "spans": [],
-                "gateway_log": None,
+                "upstream_gateway_log": None,
+                "downstream_gateway_log": None,
             }
 
         # 2. 分类：HTTP 层 vs MCP 协议层
@@ -171,9 +173,11 @@ class MCPServerLogChainSearchClient:
             return {
                 "request_id": "",
                 "x_request_id": self._x_request_id,
+                "timestamp": None,
                 "total_latency_ms": 0,
                 "spans": [],
-                "gateway_log": None,
+                "upstream_gateway_log": None,
+                "downstream_gateway_log": None,
             }
 
         # 2. 分类：HTTP 层 vs MCP 协议层

--- a/src/dashboard/apigateway/apigateway/biz/mcp_server_log/constants.py
+++ b/src/dashboard/apigateway/apigateway/biz/mcp_server_log/constants.py
@@ -36,6 +36,16 @@ MCP_SERVER_LOG_FIELDS = [
         "is_filter": False,
     },
     {
+        "label": _("HTTP 方法"),
+        "field": "method",
+        "is_filter": True,
+    },
+    {
+        "label": _("请求路径"),
+        "field": "path",
+        "is_filter": True,
+    },
+    {
         "label": _("网关ID"),
         "field": "gateway_id",
         "is_filter": True,

--- a/src/dashboard/apigateway/apigateway/biz/mcp_server_log/constants.py
+++ b/src/dashboard/apigateway/apigateway/biz/mcp_server_log/constants.py
@@ -1,0 +1,140 @@
+#
+# TencentBlueKing is pleased to support the open source community by making
+# 蓝鲸智云 - API 网关(BlueKing - APIGateway) available.
+# Copyright (C) 2025 Tencent. All rights reserved.
+# Licensed under the MIT License (the "License"); you may not use this file except
+# in compliance with the License. You may obtain a copy of the License at
+#
+#     http://opensource.org/licenses/MIT
+#
+# Unless required by applicable law or agreed to in writing, software distributed under
+# the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+# either express or implied. See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# We undertake not to change the open source license (MIT license) applicable
+# to the current version of the project delivered to anyone in the future.
+#
+from django.utils.translation import gettext_lazy as _
+
+# MCP Server 日志字段定义
+# 基于 mcp-proxy LoggingMiddleware 输出的字段
+MCP_SERVER_LOG_FIELDS = [
+    {
+        "label": _("请求ID"),
+        "field": "request_id",
+        "is_filter": True,
+    },
+    {
+        "label": _("全链路请求ID"),
+        "field": "x_request_id",
+        "is_filter": True,
+    },
+    {
+        "label": _("请求时间"),
+        "field": "timestamp",
+        "is_filter": False,
+    },
+    {
+        "label": _("网关ID"),
+        "field": "gateway_id",
+        "is_filter": True,
+    },
+    {
+        "label": _("网关名称"),
+        "field": "gateway_name",
+        "is_filter": True,
+    },
+    {
+        "label": _("MCP Server ID"),
+        "field": "mcp_server_id",
+        "is_filter": True,
+    },
+    {
+        "label": _("MCP Server"),
+        "field": "mcp_server_name",
+        "is_filter": True,
+    },
+    {
+        "label": _("MCP 方法"),
+        "field": "mcp_method",
+        "is_filter": True,
+    },
+    {
+        "label": _("工具名称"),
+        "field": "tool_name",
+        "is_filter": True,
+    },
+    {
+        "label": _("Prompt 名称"),
+        "field": "prompt_name",
+        "is_filter": True,
+    },
+    {
+        "label": _("蓝鲸应用"),
+        "field": "app_code",
+        "is_filter": True,
+    },
+    {
+        "label": _("蓝鲸用户"),
+        "field": "bk_username",
+        "is_filter": True,
+    },
+    {
+        "label": _("客户端IP"),
+        "field": "client_ip",
+        "is_filter": True,
+    },
+    {
+        "label": _("客户端ID"),
+        "field": "client_id",
+        "is_filter": True,
+    },
+    {
+        "label": _("会话ID"),
+        "field": "session_id",
+        "is_filter": True,
+    },
+    {
+        "label": _("请求参数"),
+        "field": "params",
+        "is_filter": False,
+    },
+    {
+        "label": _("响应内容"),
+        "field": "response",
+        "is_filter": False,
+    },
+    {
+        "label": _("请求体大小"),
+        "field": "request_body_size",
+        "is_filter": False,
+    },
+    {
+        "label": _("响应体大小"),
+        "field": "response_body_size",
+        "is_filter": False,
+    },
+    {
+        "label": _("耗时"),
+        "field": "latency",
+        "is_filter": True,
+    },
+    {
+        "label": _("Trace ID"),
+        "field": "trace_id",
+        "is_filter": True,
+    },
+    {
+        "label": _("状态"),
+        "field": "status",
+        "is_filter": True,
+    },
+    {
+        "label": _("错误"),
+        "field": "error",
+        "is_filter": True,
+    },
+]
+
+MCP_SERVER_LOG_OUTPUT_FIELDS = [field["field"] for field in MCP_SERVER_LOG_FIELDS]

--- a/src/dashboard/apigateway/apigateway/biz/mcp_server_log/constants.py
+++ b/src/dashboard/apigateway/apigateway/biz/mcp_server_log/constants.py
@@ -149,6 +149,56 @@ MCP_SERVER_LOG_FIELDS = [
 
 MCP_SERVER_LOG_OUTPUT_FIELDS = [field["field"] for field in MCP_SERVER_LOG_FIELDS]
 
+# 前端 status 参数到 HTTP 状态码的映射
+# MCP 协议层 status 是字符串 "success"/"failed"
+# HTTP 层 status 是整数（如 200、500），但 ES 中 status 字段可能是 keyword 类型
+# （由第一条写入的日志决定 mapping），且 __ext_json 是 flattened 类型（所有值为字符串）。
+# 因此必须同时用 整数值 和 字符串值 匹配，且不能依赖 range 查询（keyword 上 range 行为不确定）。
+STATUS_HTTP_CODES = {
+    "success": [
+        # 整数形式（适用于 integer/long 类型 mapping）
+        200,
+        201,
+        202,
+        204,
+        301,
+        302,
+        304,
+        # 字符串形式（适用于 keyword/flattened 类型 mapping）
+        "200",
+        "201",
+        "202",
+        "204",
+        "301",
+        "302",
+        "304",
+    ],
+    "failed": [
+        400,
+        401,
+        403,
+        404,
+        405,
+        408,
+        429,
+        500,
+        502,
+        503,
+        504,
+        "400",
+        "401",
+        "403",
+        "404",
+        "405",
+        "408",
+        "429",
+        "500",
+        "502",
+        "503",
+        "504",
+    ],
+}
+
 # MCP Proxy 的 ES 日志中，所有层共有的字段
 CHAIN_OUTPUT_FIELDS = [
     # 链路标识

--- a/src/dashboard/apigateway/apigateway/biz/mcp_server_log/constants.py
+++ b/src/dashboard/apigateway/apigateway/biz/mcp_server_log/constants.py
@@ -138,3 +138,44 @@ MCP_SERVER_LOG_FIELDS = [
 ]
 
 MCP_SERVER_LOG_OUTPUT_FIELDS = [field["field"] for field in MCP_SERVER_LOG_FIELDS]
+
+# MCP Proxy 的 ES 日志中，所有层共有的字段
+CHAIN_OUTPUT_FIELDS = [
+    # 链路标识
+    "request_id",
+    "x_request_id",
+    "session_id",
+    # 网关信息
+    "gateway_id",
+    "gateway_name",
+    "mcp_server_name",
+    "mcp_server_id",
+    # HTTP 层字段（注意：ES 中 method/path/status 在 __ext_json 中）
+    "method",
+    "path",
+    "status",
+    # Filebeat 提取的字段
+    "__ext_json",
+    # MCP 协议层字段
+    "mcp_method",
+    "tool_name",
+    "prompt_name",  # prompt 名称
+    "tool",  # audit 日志中的原始 tool 配置字符串
+    "params",
+    "request",  # audit 日志使用 request 字段存储请求参数
+    "response",
+    "request_body_size",
+    "response_body_size",
+    "upstream_request_id",  # 上游 API 返回的 request_id
+    # 调用方信息
+    "app_code",
+    "bk_username",
+    "client_ip",
+    "client_id",
+    # 性能
+    "latency",
+    # trace
+    "trace_id",
+    # 错误
+    "error",
+]

--- a/src/dashboard/apigateway/apigateway/biz/mcp_server_log/es_query.py
+++ b/src/dashboard/apigateway/apigateway/biz/mcp_server_log/es_query.py
@@ -1,0 +1,197 @@
+#
+# TencentBlueKing is pleased to support the open source community by making
+# 蓝鲸智云 - API 网关(BlueKing - APIGateway) available.
+# Copyright (C) 2025 Tencent. All rights reserved.
+# Licensed under the MIT License (the "License"); you may not use this file except
+# in compliance with the License. You may obtain a copy of the License at
+#
+#     http://opensource.org/licenses/MIT
+#
+# Unless required by applicable law or agreed to in writing, software distributed under
+# the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+# either express or implied. See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# We undertake not to change the open source license (MIT license) applicable
+# to the current version of the project delivered to anyone in the future.
+#
+import logging
+from typing import Dict, List
+
+from elasticsearch_dsl import Search
+
+from apigateway.biz.mcp_server_log.constants import CHAIN_OUTPUT_FIELDS
+from apigateway.common.error_codes import error_codes
+from apigateway.service.es.clients import BKLogESClient
+from apigateway.utils import time as time_utils
+from apigateway.utils.time import SmartTimeRange
+
+logger = logging.getLogger(__name__)
+
+# 默认时间范围（7天），避免ES查询超时或返回过多数据
+_DEFAULT_TIME_RANGE_SECONDS = 7 * 24 * 60 * 60
+
+
+def search_all_layers(
+    es_client: BKLogESClient,
+    es_time_field_name: str,
+    request_id: str = "",
+    x_request_id: str = "",
+) -> List[Dict]:  # noqa: C901, PLR0912
+    """从 ES 中查询同一 request_id 或 x_request_id 的所有层级日志"""
+    s = Search()
+
+    # 根据传入的参数决定查询条件
+    if request_id:
+        s = s.filter("term", request_id=request_id)
+    elif x_request_id:
+        s = s.filter("term", x_request_id=x_request_id)
+    else:
+        return []
+
+    # 添加默认时间范围（最近7天），避免ES查询超时或返回过多数据
+    # 由于request_id/x_request_id是唯一的，时间范围不会影响结果准确性
+    time_range = SmartTimeRange(time_range=_DEFAULT_TIME_RANGE_SECONDS)
+    time_start, time_end = time_range.get_head_and_tail()
+    s = s.filter(
+        "range",
+        **{
+            es_time_field_name: {
+                "gte": time_utils.convert_second_to_epoch_millisecond(time_start),
+                "lte": time_utils.convert_second_to_epoch_millisecond(time_end),
+            }
+        },
+    )
+
+    s = s.source(fields=CHAIN_OUTPUT_FIELDS)
+    s = s.sort({es_time_field_name: {"order": "asc"}})
+    s = s[:100]  # 限制最多 100 条
+
+    try:
+        data = es_client.execute_search(s.to_dict())
+    except Exception as e:
+        logger.exception(
+            "failed to search mcp server chain logs for request_id=%s, x_request_id=%s",
+            request_id,
+            x_request_id,
+        )
+        # 重新抛出异常，让上层处理
+        raise error_codes.INTERNAL.format(message=f"ES query failed: {str(e)}")
+
+    hits = data.get("hits", {}).get("hits", [])
+    logger.debug(
+        "search mcp server chain logs success, request_id=%s, x_request_id=%s, hits=%s",
+        request_id,
+        x_request_id,
+        len(hits),
+    )
+
+    return _parse_hits(hits)
+
+
+def search_by_upstream_request_id(
+    es_client: BKLogESClient,
+    es_time_field_name: str,
+    upstream_request_id: str,
+) -> List[Dict]:
+    """从 ES 中查询 upstream_request_id 匹配的日志
+
+    当用户通过上游 API 返回的 request_id（即 biz-gateway 的 request_id）查询时使用。
+    mcp-proxy 的 tools/call 日志中存储了 upstream_request_id 字段，
+    该值是下游 API 响应中返回的 request_id。
+    """
+    if not upstream_request_id:
+        return []
+
+    s = Search()
+    s = s.filter("term", upstream_request_id=upstream_request_id)
+
+    # 添加默认时间范围（最近7天）
+    time_range = SmartTimeRange(time_range=_DEFAULT_TIME_RANGE_SECONDS)
+    time_start, time_end = time_range.get_head_and_tail()
+    s = s.filter(
+        "range",
+        **{
+            es_time_field_name: {
+                "gte": time_utils.convert_second_to_epoch_millisecond(time_start),
+                "lte": time_utils.convert_second_to_epoch_millisecond(time_end),
+            }
+        },
+    )
+
+    s = s.source(fields=CHAIN_OUTPUT_FIELDS)
+    s = s.sort({es_time_field_name: {"order": "asc"}})
+    s = s[:100]  # 同一 upstream_request_id 可能关联多条日志
+
+    try:
+        data = es_client.execute_search(s.to_dict())
+    except Exception:
+        logger.exception(
+            "failed to search mcp server logs by upstream_request_id=%s",
+            upstream_request_id,
+        )
+        return []
+
+    hits = data.get("hits", {}).get("hits", [])
+    logger.debug(
+        "search mcp server logs by upstream_request_id=%s, hits=%s",
+        upstream_request_id,
+        len(hits),
+    )
+
+    return _parse_hits(hits, log_prefix="[upstream_request_id]")
+
+
+def _parse_hits(hits: list, log_prefix: str = "") -> List[Dict]:
+    """解析 ES 查询结果，提取字段并过滤无效日志"""
+    result = []
+    for hit in hits:
+        log = hit["_source"]
+        # 检查 sort 字段
+        sort = hit.get("sort")
+        logger.debug(
+            "%s hit sort field: hit_id=%s, sort=%s, is_list=%s, len=%s",
+            log_prefix,
+            hit.get("_id"),
+            sort,
+            isinstance(sort, list),
+            len(sort) if isinstance(sort, list) else "N/A",
+        )
+        if sort and len(sort) > 0:
+            log["timestamp"] = time_utils.convert_epoch_millisecond_to_second(sort[0])
+            log["timestamp_ms"] = sort[0]
+            logger.debug("%s added timestamp=%s to log", log_prefix, log.get("timestamp"))
+        else:
+            logger.warning("%s sort field is missing or empty for hit_id=%s", log_prefix, hit.get("_id"))
+
+        # 合并 __ext_json 中的字段到顶层（Filebeat 提取的字段）
+        log = _merge_ext_json(log)
+
+        # 排除文件访问日志：如果 __ext_json.method 为空，说明是文件访问日志
+        # 真正的 HTTP 请求日志有 __ext_json.method 字段
+        # 但 MCP 协议层日志（audit 日志）没有 __ext_json，通过 mcp_method 字段识别
+        ext_json = log.get("__ext_json", {}) or {}
+        if not ext_json.get("method") and not log.get("mcp_method"):
+            continue
+
+        # 排除健康检查请求
+        path = log.get("path", "")
+        if "/health" in path and path.split("?")[0].split("/")[-1] == "/health":
+            continue
+
+        result.append(log)
+    return result
+
+
+def _merge_ext_json(log: Dict) -> Dict:
+    """合并 __ext_json 中的字段到顶层（Filebeat 提取的字段）
+
+    Filebeat 可能将某些字段提取到 __ext_json 中，需要合并到顶层。
+    只在顶层字段为空或不存在时，才用 __ext_json 中的值覆盖。
+    """
+    ext_json = log.get("__ext_json", {}) or {}
+    if ext_json:
+        for key, value in ext_json.items():
+            if value is not None and value != "" and (key not in log or log.get(key) is None or log.get(key) == ""):
+                log[key] = value
+    return log

--- a/src/dashboard/apigateway/apigateway/biz/mcp_server_log/es_query.py
+++ b/src/dashboard/apigateway/apigateway/biz/mcp_server_log/es_query.py
@@ -183,15 +183,29 @@ def _parse_hits(hits: list, log_prefix: str = "") -> List[Dict]:
     return result
 
 
+# __ext_json 中的业务字段应优先覆盖顶层同名字段。
+# 原因：Filebeat 在顶层写入的 path 是日志文件路径（如 /app/logs/mcp_proxy_api.log），
+# 而 __ext_json.path 才是真正的 HTTP 请求路径（如 /bk-apigateway-prod-context/mcp）。
+# 类似的字段还有 method、gateway_name 等。
+_EXT_JSON_OVERRIDE_FIELDS = frozenset({"path", "method", "gateway_name", "mcp_server_name"})
+
+
 def _merge_ext_json(log: Dict) -> Dict:
     """合并 __ext_json 中的字段到顶层（Filebeat 提取的字段）
 
-    Filebeat 可能将某些字段提取到 __ext_json 中，需要合并到顶层。
-    只在顶层字段为空或不存在时，才用 __ext_json 中的值覆盖。
+    Go logger 输出的完整字段存储在 __ext_json 中，需要合并到顶层才能正常展示。
+    合并策略：
+      1. __ext_json 中的 None 值跳过（无意义）
+      2. _EXT_JSON_OVERRIDE_FIELDS 中的字段始终覆盖（顶层可能是 Filebeat 写入的无关数据）
+      3. 其他字段：顶层为 None 时用 __ext_json 的值填充（包括空字符串和零值，
+         因为它们表示"字段存在但无值"，比 null 更有意义）
     """
     ext_json = log.get("__ext_json", {}) or {}
     if ext_json:
         for key, value in ext_json.items():
-            if value is not None and value != "" and (key not in log or log.get(key) is None or log.get(key) == ""):
+            if value is None:
+                continue
+            # 优先覆盖字段：__ext_json 中的值始终优先
+            if key in _EXT_JSON_OVERRIDE_FIELDS or key not in log or log.get(key) is None:
                 log[key] = value
     return log

--- a/src/dashboard/apigateway/apigateway/biz/mcp_server_log/es_query.py
+++ b/src/dashboard/apigateway/apigateway/biz/mcp_server_log/es_query.py
@@ -167,6 +167,11 @@ def _parse_hits(hits: list, log_prefix: str = "") -> List[Dict]:
         # 合并 __ext_json 中的字段到顶层（Filebeat 提取的字段）
         log = _merge_ext_json(log)
 
+        # 清理 Filebeat 注入的日志文件路径：MCP 协议层日志（旧版本）可能没有输出 path 字段，
+        # 导致顶层 path 保留了 Filebeat 写入的日志文件物理路径（如 /app/logs/mcp_proxy_api.log）。
+        # 这类路径对用户无意义，应清空。
+        log = _sanitize_filebeat_path(log)
+
         # 排除文件访问日志：如果 __ext_json.method 为空，说明是文件访问日志
         # 真正的 HTTP 请求日志有 __ext_json.method 字段
         # 但 MCP 协议层日志（audit 日志）没有 __ext_json，通过 mcp_method 字段识别
@@ -208,4 +213,20 @@ def _merge_ext_json(log: Dict) -> Dict:
             # 优先覆盖字段：__ext_json 中的值始终优先
             if key in _EXT_JSON_OVERRIDE_FIELDS or key not in log or log.get(key) is None:
                 log[key] = value
+    return log
+
+
+def _sanitize_filebeat_path(log: Dict) -> Dict:
+    """清理 Filebeat 注入的日志文件物理路径
+
+    Filebeat 在采集日志时会在顶层写入 path 字段，值为日志文件的物理路径
+    （如 /app/logs/mcp_proxy_api.log）。对于 HTTP 层日志，__ext_json.path 会覆盖
+    该值（通过 _EXT_JSON_OVERRIDE_FIELDS）；但对于 MCP 协议层日志（旧版本未输出 path），
+    Filebeat 的文件路径会残留在顶层，对用户展示无意义。
+
+    判断逻辑：如果 path 以 .log 结尾，认为是 Filebeat 的文件路径，清空为空字符串。
+    """
+    path = log.get("path", "")
+    if path and isinstance(path, str) and path.endswith(".log"):
+        log["path"] = ""
     return log

--- a/src/dashboard/apigateway/apigateway/biz/mcp_server_log/es_query.py
+++ b/src/dashboard/apigateway/apigateway/biz/mcp_server_log/es_query.py
@@ -42,10 +42,29 @@ def search_all_layers(
     s = Search()
 
     # 根据传入的参数决定查询条件
+    # BKLog 中 __ext_json 是 flattened 类型，request_id/x_request_id 同时搜索顶层和 __ext_json
+    # 注意：Q("term", **{"__ext_json.xxx": v}) 会被 elasticsearch_dsl 错误处理，
+    # 把 __ext_json 前缀的 __ 去掉变成 .ext_json，必须用 Q({"term": {...}}) 传 raw dict
+    from elasticsearch_dsl import Q  # noqa: PLC0415
+
     if request_id:
-        s = s.filter("term", request_id=request_id)
+        s = s.filter(
+            "bool",
+            should=[
+                Q("term", request_id=request_id),
+                Q({"term": {"__ext_json.request_id": request_id}}),
+            ],
+            minimum_should_match=1,
+        )
     elif x_request_id:
-        s = s.filter("term", x_request_id=x_request_id)
+        s = s.filter(
+            "bool",
+            should=[
+                Q("term", x_request_id=x_request_id),
+                Q({"term": {"__ext_json.x_request_id": x_request_id}}),
+            ],
+            minimum_should_match=1,
+        )
     else:
         return []
 
@@ -104,7 +123,16 @@ def search_by_upstream_request_id(
         return []
 
     s = Search()
-    s = s.filter("term", upstream_request_id=upstream_request_id)
+    from elasticsearch_dsl import Q  # noqa: PLC0415
+
+    s = s.filter(
+        "bool",
+        should=[
+            Q("term", upstream_request_id=upstream_request_id),
+            Q({"term": {"__ext_json.upstream_request_id": upstream_request_id}}),
+        ],
+        minimum_should_match=1,
+    )
 
     # 添加默认时间范围（最近7天）
     time_range = SmartTimeRange(time_range=_DEFAULT_TIME_RANGE_SECONDS)
@@ -204,11 +232,18 @@ def _merge_ext_json(log: Dict) -> Dict:
       2. _EXT_JSON_OVERRIDE_FIELDS 中的字段始终覆盖（顶层可能是 Filebeat 写入的无关数据）
       3. 其他字段：顶层为 None 时用 __ext_json 的值填充（包括空字符串和零值，
          因为它们表示"字段存在但无值"，比 null 更有意义）
+      4. MCP 层日志（有 mcp_method）的 path/method 保持为空，不从 __ext_json 覆盖
     """
+    # 判断是否是 MCP 协议层日志
+    is_mcp_layer = bool(log.get("mcp_method"))
+
     ext_json = log.get("__ext_json", {}) or {}
     if ext_json:
         for key, value in ext_json.items():
             if value is None:
+                continue
+            # MCP 层日志：path 和 method 保持为空（Go 层已置空）
+            if is_mcp_layer and key in ("path", "method"):
                 continue
             # 优先覆盖字段：__ext_json 中的值始终优先
             if key in _EXT_JSON_OVERRIDE_FIELDS or key not in log or log.get(key) is None:

--- a/src/dashboard/apigateway/apigateway/biz/mcp_server_log/gateway_log.py
+++ b/src/dashboard/apigateway/apigateway/biz/mcp_server_log/gateway_log.py
@@ -1,0 +1,100 @@
+#
+# TencentBlueKing is pleased to support the open source community by making
+# 蓝鲸智云 - API 网关(BlueKing - APIGateway) available.
+# Copyright (C) 2025 Tencent. All rights reserved.
+# Licensed under the MIT License (the "License"); you may not use this file except
+# in compliance with the License. You may obtain a copy of the License at
+#
+#     http://opensource.org/licenses/MIT
+#
+# Unless required by applicable law or agreed to in writing, software distributed under
+# the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+# either express or implied. See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# We undertake not to change the open source license (MIT license) applicable
+# to the current version of the project delivered to anyone in the future.
+#
+import logging
+from typing import Dict, Optional
+
+from apigateway.biz.access_log.log_search import LogSearchClient
+
+logger = logging.getLogger(__name__)
+
+
+def search_gateway_log(request_id: str, gateway_type: str = "upstream") -> Optional[Dict]:
+    """通过 request_id 查询网关日志
+
+    bk-apigateway 的 access_log ES 中，request_id 字段对应的是 X-Bkapi-Request-ID，
+    而这个值就是 mcp-proxy 日志中的 request_id 字段（从上游传入的）。
+
+    Args:
+        request_id: 网关的请求 ID
+        gateway_type: 网关类型，"upstream" 或 "downstream"
+    """
+    if not request_id:
+        logger.warning("search_gateway_log called with empty request_id, gateway_type=%s", gateway_type)
+        return None
+
+    try:
+        # 使用已有的 access_log LogSearchClient 查询
+        # 注意：这里查询的是 bk-apigateway 的日志索引
+        # 对于 upstream（bk-apigateway），request_id 是直接对应的
+        # 对于 downstream（biz-gateway），如果它的日志也在同一个 ES 索引中，才能查询到
+        logger.debug(
+            "searching %s gateway log with request_id=%s",
+            gateway_type,
+            request_id,
+        )
+        client = LogSearchClient(request_id=request_id, time_range=7 * 24 * 60 * 60)  # 7天
+        total_count, logs = client.search_logs(offset=0, limit=1)
+        logger.debug(
+            "%s gateway log search result: request_id=%s, total_count=%s, has_logs=%s",
+            gateway_type,
+            request_id,
+            total_count,
+            bool(logs),
+        )
+        if logs:
+            log = logs[0]
+            return _format_gateway_log(log, gateway_type)
+        logger.warning(
+            "no %s gateway log found for request_id=%s, may be out of time range or not indexed",
+            gateway_type,
+            request_id,
+        )
+    except Exception:
+        logger.exception(
+            "failed to search %s gateway log for request_id=%s",
+            gateway_type,
+            request_id,
+        )
+
+    return None
+
+
+def _format_gateway_log(log: Dict, gateway_type: str) -> Dict:
+    """格式化网关日志"""
+    return {
+        "layer": "gateway",
+        "service": "bk-apigateway" if gateway_type == "upstream" else "biz-gateway",
+        "timestamp": log.get("timestamp"),
+        "request_id": log.get("request_id"),
+        "method": log.get("method"),
+        "http_host": log.get("http_host"),
+        "http_path": log.get("http_path"),
+        "status": log.get("status"),
+        "request_duration": log.get("request_duration"),
+        "backend_duration": log.get("backend_duration"),
+        "stage": log.get("stage"),
+        "resource_name": log.get("resource_name"),
+        "backend_host": log.get("backend_host"),
+        "backend_path": log.get("backend_path"),
+        "backend_method": log.get("backend_method"),
+        "backend_scheme": log.get("backend_scheme"),
+        "app_code": log.get("app_code"),
+        "client_ip": log.get("client_ip"),
+        "error": log.get("error"),
+        "code_name": log.get("code_name"),
+    }

--- a/src/dashboard/apigateway/apigateway/biz/mcp_server_log/gateway_log.py
+++ b/src/dashboard/apigateway/apigateway/biz/mcp_server_log/gateway_log.py
@@ -76,9 +76,12 @@ def search_gateway_log(request_id: str, gateway_type: str = "upstream") -> Optio
 
 def _format_gateway_log(log: Dict, gateway_type: str) -> Dict:
     """格式化网关日志"""
+    # 下游网关使用实际的 backend_name 字段作为 service 名称
+    service = log.get("backend_name") or "biz-gateway" if gateway_type == "downstream" else "bk-apigateway"
+
     return {
         "layer": "gateway",
-        "service": "bk-apigateway" if gateway_type == "upstream" else "biz-gateway",
+        "service": service,
         "timestamp": log.get("timestamp"),
         "request_id": log.get("request_id"),
         "method": log.get("method"),

--- a/src/dashboard/apigateway/apigateway/biz/mcp_server_log/log_search.py
+++ b/src/dashboard/apigateway/apigateway/biz/mcp_server_log/log_search.py
@@ -87,8 +87,13 @@ class MCPServerLogSearchClient:
     def search_logs(self, offset: int = 0, limit: Optional[int] = None) -> Tuple[int, List[Dict]]:
         """查询 MCP Server 日志列表"""
         s = self._build_logs_search(offset=offset, limit=limit, order=True)
-        data = self._es_client.execute_search(s.to_dict())
+        query_dict = s.to_dict()
+        logger.info("MCPServerLogSearchClient search_logs query: %s", query_dict)
+        data = self._es_client.execute_search(query_dict)
         hits = data["hits"]
+        logger.info(
+            "MCPServerLogSearchClient search_logs result: total=%s, hits_count=%s", hits["total"], len(hits["hits"])
+        )
         return hits["total"], [self._to_log_display(hit) for hit in hits["hits"]]
 
     def get_time_chart(self) -> Dict:
@@ -118,6 +123,8 @@ class MCPServerLogSearchClient:
 
     def _apply_term_filters(self, s: Search) -> Search:
         """Apply term filters for MCP-specific fields."""
+        # Note: For fields that may be mapped as text in ES, we use match query instead of term filter
+        # This ensures the filter works regardless of the field's mapping type
         term_fields = {
             "gateway_name": self._gateway_name,
             "mcp_server_name": self._mcp_server_name,
@@ -130,9 +137,15 @@ class MCPServerLogSearchClient:
             "session_id": self._session_id,
             "status": self._status,
         }
+        applied_filters = {}
         for field, value in term_fields.items():
             if value:
-                s = s.filter("term", **{field: value})
+                # Use match query for fields that might be text type in ES
+                # This is more reliable than term filter for text fields
+                s = s.filter("match", **{field: value})
+                applied_filters[field] = value
+        if applied_filters:
+            logger.info("MCPServerLogSearchClient applied term filters: %s", applied_filters)
         return s
 
     def _apply_conditions(self, s: Search) -> Search:

--- a/src/dashboard/apigateway/apigateway/biz/mcp_server_log/log_search.py
+++ b/src/dashboard/apigateway/apigateway/biz/mcp_server_log/log_search.py
@@ -88,10 +88,10 @@ class MCPServerLogSearchClient:
         """查询 MCP Server 日志列表"""
         s = self._build_logs_search(offset=offset, limit=limit, order=True)
         query_dict = s.to_dict()
-        logger.info("MCPServerLogSearchClient search_logs query: %s", query_dict)
+        logger.debug("MCPServerLogSearchClient search_logs query: %s", query_dict)
         data = self._es_client.execute_search(query_dict)
         hits = data["hits"]
-        logger.info(
+        logger.debug(
             "MCPServerLogSearchClient search_logs result: total=%s, hits_count=%s", hits["total"], len(hits["hits"])
         )
         return hits["total"], [self._to_log_display(hit) for hit in hits["hits"]]
@@ -145,7 +145,7 @@ class MCPServerLogSearchClient:
                 s = s.filter("match", **{field: value})
                 applied_filters[field] = value
         if applied_filters:
-            logger.info("MCPServerLogSearchClient applied term filters: %s", applied_filters)
+            logger.debug("MCPServerLogSearchClient applied term filters: %s", applied_filters)
         return s
 
     def _apply_conditions(self, s: Search) -> Search:

--- a/src/dashboard/apigateway/apigateway/biz/mcp_server_log/log_search.py
+++ b/src/dashboard/apigateway/apigateway/biz/mcp_server_log/log_search.py
@@ -26,7 +26,7 @@ from apigateway.service.es.clients import BKLogESClient
 from apigateway.utils import time as time_utils
 from apigateway.utils.time import SmartTimeRange
 
-from .constants import MCP_SERVER_LOG_OUTPUT_FIELDS
+from .constants import MCP_SERVER_LOG_OUTPUT_FIELDS, STATUS_HTTP_CODES
 
 logger = logging.getLogger(__name__)
 
@@ -90,10 +90,10 @@ class MCPServerLogSearchClient:
         """查询 MCP Server 日志列表"""
         s = self._build_logs_search(offset=offset, limit=limit, order=True)
         query_dict = s.to_dict()
-        logger.debug("MCPServerLogSearchClient search_logs query: %s", query_dict)
+        logger.info("MCPServerLogSearchClient search_logs query: %s", query_dict)
         data = self._es_client.execute_search(query_dict)
         hits = data["hits"]
-        logger.debug(
+        logger.info(
             "MCPServerLogSearchClient search_logs result: total=%s, hits_count=%s", hits["total"], len(hits["hits"])
         )
         return hits["total"], [self._to_log_display(hit) for hit in hits["hits"]]
@@ -110,9 +110,20 @@ class MCPServerLogSearchClient:
         # mcp-proxy 的 HTTP 层日志和 MCP 协议层日志共用同一个 ES index，
         # 同时展示 HTTP 层和 MCP 协议层日志，不再强制要求 mcp_method 字段存在
 
-        # 使用 gateway_id 做精确过滤（与普通网关日志 LogSearchClient 对齐，使用整数 term 查询）
+        # BKLog 中 Go logger 输出的字段存储在 __ext_json 中，gateway_id 需要同时搜顶层和 __ext_json
+        # 注意：Q("term", **{"__ext_json.xxx": v}) 会被 elasticsearch_dsl 错误处理，
+        # 把 __ext_json 前缀的 __ 去掉变成 .ext_json，必须用 Q({"term": {...}}) 传 raw dict
         if self._gateway_id:
-            s = s.filter("term", gateway_id=self._gateway_id)
+            from elasticsearch_dsl import Q  # noqa: PLC0415
+
+            s = s.filter(
+                "bool",
+                should=[
+                    Q("term", gateway_id=self._gateway_id),
+                    Q({"term": {"__ext_json.gateway_id": self._gateway_id}}),
+                ],
+                minimum_should_match=1,
+            )
 
         s = self._apply_term_filters(s)
         s = self._apply_conditions(s)
@@ -129,46 +140,85 @@ class MCPServerLogSearchClient:
     def _apply_term_filters(self, s: Search) -> Search:
         """Apply term filters for MCP-specific fields.
 
-        注意：HTTP 层日志的部分字段（如 gateway_name, mcp_server_name, method, path 等）
+        注意：HTTP 层日志的部分字段（如 mcp_server_name, app_code, request_id 等）
         存储在 __ext_json 中而非顶层。对于这些字段，需要同时搜索顶层和 __ext_json 嵌套路径。
+        BKLog 中 __ext_json 是 flattened 类型，支持 term 查询。
 
         gateway_name 不在此处过滤，因为已通过 gateway_id（整数，总在顶层）做精确过滤。
+        mcp_method/tool_name/prompt_name 仅存在于 MCP 协议层日志的顶层，无需搜 __ext_json。
+
+        重要：Q("term", **{"__ext_json.xxx": v}) 会被 elasticsearch_dsl 错误处理，
+        把 __ext_json 的 __ 前缀去掉变成 .ext_json，必须用 Q({"term": {...}}) 传 raw dict。
         """
-        # 只过滤 MCP 协议层字段（这些字段在 MCP 层日志中位于顶层）
-        term_fields = {
+        from elasticsearch_dsl import Q  # noqa: PLC0415
+
+        # MCP 协议层专属字段，仅存在于顶层
+        top_level_only_fields = {
             "mcp_method": self._mcp_method,
             "tool_name": self._tool_name,
             "prompt_name": self._prompt_name,
+        }
+        for field, value in top_level_only_fields.items():
+            if value:
+                s = s.filter("term", **{field: value})
+
+        # 同时搜索顶层和 __ext_json 的字段（HTTP 层日志这些字段在 __ext_json 中）
+        both_level_fields = {
+            "mcp_server_name": self._mcp_server_name,
             "app_code": self._app_code,
             "request_id": self._request_id,
             "x_request_id": self._x_request_id,
             "session_id": self._session_id,
-            "status": self._status,
         }
-        # mcp_server_name 可能在顶层（MCP 协议层）或 __ext_json 中（HTTP 层），
-        # 需要用 should 同时搜索两个位置
-        # 注意：必须用 term 精确匹配，match 会分词导致 "bk-apigateway-prod-context"
-        # 被拆成 bk/apigateway/prod/context 多个 token，筛选失效
-        if self._mcp_server_name:
-            from elasticsearch_dsl import Q  # noqa: PLC0415
-
-            s = s.filter(
-                "bool",
-                should=[
-                    Q("term", mcp_server_name=self._mcp_server_name),
-                    Q("term", **{"__ext_json.mcp_server_name": self._mcp_server_name}),
-                ],
-                minimum_should_match=1,
-            )
-
-        applied_filters = {}
-        for field, value in term_fields.items():
+        for field, value in both_level_fields.items():
             if value:
-                s = s.filter("term", **{field: value})
-                applied_filters[field] = value
-        if applied_filters:
-            logger.debug("MCPServerLogSearchClient applied term filters: %s", applied_filters)
+                s = s.filter(
+                    "bool",
+                    should=[
+                        Q("term", **{field: value}),
+                        Q({"term": {f"__ext_json.{field}": value}}),
+                    ],
+                    minimum_should_match=1,
+                )
+
+        # status 字段需要特殊处理：HTTP 层 status 是整数（如 200、500），
+        # MCP 协议层 status 是字符串（"success"/"failed"），需要同时兼容两种格式。
+        if self._status:
+            s = self._filter_status(s)
         return s
+
+    def _filter_status(self, s: Search) -> Search:
+        """过滤 status 字段，同时兼容 MCP 层字符串和 HTTP 层整数格式。
+
+        MCP 协议层: status 是字符串 "success"/"failed"，在顶层。
+        HTTP 层: status 是整数 HTTP 状态码（如 200），存储在 __ext_json 中，
+                 但 __ext_json 是 flattened 类型（所有值为字符串），且顶层 status
+                 的 mapping 类型不确定（可能是 keyword 或 integer）。
+
+        策略：用 terms 枚举具体状态码值（同时包含 int 和 str 两种形式），
+        避免 range 查询在 keyword/flattened 类型上的不确定行为。
+        """
+        from elasticsearch_dsl import Q  # noqa: PLC0415
+
+        status_value = self._status
+        http_codes = STATUS_HTTP_CODES.get(status_value or "", [])
+
+        should_clauses = [
+            # MCP 协议层：status 是字符串 "success"/"failed"
+            Q("term", status=status_value),
+            Q({"term": {"__ext_json.status": status_value}}),
+        ]
+
+        if http_codes:
+            # HTTP 层：status 是 HTTP 状态码，用 terms 同时匹配 int 和 str 形式
+            should_clauses.append(Q("terms", status=http_codes))
+            should_clauses.append(Q({"terms": {"__ext_json.status": http_codes}}))
+
+        return s.filter(
+            "bool",
+            should=should_clauses,
+            minimum_should_match=1,
+        )
 
     def _apply_conditions(self, s: Search) -> Search:
         """Apply include/exclude conditions."""
@@ -247,9 +297,26 @@ class MCPServerLogSearchClient:
     # 类似的字段还有 method、gateway_name 等。
     _EXT_JSON_OVERRIDE_FIELDS = frozenset({"path", "method", "gateway_name", "mcp_server_name"})
 
+    def _normalize_status(self, status_value) -> str:
+        """将 status 字段统一为 "success"/"failed" 字符串格式。
+
+        HTTP 层日志的 status 是整数（如 200、500），
+        MCP 协议层日志的 status 是字符串（"success"/"failed"）。
+        前端统一展示为字符串格式。
+        """
+        if isinstance(status_value, int):
+            return "success" if 200 <= status_value < 400 else "failed"
+        if isinstance(status_value, str):
+            return status_value
+        return str(status_value) if status_value is not None else ""
+
     def _to_log_display(self, hit: Dict) -> Dict:
         log = hit["_source"]
         log["timestamp"] = time_utils.convert_epoch_millisecond_to_second(hit["sort"][0])
+
+        # 判断是否是 MCP 协议层日志（有 mcp_method 字段）
+        # MCP 层日志不需要展示 HTTP path/method，置空
+        is_mcp_layer = bool(log.get("mcp_method"))
 
         # 合并 __ext_json 中的字段到顶层
         # Go logger 输出的完整字段存储在 __ext_json 中，需要合并到顶层才能正常展示。
@@ -258,13 +325,21 @@ class MCPServerLogSearchClient:
         #   2. _EXT_JSON_OVERRIDE_FIELDS 中的字段始终覆盖（顶层可能是 Filebeat 写入的无关数据）
         #   3. 其他字段：顶层为 None 时用 __ext_json 的值填充（包括空字符串和零值，
         #      因为它们表示"字段存在但无值"，比 null 更有意义）
+        #   4. MCP 层日志的 path/method 保持为空，不从 __ext_json 覆盖
         ext_json = log.get("__ext_json", {}) or {}
         if ext_json:
             for key, value in ext_json.items():
                 if value is None:
                     continue
+                # MCP 层日志：path 和 method 保持为空（Go 层已置空）
+                if is_mcp_layer and key in ("path", "method"):
+                    continue
                 # 优先覆盖字段：__ext_json 中的值始终优先（顶层值可能是 Filebeat 写入的无关数据）
                 if key in self._EXT_JSON_OVERRIDE_FIELDS or key not in log or log.get(key) is None:
                     log[key] = value
+
+        # 统一 status 展示格式：HTTP 层整数状态码映射为 "success"/"failed"
+        if "status" in log and log["status"] is not None:
+            log["status"] = self._normalize_status(log["status"])
 
         return log

--- a/src/dashboard/apigateway/apigateway/biz/mcp_server_log/log_search.py
+++ b/src/dashboard/apigateway/apigateway/biz/mcp_server_log/log_search.py
@@ -239,21 +239,30 @@ class MCPServerLogSearchClient:
             "timeline": timeline,
         }
 
+    # __ext_json 中的业务字段应优先覆盖顶层同名字段。
+    # 原因：Filebeat 在顶层写入的 path 是日志文件路径（如 /app/logs/mcp_proxy_api.log），
+    # 而 __ext_json.path 才是真正的 HTTP 请求路径（如 /bk-apigateway-prod-context/mcp）。
+    # 类似的字段还有 method、gateway_name 等。
+    _EXT_JSON_OVERRIDE_FIELDS = frozenset({"path", "method", "gateway_name", "mcp_server_name"})
+
     def _to_log_display(self, hit: Dict) -> Dict:
         log = hit["_source"]
         log["timestamp"] = time_utils.convert_epoch_millisecond_to_second(hit["sort"][0])
 
         # 合并 __ext_json 中的字段到顶层
-        # HTTP 层日志的 gateway_name、method、path 等字段存储在 __ext_json 中，
-        # 需要合并到顶层才能正常展示
+        # Go logger 输出的完整字段存储在 __ext_json 中，需要合并到顶层才能正常展示。
+        # 合并策略：
+        #   1. __ext_json 中的 None 值跳过（无意义）
+        #   2. _EXT_JSON_OVERRIDE_FIELDS 中的字段始终覆盖（顶层可能是 Filebeat 写入的无关数据）
+        #   3. 其他字段：顶层为 None 时用 __ext_json 的值填充（包括空字符串和零值，
+        #      因为它们表示"字段存在但无值"，比 null 更有意义）
         ext_json = log.get("__ext_json", {}) or {}
         if ext_json:
             for key, value in ext_json.items():
-                if (
-                    value is not None
-                    and value != ""
-                    and (key not in log or log.get(key) is None or log.get(key) == "")
-                ):
+                if value is None:
+                    continue
+                # 优先覆盖字段：__ext_json 中的值始终优先（顶层值可能是 Filebeat 写入的无关数据）
+                if key in self._EXT_JSON_OVERRIDE_FIELDS or key not in log or log.get(key) is None:
                     log[key] = value
 
         return log

--- a/src/dashboard/apigateway/apigateway/biz/mcp_server_log/log_search.py
+++ b/src/dashboard/apigateway/apigateway/biz/mcp_server_log/log_search.py
@@ -26,34 +26,49 @@ from apigateway.service.es.clients import BKLogESClient
 from apigateway.utils import time as time_utils
 from apigateway.utils.time import SmartTimeRange
 
-from .constants import ES_OUTPUT_FIELDS
+from .constants import MCP_SERVER_LOG_OUTPUT_FIELDS
 
 logger = logging.getLogger(__name__)
 
 
-class LogSearchClient:
-    _es_index: str = settings.ACCESS_LOG_CONFIG["es_index"]
-    _es_time_field_name: str = settings.ACCESS_LOG_CONFIG["es_time_field_name"]
+class MCPServerLogSearchClient:
+    """MCP Server 日志搜索客户端
+
+    查询 mcp-proxy LoggingMiddleware 输出到 ES 的访问日志。
+    """
+
+    _es_index: str = settings.MCP_SERVER_ACCESS_LOG_CONFIG["es_index"]
+    _es_time_field_name: str = settings.MCP_SERVER_ACCESS_LOG_CONFIG["es_time_field_name"]
 
     def __init__(
         self,
-        gateway_id: Optional[int] = None,
-        stage_name: Optional[str] = None,
-        resource_id: Optional[int] = None,
+        gateway_name: Optional[str] = None,
+        mcp_server_name: Optional[str] = None,
+        mcp_method: Optional[str] = None,
+        tool_name: Optional[str] = None,
+        prompt_name: Optional[str] = None,
+        app_code: Optional[str] = None,
         request_id: Optional[str] = None,
+        x_request_id: Optional[str] = None,
+        session_id: Optional[str] = None,
+        status: Optional[str] = None,
         query: Optional[str] = None,
-        backend_name: Optional[str] = None,
         include_conditions: Optional[List[Tuple[str, str]]] = None,
         exclude_conditions: Optional[List[Tuple[str, str]]] = None,
         time_start: Optional[int] = None,
         time_end: Optional[int] = None,
         time_range: Optional[int] = None,
     ):
-        self._gateway_id = gateway_id
-        self._stage_name = stage_name
-        self._backend_name = backend_name
-        self._resource_id = resource_id
+        self._gateway_name = gateway_name
+        self._mcp_server_name = mcp_server_name
+        self._mcp_method = mcp_method
+        self._tool_name = tool_name
+        self._prompt_name = prompt_name
+        self._app_code = app_code
         self._request_id = request_id
+        self._x_request_id = x_request_id
+        self._session_id = session_id
+        self._status = status
         self._query_string = query
         self._include_conditions = include_conditions
         self._exclude_conditions = exclude_conditions
@@ -70,49 +85,58 @@ class LogSearchClient:
         self._es_client = BKLogESClient(self._es_index)
 
     def search_logs(self, offset: int = 0, limit: Optional[int] = None) -> Tuple[int, List[Dict]]:
-        """
-        查询日志列表
-
-        :param offset: 偏移量
-        :param limit: 查询数据量，limit 为 None 表示 offset 偏移量后的全部数据
-        """
+        """查询 MCP Server 日志列表"""
         s = self._build_logs_search(offset=offset, limit=limit, order=True)
         data = self._es_client.execute_search(s.to_dict())
         hits = data["hits"]
         return hits["total"], [self._to_log_display(hit) for hit in hits["hits"]]
 
     def get_time_chart(self) -> Dict:
-        """
-        查询请求量图例
-
-        :return: series 为时间点对应的数据个数，timeline 为时间点对应的时间戳
-            {
-                "series": [3, 5, 20],
-                "timeline": [1690330800, 1690330860, 1690330920]
-            }
-        """
+        """查询请求量时间分布图"""
         s = self._build_date_histogram_search()
         data = self._es_client.execute_search(s.to_dict())
         return self._convert_histogram_buckets(data.get("aggregations", {}))
 
-    def _build_base_search(self, order: Optional[bool] = None) -> Search:  # noqa
+    def _build_base_search(self, order: Optional[bool] = None) -> Search:
         s = Search()
 
-        if self._gateway_id:
-            s = s.filter("term", api_id=self._gateway_id)
+        # mcp-proxy 的 HTTP 层日志和 MCP 协议层日志共用同一个 ES index，
+        # 通过 exists 过滤只查询 MCP 协议层日志（仅该层包含 mcp_method 字段）
+        s = s.filter("exists", field="mcp_method")
 
-        if self._stage_name:
-            s = s.filter("term", stage=self._stage_name)
+        s = self._apply_term_filters(s)
+        s = self._apply_conditions(s)
+        s = self._apply_time_range(s)
 
-        if self._backend_name:
-            s = s.filter("term", backend_name=self._backend_name)
+        if order:
+            s = s.sort({self._es_time_field_name: {"order": "desc"}})
 
-        if self._resource_id:
-            s = s.filter("term", resource_id=self._resource_id)
+        if self._query_string:
+            s = s.query("query_string", query=self._query_string)
 
-        if self._request_id:
-            s = s.filter("term", request_id=self._request_id)
+        return s
 
+    def _apply_term_filters(self, s: Search) -> Search:
+        """Apply term filters for MCP-specific fields."""
+        term_fields = {
+            "gateway_name": self._gateway_name,
+            "mcp_server_name": self._mcp_server_name,
+            "mcp_method": self._mcp_method,
+            "tool_name": self._tool_name,
+            "prompt_name": self._prompt_name,
+            "app_code": self._app_code,
+            "request_id": self._request_id,
+            "x_request_id": self._x_request_id,
+            "session_id": self._session_id,
+            "status": self._status,
+        }
+        for field, value in term_fields.items():
+            if value:
+                s = s.filter("term", **{field: value})
+        return s
+
+    def _apply_conditions(self, s: Search) -> Search:
+        """Apply include/exclude conditions."""
         if self._include_conditions:
             for key, val in self._include_conditions:
                 s = s.filter("term", **{key: val})
@@ -121,7 +145,10 @@ class LogSearchClient:
             for key, val in self._exclude_conditions:
                 s = s.exclude("term", **{key: val})
 
-        # time range
+        return s
+
+    def _apply_time_range(self, s: Search) -> Search:
+        """Apply time range filter."""
         if self._smart_time_range:
             time_start, time_end = self._smart_time_range.get_head_and_tail()
             s = s.filter(
@@ -133,19 +160,11 @@ class LogSearchClient:
                     }
                 },
             )
-
-        if order:
-            s = s.sort({self._es_time_field_name: {"order": "desc"}})
-
-        if self._query_string:
-            # 不能添加 fields 参数，如果 fields 中包含整数字段，查询会失败
-            s = s.query("query_string", query=self._query_string)
-
         return s
 
     def _build_logs_search(self, offset: int = 0, limit: Optional[int] = None, order: Optional[bool] = None) -> Search:
         s = self._build_base_search(order=order)
-        s = s.source(fields=ES_OUTPUT_FIELDS)
+        s = s.source(fields=MCP_SERVER_LOG_OUTPUT_FIELDS)
         if limit is None:
             return s[offset:]
         return s[offset : offset + limit]
@@ -159,7 +178,6 @@ class LogSearchClient:
             "date_histogram",
             field=self._es_time_field_name,
             fixed_interval=self._smart_time_range.get_interval(),
-            # min_doc_count=0，extended_bounds 强制返回空数据，时间间隔内缺少数据时，则自动补充 0，使存在空数据时，图例时间范围完整
             min_doc_count=0,
             extended_bounds={
                 "min": time_utils.convert_second_to_epoch_millisecond(start),
@@ -186,19 +204,5 @@ class LogSearchClient:
 
     def _to_log_display(self, hit: Dict) -> Dict:
         log = hit["_source"]
-        # 从 ES 排序结果获取时间戳（排序字段为 dtEventTimeStamp）
-        # hit["sort"] 在 order=True 时总是存在
-        sort = hit.get("sort")
-        logger.info(
-            "LogSearchClient._to_log_display: hit_id=%s, sort=%s, is_list=%s, len=%s",
-            hit.get("_id"),
-            sort,
-            isinstance(sort, list),
-            len(sort) if isinstance(sort, list) else "N/A",
-        )
-        if sort and len(sort) > 0:
-            log["timestamp"] = time_utils.convert_epoch_millisecond_to_second(sort[0])
-            logger.info("LogSearchClient._to_log_display: added timestamp=%s to log", log.get("timestamp"))
-        else:
-            logger.warning("LogSearchClient._to_log_display: sort field is missing or empty!")
+        log["timestamp"] = time_utils.convert_epoch_millisecond_to_second(hit["sort"][0])
         return log

--- a/src/dashboard/apigateway/apigateway/biz/mcp_server_log/log_search.py
+++ b/src/dashboard/apigateway/apigateway/biz/mcp_server_log/log_search.py
@@ -147,14 +147,16 @@ class MCPServerLogSearchClient:
         }
         # mcp_server_name 可能在顶层（MCP 协议层）或 __ext_json 中（HTTP 层），
         # 需要用 should 同时搜索两个位置
+        # 注意：必须用 term 精确匹配，match 会分词导致 "bk-apigateway-prod-context"
+        # 被拆成 bk/apigateway/prod/context 多个 token，筛选失效
         if self._mcp_server_name:
             from elasticsearch_dsl import Q  # noqa: PLC0415
 
             s = s.filter(
                 "bool",
                 should=[
-                    Q("match", mcp_server_name=self._mcp_server_name),
-                    Q("match", **{"__ext_json.mcp_server_name": self._mcp_server_name}),
+                    Q("term", mcp_server_name=self._mcp_server_name),
+                    Q("term", **{"__ext_json.mcp_server_name": self._mcp_server_name}),
                 ],
                 minimum_should_match=1,
             )
@@ -162,7 +164,7 @@ class MCPServerLogSearchClient:
         applied_filters = {}
         for field, value in term_fields.items():
             if value:
-                s = s.filter("match", **{field: value})
+                s = s.filter("term", **{field: value})
                 applied_filters[field] = value
         if applied_filters:
             logger.debug("MCPServerLogSearchClient applied term filters: %s", applied_filters)

--- a/src/dashboard/apigateway/apigateway/biz/mcp_server_log/log_search.py
+++ b/src/dashboard/apigateway/apigateway/biz/mcp_server_log/log_search.py
@@ -43,6 +43,7 @@ class MCPServerLogSearchClient:
     def __init__(
         self,
         gateway_name: Optional[str] = None,
+        gateway_id: Optional[int] = None,
         mcp_server_name: Optional[str] = None,
         mcp_method: Optional[str] = None,
         tool_name: Optional[str] = None,
@@ -60,6 +61,7 @@ class MCPServerLogSearchClient:
         time_range: Optional[int] = None,
     ):
         self._gateway_name = gateway_name
+        self._gateway_id = gateway_id
         self._mcp_server_name = mcp_server_name
         self._mcp_method = mcp_method
         self._tool_name = tool_name
@@ -106,8 +108,11 @@ class MCPServerLogSearchClient:
         s = Search()
 
         # mcp-proxy 的 HTTP 层日志和 MCP 协议层日志共用同一个 ES index，
-        # 通过 exists 过滤只查询 MCP 协议层日志（仅该层包含 mcp_method 字段）
-        s = s.filter("exists", field="mcp_method")
+        # 同时展示 HTTP 层和 MCP 协议层日志，不再强制要求 mcp_method 字段存在
+
+        # 使用 gateway_id 做精确过滤（与普通网关日志 LogSearchClient 对齐，使用整数 term 查询）
+        if self._gateway_id:
+            s = s.filter("term", gateway_id=self._gateway_id)
 
         s = self._apply_term_filters(s)
         s = self._apply_conditions(s)
@@ -122,12 +127,15 @@ class MCPServerLogSearchClient:
         return s
 
     def _apply_term_filters(self, s: Search) -> Search:
-        """Apply term filters for MCP-specific fields."""
-        # Note: For fields that may be mapped as text in ES, we use match query instead of term filter
-        # This ensures the filter works regardless of the field's mapping type
+        """Apply term filters for MCP-specific fields.
+
+        注意：HTTP 层日志的部分字段（如 gateway_name, mcp_server_name, method, path 等）
+        存储在 __ext_json 中而非顶层。对于这些字段，需要同时搜索顶层和 __ext_json 嵌套路径。
+
+        gateway_name 不在此处过滤，因为已通过 gateway_id（整数，总在顶层）做精确过滤。
+        """
+        # 只过滤 MCP 协议层字段（这些字段在 MCP 层日志中位于顶层）
         term_fields = {
-            "gateway_name": self._gateway_name,
-            "mcp_server_name": self._mcp_server_name,
             "mcp_method": self._mcp_method,
             "tool_name": self._tool_name,
             "prompt_name": self._prompt_name,
@@ -137,11 +145,23 @@ class MCPServerLogSearchClient:
             "session_id": self._session_id,
             "status": self._status,
         }
+        # mcp_server_name 可能在顶层（MCP 协议层）或 __ext_json 中（HTTP 层），
+        # 需要用 should 同时搜索两个位置
+        if self._mcp_server_name:
+            from elasticsearch_dsl import Q  # noqa: PLC0415
+
+            s = s.filter(
+                "bool",
+                should=[
+                    Q("match", mcp_server_name=self._mcp_server_name),
+                    Q("match", **{"__ext_json.mcp_server_name": self._mcp_server_name}),
+                ],
+                minimum_should_match=1,
+            )
+
         applied_filters = {}
         for field, value in term_fields.items():
             if value:
-                # Use match query for fields that might be text type in ES
-                # This is more reliable than term filter for text fields
                 s = s.filter("match", **{field: value})
                 applied_filters[field] = value
         if applied_filters:
@@ -177,7 +197,11 @@ class MCPServerLogSearchClient:
 
     def _build_logs_search(self, offset: int = 0, limit: Optional[int] = None, order: Optional[bool] = None) -> Search:
         s = self._build_base_search(order=order)
-        s = s.source(fields=MCP_SERVER_LOG_OUTPUT_FIELDS)
+        # 除了业务字段，还需取回 __ext_json 用于合并 HTTP 层字段
+        source_fields = list(MCP_SERVER_LOG_OUTPUT_FIELDS)
+        if "__ext_json" not in source_fields:
+            source_fields.append("__ext_json")
+        s = s.source(fields=source_fields)
         if limit is None:
             return s[offset:]
         return s[offset : offset + limit]
@@ -218,4 +242,18 @@ class MCPServerLogSearchClient:
     def _to_log_display(self, hit: Dict) -> Dict:
         log = hit["_source"]
         log["timestamp"] = time_utils.convert_epoch_millisecond_to_second(hit["sort"][0])
+
+        # 合并 __ext_json 中的字段到顶层
+        # HTTP 层日志的 gateway_name、method、path 等字段存储在 __ext_json 中，
+        # 需要合并到顶层才能正常展示
+        ext_json = log.get("__ext_json", {}) or {}
+        if ext_json:
+            for key, value in ext_json.items():
+                if (
+                    value is not None
+                    and value != ""
+                    and (key not in log or log.get(key) is None or log.get(key) == "")
+                ):
+                    log[key] = value
+
         return log

--- a/src/dashboard/apigateway/apigateway/biz/mcp_server_log/span_builder.py
+++ b/src/dashboard/apigateway/apigateway/biz/mcp_server_log/span_builder.py
@@ -198,7 +198,7 @@ def _calc_base_timestamp_ms(
     return None
 
 
-def _calc_start_offset_ms(base_ts_ms: Optional[float], log: Dict, latency_ms: float) -> float:
+def _calc_start_offset_ms(base_ts_ms: Optional[float], log: Dict, latency_ms: Optional[float]) -> float:
     """计算 span 的 start_offset_ms"""
     if base_ts_ms is not None and log.get("timestamp_ms"):
         log_start_ms = log["timestamp_ms"] - (latency_ms or 0)

--- a/src/dashboard/apigateway/apigateway/biz/mcp_server_log/span_builder.py
+++ b/src/dashboard/apigateway/apigateway/biz/mcp_server_log/span_builder.py
@@ -1,0 +1,267 @@
+#
+# TencentBlueKing is pleased to support the open source community by making
+# 蓝鲸智云 - API 网关(BlueKing - APIGateway) available.
+# Copyright (C) 2025 Tencent. All rights reserved.
+# Licensed under the MIT License (the "License"); you may not use this file except
+# in compliance with the License. You may obtain a copy of the License at
+#
+#     http://opensource.org/licenses/MIT
+#
+# Unless required by applicable law or agreed to in writing, software distributed under
+# the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+# either express or implied. See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# We undertake not to change the open source license (MIT license) applicable
+# to the current version of the project delivered to anyone in the future.
+#
+import logging
+import re
+from typing import Dict, List, Optional
+
+from apigateway.biz.mcp_server_log.utils import parse_latency_ms
+
+logger = logging.getLogger(__name__)
+
+
+def build_spans(http_logs: List[Dict], mcp_logs: List[Dict]) -> List[Dict]:
+    """将日志构建为 span 树结构"""
+    spans = []
+
+    # HTTP 入口 span (如果存在)
+    http_entry = None
+    if http_logs:
+        log = http_logs[0]
+        latency_ms = parse_latency_ms(log.get("latency", ""))
+        http_entry = {
+            "span_id": "http_entry",
+            "parent_span_id": None,
+            "layer": "http",
+            "service": "mcp-proxy",
+            "upstream": log.get("mcp_server_name", "") or "",
+            "operation": f"{log.get('method', '')} {log.get('path', '')}",
+            "latency": log.get("latency", ""),
+            "latency_ms": latency_ms,
+            "start_offset_ms": 0,
+            "status": log.get("status"),
+            "detail": {
+                "timestamp": log.get("timestamp"),
+                "method": log.get("method"),
+                "path": log.get("path"),
+                "status": log.get("status"),
+                "client_ip": log.get("client_ip"),
+                "app_code": log.get("app_code"),
+                "gateway_name": log.get("gateway_name"),
+                "mcp_server_name": log.get("mcp_server_name"),
+                "request_id": log.get("request_id"),
+                "x_request_id": log.get("x_request_id"),
+            },
+            "children": [],
+        }
+        spans.append(http_entry)
+
+    # MCP 协议层 span
+    # 计算 base timestamp 用于 start_offset_ms
+    base_ts_ms = _calc_base_timestamp_ms(http_entry, http_logs, mcp_logs)
+
+    for i, log in enumerate(mcp_logs):
+        latency_ms = parse_latency_ms(log.get("latency", ""))
+        mcp_method = log.get("mcp_method", "")
+
+        # Audit 日志中 tool 字段存储工具配置字符串，需要提取工具名
+        tool_name = _extract_tool_name(log)
+
+        operation = mcp_method
+        if tool_name:
+            operation = f"{mcp_method} {tool_name}"
+
+        # 计算 start_offset_ms: MCP 日志的 timestamp 是完成时间，
+        # 所以 start = 完成时间 - 耗时 - base_ts
+        start_offset_ms = _calc_start_offset_ms(base_ts_ms, log, latency_ms)
+
+        # Audit 日志中的 request 字段存储请求参数
+        params = log.get("params") or log.get("request")
+
+        span = {
+            "span_id": f"mcp_{i}",
+            "parent_span_id": "http_entry" if http_entry else None,
+            "layer": "mcp",
+            "service": log.get("mcp_server_name") or log.get("gateway_name", ""),
+            "upstream": log.get("gateway_name", "") or "",
+            "operation": operation,
+            "latency": log.get("latency", ""),
+            "latency_ms": latency_ms,
+            "start_offset_ms": start_offset_ms,
+            "status": None,
+            "detail": {
+                "timestamp": log.get("timestamp"),
+                "mcp_method": mcp_method,
+                "tool_name": tool_name,
+                "prompt_name": log.get("prompt_name"),
+                "tool": log.get("tool", ""),  # 保留原始 tool 字符串
+                "params": params,
+                "response": log.get("response"),
+                "request_body_size": log.get("request_body_size"),
+                "response_body_size": log.get("response_body_size"),
+                "app_code": log.get("app_code"),
+                "bk_username": log.get("bk_username"),
+                "client_ip": log.get("client_ip"),
+                "client_id": log.get("client_id"),
+                "session_id": log.get("session_id"),
+                "request_id": log.get("request_id"),
+                "x_request_id": log.get("x_request_id"),
+                "trace_id": log.get("trace_id"),
+                "error": log.get("error"),
+            },
+            "children": [],
+        }
+
+        if http_entry:
+            http_entry["children"].append(span)
+        else:
+            spans.append(span)
+
+    return spans
+
+
+def merge_mcp_logs(mcp_logs: List[Dict]) -> List[Dict]:  # noqa: C901, PLR0912
+    """合并同一 request_id + mcp_method + tool_name 的多条 MCP 日志
+
+    mcp-proxy 会输出多份 MCP 层日志：
+    - "call tool": 开始调用时记录，只有 request 字段
+    - "call tool request params": 请求参数信息，包含 header, query, path, body
+    - "call tool complete": 函数返回时记录，有完整的 params, response, latency 等字段
+    - api log: 包含完整字段（但如果 filebeat 过滤可能不存在）
+
+    需要合并这些日志，优先使用有 latency 字段的日志（即 "call tool complete"）。
+    如果某些日志缺少 mcp_method，则按 request_id + tool_name 分组。
+    """
+    if not mcp_logs:
+        return []
+
+    # 按 (request_id, mcp_method, tool_name) 分组
+    # 如果 mcp_method 缺失，则使用 tool_name 作为分组键的一部分
+    log_groups: Dict[tuple, List[Dict]] = {}
+    for idx, log in enumerate(mcp_logs):
+        tool_name = _extract_tool_name(log)
+
+        # 如果 mcp_method 缺失，使用 tool_name 作为分组键
+        mcp_method = log.get("mcp_method", "") or "tools/call"  # 默认值
+        key = (
+            log.get("request_id", ""),
+            mcp_method,
+            tool_name,
+        )
+        logger.debug(
+            "merge_mcp_logs: log[%s] key=%s, has_latency=%s, has_params=%s, has_response=%s",
+            idx,
+            key,
+            bool(log.get("latency")),
+            bool(log.get("params")),
+            bool(log.get("response")),
+        )
+        if key not in log_groups:
+            log_groups[key] = []
+        log_groups[key].append(log)
+
+    logger.debug("merge_mcp_logs: total groups=%s, group_keys=%s", len(log_groups), list(log_groups.keys()))
+
+    # 合并每组日志：优先使用有 latency 的日志（"call tool complete"）
+    merged_logs = []
+    for key, logs in log_groups.items():
+        logger.debug(
+            "merging group %s: log_count=%s",
+            key,
+            len(logs),
+        )
+        if len(logs) == 1:
+            merged_logs.append(logs[0])
+            continue
+
+        merged = _merge_log_group(logs)
+        merged_logs.append(merged)
+
+    return merged_logs
+
+
+def _calc_base_timestamp_ms(
+    http_entry: Optional[Dict], http_logs: List[Dict], mcp_logs: List[Dict]
+) -> Optional[float]:
+    """计算用于 start_offset_ms 的基准时间戳"""
+    if http_entry and http_logs and http_logs[0].get("timestamp_ms"):
+        # HTTP 入口的 timestamp 是请求完成后记录的，所以 MCP span 的偏移需要用 HTTP 开始时间
+        # 近似用 HTTP 完成时间 - HTTP 耗时
+        http_latency_ms = http_entry.get("latency_ms") or 0
+        return http_logs[0]["timestamp_ms"] - http_latency_ms
+    if mcp_logs and mcp_logs[0].get("timestamp_ms"):
+        return mcp_logs[0]["timestamp_ms"]
+    return None
+
+
+def _calc_start_offset_ms(base_ts_ms: Optional[float], log: Dict, latency_ms: float) -> float:
+    """计算 span 的 start_offset_ms"""
+    if base_ts_ms is not None and log.get("timestamp_ms"):
+        log_start_ms = log["timestamp_ms"] - (latency_ms or 0)
+        return max(0, round(log_start_ms - base_ts_ms, 3))
+    return 0
+
+
+def _extract_tool_name(log: Dict) -> str:
+    """从日志中提取工具名称
+
+    优先使用 tool_name 字段，如果没有则从 tool 字符串中提取。
+    格式: "tool:[name:xxx,url:xxx, method:GET]"
+    """
+    tool_name = log.get("tool_name", "")
+    if tool_name:
+        return tool_name
+
+    tool_str = log.get("tool", "")
+    if tool_str:
+        match = re.search(r"name:([^,]+)", tool_str)
+        if match:
+            return match.group(1).strip()
+    return ""
+
+
+def _merge_log_group(logs: List[Dict]) -> Dict:
+    """合并同一组的日志，优先使用有 latency 的日志"""
+    # 找到有 latency 的日志（通常是 "call tool complete"）
+    complete_log = None
+    for log in logs:
+        if log.get("latency"):
+            complete_log = log
+            break
+
+    if complete_log:
+        # 使用 complete_log 作为基础，但补充其他日志中的非空字段
+        merged = dict(complete_log)
+        for log in logs:
+            if log is complete_log:
+                continue
+            for field_name, value in log.items():
+                if (
+                    value is not None
+                    and value != ""
+                    and (field_name not in merged or merged[field_name] is None or merged[field_name] == "")
+                ):
+                    merged[field_name] = value
+        logger.debug(
+            "merged with complete_log: has_latency=%s, has_params=%s, has_response=%s",
+            bool(merged.get("latency")),
+            bool(merged.get("params")),
+            bool(merged.get("response")),
+        )
+        return merged
+    # 如果没有 complete log，使用第一个日志并合并其他字段
+    merged = dict(logs[0])
+    for log in logs[1:]:
+        for field_name, value in log.items():
+            if (
+                value is not None
+                and value != ""
+                and (field_name not in merged or merged[field_name] is None or merged[field_name] == "")
+            ):
+                merged[field_name] = value
+    logger.debug("merged without complete_log")
+    return merged

--- a/src/dashboard/apigateway/apigateway/biz/mcp_server_log/utils.py
+++ b/src/dashboard/apigateway/apigateway/biz/mcp_server_log/utils.py
@@ -64,17 +64,19 @@ def calc_max_end_time(span_list: List[Dict], max_end: float = 0) -> float:
     return max_end
 
 
-def build_mcp_server_log_client(gateway_name: str, data: dict) -> "MCPServerLogSearchClient":
+def build_mcp_server_log_client(gateway_name: str, data: dict, gateway_id: int = 0) -> "MCPServerLogSearchClient":
     """根据网关名称和查询参数构建 MCP Server 日志搜索客户端
 
     Args:
         gateway_name: 网关名称
         data: 查询参数字典
+        gateway_id: 网关 ID，用于 ES 精确过滤（优先使用，比 gateway_name 更可靠）
     """
     from .log_search import MCPServerLogSearchClient  # noqa: PLC0415
 
     return MCPServerLogSearchClient(
         gateway_name=gateway_name,
+        gateway_id=gateway_id,
         mcp_server_name=data.get("mcp_server_name"),
         mcp_method=data.get("mcp_method"),
         tool_name=data.get("tool_name"),

--- a/src/dashboard/apigateway/apigateway/biz/mcp_server_log/utils.py
+++ b/src/dashboard/apigateway/apigateway/biz/mcp_server_log/utils.py
@@ -1,0 +1,93 @@
+#
+# TencentBlueKing is pleased to support the open source community by making
+# 蓝鲸智云 - API 网关(BlueKing - APIGateway) available.
+# Copyright (C) 2025 Tencent. All rights reserved.
+# Licensed under the MIT License (the "License"); you may not use this file except
+# in compliance with the License. You may obtain a copy of the License at
+#
+#     http://opensource.org/licenses/MIT
+#
+# Unless required by applicable law or agreed to in writing, software distributed under
+# the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+# either express or implied. See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# We undertake not to change the open source license (MIT license) applicable
+# to the current version of the project delivered to anyone in the future.
+#
+import re
+from typing import TYPE_CHECKING, Dict, List, Optional
+
+if TYPE_CHECKING:
+    from .log_search import MCPServerLogSearchClient
+
+# latency 字符串(如 "37.36ms", "1.2s", "500µs") 转换为毫秒
+_LATENCY_PATTERN = re.compile(r"^([\d.]+)(µs|us|ms|s|m|h)$")
+
+_UNIT_TO_MS = {
+    "µs": 0.001,
+    "us": 0.001,
+    "ms": 1.0,
+    "s": 1000.0,
+    "m": 60_000.0,
+    "h": 3_600_000.0,
+}
+
+
+def parse_latency_ms(latency_str: str) -> Optional[float]:
+    """将 Go 的 duration 字符串转换为毫秒数值
+
+    支持格式: "37.36ms", "1.2s", "500µs", "100us", "2m", "1h"
+    """
+    if not latency_str:
+        return None
+    m = _LATENCY_PATTERN.match(latency_str.strip())
+    if not m:
+        return None
+    value = float(m.group(1))
+    unit = m.group(2)
+    return round(value * _UNIT_TO_MS.get(unit, 1.0), 3)
+
+
+def calc_max_end_time(span_list: List[Dict], max_end: float = 0) -> float:
+    """递归计算所有 span 的最大结束时间
+
+    结束时间 = start_offset_ms + latency_ms
+    """
+    for span in span_list:
+        start = span.get("start_offset_ms", 0) or 0
+        latency = span.get("latency_ms", 0) or 0
+        end_time = start + latency
+        max_end = max(max_end, end_time)
+        # 递归计算子 span
+        max_end = calc_max_end_time(span.get("children", []), max_end)
+    return max_end
+
+
+def build_mcp_server_log_client(gateway_name: str, data: dict) -> "MCPServerLogSearchClient":
+    """根据网关名称和查询参数构建 MCP Server 日志搜索客户端
+
+    Args:
+        gateway_name: 网关名称
+        data: 查询参数字典
+    """
+    from .log_search import MCPServerLogSearchClient  # noqa: PLC0415
+
+    return MCPServerLogSearchClient(
+        gateway_name=gateway_name,
+        mcp_server_name=data.get("mcp_server_name"),
+        mcp_method=data.get("mcp_method"),
+        tool_name=data.get("tool_name"),
+        prompt_name=data.get("prompt_name"),
+        app_code=data.get("app_code"),
+        request_id=data.get("request_id"),
+        x_request_id=data.get("x_request_id"),
+        session_id=data.get("session_id"),
+        status=data.get("status"),
+        query=data.get("query"),
+        include_conditions=data.get("include_conditions"),
+        exclude_conditions=data.get("exclude_conditions"),
+        time_start=data.get("time_start"),
+        time_end=data.get("time_end"),
+        time_range=data.get("time_range"),
+    )

--- a/src/dashboard/apigateway/apigateway/biz/programmable/releaser.py
+++ b/src/dashboard/apigateway/apigateway/biz/programmable/releaser.py
@@ -69,7 +69,7 @@ class ProgrammableGatewayReleaser:
             stage=stage.name,
             env={
                 # "1.0.0+prod": 代码模版有通过版本号和环境名拼接的方式获取版本号，所以这里需要去掉
-                "BK_APIGW_RELEASE_VERSION": version.split("+")[0],  # 不带环境 name
+                "BK_APIGW_RELEASE_VERSION": version.split("+", maxsplit=1)[0],  # 不带环境 name
                 "BK_APIGW_RELEASE_COMMENT": comment,
             },
             user_credentials=user_credentials,

--- a/src/dashboard/apigateway/apigateway/biz/programmable/releaser.py
+++ b/src/dashboard/apigateway/apigateway/biz/programmable/releaser.py
@@ -69,7 +69,7 @@ class ProgrammableGatewayReleaser:
             stage=stage.name,
             env={
                 # "1.0.0+prod": 代码模版有通过版本号和环境名拼接的方式获取版本号，所以这里需要去掉
-                "BK_APIGW_RELEASE_VERSION": version.split("+", maxsplit=1)[0],  # 不带环境 name
+                "BK_APIGW_RELEASE_VERSION": version.split("+")[0],  # 不带环境 name
                 "BK_APIGW_RELEASE_COMMENT": comment,
             },
             user_credentials=user_credentials,

--- a/src/dashboard/apigateway/apigateway/conf/default.py
+++ b/src/dashboard/apigateway/apigateway/conf/default.py
@@ -826,6 +826,8 @@ DEFAULT_FEATURE_FLAG = get_default_feature_flags(
     enable_bk_notice=ENABLE_BK_NOTICE,
     enable_multi_tenant_mode=ENABLE_MULTI_TENANT_MODE,
     ai_open_api_base_url=AI_OPEN_API_BASE_URL,
+    enable_gateway_operation_status=ENABLE_GATEWAY_OPERATION_STATUS,
+    enable_run_data_metrics=ENABLE_RUN_DATA_METRICS,
 )
 
 # 用户功能开关，将与 DEFAULT_FEATURE_FLAG 合并

--- a/src/dashboard/apigateway/apigateway/conf/default.py
+++ b/src/dashboard/apigateway/apigateway/conf/default.py
@@ -759,6 +759,11 @@ BK_ESB_ACCESS_LOG_CONFIG = {
     "es_index": env.str("BK_ESB_API_LOG_ES_INDEX", "2_bklog_bkapigateway_esb_container*"),
 }
 
+MCP_SERVER_ACCESS_LOG_CONFIG = {
+    "es_time_field_name": "dtEventTimeStamp",
+    "es_index": env.str("BK_APIGW_MCP_SERVER_LOG_ES_INDEX", "2_bklog_bkapigateway_mcp_proxy_container*"),
+}
+
 
 # ==============================================================================
 # prometheus 配置
@@ -821,8 +826,6 @@ DEFAULT_FEATURE_FLAG = get_default_feature_flags(
     enable_bk_notice=ENABLE_BK_NOTICE,
     enable_multi_tenant_mode=ENABLE_MULTI_TENANT_MODE,
     ai_open_api_base_url=AI_OPEN_API_BASE_URL,
-    enable_gateway_operation_status=ENABLE_GATEWAY_OPERATION_STATUS,
-    enable_run_data_metrics=ENABLE_RUN_DATA_METRICS,
 )
 
 # 用户功能开关，将与 DEFAULT_FEATURE_FLAG 合并

--- a/src/dashboard/apigateway/apigateway/conf/utils.py
+++ b/src/dashboard/apigateway/apigateway/conf/utils.py
@@ -167,16 +167,14 @@ def get_default_feature_flags(
     enable_bk_notice: bool,
     enable_multi_tenant_mode: bool,
     ai_open_api_base_url: str,
-    enable_gateway_operation_status: bool,
-    enable_run_data_metrics: bool,
 ) -> dict:
     return {
         # 是否展示"监控告警"子菜单
         "ENABLE_MONITOR": env.bool("FEATURE_FLAG_ENABLE_MONITOR", False),
         # 是否展示"运行数据"子菜单
-        "ENABLE_RUN_DATA": env.bool("FEATURE_FLAG_ENABLE_RUN_DATA", False),
+        "ENABLE_RUN_DATA": env.bool("FEATURE_FLAG_ENABLE_RUN_DATA", True),
         # 是否展示 "运行数据" => 仪表盘 子菜单
-        "ENABLE_RUN_DATA_METRICS": enable_run_data_metrics,
+        "ENABLE_RUN_DATA_METRICS": env.bool("FEATURE_FLAG_ENABLE_RUN_DATA_METRICS", True),
         # 是否展示"组件管理"菜单项，企业版展示，上云版不展示
         "MENU_ITEM_ESB_API": env.bool("FEATURE_FLAG_MENU_ITEM_ESB_API", True),
         # TODO: remove in the future, and remove in the helm-chart and te repo
@@ -206,7 +204,7 @@ def get_default_feature_flags(
             enable_multi_tenant_mode or env.bool("FEATURE_FLAG_ENABLE_DISPLAY_NAME_RENDER", True)
         ),
         # 是否展示网关运营状态
-        "ENABLE_GATEWAY_OPERATION_STATUS": enable_gateway_operation_status,
+        "ENABLE_GATEWAY_OPERATION_STATUS": env.bool("FEATURE_FLAG_ENABLE_GATEWAY_OPERATION_STATUS", False),
         # 是否启用 MCP Prompt 功能
         "ENABLE_MCP_SERVER_PROMPT": env.bool("FEATURE_FLAG_ENABLE_MCP_SERVER_PROMPT", False),
         # 是否启用健康检查

--- a/src/dashboard/apigateway/apigateway/conf/utils.py
+++ b/src/dashboard/apigateway/apigateway/conf/utils.py
@@ -167,6 +167,8 @@ def get_default_feature_flags(
     enable_bk_notice: bool,
     enable_multi_tenant_mode: bool,
     ai_open_api_base_url: str,
+    enable_gateway_operation_status: bool,
+    enable_run_data_metrics: bool,
 ) -> dict:
     return {
         # 是否展示"监控告警"子菜单
@@ -174,7 +176,7 @@ def get_default_feature_flags(
         # 是否展示"运行数据"子菜单
         "ENABLE_RUN_DATA": env.bool("FEATURE_FLAG_ENABLE_RUN_DATA", True),
         # 是否展示 "运行数据" => 仪表盘 子菜单
-        "ENABLE_RUN_DATA_METRICS": env.bool("FEATURE_FLAG_ENABLE_RUN_DATA_METRICS", True),
+        "ENABLE_RUN_DATA_METRICS": enable_run_data_metrics,
         # 是否展示"组件管理"菜单项，企业版展示，上云版不展示
         "MENU_ITEM_ESB_API": env.bool("FEATURE_FLAG_MENU_ITEM_ESB_API", True),
         # TODO: remove in the future, and remove in the helm-chart and te repo
@@ -204,7 +206,7 @@ def get_default_feature_flags(
             enable_multi_tenant_mode or env.bool("FEATURE_FLAG_ENABLE_DISPLAY_NAME_RENDER", True)
         ),
         # 是否展示网关运营状态
-        "ENABLE_GATEWAY_OPERATION_STATUS": env.bool("FEATURE_FLAG_ENABLE_GATEWAY_OPERATION_STATUS", False),
+        "ENABLE_GATEWAY_OPERATION_STATUS": enable_gateway_operation_status,
         # 是否启用 MCP Prompt 功能
         "ENABLE_MCP_SERVER_PROMPT": env.bool("FEATURE_FLAG_ENABLE_MCP_SERVER_PROMPT", False),
         # 是否启用健康检查

--- a/src/dashboard/apigateway/apigateway/conf/utils.py
+++ b/src/dashboard/apigateway/apigateway/conf/utils.py
@@ -174,7 +174,7 @@ def get_default_feature_flags(
         # 是否展示"监控告警"子菜单
         "ENABLE_MONITOR": env.bool("FEATURE_FLAG_ENABLE_MONITOR", False),
         # 是否展示"运行数据"子菜单
-        "ENABLE_RUN_DATA": env.bool("FEATURE_FLAG_ENABLE_RUN_DATA", True),
+        "ENABLE_RUN_DATA": env.bool("FEATURE_FLAG_ENABLE_RUN_DATA", False),
         # 是否展示 "运行数据" => 仪表盘 子菜单
         "ENABLE_RUN_DATA_METRICS": enable_run_data_metrics,
         # 是否展示"组件管理"菜单项，企业版展示，上云版不展示

--- a/src/dashboard/apigateway/apigateway/data/apigw-definitions/bk-apigateway-definition.yaml
+++ b/src/dashboard/apigateway/apigateway/data/apigw-definitions/bk-apigateway-definition.yaml
@@ -66,10 +66,10 @@ stages:
           - v2_open_tools_time_parse_datetime_str_to_timestamp
           - v2_open_tools_log_query_by_request_id
         tool_names:
-          - tools_time_get_datetime
-          - tools_time_get_current_unix_timestamp
-          - tools_time_parse_datetime_str_to_timestamp
-          - tools_log_query_by_request_id
+          - get_datetime
+          - get_current_unix_timestamp
+          - parse_datetime_str_to_timestamp
+          - log_query_by_request_id
         is_public: true
         status: 1
         protocol_type: "streamable_http"

--- a/src/dashboard/apigateway/apigateway/service/prometheus/mcp_server_dimension.py
+++ b/src/dashboard/apigateway/apigateway/service/prometheus/mcp_server_dimension.py
@@ -249,10 +249,10 @@ class MCPServerRequestBodySizeMetrics(BaseMCPServerMetrics):
     def _get_query_promql(self, gateway_name, mcp_server_name, app_code, step):
         # body size 指标不包含 app_code label，忽略 app_code 参数
         labels = self._get_mcp_labels_expression(gateway_name, mcp_server_name, app_code=None)
-        # 使用 sum(increase()) / count() 来计算平均值
+        # 使用 sum(increase()) / count() 来计算平均值，clamp_min 保护分母为0
         return (
             f"sum(increase({self.metric_name_prefix}mcp_proxy_mcp_request_body_size_bytes_sum{{{labels}}}[{step}])) / "
-            f"sum(increase({self.metric_name_prefix}mcp_proxy_mcp_request_body_size_bytes_count{{{labels}}}[{step}]))"
+            f"clamp_min(sum(increase({self.metric_name_prefix}mcp_proxy_mcp_request_body_size_bytes_count{{{labels}}}[{step}])), 1)"
         )
 
 
@@ -267,10 +267,10 @@ class MCPServerResponseBodySizeMetrics(BaseMCPServerMetrics):
     def _get_query_promql(self, gateway_name, mcp_server_name, app_code, step):
         # body size 指标不包含 app_code label，忽略 app_code 参数
         labels = self._get_mcp_labels_expression(gateway_name, mcp_server_name, app_code=None)
-        # 使用 sum(increase()) / count() 来计算平均值
+        # 使用 sum(increase()) / count() 来计算平均值，clamp_min 保护分母为0
         return (
             f"sum(increase({self.metric_name_prefix}mcp_proxy_mcp_response_body_size_bytes_sum{{{labels}}}[{step}])) / "
-            f"sum(increase({self.metric_name_prefix}mcp_proxy_mcp_response_body_size_bytes_count{{{labels}}}[{step}]))"
+            f"clamp_min(sum(increase({self.metric_name_prefix}mcp_proxy_mcp_response_body_size_bytes_count{{{labels}}}[{step}])), 1)"
         )
 
 

--- a/src/dashboard/apigateway/apigateway/service/prometheus/mcp_server_dimension.py
+++ b/src/dashboard/apigateway/apigateway/service/prometheus/mcp_server_dimension.py
@@ -1,0 +1,414 @@
+# -*- coding: utf-8 -*-
+#
+# TencentBlueKing is pleased to support the open source community by making
+# 蓝鲸智云 - API 网关 (BlueKing - APIGateway) available.
+# Copyright (C) 2025 Tencent. All rights reserved.
+# Licensed under the MIT License (the "License"); you may not use this file except
+# in compliance with the License. You may obtain a copy of the License at
+#
+#     http://opensource.org/licenses/MIT
+#
+# Unless required by applicable law or agreed to in writing, software distributed under
+# the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+# either express or implied. See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# We undertake not to change the open source license (MIT license) applicable
+# to the current version of the project delivered to anyone in the future.
+#
+from typing import ClassVar, Dict, Optional, Type
+
+from django.conf import settings
+
+from apigateway.apps.mcp_server.metrics_constants import (
+    MCPServerMetricsInstantEnum,
+    MCPServerMetricsRangeEnum,
+)
+from apigateway.common.error_codes import error_codes
+from apigateway.components.bkmonitor import query_range
+
+from .base import BasePrometheusMetrics
+from .dimension import get_data_differ_number
+
+
+class BaseMCPServerMetrics(BasePrometheusMetrics):
+    """Base class for MCP Server Prometheus metrics queries.
+
+    Uses mcp-proxy's metric names (with configurable prefix, default "bk_apigateway_"):
+    - {prefix}mcp_proxy_mcp_requests_total (counter)
+    - {prefix}mcp_proxy_mcp_request_duration_milliseconds (histogram)
+    - {prefix}mcp_proxy_mcp_tool_calls_total (counter)
+    - {prefix}mcp_proxy_mcp_sessions_active (gauge)
+    - {prefix}mcp_proxy_mcp_errors_total (counter)
+    """
+
+    metrics: ClassVar[str]
+
+    def _get_mcp_labels_expression(
+        self,
+        gateway_name: str,
+        mcp_server_name: Optional[str] = None,
+        app_code: Optional[str] = None,
+        extra_labels: Optional[list] = None,
+    ) -> str:
+        labels = [
+            *self.default_labels,
+            ("gateway_name", "=", gateway_name),
+        ]
+        if mcp_server_name:
+            labels.append(("mcp_server_name", "=", mcp_server_name))
+        if app_code:
+            labels.append(("app_code", "=", app_code))
+        if extra_labels:
+            labels.extend(extra_labels)
+        return self._get_labels_expression(labels)
+
+    def query_range(
+        self,
+        gateway_name: str,
+        mcp_server_name: Optional[str],
+        app_code: Optional[str],
+        start: int,
+        end: int,
+        step: str,
+    ):
+        promql = self._get_query_promql(gateway_name, mcp_server_name, app_code, step)
+        return query_range(
+            bk_biz_id=getattr(settings, "BCS_CLUSTER_BK_BIZ_ID", ""),
+            promql=promql,
+            start=start,
+            end=end,
+            step=step,
+        )
+
+    def query_instant(
+        self,
+        gateway_name: str,
+        mcp_server_name: Optional[str],
+        app_code: Optional[str],
+        start: int,
+        end: int,
+        step: str,
+    ):
+        promql = self._get_query_promql(gateway_name, mcp_server_name, app_code, step)
+        data = query_range(
+            bk_biz_id=getattr(settings, "BCS_CLUSTER_BK_BIZ_ID", ""),
+            promql=promql,
+            start=start,
+            end=end,
+            step=step,
+        )
+        result_number = get_data_differ_number(data)
+        return {"instant": result_number}
+
+    def _get_query_promql(
+        self,
+        gateway_name: str,
+        mcp_server_name: Optional[str],
+        app_code: Optional[str],
+        step: str,
+    ) -> str:
+        raise NotImplementedError
+
+
+# ==================== Range Metrics ====================
+
+
+class MCPServerRequestsMetrics(BaseMCPServerMetrics):
+    """Total MCP requests trend (sum across all methods)"""
+
+    metrics = MCPServerMetricsRangeEnum.REQUESTS
+
+    def _get_query_promql(self, gateway_name, mcp_server_name, app_code, step):
+        labels = self._get_mcp_labels_expression(gateway_name, mcp_server_name, app_code)
+        return f"sum(increase({self.metric_name_prefix}mcp_proxy_mcp_requests_total{{{labels}}}[{step}]))"
+
+
+class MCPServerRequests2XXMetrics(BaseMCPServerMetrics):
+    """2XX status requests trend"""
+
+    metrics = MCPServerMetricsRangeEnum.REQUESTS_2XX
+
+    def _get_query_promql(self, gateway_name, mcp_server_name, app_code, step):
+        labels = self._get_mcp_labels_expression(
+            gateway_name,
+            mcp_server_name,
+            app_code,
+            extra_labels=[("error", "=", "0")],
+        )
+        return f"sum(increase({self.metric_name_prefix}mcp_proxy_mcp_requests_total{{{labels}}}[{step}]))"
+
+
+class MCPServerNon2XXStatusMetrics(BaseMCPServerMetrics):
+    """Non-2XX status requests trend, grouped by error_code"""
+
+    metrics = MCPServerMetricsRangeEnum.NON_2XX_STATUS
+
+    def _get_query_promql(self, gateway_name, mcp_server_name, app_code, step):
+        labels = self._get_mcp_labels_expression(
+            gateway_name,
+            mcp_server_name,
+            app_code,
+            extra_labels=[("error", "=", "1")],
+        )
+        return (
+            f"topk(10, sum(increase({self.metric_name_prefix}mcp_proxy_mcp_requests_total"
+            f"{{{labels}}}[{step}])) by (error_code))"
+        )
+
+
+class MCPServerAppRequestsMetrics(BaseMCPServerMetrics):
+    """Requests grouped by app_code"""
+
+    metrics = MCPServerMetricsRangeEnum.APP_REQUESTS
+
+    def _get_query_promql(self, gateway_name, mcp_server_name, app_code, step):
+        labels = self._get_mcp_labels_expression(gateway_name, mcp_server_name, app_code)
+        return (
+            f"topk(10, sum(increase({self.metric_name_prefix}mcp_proxy_mcp_requests_total"
+            f"{{{labels}}}[{step}])) by (app_code))"
+        )
+
+
+class MCPServerToolRequestsMetrics(BaseMCPServerMetrics):
+    """Requests grouped by tool_name (MCP tools/call)"""
+
+    metrics = MCPServerMetricsRangeEnum.TOOL_REQUESTS
+
+    def _get_query_promql(self, gateway_name, mcp_server_name, app_code, step):
+        labels = self._get_mcp_labels_expression(gateway_name, mcp_server_name, app_code)
+        return (
+            f"topk(10, sum(increase({self.metric_name_prefix}mcp_proxy_mcp_tool_calls_total"
+            f"{{{labels}}}[{step}])) by (tool_name))"
+        )
+
+
+class MCPServerResponseTime50thMetrics(BaseMCPServerMetrics):
+    """P50 response time distribution"""
+
+    metrics = MCPServerMetricsRangeEnum.RESPONSE_TIME_50TH
+
+    def _get_query_promql(self, gateway_name, mcp_server_name, app_code, step):
+        labels = self._get_mcp_labels_expression(gateway_name, mcp_server_name, app_code)
+        return (
+            f"histogram_quantile(0.50, "
+            f"sum(rate({self.metric_name_prefix}mcp_proxy_mcp_request_duration_milliseconds_bucket"
+            f"{{{labels}}}[{step}])) by (le))"
+        )
+
+
+class MCPServerResponseTime95thMetrics(BaseMCPServerMetrics):
+    """P95 response time distribution"""
+
+    metrics = MCPServerMetricsRangeEnum.RESPONSE_TIME_95TH
+
+    def _get_query_promql(self, gateway_name, mcp_server_name, app_code, step):
+        labels = self._get_mcp_labels_expression(gateway_name, mcp_server_name, app_code)
+        return (
+            f"histogram_quantile(0.95, "
+            f"sum(rate({self.metric_name_prefix}mcp_proxy_mcp_request_duration_milliseconds_bucket"
+            f"{{{labels}}}[{step}])) by (le))"
+        )
+
+
+class MCPServerResponseTime99thMetrics(BaseMCPServerMetrics):
+    """P99 response time distribution"""
+
+    metrics = MCPServerMetricsRangeEnum.RESPONSE_TIME_99TH
+
+    def _get_query_promql(self, gateway_name, mcp_server_name, app_code, step):
+        labels = self._get_mcp_labels_expression(gateway_name, mcp_server_name, app_code)
+        return (
+            f"histogram_quantile(0.99, "
+            f"sum(rate({self.metric_name_prefix}mcp_proxy_mcp_request_duration_milliseconds_bucket"
+            f"{{{labels}}}[{step}])) by (le))"
+        )
+
+
+class MCPServerMethodRequestsMetrics(BaseMCPServerMetrics):
+    """Requests grouped by MCP method (initialize, tools/call, tools/list, etc.)"""
+
+    metrics = MCPServerMetricsRangeEnum.METHOD_REQUESTS
+
+    def _get_query_promql(self, gateway_name, mcp_server_name, app_code, step):
+        labels = self._get_mcp_labels_expression(gateway_name, mcp_server_name, app_code)
+        return (
+            f"topk(10, sum(increase({self.metric_name_prefix}mcp_proxy_mcp_requests_total"
+            f"{{{labels}}}[{step}])) by (method))"
+        )
+
+
+class MCPServerRequestBodySizeMetrics(BaseMCPServerMetrics):
+    """Request body size trend (avg bytes)
+
+    Note: body size metrics do not include app_code label to reduce cardinality.
+    """
+
+    metrics = MCPServerMetricsRangeEnum.REQUEST_BODY_SIZE
+
+    def _get_query_promql(self, gateway_name, mcp_server_name, app_code, step):
+        # body size 指标不包含 app_code label，忽略 app_code 参数
+        labels = self._get_mcp_labels_expression(gateway_name, mcp_server_name, app_code=None)
+        # 使用 sum(increase()) / count() 来计算平均值
+        return (
+            f"sum(increase({self.metric_name_prefix}mcp_proxy_mcp_request_body_size_bytes_sum{{{labels}}}[{step}])) / "
+            f"sum(increase({self.metric_name_prefix}mcp_proxy_mcp_request_body_size_bytes_count{{{labels}}}[{step}]))"
+        )
+
+
+class MCPServerResponseBodySizeMetrics(BaseMCPServerMetrics):
+    """Response body size trend (avg bytes)
+
+    Note: body size metrics do not include app_code label to reduce cardinality.
+    """
+
+    metrics = MCPServerMetricsRangeEnum.RESPONSE_BODY_SIZE
+
+    def _get_query_promql(self, gateway_name, mcp_server_name, app_code, step):
+        # body size 指标不包含 app_code label，忽略 app_code 参数
+        labels = self._get_mcp_labels_expression(gateway_name, mcp_server_name, app_code=None)
+        # 使用 sum(increase()) / count() 来计算平均值
+        return (
+            f"sum(increase({self.metric_name_prefix}mcp_proxy_mcp_response_body_size_bytes_sum{{{labels}}}[{step}])) / "
+            f"sum(increase({self.metric_name_prefix}mcp_proxy_mcp_response_body_size_bytes_count{{{labels}}}[{step}]))"
+        )
+
+
+# ==================== Instant Metrics ====================
+
+
+class MCPServerRequestsTotalMetrics(BaseMCPServerMetrics):
+    """Total request count (instant value)"""
+
+    metrics = MCPServerMetricsInstantEnum.REQUESTS_TOTAL
+
+    def _get_query_promql(self, gateway_name, mcp_server_name, app_code, step):
+        labels = self._get_mcp_labels_expression(gateway_name, mcp_server_name, app_code)
+        return f"sum({self.metric_name_prefix}mcp_proxy_mcp_requests_total{{{labels}}})"
+
+
+class MCPServerNon2XXTotalMetrics(BaseMCPServerMetrics):
+    """Non-2XX total request count (instant value)"""
+
+    metrics = MCPServerMetricsInstantEnum.NON_2XX_TOTAL
+
+    def _get_query_promql(self, gateway_name, mcp_server_name, app_code, step):
+        labels = self._get_mcp_labels_expression(
+            gateway_name,
+            mcp_server_name,
+            app_code,
+            extra_labels=[("error", "=", "1")],
+        )
+        return f"sum({self.metric_name_prefix}mcp_proxy_mcp_requests_total{{{labels}}})"
+
+
+class MCPServerHealthRateMetrics(BaseMCPServerMetrics):
+    """Health rate (success rate) instant value"""
+
+    metrics = MCPServerMetricsInstantEnum.HEALTH_RATE
+
+    def query_instant(
+        self,
+        gateway_name: str,
+        mcp_server_name: Optional[str],
+        app_code: Optional[str],
+        start: int,
+        end: int,
+        step: str,
+    ):
+        # 获取总请求数
+        total_labels = self._get_mcp_labels_expression(gateway_name, mcp_server_name, app_code)
+        total_promql = f"sum({self.metric_name_prefix}mcp_proxy_mcp_requests_total{{{total_labels}}})"
+        total_data = query_range(
+            bk_biz_id=getattr(settings, "BCS_CLUSTER_BK_BIZ_ID", ""),
+            promql=total_promql,
+            start=start,
+            end=end,
+            step=step,
+        )
+        total_count = get_data_differ_number(total_data)
+
+        if total_count == 0:
+            return {"instant": "100.00"}
+
+        # 获取失败请求数 (error="1")
+        error_labels = self._get_mcp_labels_expression(
+            gateway_name,
+            mcp_server_name,
+            app_code,
+            extra_labels=[("error", "=", "1")],
+        )
+        error_promql = f"sum({self.metric_name_prefix}mcp_proxy_mcp_requests_total{{{error_labels}}})"
+        error_data = query_range(
+            bk_biz_id=getattr(settings, "BCS_CLUSTER_BK_BIZ_ID", ""),
+            promql=error_promql,
+            start=start,
+            end=end,
+            step=step,
+        )
+        error_count = get_data_differ_number(error_data)
+
+        # 健康率 = (1 - 失败数/总数) * 100
+        health_rate = (1 - error_count / total_count) * 100
+        return {"instant": f"{health_rate:.2f}"}
+
+    def _get_query_promql(self, gateway_name, mcp_server_name, app_code, step):
+        # 这个方法不会被调用，因为 query_instant 被重写了
+        return ""
+
+
+# ==================== Factories ====================
+
+
+class MCPServerMetricsRangeFactory:
+    _registry: Dict[MCPServerMetricsRangeEnum, Type[BaseMCPServerMetrics]] = {}
+
+    @classmethod
+    def create_metrics(cls, metrics: MCPServerMetricsRangeEnum) -> BaseMCPServerMetrics:
+        _class = cls._registry.get(metrics)
+        if not _class:
+            raise error_codes.INVALID_ARGUMENT.format(f"unsupported mcp server metrics={metrics.value}")
+        return _class()
+
+    @classmethod
+    def register(cls, metrics_class: Type[BaseMCPServerMetrics]):
+        if not hasattr(metrics_class, "metrics"):
+            raise ValueError("metrics_class must have a 'metrics' ClassVar")
+        key = MCPServerMetricsRangeEnum(metrics_class.metrics)
+        cls._registry[key] = metrics_class
+
+
+class MCPServerMetricsInstantFactory:
+    _registry: Dict[MCPServerMetricsInstantEnum, Type[BaseMCPServerMetrics]] = {}
+
+    @classmethod
+    def create_metrics(cls, metrics: MCPServerMetricsInstantEnum) -> BaseMCPServerMetrics:
+        _class = cls._registry.get(metrics)
+        if not _class:
+            raise error_codes.INVALID_ARGUMENT.format(f"unsupported mcp server metrics={metrics.value}")
+        return _class()
+
+    @classmethod
+    def register(cls, metrics_class: Type[BaseMCPServerMetrics]):
+        if not hasattr(metrics_class, "metrics"):
+            raise ValueError("metrics_class must have a 'metrics' ClassVar")
+        key = MCPServerMetricsInstantEnum(metrics_class.metrics)
+        cls._registry[key] = metrics_class
+
+
+# Register all metric classes
+MCPServerMetricsRangeFactory.register(MCPServerRequestsMetrics)
+MCPServerMetricsRangeFactory.register(MCPServerRequests2XXMetrics)
+MCPServerMetricsRangeFactory.register(MCPServerNon2XXStatusMetrics)
+MCPServerMetricsRangeFactory.register(MCPServerAppRequestsMetrics)
+MCPServerMetricsRangeFactory.register(MCPServerToolRequestsMetrics)
+MCPServerMetricsRangeFactory.register(MCPServerResponseTime50thMetrics)
+MCPServerMetricsRangeFactory.register(MCPServerResponseTime95thMetrics)
+MCPServerMetricsRangeFactory.register(MCPServerResponseTime99thMetrics)
+MCPServerMetricsRangeFactory.register(MCPServerMethodRequestsMetrics)
+MCPServerMetricsRangeFactory.register(MCPServerRequestBodySizeMetrics)
+MCPServerMetricsRangeFactory.register(MCPServerResponseBodySizeMetrics)
+
+MCPServerMetricsInstantFactory.register(MCPServerRequestsTotalMetrics)
+MCPServerMetricsInstantFactory.register(MCPServerNon2XXTotalMetrics)
+MCPServerMetricsInstantFactory.register(MCPServerHealthRateMetrics)

--- a/src/dashboard/apigateway/apigateway/urls.py
+++ b/src/dashboard/apigateway/apigateway/urls.py
@@ -37,6 +37,11 @@ from django.urls import include, path, re_path
 from django.views.i18n import set_language
 
 from apigateway.apis.web.access_log.views import LogDetailInfoApi
+from apigateway.apis.web.mcp_server_log.views import (
+    MCPServerLogQueryApi,
+    MCPServerLogQueryChainApi,
+    MCPServerLogQuerySummaryApi,
+)
 from apigateway.common.swagger import schema_view
 
 urlpatterns = [
@@ -76,6 +81,14 @@ urlpatterns = [
     path("backend/gateways/<int:gateway_id>/audits/", include("apigateway.apis.web.audit.urls")),
     path("backend/gateways/<int:gateway_id>/ai/", include("apigateway.apis.web.ai_completion.urls")),
     path("backend/gateways/<int:gateway_id>/mcp-servers/", include("apigateway.apis.web.mcp_server.urls")),
+    path(
+        "backend/gateways/<int:gateway_id>/mcp-servers/-/metrics/",
+        include("apigateway.apis.web.mcp_server_metrics.urls"),
+    ),
+    path(
+        "backend/gateways/<int:gateway_id>/mcp-servers/-/logs/",
+        include("apigateway.apis.web.mcp_server_log.urls"),
+    ),
     # mcp server marketplace
     path("backend/mcp-marketplace/", include("apigateway.apis.web.mcp_marketplace.urls")),
     # todo 不应该放在顶层，后续要想办法挪到下层
@@ -86,6 +99,21 @@ urlpatterns = [
     #     name="monitors.alarm_records.summary",
     # ),
     path("backend/gateways/logs/query/<slug:request_id>/", LogDetailInfoApi.as_view(), name="access_log.logs.query"),
+    path(
+        "backend/gateways/mcp-server-logs/query/<slug:request_id>/",
+        MCPServerLogQueryApi.as_view(),
+        name="mcp_server_log.logs.query",
+    ),
+    path(
+        "backend/gateways/mcp-server-logs/query/<slug:request_id>/summary/",
+        MCPServerLogQuerySummaryApi.as_view(),
+        name="mcp_server_log.logs.query.summary",
+    ),
+    path(
+        "backend/gateways/mcp-server-logs/query/<slug:request_id>/chain/",
+        MCPServerLogQueryChainApi.as_view(),
+        name="mcp_server_log.logs.query.chain",
+    ),
     # notice
     path("backend/notice/", include(("bk_notice_sdk.urls", "notice"), namespace="notice")),
 ]

--- a/src/mcp-proxy/cmd/init.go
+++ b/src/mcp-proxy/cmd/init.go
@@ -20,7 +20,6 @@ package cmd
 
 import (
 	"fmt"
-	"time"
 
 	"github.com/spf13/viper"
 
@@ -54,7 +53,6 @@ func initConfig() {
 }
 
 func initDatabase() {
-	start := time.Now()
 	defaultDBConfig, ok := globalConfig.DatabaseMap["apigateway"]
 	if !ok {
 		panic("database config apigateway not found")
@@ -62,7 +60,6 @@ func initDatabase() {
 	database.InitDBClient(&defaultDBConfig)
 	// 设置repo db
 	repo.SetDefault(database.Client())
-	logging.GetLogger().Infof("init database success, duration=%s", time.Since(start))
 }
 
 func initLogger() {
@@ -70,19 +67,17 @@ func initLogger() {
 }
 
 func initSentry() {
-	start := time.Now()
 	err := sty.Init(globalConfig.Sentry)
 	if err != nil {
 		logging.GetLogger().Errorf("init Sentry fail: %s", err)
 	} else {
-		logging.GetLogger().Infof("init Sentry success, duration=%s", time.Since(start))
+		logging.GetLogger().Info("init Sentry success")
 	}
 }
 
 func initMetrics() {
-	start := time.Now()
-	metric.InitMetrics()
-	logging.GetLogger().Infof("init Metrics success, duration=%s", time.Since(start))
+	metric.InitMetrics(globalConfig.Metric.NamePrefix)
+	logging.GetLogger().Info("init Metrics success")
 }
 
 func initTracing() {
@@ -90,12 +85,11 @@ func initTracing() {
 		logging.GetLogger().Info("tracing is not enabled, will not init it")
 		return
 	}
-	start := time.Now()
 	logging.GetLogger().Info("enabling tracing")
 	err := trace.InitTrace(globalConfig.Tracing)
 	if err != nil {
 		logging.GetLogger().Errorf("init tracing fail: %+v", err)
 		return
 	}
-	logging.GetLogger().Infof("init tracing success, duration=%s", time.Since(start))
+	logging.GetLogger().Info("init tracing success")
 }

--- a/src/mcp-proxy/config.yaml.tpl
+++ b/src/mcp-proxy/config.yaml.tpl
@@ -56,37 +56,16 @@ logger:
 
 
 
-## config for mcpServer
-mcpServer:
-  interval: 60
-  bkApiUrlTmpl: ""
+## config for metric/prometheus
+metric:
   ## Metric name prefix, should be aligned with the dashboard's PROMETHEUS_METRIC_NAME_PREFIX.
   ## Can also be overridden by the PROMETHEUS_METRIC_NAME_PREFIX environment variable.
-  metricNamePrefix: "bk_apigateway_"
-
-## config for trace
-tracing:
-  enable: true
-  endpoint: "127.0.0.1:4318"
-  ## report type: grpc/http
-  type: "http"
-  ## support: "always_on"/"always_off"/"trace_id_ratio"/"parentbased_always_on",if not config,default: "trace_id_ratio"
-  sampler: "trace_id_ratio"
-  samplerRatio: 0.001
-  token: "blueking"
-  serviceName: "apigateway-mcp-proxy"
-  instrument:
-    ginAPI: true
-    dbAPI: true
-    mcpAPI: true
-
-## config for pprof
-pprof:
-  username: "bk-apigateway"  # 可通过环境变量 PPROF_USERNAME 覆盖
-  password: "xxxxx"  # 可通过环境变量 PPROF_PASSWORD 覆盖，生产环境请使用强密码
+  namePrefix: "bk_apigateway_"
 
 ## config for mcp server
 mcpServer:
+  interval: 60
+  bkApiUrlTmpl: ""
   # messageUrlFormat / messageApplicationUrlFormat：蓝鲸网关资源路径模板；第一个 % 之前的段用于推导 SSE 对外前缀（网关剥前缀时与官方 SDK 的 endpoint 一致）
   # messageUrlFormat: "/api/bk-apigateway/prod/api/v2/mcp-servers/%s/sse/message"
   # messageApplicationUrlFormat: "/api/bk-apigateway/prod/api/v2/mcp-servers/%s/application/sse/message"
@@ -111,3 +90,24 @@ mcpServer:
     apiLogResponseSize: 1024
     # MCP API log response size limit (error responses, keeps more diagnostic info)
     apiLogErrorResponseSize: 4096
+
+## config for trace
+tracing:
+  enable: true
+  endpoint: "127.0.0.1:4318"
+  ## report type: grpc/http
+  type: "http"
+  ## support: "always_on"/"always_off"/"trace_id_ratio"/"parentbased_always_on",if not config,default: "trace_id_ratio"
+  sampler: "trace_id_ratio"
+  samplerRatio: 0.001
+  token: "blueking"
+  serviceName: "apigateway-mcp-proxy"
+  instrument:
+    ginAPI: true
+    dbAPI: true
+    mcpAPI: true
+
+## config for pprof
+pprof:
+  username: "bk-apigateway"  # 可通过环境变量 PPROF_USERNAME 覆盖
+  password: "xxxxx"  # 可通过环境变量 PPROF_PASSWORD 覆盖，生产环境请使用强密码

--- a/src/mcp-proxy/config.yaml.tpl
+++ b/src/mcp-proxy/config.yaml.tpl
@@ -53,13 +53,16 @@ logger:
     writer: file
     buffered: true
     settings: {name: core_api.log, size: 100, backups: 10, age: 7, path: ./}
-  database:
-    level: info
-    writer: os
-    buffered: false
-    settings: {name: stdout}
 
 
+
+## config for mcpServer
+mcpServer:
+  interval: 60
+  bkApiUrlTmpl: ""
+  ## Metric name prefix, should be aligned with the dashboard's PROMETHEUS_METRIC_NAME_PREFIX.
+  ## Can also be overridden by the PROMETHEUS_METRIC_NAME_PREFIX environment variable.
+  metricNamePrefix: "bk_apigateway_"
 
 ## config for trace
 tracing:

--- a/src/mcp-proxy/pkg/config/config.go
+++ b/src/mcp-proxy/pkg/config/config.go
@@ -253,6 +253,16 @@ type McpServer struct {
 	LogTruncate LogTruncate
 }
 
+// Metric is the config for metric/prometheus
+type Metric struct {
+	// NamePrefix is the prefix for all metric names.
+	// This should be aligned with the dashboard's PROMETHEUS_METRIC_NAME_PREFIX
+	// so that PromQL queries from the dashboard can match these metrics.
+	// Can be overridden by the PROMETHEUS_METRIC_NAME_PREFIX environment variable.
+	// Default: "bk_apigateway_"
+	NamePrefix string
+}
+
 // DerivePublicPathPrefix extracts the client-visible path prefix from a message URL format string
 // by taking the segment before the first "%" placeholder and trimming the trailing slash.
 //
@@ -298,6 +308,7 @@ type Config struct {
 
 	Logger  Logger
 	Tracing Tracing
+	Metric  Metric
 
 	McpServer McpServer
 	PProf     Pprof
@@ -383,6 +394,12 @@ func Load(v *viper.Viper) (*Config, error) {
 	}
 	if cfg.McpServer.LogTruncate.APILogErrorResponseSize == 0 {
 		cfg.McpServer.LogTruncate.APILogErrorResponseSize = defaultAPILogErrorRespSize
+	}
+	if cfg.Metric.NamePrefix == "" {
+		cfg.Metric.NamePrefix = os.Getenv("PROMETHEUS_METRIC_NAME_PREFIX")
+		if cfg.Metric.NamePrefix == "" {
+			cfg.Metric.NamePrefix = "bk_apigateway_"
+		}
 	}
 
 	if cfg.PProf.Username == "" {

--- a/src/mcp-proxy/pkg/infra/logging/init.go
+++ b/src/mcp-proxy/pkg/infra/logging/init.go
@@ -114,7 +114,7 @@ func GetAuditLoggerWithContext(ctx context.Context) *zap.Logger {
 		ctxLogger = ctxLogger.With(zap.String("trace_id", traceID))
 	}
 	if appCode, ok := ctx.Value(constant.BkAppCode).(string); ok {
-		ctxLogger = ctxLogger.With(zap.String("bk_app_code", appCode))
+		ctxLogger = ctxLogger.With(zap.String("app_code", appCode))
 	}
 	if username, ok := ctx.Value(constant.BkUsername).(string); ok && username != "" {
 		ctxLogger = ctxLogger.With(zap.String("bk_username", username))

--- a/src/mcp-proxy/pkg/infra/proxy/helpers_test.go
+++ b/src/mcp-proxy/pkg/infra/proxy/helpers_test.go
@@ -26,28 +26,30 @@ import (
 var _ = Describe("Helper Functions", func() {
 	Describe("buildToolResponseEnvelope", func() {
 		It("should include all fields when body is provided", func() {
-			envelope := buildToolResponseEnvelope(200, "req-1", "trace-1", "body-content")
+			envelope := buildToolResponseEnvelope(200, "req-1", "trace-1", "x-req-1", "body-content")
 
 			Expect(envelope[toolResponseStatusCodeField]).To(Equal(200))
 			Expect(envelope[toolResponseRequestIDField]).To(Equal("req-1"))
 			Expect(envelope[toolResponseTraceIDField]).To(Equal("trace-1"))
+			Expect(envelope[toolResponseXRequestIDField]).To(Equal("x-req-1"))
 			Expect(envelope[toolResponseBodyField]).To(Equal("body-content"))
 		})
 
 		It("should include response_body as nil when body is nil", func() {
-			envelope := buildToolResponseEnvelope(204, "req-1", "trace-1", nil)
+			envelope := buildToolResponseEnvelope(204, "req-1", "trace-1", "x-req-1", nil)
 
-			Expect(envelope).To(HaveLen(4))
+			Expect(envelope).To(HaveLen(5))
 			Expect(envelope).To(HaveKey(toolResponseBodyField))
 			Expect(envelope[toolResponseBodyField]).To(BeNil())
 		})
 
 		It("should handle zero status code", func() {
-			envelope := buildToolResponseEnvelope(0, "", "", nil)
+			envelope := buildToolResponseEnvelope(0, "", "", "", nil)
 
 			Expect(envelope[toolResponseStatusCodeField]).To(Equal(0))
 			Expect(envelope[toolResponseRequestIDField]).To(Equal(""))
 			Expect(envelope[toolResponseTraceIDField]).To(Equal(""))
+			Expect(envelope[toolResponseXRequestIDField]).To(Equal(""))
 		})
 	})
 

--- a/src/mcp-proxy/pkg/infra/proxy/proxy.go
+++ b/src/mcp-proxy/pkg/infra/proxy/proxy.go
@@ -1078,6 +1078,9 @@ func logToolCall(
 		zap.String("mcp_server_name", serverName),
 		zap.Int("mcp_server_id", ctxInfo.mcpServerID),
 		zap.String("mcp_method", "tools/call"),
+		// HTTP request info: MCP 协议层不需要展示 HTTP path/method，置空保持字段一致
+		zap.String("method", ""),
+		zap.String("path", ""),
 		// Caller info
 		zap.String("app_code", ctxInfo.appCode),
 		zap.String("bk_username", ctxInfo.username),

--- a/src/mcp-proxy/pkg/infra/proxy/proxy.go
+++ b/src/mcp-proxy/pkg/infra/proxy/proxy.go
@@ -617,36 +617,145 @@ func setHandlerRequestParams(
 	return nil
 }
 
+// setupToolCallSpan creates a trace span for tool call if tracing is enabled.
+func setupToolCallSpan(
+	ctx context.Context, toolName, toolMethod, toolURL, toolHost string,
+) (context.Context, oteltrace.Span) {
+	if config.G == nil || !config.G.Tracing.McpAPIEnabled() {
+		return ctx, nil
+	}
+	ctx, span := trace.StartTrace(ctx, fmt.Sprintf("mcp.tool.%s", toolName))
+	if span != nil {
+		span.SetAttributes(
+			attribute.String("mcp.tool_name", toolName),
+			attribute.String("mcp.tool_method", toolMethod),
+			attribute.String("mcp.tool_url", toolURL),
+			attribute.String("mcp.tool_host", toolHost),
+		)
+	}
+	return ctx, span
+}
+
+// prepareToolCallAuditLog prepares audit logger with request context information.
+func prepareToolCallAuditLog(
+	ctx context.Context,
+	req *mcp.CallToolRequest,
+	toolName, toolConfig string,
+) (*zap.Logger, string, string, string, string, string) {
+	requestID := util.GetRequestIDFromContext(ctx)
+	xRequestID := util.GetXRequestIDFromContext(ctx)
+	appCode := util.GetAppCodeFromContext(ctx)
+	username := util.GetUsernameFromContext(ctx)
+	clientIP := util.GetClientIPFromContext(ctx)
+
+	// Extract request_id and x_request_id from request header if not found in context
+	if req != nil {
+		if extra := req.GetExtra(); extra != nil && extra.Header != nil {
+			if requestID == "" {
+				requestID = extra.Header.Get(constant.BkGatewayRequestIDKey)
+			}
+			if xRequestID == "" {
+				xRequestID = extra.Header.Get(constant.RequestIDHeaderKey)
+			}
+		}
+	}
+
+	auditLog := logging.GetAuditLoggerWithContext(ctx).With(
+		zap.String("request_id", requestID),
+		zap.String("x_request_id", xRequestID),
+		zap.String("mcp_method", "tools/call"),
+		zap.String("tool_name", toolName),
+		zap.String("tool", toolConfig),
+		zap.String("app_code", appCode),
+		zap.String("bk_username", username),
+		zap.String("client_ip", clientIP),
+	)
+
+	return auditLog, requestID, xRequestID, appCode, username, clientIP
+}
+
+// buildToolCallClient creates HTTP client with shared transport and logging.
+func buildToolCallClient(
+	ctx context.Context,
+	toolApiConfig *ToolConfig,
+	appCode, username, requestID, xRequestID string,
+) *http.Client {
+	logTransport := buildLoggingTransport(
+		ctx,
+		sharedTransport,
+		toolApiConfig,
+		appCode,
+		username,
+		requestID,
+		xRequestID,
+	)
+	return &http.Client{Transport: logTransport}
+}
+
+// handleToolCallError handles errors from tool calls and returns appropriate result.
+func handleToolCallError(
+	ctx context.Context,
+	err error,
+	toolApiConfig *ToolConfig,
+	auditLog *zap.Logger,
+	headerInfo map[string]string,
+	span oteltrace.Span,
+	start time.Time,
+) *mcp.CallToolResult {
+	msg := fmt.Sprintf("call %s error:%s", toolApiConfig, err.Error())
+	duration := time.Since(start)
+
+	auditLog.Error("call tool err",
+		zap.Any("header", util.MaskSensitiveHeaders(headerInfo)),
+		zap.Error(err),
+		zap.String("latency", duration.String()),
+		zap.String("status", "failed"),
+		zap.Int64("response_body_size", 0),
+	)
+
+	if span != nil {
+		span.SetStatus(codes.Error, msg)
+		span.RecordError(err)
+	}
+
+	result := &mcp.CallToolResult{
+		Content: []mcp.Content{
+			&mcp.TextContent{
+				Text: msg,
+			},
+		},
+		IsError: true,
+	}
+
+	if _, ok := err.(*runtime.APIError); !ok {
+		// For non-APIError, append trace_id to the error message for traceability
+		if traceID := trace.GetTraceIDFromContext(ctx); traceID != "" {
+			msg = fmt.Sprintf("%s (trace_id=%s)", msg, traceID)
+			result.Content = []mcp.Content{
+				&mcp.TextContent{
+					Text: msg,
+				},
+			}
+		}
+	}
+
+	return result
+}
+
 func genToolHandler(toolApiConfig *ToolConfig, serverName string) ToolHandler {
 	// 生成handler
 	handler := func(ctx context.Context, req *mcp.CallToolRequest) (result *mcp.CallToolResult, err error) {
 		start := time.Now()
 
-		// Start a trace span for the actual upstream tool invocation (only when MCP tracing is enabled).
-		// NOTE: This is intentionally separate from TracingMiddleware's "mcp.tools/call" span:
-		//   - TracingMiddleware spans cover the MCP protocol layer (request/response lifecycle).
-		//   - This span covers the actual upstream HTTP call to the backend API, providing
-		//     tool-specific attributes (method, url, host) for fine-grained observability.
-		var span oteltrace.Span
-		if config.G != nil && config.G.Tracing.McpAPIEnabled() {
-			ctx, span = trace.StartTrace(ctx, fmt.Sprintf("mcp.tool.%s", toolApiConfig.Name))
-		}
+		// Start a trace span for the actual upstream tool invocation
+		ctx, span := setupToolCallSpan(ctx, toolApiConfig.Name, toolApiConfig.Method, toolApiConfig.Url, toolApiConfig.Host)
 		if span != nil {
 			defer span.End()
-			span.SetAttributes(
-				attribute.String("mcp.tool_name", toolApiConfig.Name),
-				attribute.String("mcp.tool_method", toolApiConfig.Method),
-				attribute.String("mcp.tool_url", toolApiConfig.Url),
-				attribute.String("mcp.tool_host", toolApiConfig.Host),
-			)
 		}
 
 		// MCP protocol-level logging and metrics
-		// NOTE: tools/call handler is invoked inside callTool(), which does not go through
-		// the MCP middleware chain. Therefore, we need to manually log and record metrics here.
 		defer func() {
 			if r := recover(); r != nil {
-				// Log panic and convert to error
 				logging.GetAPILogger().Error("panic in tool handler",
 					zap.String("mcp_method", "tools/call"),
 					zap.String("tool_name", toolApiConfig.Name),
@@ -657,43 +766,13 @@ func genToolHandler(toolApiConfig *ToolConfig, serverName string) ToolHandler {
 					err = fmt.Errorf("panic: %v", r)
 				}
 			}
-			// Record MCP protocol-level metrics
 			recordToolCallMetrics(ctx, serverName, toolApiConfig.Name, req, result, err, start)
-			// Log MCP protocol-level request/response
 			logToolCall(ctx, serverName, toolApiConfig.Name, req, result, err, start)
 		}()
 
-		auditLog := logging.GetAuditLoggerWithContext(ctx)
-		requestID := util.GetRequestIDFromContext(ctx)
-		xRequestID := util.GetXRequestIDFromContext(ctx)
-		appCode := util.GetAppCodeFromContext(ctx)
-		username := util.GetUsernameFromContext(ctx)
-		clientIP := util.GetClientIPFromContext(ctx)
-
-		// Extract request_id and x_request_id from request header if not found in context
-		// This is needed because the context passed by MCP SDK does not contain HTTP request info
-		if req != nil {
-			if extra := req.GetExtra(); extra != nil && extra.Header != nil {
-				if requestID == "" {
-					requestID = extra.Header.Get(constant.BkGatewayRequestIDKey)
-				}
-				if xRequestID == "" {
-					xRequestID = extra.Header.Get(constant.RequestIDHeaderKey)
-				}
-			}
-		}
-
-		// 在所有日志中添加 request_id, x_request_id, app_code, username 和 client_ip
-		auditLog = auditLog.With(
-			zap.String("request_id", requestID),
-			zap.String("x_request_id", xRequestID),
-			zap.String("mcp_method", "tools/call"),
-			zap.String("tool_name", toolApiConfig.Name),
-			zap.String("tool", toolApiConfig.String()),
-			zap.String("app_code", appCode),
-			zap.String("bk_username", username),
-			zap.String("client_ip", clientIP),
-		)
+		// Prepare audit log with request context
+		auditLog, requestID, xRequestID, appCode, username, _ := prepareToolCallAuditLog(
+			ctx, req, toolApiConfig.Name, toolApiConfig.String())
 		// 延迟签发 inner JWT - 只有在调用外部 API 时才签发
 		innerJwt, err := util.SignInnerJWTFromContext(ctx)
 		if err != nil {
@@ -749,17 +828,8 @@ func genToolHandler(toolApiConfig *ToolConfig, serverName string) ToolHandler {
 				string(argsBytes)), zap.Error(err))
 			return nil, trace.WrapErrorWithTraceID(ctx, err)
 		}
-		// 使用共享的 HTTP Transport 连接池，避免每次 tool call 创建新连接
-		logTransport := buildLoggingTransport(
-			ctx,
-			sharedTransport,
-			toolApiConfig,
-			appCode,
-			username,
-			requestID,
-			xRequestID,
-		)
-		client := &http.Client{Transport: logTransport}
+		// Build HTTP client with shared transport
+		client := buildToolCallClient(ctx, toolApiConfig, appCode, username, requestID, xRequestID)
 		timeout := util.GetBkApiTimeout(ctx)
 		headerInfo := map[string]string{constant.BkApiTimeoutHeaderKey: fmt.Sprintf("%v", timeout)}
 		requestParam := runtime.ClientRequestWriterFunc(func(req runtime.ClientRequest, _ strfmt.Registry) error {
@@ -860,45 +930,13 @@ func genToolHandler(toolApiConfig *ToolConfig, serverName string) ToolHandler {
 		openAPIClient := cli.New(toolApiConfig.Host, toolApiConfig.BasePath, []string{toolApiConfig.Schema})
 		submit, err := openAPIClient.Submit(operation)
 		if err != nil {
-			msg := fmt.Sprintf("call %s error:%s", toolApiConfig, err.Error())
 			duration := time.Since(start)
-			// 设置 audit log 变量，供 defer 中的 "call tool complete" 使用
-			auditResponse = msg
+			auditResponse = fmt.Sprintf("call %s error:%s", toolApiConfig, err.Error())
 			auditResponseSize = 0
 			auditLatency = duration
 			auditStatus = "failed"
-			auditLog.Error("call tool err",
-				zap.Any("header", util.MaskSensitiveHeaders(headerInfo)),
-				zap.Error(err),
-				zap.String("latency", duration.String()),
-				zap.String("status", "failed"),
-				zap.Int64("response_body_size", 0),
-			)
-			if span != nil {
-				span.SetStatus(codes.Error, msg)
-				span.RecordError(err)
-			}
-			result := &mcp.CallToolResult{
-				Content: []mcp.Content{
-					&mcp.TextContent{
-						Text: msg,
-					},
-				},
-				IsError: true,
-			}
-			if _, ok := err.(*runtime.APIError); !ok {
-				// For non-APIError, append trace_id to the error message for traceability
-				if traceID := trace.GetTraceIDFromContext(ctx); traceID != "" {
-					msg = fmt.Sprintf("%s (trace_id=%s)", msg, traceID)
-					result.Content = []mcp.Content{
-						&mcp.TextContent{
-							Text: msg,
-						},
-					}
-				}
-			}
 			// nolint:nilerr
-			return result, nil
+			return handleToolCallError(ctx, err, toolApiConfig, auditLog, headerInfo, span, start), nil
 		}
 		duration := time.Since(start)
 		responseBody := util.TruncateJSON(submit, logTruncate.GetAuditLogMaxResponseSize())
@@ -1144,10 +1182,12 @@ func extractUpstreamRequestID(result *mcp.CallToolResult) string {
 	for i, content := range result.Content {
 		if text, ok := content.(*mcp.TextContent); ok && text != nil {
 			textContent = text.Text
-			logging.GetLogger().Debug("extractUpstreamRequestID: found TextContent", zap.Int("index", i), zap.Int("text_length", len(textContent)))
+			logging.GetLogger().Debug("extractUpstreamRequestID: found TextContent",
+				zap.Int("index", i), zap.Int("text_length", len(textContent)))
 			break
 		} else {
-			logging.GetLogger().Debug("extractUpstreamRequestID: content type mismatch", zap.Int("index", i), zap.String("type", fmt.Sprintf("%T", content)))
+			logging.GetLogger().Debug("extractUpstreamRequestID: content type mismatch",
+				zap.Int("index", i), zap.String("type", fmt.Sprintf("%T", content)))
 		}
 	}
 	if textContent == "" {
@@ -1158,7 +1198,12 @@ func extractUpstreamRequestID(result *mcp.CallToolResult) string {
 	// Parse JSON to extract request_id
 	var envelope map[string]any
 	if err := json.Unmarshal([]byte(textContent), &envelope); err != nil {
-		logging.GetLogger().Debug("extractUpstreamRequestID: failed to unmarshal textContent", zap.Error(err), zap.String("text_content_preview", textContent[:min(len(textContent), 200)]))
+		preview := textContent
+		if len(textContent) > 200 {
+			preview = textContent[:200]
+		}
+		logging.GetLogger().Debug("extractUpstreamRequestID: failed to unmarshal textContent",
+			zap.Error(err), zap.String("text_content_preview", preview))
 		return ""
 	}
 

--- a/src/mcp-proxy/pkg/infra/proxy/proxy.go
+++ b/src/mcp-proxy/pkg/infra/proxy/proxy.go
@@ -968,7 +968,9 @@ func recordToolCallMetrics(
 	}
 
 	duration := time.Since(start)
-	hasError := err != nil
+	// Check both err and result.IsError: MCP framework-level failures (e.g., upstream API errors)
+	// are often returned as CallToolResult{IsError: true} with err == nil
+	hasError := err != nil || (result != nil && result.IsError)
 	gatewayName := util.GetGatewayNameFromContext(ctx)
 	appCode := util.GetAppCodeFromContext(ctx)
 
@@ -1032,7 +1034,9 @@ func logToolCall(
 ) {
 	logger := logging.GetAPILogger()
 	duration := time.Since(start)
-	hasError := err != nil
+	// Check both err and result.IsError: MCP framework-level failures (e.g., upstream API errors)
+	// are often returned as CallToolResult{IsError: true} with err == nil
+	hasError := err != nil || (result != nil && result.IsError)
 
 	// Resolve truncation limits from config
 	logTruncate := config.G.McpServer.LogTruncate

--- a/src/mcp-proxy/pkg/infra/proxy/proxy.go
+++ b/src/mcp-proxy/pkg/infra/proxy/proxy.go
@@ -748,7 +748,13 @@ func genToolHandler(toolApiConfig *ToolConfig, serverName string) ToolHandler {
 		start := time.Now()
 
 		// Start a trace span for the actual upstream tool invocation
-		ctx, span := setupToolCallSpan(ctx, toolApiConfig.Name, toolApiConfig.Method, toolApiConfig.Url, toolApiConfig.Host)
+		ctx, span := setupToolCallSpan(
+			ctx,
+			toolApiConfig.Name,
+			toolApiConfig.Method,
+			toolApiConfig.Url,
+			toolApiConfig.Host,
+		)
 		if span != nil {
 			defer span.End()
 		}

--- a/src/mcp-proxy/pkg/infra/proxy/proxy.go
+++ b/src/mcp-proxy/pkg/infra/proxy/proxy.go
@@ -1041,82 +1041,20 @@ func logToolCall(
 	// Resolve truncation limits from config
 	logTruncate := config.G.McpServer.LogTruncate
 
-	// Serialize request params
-	var params string
-	var requestBodySize int64
-	if req != nil && req.Params != nil && req.Params.Arguments != nil {
-		if paramsBytes, marshalErr := json.Marshal(req.Params.Arguments); marshalErr == nil {
-			requestBodySize = int64(len(paramsBytes))
-			params = stringx.Truncate(string(paramsBytes), logTruncate.GetAPILogRequestSize())
-		}
-	}
-
-	// Serialize response result
-	var response string
-	var responseBodySize int64
-	var upstreamRequestID string
-	if result != nil {
-		if resultBytes, marshalErr := json.Marshal(result); marshalErr == nil {
-			responseBodySize = int64(len(resultBytes))
-			if hasError {
-				response = stringx.Truncate(string(resultBytes), logTruncate.GetAPILogErrorResponseSize())
-			} else {
-				response = stringx.Truncate(string(resultBytes), logTruncate.GetAPILogResponseSize())
-			}
-			// Extract upstream request_id from result for traceability
-			upstreamRequestID = extractUpstreamRequestID(result)
-		}
-	}
+	// Serialize request params and response
+	params, requestBodySize := serializeToolCallRequest(req, logTruncate)
+	response, responseBodySize, upstreamRequestID := serializeToolCallResponse(result, hasError, logTruncate)
 
 	// Retrieve extra info from context
-	gatewayID := util.GetGatewayIDFromContext(ctx)
-	gatewayName := util.GetGatewayNameFromContext(ctx)
-	mcpServerID := util.GetMCPServerIDFromContext(ctx)
-	requestID := util.GetRequestIDFromContext(ctx)
-	xRequestID := util.GetXRequestIDFromContext(ctx)
-	appCode := util.GetAppCodeFromContext(ctx)
-	username := util.GetUsernameFromContext(ctx)
-	clientIP := util.GetClientIPFromContext(ctx)
-	clientID := util.GetClientIDFromContext(ctx)
+	ctxInfo := extractToolCallContextInfo(ctx, req)
 
-	// Extract X-Request-ID from request header if not found in context
-	if xRequestID == "" && req != nil {
-		if extra := req.GetExtra(); extra != nil && extra.Header != nil {
-			xRequestID = extra.Header.Get(constant.RequestIDHeaderKey)
-		}
-	}
-
-	// Extract X-Bkapi-Request-ID from request header if not found in context
-	// This is the request_id for the MCP request
-	if requestID == "" && req != nil {
-		if extra := req.GetExtra(); extra != nil && extra.Header != nil {
-			requestID = extra.Header.Get(constant.BkGatewayRequestIDKey)
-		}
-	}
-
-	// Try to get gateway_name from cache if not found in context
-	if gatewayName == "" && gatewayID > 0 {
-		if gateway, err := cacheimpls.GetGatewayByID(ctx, gatewayID); err == nil && gateway != nil {
-			gatewayName = gateway.Name
-		}
-	}
-
-	// Get session ID and client_id from session's InitializeParams
-	var sessionID string
-	if req != nil {
-		if ss, ok := req.GetSession().(*mcp.ServerSession); ok && ss != nil {
-			sessionID = ss.ID()
-			// Enrich client_id with clientInfo from initialize handshake
-			if initParams := ss.InitializeParams(); initParams != nil && initParams.ClientInfo != nil {
-				clientID = initParams.ClientInfo.Name
-			}
-		}
-	}
+	// Get session info
+	sessionID, clientID := extractToolCallSessionInfo(req, ctxInfo.clientID)
 
 	// trace_id from HTTP layer
 	traceID := trace.GetTraceIDFromContext(ctx)
 
-	// Status: success or failed
+	// Build log fields
 	status := "success"
 	if hasError {
 		status = "failed"
@@ -1124,20 +1062,20 @@ func logToolCall(
 
 	fields := []zap.Field{
 		// Trace identifiers
-		zap.String("request_id", requestID),
-		zap.String("x_request_id", xRequestID),
+		zap.String("request_id", ctxInfo.requestID),
+		zap.String("x_request_id", ctxInfo.xRequestID),
 		zap.String("session_id", sessionID),
 		// Gateway info
-		zap.Int("gateway_id", gatewayID),
-		zap.String("gateway_name", gatewayName),
+		zap.Int("gateway_id", ctxInfo.gatewayID),
+		zap.String("gateway_name", ctxInfo.gatewayName),
 		// MCP request info
 		zap.String("mcp_server_name", serverName),
-		zap.Int("mcp_server_id", mcpServerID),
+		zap.Int("mcp_server_id", ctxInfo.mcpServerID),
 		zap.String("mcp_method", "tools/call"),
 		// Caller info
-		zap.String("app_code", appCode),
-		zap.String("bk_username", username),
-		zap.String("client_ip", clientIP),
+		zap.String("app_code", ctxInfo.appCode),
+		zap.String("bk_username", ctxInfo.username),
+		zap.String("client_ip", ctxInfo.clientIP),
 		zap.String("client_id", clientID),
 		// Tool specific fields
 		zap.String("tool_name", toolName),
@@ -1169,6 +1107,111 @@ func logToolCall(
 	}
 
 	logger.Info("-", fields...)
+}
+
+// serializeToolCallRequest serializes the tool call request params.
+func serializeToolCallRequest(req *mcp.CallToolRequest, logTruncate config.LogTruncate) (string, int64) {
+	if req == nil || req.Params == nil || req.Params.Arguments == nil {
+		return "", 0
+	}
+	paramsBytes, marshalErr := json.Marshal(req.Params.Arguments)
+	if marshalErr != nil {
+		return "", 0
+	}
+	requestBodySize := int64(len(paramsBytes))
+	params := stringx.Truncate(string(paramsBytes), logTruncate.GetAPILogRequestSize())
+	return params, requestBodySize
+}
+
+// serializeToolCallResponse serializes the tool call response result.
+func serializeToolCallResponse(
+	result *mcp.CallToolResult,
+	hasError bool,
+	logTruncate config.LogTruncate,
+) (string, int64, string) {
+	if result == nil {
+		return "", 0, ""
+	}
+	resultBytes, marshalErr := json.Marshal(result)
+	if marshalErr != nil {
+		return "", 0, ""
+	}
+	responseBodySize := int64(len(resultBytes))
+	var response string
+	if hasError {
+		response = stringx.Truncate(string(resultBytes), logTruncate.GetAPILogErrorResponseSize())
+	} else {
+		response = stringx.Truncate(string(resultBytes), logTruncate.GetAPILogResponseSize())
+	}
+	upstreamRequestID := extractUpstreamRequestID(result)
+	return response, responseBodySize, upstreamRequestID
+}
+
+// toolCallContextInfo holds context-derived info for tool call logging.
+type toolCallContextInfo struct {
+	requestID   string
+	xRequestID  string
+	gatewayID   int
+	gatewayName string
+	mcpServerID int
+	appCode     string
+	username    string
+	clientIP    string
+	clientID    string
+}
+
+// extractToolCallContextInfo extracts gateway, request, and caller info from context and request headers.
+func extractToolCallContextInfo(ctx context.Context, req *mcp.CallToolRequest) toolCallContextInfo {
+	info := toolCallContextInfo{
+		gatewayID:   util.GetGatewayIDFromContext(ctx),
+		gatewayName: util.GetGatewayNameFromContext(ctx),
+		mcpServerID: util.GetMCPServerIDFromContext(ctx),
+		requestID:   util.GetRequestIDFromContext(ctx),
+		xRequestID:  util.GetXRequestIDFromContext(ctx),
+		appCode:     util.GetAppCodeFromContext(ctx),
+		username:    util.GetUsernameFromContext(ctx),
+		clientIP:    util.GetClientIPFromContext(ctx),
+		clientID:    util.GetClientIDFromContext(ctx),
+	}
+
+	// Extract X-Request-ID from request header if not found in context
+	if info.xRequestID == "" && req != nil {
+		if extra := req.GetExtra(); extra != nil && extra.Header != nil {
+			info.xRequestID = extra.Header.Get(constant.RequestIDHeaderKey)
+		}
+	}
+
+	// Extract X-Bkapi-Request-ID from request header if not found in context
+	if info.requestID == "" && req != nil {
+		if extra := req.GetExtra(); extra != nil && extra.Header != nil {
+			info.requestID = extra.Header.Get(constant.BkGatewayRequestIDKey)
+		}
+	}
+
+	// Try to get gateway_name from cache if not found in context
+	if info.gatewayName == "" && info.gatewayID > 0 {
+		if gw, err := cacheimpls.GetGatewayByID(ctx, info.gatewayID); err == nil && gw != nil {
+			info.gatewayName = gw.Name
+		}
+	}
+
+	return info
+}
+
+// extractToolCallSessionInfo extracts session ID and client_id from the MCP session.
+func extractToolCallSessionInfo(req *mcp.CallToolRequest, clientID string) (string, string) {
+	if req == nil {
+		return "", clientID
+	}
+	var sessionID string
+	if ss, ok := req.GetSession().(*mcp.ServerSession); ok && ss != nil {
+		sessionID = ss.ID()
+		// Enrich client_id with clientInfo from initialize handshake
+		if initParams := ss.InitializeParams(); initParams != nil && initParams.ClientInfo != nil {
+			clientID = initParams.ClientInfo.Name
+		}
+	}
+	return sessionID, clientID
 }
 
 // extractUpstreamRequestID extracts the upstream API request_id from tool call result.

--- a/src/mcp-proxy/pkg/infra/proxy/proxy.go
+++ b/src/mcp-proxy/pkg/infra/proxy/proxy.go
@@ -984,6 +984,7 @@ func recordToolCallMetrics(
 	}
 
 	// Record metrics
+	metric.MCPRequestTotal.WithLabelValues(gatewayName, serverName, "tools/call", appCode, errorCode, errorLabel).Inc()
 	metric.MCPToolCallTotal.WithLabelValues(gatewayName, serverName, toolName, appCode, errorCode, errorLabel).Inc()
 	metric.MCPRequestDuration.WithLabelValues(gatewayName, serverName, "tools/call", appCode).
 		Observe(duration.Seconds() * 1000)

--- a/src/mcp-proxy/pkg/infra/proxy/proxy.go
+++ b/src/mcp-proxy/pkg/infra/proxy/proxy.go
@@ -30,6 +30,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/TencentBlueKing/gopkg/stringx"
 	"github.com/getkin/kin-openapi/openapi3"
 	"github.com/gin-gonic/gin"
 	"github.com/go-openapi/runtime"
@@ -45,10 +46,12 @@ import (
 	oteltrace "go.opentelemetry.io/otel/trace"
 	"go.uber.org/zap"
 
+	"mcp_proxy/pkg/cacheimpls"
 	"mcp_proxy/pkg/config"
 	"mcp_proxy/pkg/constant"
 	"mcp_proxy/pkg/infra/logging"
 	"mcp_proxy/pkg/infra/trace"
+	"mcp_proxy/pkg/metric"
 	"mcp_proxy/pkg/util"
 )
 
@@ -56,6 +59,7 @@ const (
 	toolResponseStatusCodeField = "status_code"
 	toolResponseRequestIDField  = "request_id"
 	toolResponseTraceIDField    = "trace_id"
+	toolResponseXRequestIDField = "x_request_id"
 	toolResponseBodyField       = "response_body"
 )
 
@@ -168,11 +172,12 @@ func buildToolInputSchema(toolConfig *ToolConfig, serverName string) map[string]
 	return inputSchema
 }
 
-func buildToolResponseEnvelope(statusCode int, requestID, traceID string, responseBody any) map[string]any {
+func buildToolResponseEnvelope(statusCode int, requestID, traceID, xRequestID string, responseBody any) map[string]any {
 	responseResult := map[string]any{
 		toolResponseStatusCodeField: statusCode,
 		toolResponseRequestIDField:  requestID,
 		toolResponseTraceIDField:    traceID,
+		toolResponseXRequestIDField: xRequestID,
 		// Always include response_body to keep consistency with the outputSchema definition.
 		// When responseBody is nil, the field will be JSON null, which matches the schema expectation.
 		toolResponseBodyField: responseBody,
@@ -231,7 +236,7 @@ func (m *MCPProxy) AddMCPServerFromConfigs(configs []*MCPServerConfig) error {
 
 		// register tool
 		for _, toolConfig := range config.Tools {
-			toolHandler := genToolHandler(toolConfig)
+			toolHandler := genToolHandler(toolConfig, config.Name)
 			mcpServer.AddTool(buildMCPTool(toolConfig, config.Name), toolHandler)
 		}
 		m.AddMCPServer(config.Name, mcpServer)
@@ -276,7 +281,7 @@ func (m *MCPProxy) UpdateMCPServerFromOpenApiSpec(
 	}
 	// update tool
 	for _, toolConfig := range mcpServerConfig.Tools {
-		toolHandler := genToolHandler(toolConfig)
+		toolHandler := genToolHandler(toolConfig, name)
 		mcpServer.AddTool(buildMCPTool(toolConfig, name), toolHandler)
 	}
 	// 更新资源版本号
@@ -612,9 +617,11 @@ func setHandlerRequestParams(
 	return nil
 }
 
-func genToolHandler(toolApiConfig *ToolConfig) ToolHandler {
+func genToolHandler(toolApiConfig *ToolConfig, serverName string) ToolHandler {
 	// 生成handler
-	handler := func(ctx context.Context, req *mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	handler := func(ctx context.Context, req *mcp.CallToolRequest) (result *mcp.CallToolResult, err error) {
+		start := time.Now()
+
 		// Start a trace span for the actual upstream tool invocation (only when MCP tracing is enabled).
 		// NOTE: This is intentionally separate from TracingMiddleware's "mcp.tools/call" span:
 		//   - TracingMiddleware spans cover the MCP protocol layer (request/response lifecycle).
@@ -634,6 +641,28 @@ func genToolHandler(toolApiConfig *ToolConfig) ToolHandler {
 			)
 		}
 
+		// MCP protocol-level logging and metrics
+		// NOTE: tools/call handler is invoked inside callTool(), which does not go through
+		// the MCP middleware chain. Therefore, we need to manually log and record metrics here.
+		defer func() {
+			if r := recover(); r != nil {
+				// Log panic and convert to error
+				logging.GetAPILogger().Error("panic in tool handler",
+					zap.String("mcp_method", "tools/call"),
+					zap.String("tool_name", toolApiConfig.Name),
+					zap.Any("panic", r),
+					zap.String("server_name", serverName),
+				)
+				if err == nil {
+					err = fmt.Errorf("panic: %v", r)
+				}
+			}
+			// Record MCP protocol-level metrics
+			recordToolCallMetrics(ctx, serverName, toolApiConfig.Name, req, result, err, start)
+			// Log MCP protocol-level request/response
+			logToolCall(ctx, serverName, toolApiConfig.Name, req, result, err, start)
+		}()
+
 		auditLog := logging.GetAuditLoggerWithContext(ctx)
 		requestID := util.GetRequestIDFromContext(ctx)
 		xRequestID := util.GetXRequestIDFromContext(ctx)
@@ -641,8 +670,25 @@ func genToolHandler(toolApiConfig *ToolConfig) ToolHandler {
 		username := util.GetUsernameFromContext(ctx)
 		clientIP := util.GetClientIPFromContext(ctx)
 
-		// 在所有日志中添加 app_code, username 和 client_ip
+		// Extract request_id and x_request_id from request header if not found in context
+		// This is needed because the context passed by MCP SDK does not contain HTTP request info
+		if req != nil {
+			if extra := req.GetExtra(); extra != nil && extra.Header != nil {
+				if requestID == "" {
+					requestID = extra.Header.Get(constant.BkGatewayRequestIDKey)
+				}
+				if xRequestID == "" {
+					xRequestID = extra.Header.Get(constant.RequestIDHeaderKey)
+				}
+			}
+		}
+
+		// 在所有日志中添加 request_id, x_request_id, app_code, username 和 client_ip
 		auditLog = auditLog.With(
+			zap.String("request_id", requestID),
+			zap.String("x_request_id", xRequestID),
+			zap.String("mcp_method", "tools/call"),
+			zap.String("tool_name", toolApiConfig.Name),
 			zap.String("tool", toolApiConfig.String()),
 			zap.String("app_code", appCode),
 			zap.String("bk_username", username),
@@ -655,8 +701,42 @@ func genToolHandler(toolApiConfig *ToolConfig) ToolHandler {
 			return nil, trace.WrapErrorWithTraceID(ctx, fmt.Errorf("sign inner jwt failed: %w", err))
 		}
 		logTruncate := config.G.McpServer.LogTruncate
-		auditLog.Info("call tool", zap.String("request",
-			util.TruncateJSON(req.Params.Arguments, logTruncate.GetAuditLogMaxBodySize())))
+		requestBody := util.TruncateJSON(req.Params.Arguments, logTruncate.GetAuditLogMaxBodySize())
+
+		// 用于在 defer 中记录完整的调用信息（包含 response, latency 等）
+		var (
+			auditResponse      string
+			auditResponseSize  int64
+			auditLatency       time.Duration
+			auditStatus        = "success"
+			auditUpstreamReqID string
+			auditHeaderInfo    map[string]string
+			auditQueryParam    map[string]interface{}
+			auditPathParam     map[string]interface{}
+			auditBodyParam     interface{}
+		)
+
+		// 在函数返回时记录完整的 audit log，包含 response, latency 等字段
+		defer func() {
+			if r := recover(); r != nil {
+				auditStatus = "failed"
+			}
+			// 记录完整的调用信息（合并了之前的 "call tool" 和 "call tool request params" 日志）
+			auditLog.Info("call tool complete",
+				zap.String("request", requestBody),
+				zap.String("params", requestBody),
+				zap.String("response", auditResponse),
+				zap.Int64("request_body_size", int64(len(requestBody))),
+				zap.Int64("response_body_size", auditResponseSize),
+				zap.String("latency", auditLatency.String()),
+				zap.String("status", auditStatus),
+				zap.String("upstream_request_id", auditUpstreamReqID),
+				zap.Any("header", util.MaskSensitiveHeaders(auditHeaderInfo)),
+				zap.Any("query", auditQueryParam),
+				zap.Any("path", auditPathParam),
+				zap.String("body", util.TruncateJSON(auditBodyParam, logTruncate.GetAuditLogMaxBodySize())),
+			)
+		}()
 		var handlerRequest HandlerRequest
 		argsBytes, err := json.Marshal(req.Params.Arguments)
 		if err != nil {
@@ -761,6 +841,7 @@ func genToolHandler(toolApiConfig *ToolConfig) ToolHandler {
 						response.Code(),
 						response.GetHeader(constant.BkGatewayRequestIDKey),
 						trace.GetTraceIDFromContext(ctx),
+						xRequestID,
 						res,
 					)
 					if response.Code() < 200 || response.Code() > 299 {
@@ -770,17 +851,29 @@ func genToolHandler(toolApiConfig *ToolConfig) ToolHandler {
 				},
 			),
 		}
-		auditLog.Info("call tool request params",
-			zap.Any("header", util.MaskSensitiveHeaders(headerInfo)),
-			zap.Any("query", handlerRequest.QueryParam),
-			zap.Any("path", handlerRequest.PathParam),
-			zap.String("body", util.TruncateJSON(handlerRequest.BodyParam, logTruncate.GetAuditLogMaxBodySize())),
-		)
+		// 保存请求参数，供 defer 中的 "call tool complete" 使用
+		auditHeaderInfo = headerInfo
+		auditQueryParam = handlerRequest.QueryParam
+		auditPathParam = handlerRequest.PathParam
+		auditBodyParam = handlerRequest.BodyParam
+
 		openAPIClient := cli.New(toolApiConfig.Host, toolApiConfig.BasePath, []string{toolApiConfig.Schema})
 		submit, err := openAPIClient.Submit(operation)
 		if err != nil {
 			msg := fmt.Sprintf("call %s error:%s", toolApiConfig, err.Error())
-			auditLog.Error("call tool err", zap.Any("header", util.MaskSensitiveHeaders(headerInfo)), zap.Error(err))
+			duration := time.Since(start)
+			// 设置 audit log 变量，供 defer 中的 "call tool complete" 使用
+			auditResponse = msg
+			auditResponseSize = 0
+			auditLatency = duration
+			auditStatus = "failed"
+			auditLog.Error("call tool err",
+				zap.Any("header", util.MaskSensitiveHeaders(headerInfo)),
+				zap.Error(err),
+				zap.String("latency", duration.String()),
+				zap.String("status", "failed"),
+				zap.Int64("response_body_size", 0),
+			)
 			if span != nil {
 				span.SetStatus(codes.Error, msg)
 				span.RecordError(err)
@@ -807,10 +900,283 @@ func genToolHandler(toolApiConfig *ToolConfig) ToolHandler {
 			// nolint:nilerr
 			return result, nil
 		}
-		auditLog.Info("call tool success", zap.String("tool", toolApiConfig.String()),
-			zap.String("response", util.TruncateJSON(submit, logTruncate.GetAuditLogMaxResponseSize())),
-			zap.Any("header", util.MaskSensitiveHeaders(headerInfo)))
+		duration := time.Since(start)
+		responseBody := util.TruncateJSON(submit, logTruncate.GetAuditLogMaxResponseSize())
+		// 设置 audit log 变量，供 defer 中的 "call tool complete" 使用
+		auditResponse = responseBody
+		auditResponseSize = int64(len(responseBody))
+		auditLatency = duration
+		auditStatus = "success"
+		auditUpstreamReqID = extractUpstreamRequestID(buildToolResult(submit))
+		// 注意：完整的调用结果会在 defer 中的 "call tool complete" 日志中记录
 		return buildToolResult(submit), nil
 	}
 	return handler
+}
+
+// recordToolCallMetrics records MCP protocol-level metrics for tools/call.
+// This is needed because tools/call handler is invoked inside callTool(),
+// which does not go through the MCP middleware chain.
+func recordToolCallMetrics(
+	ctx context.Context,
+	serverName, toolName string,
+	req *mcp.CallToolRequest,
+	result *mcp.CallToolResult,
+	err error,
+	start time.Time,
+) {
+	if metric.MCPToolCallTotal == nil {
+		return
+	}
+
+	duration := time.Since(start)
+	hasError := err != nil
+	gatewayName := util.GetGatewayNameFromContext(ctx)
+	appCode := util.GetAppCodeFromContext(ctx)
+
+	// Error code
+	errorLabel := "0"
+	errorCode := "0"
+	if hasError {
+		errorLabel = "1"
+		errorCode = "unknown"
+		// Try to extract jsonrpc error code if available
+		// Note: Tool handlers typically don't return jsonrpc errors directly,
+		// but we check just in case
+	}
+
+	// Record metrics
+	metric.MCPToolCallTotal.WithLabelValues(gatewayName, serverName, toolName, appCode, errorCode, errorLabel).Inc()
+	metric.MCPRequestDuration.WithLabelValues(gatewayName, serverName, "tools/call", appCode).
+		Observe(duration.Seconds() * 1000)
+
+	if hasError {
+		metric.MCPErrorTotal.WithLabelValues(gatewayName, serverName, "tools/call", appCode, errorCode).Inc()
+	}
+
+	// Record request/response body size metrics
+	if metric.MCPRequestBodySize != nil && metric.MCPResponseBodySize != nil {
+		var requestBodySize, responseBodySize int64
+
+		// Calculate request body size from CallToolRequest
+		if req != nil && req.Params != nil && req.Params.Arguments != nil {
+			if paramsBytes, marshalErr := json.Marshal(req.Params.Arguments); marshalErr == nil {
+				requestBodySize = int64(len(paramsBytes))
+			}
+		}
+
+		// Calculate response body size from CallToolResult
+		if result != nil {
+			if resultBytes, marshalErr := json.Marshal(result); marshalErr == nil {
+				responseBodySize = int64(len(resultBytes))
+			}
+		}
+
+		metric.MCPRequestBodySize.WithLabelValues(gatewayName, serverName, "tools/call").
+			Observe(float64(requestBodySize))
+		metric.MCPResponseBodySize.WithLabelValues(gatewayName, serverName, "tools/call").
+			Observe(float64(responseBodySize))
+	}
+}
+
+// logToolCall logs MCP protocol-level request/response for tools/call.
+// This is needed because tools/call handler is invoked inside callTool(),
+// which does not go through the MCP middleware chain.
+func logToolCall(
+	ctx context.Context,
+	serverName string,
+	toolName string,
+	req *mcp.CallToolRequest,
+	result *mcp.CallToolResult,
+	err error,
+	start time.Time,
+) {
+	logger := logging.GetAPILogger()
+	duration := time.Since(start)
+	hasError := err != nil
+
+	// Resolve truncation limits from config
+	logTruncate := config.G.McpServer.LogTruncate
+
+	// Serialize request params
+	var params string
+	var requestBodySize int64
+	if req != nil && req.Params != nil && req.Params.Arguments != nil {
+		if paramsBytes, marshalErr := json.Marshal(req.Params.Arguments); marshalErr == nil {
+			requestBodySize = int64(len(paramsBytes))
+			params = stringx.Truncate(string(paramsBytes), logTruncate.GetAPILogRequestSize())
+		}
+	}
+
+	// Serialize response result
+	var response string
+	var responseBodySize int64
+	var upstreamRequestID string
+	if result != nil {
+		if resultBytes, marshalErr := json.Marshal(result); marshalErr == nil {
+			responseBodySize = int64(len(resultBytes))
+			if hasError {
+				response = stringx.Truncate(string(resultBytes), logTruncate.GetAPILogErrorResponseSize())
+			} else {
+				response = stringx.Truncate(string(resultBytes), logTruncate.GetAPILogResponseSize())
+			}
+			// Extract upstream request_id from result for traceability
+			upstreamRequestID = extractUpstreamRequestID(result)
+		}
+	}
+
+	// Retrieve extra info from context
+	gatewayID := util.GetGatewayIDFromContext(ctx)
+	gatewayName := util.GetGatewayNameFromContext(ctx)
+	mcpServerID := util.GetMCPServerIDFromContext(ctx)
+	requestID := util.GetRequestIDFromContext(ctx)
+	xRequestID := util.GetXRequestIDFromContext(ctx)
+	appCode := util.GetAppCodeFromContext(ctx)
+	username := util.GetUsernameFromContext(ctx)
+	clientIP := util.GetClientIPFromContext(ctx)
+	clientID := util.GetClientIDFromContext(ctx)
+
+	// Extract X-Request-ID from request header if not found in context
+	if xRequestID == "" && req != nil {
+		if extra := req.GetExtra(); extra != nil && extra.Header != nil {
+			xRequestID = extra.Header.Get(constant.RequestIDHeaderKey)
+		}
+	}
+
+	// Extract X-Bkapi-Request-ID from request header if not found in context
+	// This is the request_id for the MCP request
+	if requestID == "" && req != nil {
+		if extra := req.GetExtra(); extra != nil && extra.Header != nil {
+			requestID = extra.Header.Get(constant.BkGatewayRequestIDKey)
+		}
+	}
+
+	// Try to get gateway_name from cache if not found in context
+	if gatewayName == "" && gatewayID > 0 {
+		if gateway, err := cacheimpls.GetGatewayByID(ctx, gatewayID); err == nil && gateway != nil {
+			gatewayName = gateway.Name
+		}
+	}
+
+	// Get session ID and client_id from session's InitializeParams
+	var sessionID string
+	if req != nil {
+		if ss, ok := req.GetSession().(*mcp.ServerSession); ok && ss != nil {
+			sessionID = ss.ID()
+			// Enrich client_id with clientInfo from initialize handshake
+			if initParams := ss.InitializeParams(); initParams != nil && initParams.ClientInfo != nil {
+				clientID = initParams.ClientInfo.Name
+			}
+		}
+	}
+
+	// trace_id from HTTP layer
+	traceID := trace.GetTraceIDFromContext(ctx)
+
+	// Status: success or failed
+	status := "success"
+	if hasError {
+		status = "failed"
+	}
+
+	fields := []zap.Field{
+		// Trace identifiers
+		zap.String("request_id", requestID),
+		zap.String("x_request_id", xRequestID),
+		zap.String("session_id", sessionID),
+		// Gateway info
+		zap.Int("gateway_id", gatewayID),
+		zap.String("gateway_name", gatewayName),
+		// MCP request info
+		zap.String("mcp_server_name", serverName),
+		zap.Int("mcp_server_id", mcpServerID),
+		zap.String("mcp_method", "tools/call"),
+		// Caller info
+		zap.String("app_code", appCode),
+		zap.String("bk_username", username),
+		zap.String("client_ip", clientIP),
+		zap.String("client_id", clientID),
+		// Tool specific fields
+		zap.String("tool_name", toolName),
+		zap.String("prompt_name", ""),
+		// Request/Response content
+		zap.String("params", params),
+		zap.String("response", response),
+		// Body sizes
+		zap.Int64("request_body_size", requestBodySize),
+		zap.Int64("response_body_size", responseBodySize),
+		// Performance
+		zap.String("latency", duration.String()),
+		// Status
+		zap.String("status", status),
+	}
+
+	// Only append upstream_request_id if non-empty (for traceability)
+	if upstreamRequestID != "" {
+		fields = append(fields, zap.String("upstream_request_id", upstreamRequestID))
+	}
+
+	// Only append trace_id if non-empty
+	if traceID != "" {
+		fields = append(fields, zap.String("trace_id", traceID))
+	}
+
+	if hasError {
+		fields = append(fields, zap.Error(err))
+	}
+
+	logger.Info("-", fields...)
+}
+
+// extractUpstreamRequestID extracts the upstream API request_id from tool call result.
+// This is the request_id returned by the upstream API (e.g., bk-apigateway),
+// which may differ from the MCP Proxy's own request_id.
+func extractUpstreamRequestID(result *mcp.CallToolResult) string {
+	if result == nil || len(result.Content) == 0 {
+		logging.GetLogger().Debug("extractUpstreamRequestID: result is nil or content is empty")
+		return ""
+	}
+
+	logging.GetLogger().Debug("extractUpstreamRequestID: content count", zap.Int("count", len(result.Content)))
+
+	// Try to get text content from result
+	var textContent string
+	for i, content := range result.Content {
+		if text, ok := content.(*mcp.TextContent); ok && text != nil {
+			textContent = text.Text
+			logging.GetLogger().Debug("extractUpstreamRequestID: found TextContent", zap.Int("index", i), zap.Int("text_length", len(textContent)))
+			break
+		} else {
+			logging.GetLogger().Debug("extractUpstreamRequestID: content type mismatch", zap.Int("index", i), zap.String("type", fmt.Sprintf("%T", content)))
+		}
+	}
+	if textContent == "" {
+		logging.GetLogger().Debug("extractUpstreamRequestID: textContent is empty")
+		return ""
+	}
+
+	// Parse JSON to extract request_id
+	var envelope map[string]any
+	if err := json.Unmarshal([]byte(textContent), &envelope); err != nil {
+		logging.GetLogger().Debug("extractUpstreamRequestID: failed to unmarshal textContent", zap.Error(err), zap.String("text_content_preview", textContent[:min(len(textContent), 200)]))
+		return ""
+	}
+
+	logging.GetLogger().Debug("extractUpstreamRequestID: envelope keys", zap.Any("keys", getMapKeys(envelope)))
+
+	if requestID, ok := envelope[toolResponseRequestIDField].(string); ok {
+		logging.GetLogger().Debug("extractUpstreamRequestID: found request_id", zap.String("request_id", requestID))
+		return requestID
+	}
+	logging.GetLogger().Debug("extractUpstreamRequestID: request_id not found or not a string")
+	return ""
+}
+
+// getMapKeys returns all keys in a map
+func getMapKeys(m map[string]any) []string {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	return keys
 }

--- a/src/mcp-proxy/pkg/infra/proxy/proxy_test.go
+++ b/src/mcp-proxy/pkg/infra/proxy/proxy_test.go
@@ -443,12 +443,13 @@ var _ = Describe("MCPProxy", func() {
 
 	Describe("buildToolResponseEnvelope", func() {
 		It("should include response_body as nil when body is nil", func() {
-			envelope := buildToolResponseEnvelope(204, "req-1", "trace-1", nil)
+			envelope := buildToolResponseEnvelope(204, "req-1", "trace-1", "x-req-1", nil)
 
 			Expect(envelope).To(Equal(map[string]any{
 				toolResponseStatusCodeField: 204,
 				toolResponseRequestIDField:  "req-1",
 				toolResponseTraceIDField:    "trace-1",
+				toolResponseXRequestIDField: "x-req-1",
 				toolResponseBodyField:       nil,
 			}))
 		})
@@ -456,7 +457,7 @@ var _ = Describe("MCPProxy", func() {
 
 	Describe("buildToolResult", func() {
 		It("should populate text content for envelope with object body", func() {
-			envelope := buildToolResponseEnvelope(200, "req-1", "trace-1", map[string]any{
+			envelope := buildToolResponseEnvelope(200, "req-1", "trace-1", "x-req-1", map[string]any{
 				"timezone": "Asia/Shanghai",
 				"datetime": "2026-03-19T15:04:05+08:00",
 			})
@@ -468,11 +469,11 @@ var _ = Describe("MCPProxy", func() {
 			Expect(result.Content[0]).To(BeAssignableToTypeOf(&mcp.TextContent{}))
 			Expect(
 				result.Content[0].(*mcp.TextContent).Text,
-			).To(MatchJSON(`{"status_code":200,"request_id":"req-1","trace_id":"trace-1","response_body":{"datetime":"2026-03-19T15:04:05+08:00","timezone":"Asia/Shanghai"}}`))
+			).To(MatchJSON(`{"status_code":200,"request_id":"req-1","trace_id":"trace-1","x_request_id":"x-req-1","response_body":{"datetime":"2026-03-19T15:04:05+08:00","timezone":"Asia/Shanghai"}}`))
 		})
 
 		It("should populate text content for envelope with array body", func() {
-			envelope := buildToolResponseEnvelope(200, "req-1", "trace-1", []any{"a", "b"})
+			envelope := buildToolResponseEnvelope(200, "req-1", "trace-1", "x-req-1", []any{"a", "b"})
 			result := buildToolResult(envelope)
 
 			Expect(result).NotTo(BeNil())
@@ -481,7 +482,7 @@ var _ = Describe("MCPProxy", func() {
 			Expect(result.Content[0]).To(BeAssignableToTypeOf(&mcp.TextContent{}))
 			Expect(
 				result.Content[0].(*mcp.TextContent).Text,
-			).To(MatchJSON(`{"status_code":200,"request_id":"req-1","trace_id":"trace-1","response_body":["a","b"]}`))
+			).To(MatchJSON(`{"status_code":200,"request_id":"req-1","trace_id":"trace-1","x_request_id":"x-req-1","response_body":["a","b"]}`))
 		})
 	})
 

--- a/src/mcp-proxy/pkg/mcp/mcp_suite_test.go
+++ b/src/mcp-proxy/pkg/mcp/mcp_suite_test.go
@@ -26,6 +26,7 @@ import (
 
 	"mcp_proxy/pkg/config"
 	"mcp_proxy/pkg/infra/logging"
+	"mcp_proxy/pkg/metric"
 )
 
 var _ = BeforeSuite(func() {
@@ -33,6 +34,8 @@ var _ = BeforeSuite(func() {
 	config.G = &config.Config{}
 	// Initialize logger for tests
 	logging.InitLogger(config.G)
+	// Initialize metrics so that metric.MCPRequestTotal etc. are not nil
+	metric.InitMetrics("")
 })
 
 func TestMcp(t *testing.T) {

--- a/src/mcp-proxy/pkg/mcp/middleware.go
+++ b/src/mcp-proxy/pkg/mcp/middleware.go
@@ -231,6 +231,9 @@ func logMCPRequest(
 		zap.String("mcp_server_name", serverName),
 		zap.Int("mcp_server_id", mcpServerID),
 		zap.String("mcp_method", method),
+		// HTTP 请求信息：MCP 协议层不需要展示 HTTP path/method，置空保持字段一致
+		zap.String("method", ""),
+		zap.String("path", ""),
 		// 调用方信息
 		zap.String("app_code", appCode),
 		zap.String("bk_username", username),

--- a/src/mcp-proxy/pkg/mcp/middleware.go
+++ b/src/mcp-proxy/pkg/mcp/middleware.go
@@ -286,17 +286,12 @@ func AddLoggingMiddleware(server *mcp.Server, serverName string) {
 
 // MetricMiddleware returns a middleware that records MCP protocol-level Prometheus metrics.
 // It tracks request counts, durations, tool calls, and error codes.
-// Note: tools/call is skipped here because metrics are recorded separately in the tool handler
-// (see genToolHandler in proxy.go), to avoid duplicate metrics and capture tool-specific breakdown.
+// Note: tools/call is only partially skipped here - if the tool does not exist,
+// we still need to record metrics since the tool handler won't be invoked.
+// For successful tool calls, metrics are recorded in the tool handler (see genToolHandler in proxy.go).
 func MetricMiddleware(serverName string) mcp.Middleware {
 	return func(next mcp.MethodHandler) mcp.MethodHandler {
 		return func(ctx context.Context, method string, req mcp.Request) (result mcp.Result, err error) {
-			// Skip metrics for tools/call - they are recorded separately in the tool handler
-			// to avoid duplicate metrics and to capture tool-specific breakdown
-			if method == "tools/call" {
-				return next(ctx, method, req)
-			}
-
 			start := time.Now()
 
 			// Ensure metrics are recorded even if handler panics
@@ -307,6 +302,13 @@ func MetricMiddleware(serverName string) mcp.Middleware {
 						err = fmt.Errorf("panic: %v", r)
 					}
 				}
+
+				// For tools/call: only record metrics if there's an error (tool not found, etc.)
+				// Successful tool calls are recorded in the tool handler to capture tool-specific breakdown
+				if method == "tools/call" && err == nil {
+					return
+				}
+
 				// Record metrics after handler completes (including panic case)
 				recordMCPMetrics(ctx, serverName, method, req, result, err, start)
 			}()

--- a/src/mcp-proxy/pkg/mcp/middleware.go
+++ b/src/mcp-proxy/pkg/mcp/middleware.go
@@ -34,7 +34,9 @@ import (
 	"go.opentelemetry.io/otel/codes"
 	"go.uber.org/zap"
 
+	"mcp_proxy/pkg/cacheimpls"
 	"mcp_proxy/pkg/config"
+	"mcp_proxy/pkg/constant"
 	"mcp_proxy/pkg/infra/logging"
 	"mcp_proxy/pkg/infra/sentry"
 	"mcp_proxy/pkg/infra/trace"
@@ -61,150 +63,219 @@ func matchErrorCodeName(code int64) string {
 }
 
 // LoggingMiddleware returns a middleware that logs all MCP method calls with timing information.
+// Note: tools/call is skipped here because it is logged separately in the tool handler
+// (see genToolHandler in proxy.go), which has access to more detailed tool-specific information.
 func LoggingMiddleware(serverName string) mcp.Middleware {
 	logger := logging.GetAPILogger()
 
 	return func(next mcp.MethodHandler) mcp.MethodHandler {
-		return func(ctx context.Context, method string, req mcp.Request) (mcp.Result, error) {
+		return func(ctx context.Context, method string, req mcp.Request) (result mcp.Result, err error) {
+			// Skip logging for tools/call - it is logged separately in the tool handler
+			// to avoid duplicate logs and to capture more detailed tool-specific information
+			if method == "tools/call" {
+				return next(ctx, method, req)
+			}
+
 			start := time.Now()
 
-			// Call the next handler
-			result, err := next(ctx, method, req)
-
-			duration := time.Since(start)
-
-			hasError := err != nil
-
-			// Resolve truncation limits from config
-			logTruncate := config.G.McpServer.LogTruncate
-
-			// Serialize request params and calculate body sizes
-			var params string
-			var requestBodySize int64
-			if req != nil {
-				if paramsBytes, marshalErr := json.Marshal(req.GetParams()); marshalErr == nil {
-					requestBodySize = int64(len(paramsBytes))
-					params = stringx.Truncate(string(paramsBytes), logTruncate.GetAPILogRequestSize())
-				}
-			}
-
-			// Serialize response result with truncation
-			// 正常响应截断到 APILogResponseSize，错误响应截断到 APILogErrorResponseSize（保留更多诊断信息）
-			var response string
-			var responseBodySize int64
-			if result != nil {
-				if resultBytes, marshalErr := json.Marshal(result); marshalErr == nil {
-					responseBodySize = int64(len(resultBytes))
-					if hasError {
-						response = stringx.Truncate(string(resultBytes), logTruncate.GetAPILogErrorResponseSize())
-					} else {
-						response = stringx.Truncate(string(resultBytes), logTruncate.GetAPILogResponseSize())
-					}
-				}
-			}
-
-			// Retrieve extra info from context
-			gatewayID := util.GetGatewayIDFromContext(ctx)
-			gatewayName := util.GetGatewayNameFromContext(ctx)
-			mcpServerID := util.GetMCPServerIDFromContext(ctx)
-			requestID := util.GetRequestIDFromContext(ctx)
-			xRequestID := util.GetXRequestIDFromContext(ctx)
-			appCode := util.GetAppCodeFromContext(ctx)
-			username := util.GetUsernameFromContext(ctx)
-			clientIP := util.GetClientIPFromContext(ctx)
-			clientID := util.GetClientIDFromContext(ctx)
-
-			// Get session ID and client_id from session's InitializeParams
-			var sessionID string
-			if req != nil {
-				if ss, ok := req.GetSession().(*mcp.ServerSession); ok && ss != nil {
-					sessionID = ss.ID()
-					// Enrich client_id with clientInfo from initialize handshake
-					if initParams := ss.InitializeParams(); initParams != nil && initParams.ClientInfo != nil {
-						clientID = initParams.ClientInfo.Name
-					}
-				}
-			}
-
-			// Extract tool_name for tools/call
-			var toolName string
-			if method == "tools/call" {
-				toolName = extractToolName(req)
-			}
-
-			// trace_id 来自 HTTP 层（otelgin middleware）注入的 span，与 TracingMiddleware 属于同一条 trace
-			traceID := trace.GetTraceIDFromContext(ctx)
-
-			fields := []zap.Field{
-				// 链路标识
-				zap.String("request_id", requestID),
-				zap.String("x_request_id", xRequestID),
-				zap.String("session_id", sessionID),
-				// 网关信息
-				zap.Int("gateway_id", gatewayID),
-				zap.String("gateway_name", gatewayName),
-				// MCP 请求信息
-				zap.String("mcp_server_name", serverName),
-				zap.Int("mcp_server_id", mcpServerID),
-				zap.String("mcp_method", method),
-				// 调用方信息
-				zap.String("app_code", appCode),
-				zap.String("bk_username", username),
-				zap.String("client_ip", clientIP),
-				zap.String("client_id", clientID),
-				// Tool 特有字段
-				zap.String("tool_name", toolName),
-				// 请求/响应内容
-				zap.String("params", params),
-				zap.String("response", response),
-				// 体积信息
-				zap.Int64("request_body_size", requestBodySize),
-				zap.Int64("response_body_size", responseBodySize),
-				// 性能
-				zap.String("latency", duration.String()),
-			}
-
-			// 仅在 trace_id 非空时附加，避免日志中出现空 trace_id 字段
-			if traceID != "" {
-				fields = append(fields, zap.String("trace_id", traceID))
-			}
-
-			if hasError {
-				fields = append(fields, zap.Error(err))
-				// Only report server-side errors to Sentry, skip client errors
-				// (parse_error, invalid_request, method_not_found, invalid_params)
-				if shouldReportToSentry(err) {
-					sentry.ReportToSentry(
-						fmt.Sprintf("MCP %s %s", serverName, method),
-						map[string]string{
-							"mcp_server_name": serverName,
-							"mcp_method":      method,
-							"gateway_name":    gatewayName,
-							"app_code":        appCode,
-						},
-						map[string]interface{}{
-							"request_id":    requestID,
-							"x_request_id":  xRequestID,
-							"session_id":    sessionID,
-							"gateway_id":    gatewayID,
-							"mcp_server_id": mcpServerID,
-							"client_ip":     clientIP,
-							"client_id":     clientID,
-							"bk_username":   username,
-							"tool_name":     toolName,
-							"params":        params,
-							"response":      response,
-							"latency":       duration.String(),
-							"error":         err.Error(),
-						},
+			// Ensure logging happens even if the handler panics
+			defer func() {
+				if r := recover(); r != nil {
+					// Log the panic
+					logger.Error("panic in MCP handler",
+						zap.String("mcp_method", method),
+						zap.Any("panic", r),
+						zap.String("server_name", serverName),
 					)
+					// Convert panic to error result
+					panicErr := fmt.Errorf("panic: %v", r)
+					if err == nil {
+						err = panicErr
+					}
 				}
-			}
+				// Log the request after handler completes (including panic case)
+				logMCPRequest(ctx, logger, serverName, method, req, result, err, start)
+			}()
 
-			logger.Info("-", fields...)
-
+			// Call the next handler
+			result, err = next(ctx, method, req)
 			return result, err
 		}
+	}
+}
+
+// logMCPRequest logs the MCP request details
+func logMCPRequest(
+	ctx context.Context,
+	logger *zap.Logger,
+	serverName string,
+	method string,
+	req mcp.Request,
+	result mcp.Result,
+	err error,
+	start time.Time,
+) {
+	duration := time.Since(start)
+
+	hasError := err != nil
+
+	// Resolve truncation limits from config
+	logTruncate := config.G.McpServer.LogTruncate
+
+	// Serialize request params and calculate body sizes
+	var params string
+	var requestBodySize int64
+	if req != nil {
+		if paramsBytes, marshalErr := json.Marshal(req.GetParams()); marshalErr == nil {
+			requestBodySize = int64(len(paramsBytes))
+			params = stringx.Truncate(string(paramsBytes), logTruncate.GetAPILogRequestSize())
+		}
+	}
+
+	// Serialize response result with truncation
+	// 正常响应截断到 APILogResponseSize，错误响应截断到 APILogErrorResponseSize（保留更多诊断信息）
+	var response string
+	var responseBodySize int64
+	if result != nil {
+		if resultBytes, marshalErr := json.Marshal(result); marshalErr == nil {
+			responseBodySize = int64(len(resultBytes))
+			if hasError {
+				response = stringx.Truncate(string(resultBytes), logTruncate.GetAPILogErrorResponseSize())
+			} else {
+				response = stringx.Truncate(string(resultBytes), logTruncate.GetAPILogResponseSize())
+			}
+		}
+	}
+
+	// Retrieve extra info from context
+	gatewayID := util.GetGatewayIDFromContext(ctx)
+	gatewayName := util.GetGatewayNameFromContext(ctx)
+	mcpServerID := util.GetMCPServerIDFromContext(ctx)
+	requestID := util.GetRequestIDFromContext(ctx)
+	xRequestID := util.GetXRequestIDFromContext(ctx)
+	appCode := util.GetAppCodeFromContext(ctx)
+	username := util.GetUsernameFromContext(ctx)
+	clientIP := util.GetClientIPFromContext(ctx)
+	clientID := util.GetClientIDFromContext(ctx)
+
+	// Extract X-Request-ID from request header if not found in context
+	// This is needed because MCP SDK uses long-lived sessions, and the HTTP request
+	// context is not propagated to subsequent requests after session initialization.
+	if xRequestID == "" && req != nil {
+		if extra := req.GetExtra(); extra != nil && extra.Header != nil {
+			xRequestID = extra.Header.Get(constant.RequestIDHeaderKey)
+		}
+	}
+
+	// Try to get gateway_name from cache if not found in context
+	if gatewayName == "" && gatewayID > 0 {
+		if gateway, err := cacheimpls.GetGatewayByID(ctx, gatewayID); err == nil && gateway != nil {
+			gatewayName = gateway.Name
+		}
+	}
+
+	// Get session ID and client_id from session's InitializeParams
+	var sessionID string
+	if req != nil {
+		if ss, ok := req.GetSession().(*mcp.ServerSession); ok && ss != nil {
+			sessionID = ss.ID()
+			// Enrich client_id with clientInfo from initialize handshake
+			if initParams := ss.InitializeParams(); initParams != nil && initParams.ClientInfo != nil {
+				clientID = initParams.ClientInfo.Name
+			}
+		}
+	}
+
+	// Extract tool_name for tools/call
+	var toolName string
+	if method == "tools/call" {
+		toolName = extractToolName(req)
+	}
+
+	// Extract prompt_name for prompts/get
+	var promptName string
+	if method == "prompts/get" {
+		promptName = extractPromptName(req)
+	}
+
+	// trace_id 来自 HTTP 层（otelgin middleware）注入的 span，与 TracingMiddleware 属于同一条 trace
+	traceID := trace.GetTraceIDFromContext(ctx)
+
+	// 状态：success 或 failed
+	status := "success"
+	if hasError {
+		status = "failed"
+	}
+
+	fields := []zap.Field{
+		// 链路标识
+		zap.String("request_id", requestID),
+		zap.String("x_request_id", xRequestID),
+		zap.String("session_id", sessionID),
+		// 网关信息
+		zap.Int("gateway_id", gatewayID),
+		zap.String("gateway_name", gatewayName),
+		// MCP 请求信息
+		zap.String("mcp_server_name", serverName),
+		zap.Int("mcp_server_id", mcpServerID),
+		zap.String("mcp_method", method),
+		// 调用方信息
+		zap.String("app_code", appCode),
+		zap.String("bk_username", username),
+		zap.String("client_ip", clientIP),
+		zap.String("client_id", clientID),
+		// Tool/Prompt 特有字段
+		zap.String("tool_name", toolName),
+		zap.String("prompt_name", promptName),
+		// 请求/响应内容
+		zap.String("params", params),
+		zap.String("response", response),
+		// 体积信息
+		zap.Int64("request_body_size", requestBodySize),
+		zap.Int64("response_body_size", responseBodySize),
+		// 性能
+		zap.String("latency", duration.String()),
+		// 状态
+		zap.String("status", status),
+	}
+
+	// 仅在 trace_id 非空时附加，避免日志中出现空 trace_id 字段
+	if traceID != "" {
+		fields = append(fields, zap.String("trace_id", traceID))
+	}
+
+	if hasError {
+		fields = append(fields, zap.Error(err))
+		// Only report server-side errors to Sentry, skip client errors
+		// (parse_error, invalid_request, method_not_found, invalid_params)
+		if shouldReportToSentry(err) {
+			sentry.ReportToSentry(
+				fmt.Sprintf("MCP %s %s", serverName, method),
+				map[string]string{
+					"mcp_server_name": serverName,
+					"mcp_method":      method,
+					"gateway_name":    gatewayName,
+					"app_code":        appCode,
+				},
+				map[string]interface{}{
+					"request_id":    requestID,
+					"x_request_id":  xRequestID,
+					"session_id":    sessionID,
+					"gateway_id":    gatewayID,
+					"mcp_server_id": mcpServerID,
+					"client_ip":     clientIP,
+					"client_id":     clientID,
+					"bk_username":   username,
+					"tool_name":     toolName,
+					"params":        params,
+					"response":      response,
+					"latency":       duration.String(),
+					"error":         err.Error(),
+				},
+			)
+		}
+
+		logger.Info("-", fields...)
 	}
 }
 
@@ -215,54 +286,107 @@ func AddLoggingMiddleware(server *mcp.Server, serverName string) {
 
 // MetricMiddleware returns a middleware that records MCP protocol-level Prometheus metrics.
 // It tracks request counts, durations, tool calls, and error codes.
+// Note: tools/call is skipped here because metrics are recorded separately in the tool handler
+// (see genToolHandler in proxy.go), to avoid duplicate metrics and capture tool-specific breakdown.
 func MetricMiddleware(serverName string) mcp.Middleware {
 	return func(next mcp.MethodHandler) mcp.MethodHandler {
-		return func(ctx context.Context, method string, req mcp.Request) (mcp.Result, error) {
+		return func(ctx context.Context, method string, req mcp.Request) (result mcp.Result, err error) {
+			// Skip metrics for tools/call - they are recorded separately in the tool handler
+			// to avoid duplicate metrics and to capture tool-specific breakdown
+			if method == "tools/call" {
+				return next(ctx, method, req)
+			}
+
 			start := time.Now()
 
-			result, err := next(ctx, method, req)
-
-			duration := time.Since(start)
-			hasError := err != nil
-			gatewayName := util.GetGatewayNameFromContext(ctx)
-
-			// 1. MCPRequestTotal: method call count with error_code and error (0/1)
-			errorLabel := "0"
-			errorCode := "0"
-			if hasError {
-				errorLabel = "1"
-				errorCode = "unknown"
-				var jsonrpcErr *jsonrpc.Error
-				if errors.As(err, &jsonrpcErr) {
-					errorCode = matchErrorCodeName(jsonrpcErr.Code)
+			// Ensure metrics are recorded even if handler panics
+			defer func() {
+				if r := recover(); r != nil {
+					// Convert panic to error for metrics
+					if err == nil {
+						err = fmt.Errorf("panic: %v", r)
+					}
 				}
-			}
-			metric.MCPRequestTotal.WithLabelValues(gatewayName, serverName, method, errorCode, errorLabel).Inc()
+				// Record metrics after handler completes (including panic case)
+				recordMCPMetrics(ctx, serverName, method, req, result, err, start)
+			}()
 
-			// 2. MCPRequestDuration: method call latency (preserve sub-millisecond precision)
-			metric.MCPRequestDuration.WithLabelValues(gatewayName, serverName, method).Observe(
-				duration.Seconds() * 1000,
-			)
-
-			// 3. MCPToolCallTotal: per-tool breakdown for tools/call
-			if method == "tools/call" {
-				toolName := extractToolName(req)
-				metric.MCPToolCallTotal.WithLabelValues(gatewayName, serverName, toolName, errorCode, errorLabel).Inc()
-			}
-
-			// 4. MCPSessionTotal: increment on successful initialize
-			if method == "initialize" && !hasError {
-				metric.MCPSessionTotal.WithLabelValues(gatewayName, serverName).Inc()
-			}
-
-			// 5. MCPErrorTotal: error count by error code (reuse errorCode from step 1)
-			if hasError {
-				metric.MCPErrorTotal.WithLabelValues(gatewayName, serverName, method, errorCode).Inc()
-			}
-
+			result, err = next(ctx, method, req)
 			return result, err
 		}
 	}
+}
+
+// recordMCPMetrics records Prometheus metrics for MCP requests
+func recordMCPMetrics(
+	ctx context.Context,
+	serverName string,
+	method string,
+	req mcp.Request,
+	result mcp.Result,
+	err error,
+	start time.Time,
+) {
+	duration := time.Since(start)
+	hasError := err != nil
+	gatewayName := util.GetGatewayNameFromContext(ctx)
+	appCode := util.GetAppCodeFromContext(ctx)
+
+	// 1. MCPRequestTotal: method call count with error_code and error (0/1)
+	errorLabel := "0"
+	errorCode := "0"
+	if hasError {
+		errorLabel = "1"
+		errorCode = "unknown"
+		var jsonrpcErr *jsonrpc.Error
+		if errors.As(err, &jsonrpcErr) {
+			errorCode = matchErrorCodeName(jsonrpcErr.Code)
+		}
+	}
+	metric.MCPRequestTotal.WithLabelValues(gatewayName, serverName, method, appCode, errorCode, errorLabel).Inc()
+
+	// 2. MCPRequestDuration: method call latency (preserve sub-millisecond precision)
+	metric.MCPRequestDuration.WithLabelValues(gatewayName, serverName, method, appCode).Observe(
+		duration.Seconds() * 1000,
+	)
+
+	// 3. MCPSessionTotal: increment on successful initialize
+	if method == "initialize" && !hasError {
+		metric.MCPSessionTotal.WithLabelValues(gatewayName, serverName, appCode).Inc()
+	}
+
+	// 4. MCPErrorTotal: error count by error code (reuse errorCode from step 1)
+	if hasError {
+		metric.MCPErrorTotal.WithLabelValues(gatewayName, serverName, method, appCode, errorCode).Inc()
+	}
+
+	// 5. MCPRequestBodySize and MCPResponseBodySize: body size distribution
+	if metric.MCPRequestBodySize != nil && metric.MCPResponseBodySize != nil {
+		requestBodySize, responseBodySize := calcBodySize(req, result)
+		metric.MCPRequestBodySize.WithLabelValues(gatewayName, serverName, method).Observe(float64(requestBodySize))
+		metric.MCPResponseBodySize.WithLabelValues(gatewayName, serverName, method).Observe(float64(responseBodySize))
+	}
+}
+
+// calcBodySize calculates request and response body sizes from MCP request and result
+func calcBodySize(req mcp.Request, result mcp.Result) (int64, int64) {
+	var requestBodySize, responseBodySize int64
+
+	// Calculate request body size
+	if req != nil && req.GetParams() != nil {
+		if paramsBytes, err := json.Marshal(req.GetParams()); err == nil {
+			requestBodySize = int64(len(paramsBytes))
+		}
+	}
+
+	// Calculate response body size
+	if result != nil {
+		if resultBytes, err := json.Marshal(result); err == nil {
+			responseBodySize = int64(len(resultBytes))
+		}
+	}
+
+	return requestBodySize, responseBodySize
 }
 
 // AddMetricMiddleware adds metric middleware to the MCP server.
@@ -310,6 +434,21 @@ func extractToolName(req mcp.Request) string {
 	return ""
 }
 
+// extractPromptName extracts the prompt name from a prompts/get request.
+func extractPromptName(req mcp.Request) string {
+	if req == nil {
+		return ""
+	}
+	params := req.GetParams()
+	if params == nil {
+		return ""
+	}
+	if getParams, ok := params.(*mcp.GetPromptParams); ok {
+		return getParams.Name
+	}
+	return ""
+}
+
 // SessionMetricMiddleware returns a middleware that tracks active MCP sessions.
 // It decrements the session gauge when a session ends (notifications/cancelled).
 //
@@ -328,7 +467,8 @@ func SessionMetricMiddleware(serverName string) mcp.Middleware {
 			// Decrement session gauge on notifications/cancelled
 			if method == "notifications/cancelled" {
 				gatewayName := util.GetGatewayNameFromContext(ctx)
-				metric.MCPSessionTotal.WithLabelValues(gatewayName, serverName).Dec()
+				appCode := util.GetAppCodeFromContext(ctx)
+				metric.MCPSessionTotal.WithLabelValues(gatewayName, serverName, appCode).Dec()
 			}
 
 			return result, err

--- a/src/mcp-proxy/pkg/mcp/middleware.go
+++ b/src/mcp-proxy/pkg/mcp/middleware.go
@@ -70,10 +70,22 @@ func LoggingMiddleware(serverName string) mcp.Middleware {
 
 	return func(next mcp.MethodHandler) mcp.MethodHandler {
 		return func(ctx context.Context, method string, req mcp.Request) (result mcp.Result, err error) {
-			// Skip logging for tools/call - it is logged separately in the tool handler
-			// to avoid duplicate logs and to capture more detailed tool-specific information
+			// Skip logging for tools/call when successful - it is logged separately in the tool handler
+			// to avoid duplicate logs and to capture more detailed tool-specific information.
+			// However, if the call fails before reaching the tool handler (e.g., tool not found,
+			// framework validation error, routing error), we still need to log it for observability.
 			if method == "tools/call" {
-				return next(ctx, method, req)
+				result, err = next(ctx, method, req)
+				if err != nil {
+					start := time.Now()
+					logger.Error("tools/call failed before reaching tool handler",
+						zap.String("mcp_method", method),
+						zap.String("server_name", serverName),
+						zap.Error(err),
+					)
+					logMCPRequest(ctx, logger, serverName, method, req, result, err, start)
+				}
+				return result, err
 			}
 
 			start := time.Now()

--- a/src/mcp-proxy/pkg/mcp/middleware_test.go
+++ b/src/mcp-proxy/pkg/mcp/middleware_test.go
@@ -97,6 +97,23 @@ var _ = Describe("Middleware", func() {
 			Expect(result).NotTo(BeNil())
 		})
 
+		It("should recover from panic and return error", func() {
+			middleware := mcppkg.LoggingMiddleware(serverName)
+
+			panicHandler := middleware(
+				func(ctx context.Context, method string, req sdkmcp.Request) (sdkmcp.Result, error) {
+					panic("intentional test panic")
+				},
+			)
+
+			// The handler should not panic, but return an error instead
+			// Note: Using "tools/list" instead of "tools/call" because "tools/call" is skipped
+			result, err := panicHandler(ctx, "tools/list", nil)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("panic: intentional test panic"))
+			Expect(result).To(BeNil())
+		})
+
 		It("should enrich client_id from session's InitializeParams.ClientInfo", func() {
 			// Create an MCP server with a tool and our LoggingMiddleware
 			server := sdkmcp.NewServer(&sdkmcp.Implementation{Name: "test-server", Version: "1.0.0"}, nil)
@@ -156,7 +173,7 @@ var _ = Describe("Middleware", func() {
 		It("should record MCPRequestTotal on successful call", func() {
 			middleware := mcppkg.MetricMiddleware(serverName)
 
-			before := getCounterValue(metric.MCPRequestTotal, gatewayName, serverName, "initialize", "0", "0")
+			before := getCounterValue(metric.MCPRequestTotal, gatewayName, serverName, "initialize", "", "0", "0")
 
 			handler := middleware(func(ctx context.Context, method string, req sdkmcp.Request) (sdkmcp.Result, error) {
 				return successResult, nil
@@ -165,29 +182,45 @@ var _ = Describe("Middleware", func() {
 			_, err := handler(ctx, "initialize", nil)
 			Expect(err).NotTo(HaveOccurred())
 
-			after := getCounterValue(metric.MCPRequestTotal, gatewayName, serverName, "initialize", "0", "0")
+			after := getCounterValue(metric.MCPRequestTotal, gatewayName, serverName, "initialize", "", "0", "0")
 			Expect(after - before).To(Equal(float64(1)))
 		})
 
 		It("should record MCPRequestTotal with error status on failure", func() {
 			middleware := mcppkg.MetricMiddleware(serverName)
 
-			before := getCounterValue(metric.MCPRequestTotal, gatewayName, serverName, "tools/call", "unknown", "1")
+			before := getCounterValue(
+				metric.MCPRequestTotal,
+				gatewayName,
+				serverName,
+				"resources/list",
+				"",
+				"unknown",
+				"1",
+			)
 
 			handler := middleware(func(ctx context.Context, method string, req sdkmcp.Request) (sdkmcp.Result, error) {
 				return nil, errors.New("test error")
 			})
 
-			_, _ = handler(ctx, "tools/call", nil)
+			_, _ = handler(ctx, "resources/list", nil)
 
-			after := getCounterValue(metric.MCPRequestTotal, gatewayName, serverName, "tools/call", "unknown", "1")
+			after := getCounterValue(
+				metric.MCPRequestTotal,
+				gatewayName,
+				serverName,
+				"resources/list",
+				"",
+				"unknown",
+				"1",
+			)
 			Expect(after - before).To(Equal(float64(1)))
 		})
 
 		It("should record MCPRequestDuration", func() {
 			middleware := mcppkg.MetricMiddleware(serverName)
 
-			before := getHistogramCount(metric.MCPRequestDuration, gatewayName, serverName, "tools/list")
+			before := getHistogramCount(metric.MCPRequestDuration, gatewayName, serverName, "tools/list", "")
 
 			handler := middleware(func(ctx context.Context, method string, req sdkmcp.Request) (sdkmcp.Result, error) {
 				return successResult, nil
@@ -196,14 +229,14 @@ var _ = Describe("Middleware", func() {
 			_, err := handler(ctx, "tools/list", nil)
 			Expect(err).NotTo(HaveOccurred())
 
-			after := getHistogramCount(metric.MCPRequestDuration, gatewayName, serverName, "tools/list")
+			after := getHistogramCount(metric.MCPRequestDuration, gatewayName, serverName, "tools/list", "")
 			Expect(after - before).To(Equal(uint64(1)))
 		})
 
 		It("should record MCPSessionTotal on successful initialize", func() {
 			middleware := mcppkg.MetricMiddleware(serverName)
 
-			before := getGaugeValue(metric.MCPSessionTotal, gatewayName, serverName)
+			before := getGaugeValue(metric.MCPSessionTotal, gatewayName, serverName, "")
 
 			handler := middleware(func(ctx context.Context, method string, req sdkmcp.Request) (sdkmcp.Result, error) {
 				return successResult, nil
@@ -212,7 +245,7 @@ var _ = Describe("Middleware", func() {
 			_, err := handler(ctx, "initialize", nil)
 			Expect(err).NotTo(HaveOccurred())
 
-			after := getGaugeValue(metric.MCPSessionTotal, gatewayName, serverName)
+			after := getGaugeValue(metric.MCPSessionTotal, gatewayName, serverName, "")
 			Expect(after - before).To(Equal(float64(1)))
 		})
 
@@ -234,7 +267,14 @@ var _ = Describe("Middleware", func() {
 		It("should record MCPErrorTotal with normalized jsonrpc error code", func() {
 			middleware := mcppkg.MetricMiddleware(serverName)
 
-			before := getCounterValue(metric.MCPErrorTotal, gatewayName, serverName, "tools/call", "method_not_found")
+			before := getCounterValue(
+				metric.MCPErrorTotal,
+				gatewayName,
+				serverName,
+				"resources/list",
+				"",
+				"method_not_found",
+			)
 
 			handler := middleware(func(ctx context.Context, method string, req sdkmcp.Request) (sdkmcp.Result, error) {
 				return nil, &jsonrpc.Error{
@@ -243,24 +283,31 @@ var _ = Describe("Middleware", func() {
 				}
 			})
 
-			_, _ = handler(ctx, "tools/call", nil)
+			_, _ = handler(ctx, "resources/list", nil)
 
-			after := getCounterValue(metric.MCPErrorTotal, gatewayName, serverName, "tools/call", "method_not_found")
+			after := getCounterValue(
+				metric.MCPErrorTotal,
+				gatewayName,
+				serverName,
+				"resources/list",
+				"",
+				"method_not_found",
+			)
 			Expect(after - before).To(Equal(float64(1)))
 		})
 
 		It("should record MCPErrorTotal with unknown error code for non-jsonrpc error", func() {
 			middleware := mcppkg.MetricMiddleware(serverName)
 
-			before := getCounterValue(metric.MCPErrorTotal, gatewayName, serverName, "tools/call", "unknown")
+			before := getCounterValue(metric.MCPErrorTotal, gatewayName, serverName, "resources/list", "", "unknown")
 
 			handler := middleware(func(ctx context.Context, method string, req sdkmcp.Request) (sdkmcp.Result, error) {
 				return nil, errors.New("some error")
 			})
 
-			_, _ = handler(ctx, "tools/call", nil)
+			_, _ = handler(ctx, "resources/list", nil)
 
-			after := getCounterValue(metric.MCPErrorTotal, gatewayName, serverName, "tools/call", "unknown")
+			after := getCounterValue(metric.MCPErrorTotal, gatewayName, serverName, "resources/list", "", "unknown")
 			Expect(after - before).To(Equal(float64(1)))
 		})
 	})
@@ -268,8 +315,8 @@ var _ = Describe("Middleware", func() {
 	Describe("SessionMetricMiddleware", func() {
 		It("should decrement MCPSessionTotal on notifications/cancelled", func() {
 			// First, set an initial value
-			metric.MCPSessionTotal.WithLabelValues(gatewayName, serverName).Inc()
-			before := getGaugeValue(metric.MCPSessionTotal, gatewayName, serverName)
+			metric.MCPSessionTotal.WithLabelValues(gatewayName, serverName, "").Inc()
+			before := getGaugeValue(metric.MCPSessionTotal, gatewayName, serverName, "")
 
 			middleware := mcppkg.SessionMetricMiddleware(serverName)
 
@@ -280,12 +327,12 @@ var _ = Describe("Middleware", func() {
 			_, err := handler(ctx, "notifications/cancelled", nil)
 			Expect(err).NotTo(HaveOccurred())
 
-			after := getGaugeValue(metric.MCPSessionTotal, gatewayName, serverName)
+			after := getGaugeValue(metric.MCPSessionTotal, gatewayName, serverName, "")
 			Expect(before - after).To(Equal(float64(1)))
 		})
 
 		It("should not decrement MCPSessionTotal for other methods", func() {
-			before := getGaugeValue(metric.MCPSessionTotal, gatewayName, serverName)
+			before := getGaugeValue(metric.MCPSessionTotal, gatewayName, serverName, "")
 
 			middleware := mcppkg.SessionMetricMiddleware(serverName)
 
@@ -296,7 +343,7 @@ var _ = Describe("Middleware", func() {
 			_, err := handler(ctx, "tools/list", nil)
 			Expect(err).NotTo(HaveOccurred())
 
-			after := getGaugeValue(metric.MCPSessionTotal, gatewayName, serverName)
+			after := getGaugeValue(metric.MCPSessionTotal, gatewayName, serverName, "")
 			Expect(after).To(Equal(before))
 		})
 	})

--- a/src/mcp-proxy/pkg/mcp/middleware_test.go
+++ b/src/mcp-proxy/pkg/mcp/middleware_test.go
@@ -252,7 +252,7 @@ var _ = Describe("Middleware", func() {
 		It("should not increment MCPSessionTotal on failed initialize", func() {
 			middleware := mcppkg.MetricMiddleware(serverName)
 
-			before := getGaugeValue(metric.MCPSessionTotal, gatewayName, serverName)
+			before := getGaugeValue(metric.MCPSessionTotal, gatewayName, serverName, "")
 
 			handler := middleware(func(ctx context.Context, method string, req sdkmcp.Request) (sdkmcp.Result, error) {
 				return nil, errors.New("init failed")
@@ -260,7 +260,7 @@ var _ = Describe("Middleware", func() {
 
 			_, _ = handler(ctx, "initialize", nil)
 
-			after := getGaugeValue(metric.MCPSessionTotal, gatewayName, serverName)
+			after := getGaugeValue(metric.MCPSessionTotal, gatewayName, serverName, "")
 			Expect(after - before).To(Equal(float64(0)))
 		})
 

--- a/src/mcp-proxy/pkg/metric/init.go
+++ b/src/mcp-proxy/pkg/metric/init.go
@@ -83,8 +83,9 @@ func InitMetrics(metricNamePrefix string) {
 
 	MCPRequestTotal = prometheus.NewCounterVec(
 		prometheus.CounterOpts{
-			Name:        metricNamePrefix + "mcp_proxy_mcp_requests_total",
-			Help:        "Total number of MCP method calls, partitioned by gateway, server, method, app_code, error_code and error.",
+			Name: metricNamePrefix + "mcp_proxy_mcp_requests_total",
+			Help: "Total number of MCP method calls, partitioned by gateway, " +
+				"server, method, app_code, error_code and error.",
 			ConstLabels: prometheus.Labels{"service": serviceName},
 		},
 		[]string{"gateway_name", "mcp_server_name", "method", "app_code", "error_code", "error"},

--- a/src/mcp-proxy/pkg/metric/init.go
+++ b/src/mcp-proxy/pkg/metric/init.go
@@ -27,21 +27,53 @@ const (
 	serviceName = "apigateway-mcp-proxy"
 )
 
-// RequestCount ...
+// Metric collectors – initialized in InitMetrics() with the configured prefix.
 var (
 	// RequestCount api状态计数 + server_ip的请求数量和状态
+	RequestCount *prometheus.CounterVec
+
+	// RequestDuration api响应时间分布
+	RequestDuration *prometheus.HistogramVec
+
+	// --- MCP 协议级指标 ---
+
+	// MCPRequestTotal MCP 方法调用计数
+	MCPRequestTotal *prometheus.CounterVec
+
+	// MCPRequestDuration MCP 方法调用耗时分布
+	MCPRequestDuration *prometheus.HistogramVec
+
+	// MCPToolCallTotal MCP tools/call 调用计数（按工具名细分）
+	MCPToolCallTotal *prometheus.CounterVec
+
+	// MCPSessionTotal 当前活跃 MCP 会话数（Gauge）
+	MCPSessionTotal *prometheus.GaugeVec
+
+	// MCPErrorTotal MCP 错误计数（按错误码分类）
+	MCPErrorTotal *prometheus.CounterVec
+
+	// MCPRequestBodySize MCP 请求体大小分布（字节）
+	MCPRequestBodySize *prometheus.HistogramVec
+
+	// MCPResponseBodySize MCP 响应体大小分布（字节）
+	MCPResponseBodySize *prometheus.HistogramVec
+)
+
+// InitMetrics creates and registers all metric collectors.
+// metricNamePrefix comes from config (McpServer.MetricNamePrefix), aligned with
+// the dashboard's PROMETHEUS_METRIC_NAME_PREFIX so that PromQL queries match.
+func InitMetrics(metricNamePrefix string) {
 	RequestCount = prometheus.NewCounterVec(
 		prometheus.CounterOpts{
-			Name:        "apigateway_mcp_proxy_requests_total",
+			Name:        metricNamePrefix + "mcp_proxy_requests_total",
 			Help:        "How many HTTP requests processed, partitioned by status code, method and HTTP path.",
 			ConstLabels: prometheus.Labels{"service": serviceName},
 		},
 		[]string{"method", "path", "status", "mcp_server_name"},
 	)
 
-	// RequestDuration api响应时间分布
 	RequestDuration = prometheus.NewHistogramVec(prometheus.HistogramOpts{
-		Name:        "apigateway_mcp_proxy_request_duration_milliseconds",
+		Name:        metricNamePrefix + "mcp_proxy_request_duration_milliseconds",
 		Help:        "How long it took to process the request, partitioned by status code, method and HTTP path.",
 		ConstLabels: prometheus.Labels{"service": serviceName},
 		Buckets:     []float64{500, 1000, 2000, 5000, 10000, 30000, 60000},
@@ -49,47 +81,41 @@ var (
 		[]string{"method", "path", "status", "mcp_server_name"},
 	)
 
-	// --- MCP 协议级指标 ---
-
-	// MCPRequestTotal MCP 方法调用计数
 	MCPRequestTotal = prometheus.NewCounterVec(
 		prometheus.CounterOpts{
-			Name:        "apigateway_mcp_proxy_mcp_requests_total",
-			Help:        "Total number of MCP method calls, partitioned by gateway, server, method, error_code and error.",
+			Name:        metricNamePrefix + "mcp_proxy_mcp_requests_total",
+			Help:        "Total number of MCP method calls, partitioned by gateway, server, method, app_code, error_code and error.",
 			ConstLabels: prometheus.Labels{"service": serviceName},
 		},
-		[]string{"gateway_name", "mcp_server_name", "method", "error_code", "error"},
+		[]string{"gateway_name", "mcp_server_name", "method", "app_code", "error_code", "error"},
 	)
 
-	// MCPRequestDuration MCP 方法调用耗时分布
 	MCPRequestDuration = prometheus.NewHistogramVec(
 		prometheus.HistogramOpts{
-			Name:        "apigateway_mcp_proxy_mcp_request_duration_milliseconds",
+			Name:        metricNamePrefix + "mcp_proxy_mcp_request_duration_milliseconds",
 			Help:        "Duration of MCP method calls in milliseconds.",
 			ConstLabels: prometheus.Labels{"service": serviceName},
 			Buckets:     []float64{50, 100, 200, 500, 1000, 2000, 5000, 10000, 30000, 60000},
 		},
-		[]string{"gateway_name", "mcp_server_name", "method"},
+		[]string{"gateway_name", "mcp_server_name", "method", "app_code"},
 	)
 
-	// MCPToolCallTotal MCP tools/call 调用计数（按工具名细分）
 	MCPToolCallTotal = prometheus.NewCounterVec(
 		prometheus.CounterOpts{
-			Name:        "apigateway_mcp_proxy_mcp_tool_calls_total",
-			Help:        "Total number of MCP tools/call invocations, partitioned by gateway, server, tool and error.",
+			Name:        metricNamePrefix + "mcp_proxy_mcp_tool_calls_total",
+			Help:        "Total number of MCP tools/call invocations, partitioned by gateway, server, tool, app_code and error.",
 			ConstLabels: prometheus.Labels{"service": serviceName},
 		},
-		[]string{"gateway_name", "mcp_server_name", "tool_name", "error_code", "error"},
+		[]string{"gateway_name", "mcp_server_name", "tool_name", "app_code", "error_code", "error"},
 	)
 
-	// MCPSessionTotal 当前活跃 MCP 会话数（Gauge）
 	MCPSessionTotal = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
-			Name:        "apigateway_mcp_proxy_mcp_sessions_active",
+			Name:        metricNamePrefix + "mcp_proxy_mcp_sessions_active",
 			Help:        "Number of currently active MCP sessions.",
 			ConstLabels: prometheus.Labels{"service": serviceName},
 		},
-		[]string{"gateway_name", "mcp_server_name"},
+		[]string{"gateway_name", "mcp_server_name", "app_code"},
 	)
 
 	// MCPErrorTotal MCP 错误计数（按错误码分类）
@@ -97,24 +123,43 @@ var (
 	// 直接查询错误分布，无需通过 MCPRequestTotal 的 error label 二次过滤。
 	MCPErrorTotal = prometheus.NewCounterVec(
 		prometheus.CounterOpts{
-			Name:        "apigateway_mcp_proxy_mcp_errors_total",
-			Help:        "Total number of MCP errors, partitioned by gateway, server, method and error code.",
+			Name:        metricNamePrefix + "mcp_proxy_mcp_errors_total",
+			Help:        "Total number of MCP errors, partitioned by gateway, server, method, app_code and error code.",
 			ConstLabels: prometheus.Labels{"service": serviceName},
 		},
-		[]string{"gateway_name", "mcp_server_name", "method", "error_code"},
+		[]string{"gateway_name", "mcp_server_name", "method", "app_code", "error_code"},
 	)
-)
 
-// InitMetrics will register the metrics
-func InitMetrics() {
-	// Register the summary and the histogram with Prometheus's default registry.
+	// MCPRequestBodySize MCP 请求体大小分布（字节）
+	MCPRequestBodySize = prometheus.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Name:        metricNamePrefix + "mcp_proxy_mcp_request_body_size_bytes",
+			Help:        "MCP request body size distribution in bytes.",
+			ConstLabels: prometheus.Labels{"service": serviceName},
+			Buckets:     []float64{100, 500, 1000, 5000, 10000, 50000, 100000, 500000, 1000000},
+		},
+		[]string{"gateway_name", "mcp_server_name", "method"},
+	)
+
+	// MCPResponseBodySize MCP 响应体大小分布（字节）
+	MCPResponseBodySize = prometheus.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Name:        metricNamePrefix + "mcp_proxy_mcp_response_body_size_bytes",
+			Help:        "MCP response body size distribution in bytes.",
+			ConstLabels: prometheus.Labels{"service": serviceName},
+			Buckets:     []float64{100, 500, 1000, 5000, 10000, 50000, 100000, 500000, 1000000},
+		},
+		[]string{"gateway_name", "mcp_server_name", "method"},
+	)
+
+	// Register all collectors
 	prometheus.MustRegister(RequestCount)
 	prometheus.MustRegister(RequestDuration)
-
-	// MCP protocol-level metrics
 	prometheus.MustRegister(MCPRequestTotal)
 	prometheus.MustRegister(MCPRequestDuration)
 	prometheus.MustRegister(MCPToolCallTotal)
 	prometheus.MustRegister(MCPSessionTotal)
 	prometheus.MustRegister(MCPErrorTotal)
+	prometheus.MustRegister(MCPRequestBodySize)
+	prometheus.MustRegister(MCPResponseBodySize)
 }

--- a/src/mcp-proxy/pkg/metric/init_test.go
+++ b/src/mcp-proxy/pkg/metric/init_test.go
@@ -28,11 +28,16 @@ import (
 var _ = Describe("Metric", func() {
 	Describe("InitMetrics", func() {
 		It("should initialize metrics without panic", func() {
-			metric.InitMetrics()
+			metric.InitMetrics("bk_apigateway_")
 		})
 	})
 
 	Describe("MCP Protocol Metrics", func() {
+		BeforeEach(func() {
+			// Metrics are already initialized by the test above via MustRegister,
+			// just verify they are not nil.
+		})
+
 		It("MCPRequestTotal should be valid", func() {
 			Expect(metric.MCPRequestTotal).NotTo(BeNil())
 		})

--- a/src/mcp-proxy/pkg/middleware/logger.go
+++ b/src/mcp-proxy/pkg/middleware/logger.go
@@ -81,20 +81,42 @@ func APILogger() gin.HandlerFunc {
 
 		status := c.Writer.Status()
 
+		// 输出与 MCP 协议层日志（middleware.go）相同的字段集合，
+		// 确保 ES 中两层日志结构一致，前端展示不会出现大量 null。
+		// HTTP 层没有的 MCP 特有字段（mcp_method、params、response 等）输出零值。
 		fields := []zap.Field{
+			// 链路标识
+			zap.String("request_id", c.GetString(util.RequestIDKey)),
+			zap.String("x_request_id", c.GetString(util.XRequestIDKey)),
+			zap.String("session_id", ""), // HTTP 层无 MCP session
+			// 网关信息
 			zap.Int("gateway_id", util.GetGatewayID(c)),
 			zap.String("gateway_name", util.GetGatewayName(c)),
 			zap.String("mcp_server_name", mcpName),
 			zap.Int("mcp_server_id", util.GetMCPServerID(c)),
+			// HTTP 请求信息
 			zap.String("method", c.Request.Method),
 			zap.String("path", c.Request.URL.Path),
 			zap.Int("status", status),
-			zap.String("latency", duration.String()),
-			zap.String("request_id", c.GetString(util.RequestIDKey)),
-			zap.String("x_request_id", c.GetString(util.XRequestIDKey)),
-			zap.String("instance_id", c.GetString(util.InstanceIDKey)),
-			zap.String("client_ip", c.ClientIP()),
+			// MCP 协议层字段（HTTP 层输出零值，保持字段一致）
+			zap.String("mcp_method", ""),
+			zap.String("tool_name", ""),
+			zap.String("prompt_name", ""),
+			zap.String("params", ""),
+			zap.String("response", ""),
+			zap.Int64("request_body_size", 0),
+			zap.Int64("response_body_size", 0),
+			// 调用方信息
 			zap.String("app_code", util.GetAppCode(c)),
+			zap.String("bk_username", util.GetBkUsername(c)),
+			zap.String("client_ip", c.ClientIP()),
+			zap.String("client_id", util.GetClientID(c)),
+			// 性能
+			zap.String("latency", duration.String()),
+			// trace
+			zap.String("trace_id", util.GetTraceID(c)),
+			// 其他
+			zap.String("instance_id", c.GetString(util.InstanceIDKey)),
 		}
 
 		// only send 5xx err to sentry

--- a/src/mcp-proxy/pkg/middleware/middleware_suite_test.go
+++ b/src/mcp-proxy/pkg/middleware/middleware_suite_test.go
@@ -23,7 +23,14 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+
+	"mcp_proxy/pkg/metric"
 )
+
+var _ = BeforeSuite(func() {
+	// Initialize metrics so that metric.RequestCount etc. are not nil
+	metric.InitMetrics("")
+})
 
 func TestMiddleware(t *testing.T) {
 	RegisterFailHandler(Fail)

--- a/src/mcp-proxy/pkg/util/context.go
+++ b/src/mcp-proxy/pkg/util/context.go
@@ -331,3 +331,5 @@ func GetPrivateKeyFromContext(ctx context.Context) []byte {
 	}
 	return nil
 }
+
+

--- a/src/mcp-proxy/pkg/util/context.go
+++ b/src/mcp-proxy/pkg/util/context.go
@@ -60,6 +60,16 @@ func GetAppCode(c *gin.Context) string {
 	return GetBkAppCode(c)
 }
 
+// GetBkUsername gets username from gin context.
+func GetBkUsername(c *gin.Context) string {
+	return c.GetString(string(constant.BkUsername))
+}
+
+// GetTraceID gets trace ID from gin context.
+func GetTraceID(c *gin.Context) string {
+	return c.GetString(string(constant.TraceID))
+}
+
 // GetAppCodeFromContext gets app code from context
 func GetAppCodeFromContext(ctx context.Context) string {
 	if appCode, ok := ctx.Value(constant.BkAppCode).(string); ok {
@@ -223,6 +233,11 @@ func GetClientIPFromContext(ctx context.Context) string {
 		return clientIP
 	}
 	return ""
+}
+
+// GetClientID gets the client ID from gin context.
+func GetClientID(c *gin.Context) string {
+	return c.GetString(string(constant.ClientID))
 }
 
 // SetClientID stores the client ID into both gin context and request context.

--- a/src/mcp-proxy/tests/integration/config.yaml
+++ b/src/mcp-proxy/tests/integration/config.yaml
@@ -33,6 +33,7 @@ mcpServer:
   innerJwtExpireTime: 5m
   bkApiUrlTmpl: ""
   interval: 60
+  metricNamePrefix: "bk_apigateway_"
   # 直连集成环境无网关剥前缀：格式取 % 前为空，避免 SSE endpoint 带默认长前缀导致 POST 404
   messageUrlFormat: "/%s/sse"
   messageApplicationUrlFormat: "/%s/application/sse"

--- a/src/mcp-proxy/tests/integration/config.yaml
+++ b/src/mcp-proxy/tests/integration/config.yaml
@@ -29,11 +29,13 @@ logger:
     buffered: false
     settings: {name: stdout}
 
+metric:
+  namePrefix: "bk_apigateway_"
+
 mcpServer:
   innerJwtExpireTime: 5m
   bkApiUrlTmpl: ""
   interval: 60
-  metricNamePrefix: "bk_apigateway_"
   # 直连集成环境无网关剥前缀：格式取 % 前为空，避免 SSE endpoint 带默认长前缀导致 POST 404
   messageUrlFormat: "/%s/sse"
   messageApplicationUrlFormat: "/%s/application/sse"

--- a/src/mcp-proxy/tests/integration/metrics_test.go
+++ b/src/mcp-proxy/tests/integration/metrics_test.go
@@ -182,13 +182,13 @@ var _ = Describe("MCP Protocol Metrics", func() {
 			metricsOutput, err := fetchMetrics(client.BaseURL)
 			Expect(err).NotTo(HaveOccurred())
 
-			Expect(containsMetricLine(metricsOutput, "apigateway_mcp_proxy_mcp_requests_total", map[string]string{
+			Expect(containsMetricLine(metricsOutput, "bk_apigateway_mcp_proxy_mcp_requests_total", map[string]string{
 				"mcp_server_name": "test-http-server",
 				"method":          "initialize",
 				"error":           "0",
 			})).To(BeTrue(), "should have mcp_requests_total for initialize")
 
-			Expect(containsMetricLine(metricsOutput, "apigateway_mcp_proxy_mcp_requests_total", map[string]string{
+			Expect(containsMetricLine(metricsOutput, "bk_apigateway_mcp_proxy_mcp_requests_total", map[string]string{
 				"mcp_server_name": "test-http-server",
 				"method":          "tools/call",
 				"error":           "0",
@@ -214,7 +214,7 @@ var _ = Describe("MCP Protocol Metrics", func() {
 			Expect(
 				containsMetricLine(
 					metricsOutput,
-					"apigateway_mcp_proxy_mcp_request_duration_milliseconds_count",
+					"bk_apigateway_mcp_proxy_mcp_request_duration_milliseconds_count",
 					map[string]string{
 						"mcp_server_name": "test-http-server",
 						"method":          "tools/call",
@@ -239,7 +239,7 @@ var _ = Describe("MCP Protocol Metrics", func() {
 			metricsOutput, err := fetchMetrics(client.BaseURL)
 			Expect(err).NotTo(HaveOccurred())
 
-			Expect(containsMetricLine(metricsOutput, "apigateway_mcp_proxy_mcp_tool_calls_total", map[string]string{
+			Expect(containsMetricLine(metricsOutput, "bk_apigateway_mcp_proxy_mcp_tool_calls_total", map[string]string{
 				"mcp_server_name": "test-http-server",
 				"tool_name":       "echo",
 				"error":           "0",
@@ -254,7 +254,7 @@ var _ = Describe("MCP Protocol Metrics", func() {
 			metricsOutput, err := fetchMetrics(client.BaseURL)
 			Expect(err).NotTo(HaveOccurred())
 
-			Expect(containsMetricLine(metricsOutput, "apigateway_mcp_proxy_mcp_sessions_active", map[string]string{
+			Expect(containsMetricLine(metricsOutput, "bk_apigateway_mcp_proxy_mcp_sessions_active", map[string]string{
 				"mcp_server_name": "test-http-server",
 			})).To(BeTrue(), "should have mcp_sessions_active for test-http-server")
 		})
@@ -273,12 +273,12 @@ var _ = Describe("MCP Protocol Metrics", func() {
 			metricsOutput, err := fetchMetrics(client.BaseURL)
 			Expect(err).NotTo(HaveOccurred())
 
-			Expect(containsMetricLine(metricsOutput, "apigateway_mcp_proxy_mcp_errors_total", map[string]string{
+			Expect(containsMetricLine(metricsOutput, "bk_apigateway_mcp_proxy_mcp_errors_total", map[string]string{
 				"mcp_server_name": "test-http-server",
 				"method":          "tools/call",
 			})).To(BeTrue(), "should have mcp_errors_total for failed tools/call")
 
-			Expect(containsMetricLine(metricsOutput, "apigateway_mcp_proxy_mcp_requests_total", map[string]string{
+			Expect(containsMetricLine(metricsOutput, "bk_apigateway_mcp_proxy_mcp_requests_total", map[string]string{
 				"mcp_server_name": "test-http-server",
 				"method":          "tools/call",
 				"error":           "1",
@@ -304,25 +304,25 @@ var _ = Describe("MCP Protocol Metrics", func() {
 			metricsOutput, err := fetchMetrics(client.BaseURL)
 			Expect(err).NotTo(HaveOccurred())
 
-			Expect(containsMetricLine(metricsOutput, "apigateway_mcp_proxy_mcp_requests_total", map[string]string{
+			Expect(containsMetricLine(metricsOutput, "bk_apigateway_mcp_proxy_mcp_requests_total", map[string]string{
 				"mcp_server_name": "test-sse-server",
 				"method":          "initialize",
 				"error":           "0",
 			})).To(BeTrue(), "should have mcp_requests_total for SSE initialize")
 
-			Expect(containsMetricLine(metricsOutput, "apigateway_mcp_proxy_mcp_requests_total", map[string]string{
+			Expect(containsMetricLine(metricsOutput, "bk_apigateway_mcp_proxy_mcp_requests_total", map[string]string{
 				"mcp_server_name": "test-sse-server",
 				"method":          "tools/call",
 				"error":           "0",
 			})).To(BeTrue(), "should have mcp_requests_total for SSE tools/call")
 
-			Expect(containsMetricLine(metricsOutput, "apigateway_mcp_proxy_mcp_tool_calls_total", map[string]string{
+			Expect(containsMetricLine(metricsOutput, "bk_apigateway_mcp_proxy_mcp_tool_calls_total", map[string]string{
 				"mcp_server_name": "test-sse-server",
 				"tool_name":       "echo",
 				"error":           "0",
 			})).To(BeTrue(), "should have mcp_tool_calls_total for SSE echo tool")
 
-			Expect(containsMetricLine(metricsOutput, "apigateway_mcp_proxy_mcp_sessions_active", map[string]string{
+			Expect(containsMetricLine(metricsOutput, "bk_apigateway_mcp_proxy_mcp_sessions_active", map[string]string{
 				"mcp_server_name": "test-sse-server",
 			})).To(BeTrue(), "should have mcp_sessions_active for test-sse-server")
 		})
@@ -346,7 +346,7 @@ var _ = Describe("MCP Protocol Metrics", func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			// The gateway_name should be "bk-apigateway" (from init.sql test data)
-			Expect(containsMetricLine(metricsOutput, "apigateway_mcp_proxy_mcp_requests_total", map[string]string{
+			Expect(containsMetricLine(metricsOutput, "bk_apigateway_mcp_proxy_mcp_requests_total", map[string]string{
 				"gateway_name":    "bk-apigateway",
 				"mcp_server_name": "test-http-server",
 				"method":          "tools/call",

--- a/src/mcp-proxy/tests/integration/metrics_test.go
+++ b/src/mcp-proxy/tests/integration/metrics_test.go
@@ -182,21 +182,21 @@ var _ = Describe("MCP Protocol Metrics", func() {
 			metricsOutput, err := fetchMetrics(client.BaseURL)
 			Expect(err).NotTo(HaveOccurred())
 
-		Expect(containsMetricLine(metricsOutput, "bk_apigateway_mcp_proxy_mcp_requests_total", map[string]string{
-			"gateway_name":    "bk-apigateway",
-			"mcp_server_name": "test-http-server",
-			"method":          "initialize",
-			"app_code":        "test-app",
-			"error":           "0",
-		})).To(BeTrue(), "should have mcp_requests_total for initialize")
+			Expect(containsMetricLine(metricsOutput, "bk_apigateway_mcp_proxy_mcp_requests_total", map[string]string{
+				"gateway_name":    "bk-apigateway",
+				"mcp_server_name": "test-http-server",
+				"method":          "initialize",
+				"app_code":        "test-app",
+				"error":           "0",
+			})).To(BeTrue(), "should have mcp_requests_total for initialize")
 
-		Expect(containsMetricLine(metricsOutput, "bk_apigateway_mcp_proxy_mcp_requests_total", map[string]string{
-			"gateway_name":    "bk-apigateway",
-			"mcp_server_name": "test-http-server",
-			"method":          "tools/call",
-			"app_code":        "test-app",
-			"error":           "0",
-		})).To(BeTrue(), "should have mcp_requests_total for tools/call")
+			Expect(containsMetricLine(metricsOutput, "bk_apigateway_mcp_proxy_mcp_requests_total", map[string]string{
+				"gateway_name":    "bk-apigateway",
+				"mcp_server_name": "test-http-server",
+				"method":          "tools/call",
+				"app_code":        "test-app",
+				"error":           "0",
+			})).To(BeTrue(), "should have mcp_requests_total for tools/call")
 		})
 
 		It("should report mcp_request_duration_milliseconds after method calls", func() {
@@ -215,18 +215,18 @@ var _ = Describe("MCP Protocol Metrics", func() {
 			metricsOutput, err := fetchMetrics(client.BaseURL)
 			Expect(err).NotTo(HaveOccurred())
 
-		Expect(
-			containsMetricLine(
-				metricsOutput,
-				"bk_apigateway_mcp_proxy_mcp_request_duration_milliseconds_count",
-				map[string]string{
-					"gateway_name":    "bk-apigateway",
-					"mcp_server_name": "test-http-server",
-					"method":          "tools/call",
-					"app_code":        "test-app",
-				},
-			),
-		).To(BeTrue(), "should have mcp_request_duration_milliseconds for tools/call")
+			Expect(
+				containsMetricLine(
+					metricsOutput,
+					"bk_apigateway_mcp_proxy_mcp_request_duration_milliseconds_count",
+					map[string]string{
+						"gateway_name":    "bk-apigateway",
+						"mcp_server_name": "test-http-server",
+						"method":          "tools/call",
+						"app_code":        "test-app",
+					},
+				),
+			).To(BeTrue(), "should have mcp_request_duration_milliseconds for tools/call")
 		})
 
 		It("should report mcp_tool_calls_total with tool name", func() {
@@ -245,13 +245,13 @@ var _ = Describe("MCP Protocol Metrics", func() {
 			metricsOutput, err := fetchMetrics(client.BaseURL)
 			Expect(err).NotTo(HaveOccurred())
 
-		Expect(containsMetricLine(metricsOutput, "bk_apigateway_mcp_proxy_mcp_tool_calls_total", map[string]string{
-			"gateway_name":    "bk-apigateway",
-			"mcp_server_name": "test-http-server",
-			"tool_name":       "echo",
-			"app_code":        "test-app",
-			"error":           "0",
-		})).To(BeTrue(), "should have mcp_tool_calls_total for echo tool")
+			Expect(containsMetricLine(metricsOutput, "bk_apigateway_mcp_proxy_mcp_tool_calls_total", map[string]string{
+				"gateway_name":    "bk-apigateway",
+				"mcp_server_name": "test-http-server",
+				"tool_name":       "echo",
+				"app_code":        "test-app",
+				"error":           "0",
+			})).To(BeTrue(), "should have mcp_tool_calls_total for echo tool")
 		})
 
 		It("should report mcp_sessions_active after initialize", func() {
@@ -262,11 +262,11 @@ var _ = Describe("MCP Protocol Metrics", func() {
 			metricsOutput, err := fetchMetrics(client.BaseURL)
 			Expect(err).NotTo(HaveOccurred())
 
-		Expect(containsMetricLine(metricsOutput, "bk_apigateway_mcp_proxy_mcp_sessions_active", map[string]string{
-			"gateway_name":    "bk-apigateway",
-			"mcp_server_name": "test-http-server",
-			"app_code":        "test-app",
-		})).To(BeTrue(), "should have mcp_sessions_active for test-http-server")
+			Expect(containsMetricLine(metricsOutput, "bk_apigateway_mcp_proxy_mcp_sessions_active", map[string]string{
+				"gateway_name":    "bk-apigateway",
+				"mcp_server_name": "test-http-server",
+				"app_code":        "test-app",
+			})).To(BeTrue(), "should have mcp_sessions_active for test-http-server")
 		})
 
 		It("should report mcp_errors_total when calling non-existent tool", func() {
@@ -283,21 +283,21 @@ var _ = Describe("MCP Protocol Metrics", func() {
 			metricsOutput, err := fetchMetrics(client.BaseURL)
 			Expect(err).NotTo(HaveOccurred())
 
-		Expect(containsMetricLine(metricsOutput, "bk_apigateway_mcp_proxy_mcp_errors_total", map[string]string{
-			"gateway_name":    "bk-apigateway",
-			"mcp_server_name": "test-http-server",
-			"method":          "tools/call",
-			"app_code":        "test-app",
-			"error_code":      "invalid_params",
-		})).To(BeTrue(), "should have mcp_errors_total for failed tools/call")
+			Expect(containsMetricLine(metricsOutput, "bk_apigateway_mcp_proxy_mcp_errors_total", map[string]string{
+				"gateway_name":    "bk-apigateway",
+				"mcp_server_name": "test-http-server",
+				"method":          "tools/call",
+				"app_code":        "test-app",
+				"error_code":      "invalid_params",
+			})).To(BeTrue(), "should have mcp_errors_total for failed tools/call")
 
-		Expect(containsMetricLine(metricsOutput, "bk_apigateway_mcp_proxy_mcp_requests_total", map[string]string{
-			"gateway_name":    "bk-apigateway",
-			"mcp_server_name": "test-http-server",
-			"method":          "tools/call",
-			"app_code":        "test-app",
-			"error":           "1",
-		})).To(BeTrue(), "should have mcp_requests_total with error for failed tools/call")
+			Expect(containsMetricLine(metricsOutput, "bk_apigateway_mcp_proxy_mcp_requests_total", map[string]string{
+				"gateway_name":    "bk-apigateway",
+				"mcp_server_name": "test-http-server",
+				"method":          "tools/call",
+				"app_code":        "test-app",
+				"error":           "1",
+			})).To(BeTrue(), "should have mcp_requests_total with error for failed tools/call")
 		})
 	})
 
@@ -319,35 +319,35 @@ var _ = Describe("MCP Protocol Metrics", func() {
 			metricsOutput, err := fetchMetrics(client.BaseURL)
 			Expect(err).NotTo(HaveOccurred())
 
-		Expect(containsMetricLine(metricsOutput, "bk_apigateway_mcp_proxy_mcp_requests_total", map[string]string{
-			"gateway_name":    "bk-apigateway",
-			"mcp_server_name": "test-sse-server",
-			"method":          "initialize",
-			"app_code":        "test-app",
-			"error":           "0",
-		})).To(BeTrue(), "should have mcp_requests_total for SSE initialize")
+			Expect(containsMetricLine(metricsOutput, "bk_apigateway_mcp_proxy_mcp_requests_total", map[string]string{
+				"gateway_name":    "bk-apigateway",
+				"mcp_server_name": "test-sse-server",
+				"method":          "initialize",
+				"app_code":        "test-app",
+				"error":           "0",
+			})).To(BeTrue(), "should have mcp_requests_total for SSE initialize")
 
-		Expect(containsMetricLine(metricsOutput, "bk_apigateway_mcp_proxy_mcp_requests_total", map[string]string{
-			"gateway_name":    "bk-apigateway",
-			"mcp_server_name": "test-sse-server",
-			"method":          "tools/call",
-			"app_code":        "test-app",
-			"error":           "0",
-		})).To(BeTrue(), "should have mcp_requests_total for SSE tools/call")
+			Expect(containsMetricLine(metricsOutput, "bk_apigateway_mcp_proxy_mcp_requests_total", map[string]string{
+				"gateway_name":    "bk-apigateway",
+				"mcp_server_name": "test-sse-server",
+				"method":          "tools/call",
+				"app_code":        "test-app",
+				"error":           "0",
+			})).To(BeTrue(), "should have mcp_requests_total for SSE tools/call")
 
-		Expect(containsMetricLine(metricsOutput, "bk_apigateway_mcp_proxy_mcp_tool_calls_total", map[string]string{
-			"gateway_name":    "bk-apigateway",
-			"mcp_server_name": "test-sse-server",
-			"tool_name":       "echo",
-			"app_code":        "test-app",
-			"error":           "0",
-		})).To(BeTrue(), "should have mcp_tool_calls_total for SSE echo tool")
+			Expect(containsMetricLine(metricsOutput, "bk_apigateway_mcp_proxy_mcp_tool_calls_total", map[string]string{
+				"gateway_name":    "bk-apigateway",
+				"mcp_server_name": "test-sse-server",
+				"tool_name":       "echo",
+				"app_code":        "test-app",
+				"error":           "0",
+			})).To(BeTrue(), "should have mcp_tool_calls_total for SSE echo tool")
 
-		Expect(containsMetricLine(metricsOutput, "bk_apigateway_mcp_proxy_mcp_sessions_active", map[string]string{
-			"gateway_name":    "bk-apigateway",
-			"mcp_server_name": "test-sse-server",
-			"app_code":        "test-app",
-		})).To(BeTrue(), "should have mcp_sessions_active for test-sse-server")
+			Expect(containsMetricLine(metricsOutput, "bk_apigateway_mcp_proxy_mcp_sessions_active", map[string]string{
+				"gateway_name":    "bk-apigateway",
+				"mcp_server_name": "test-sse-server",
+				"app_code":        "test-app",
+			})).To(BeTrue(), "should have mcp_sessions_active for test-sse-server")
 		})
 	})
 
@@ -368,13 +368,13 @@ var _ = Describe("MCP Protocol Metrics", func() {
 			metricsOutput, err := fetchMetrics(client.BaseURL)
 			Expect(err).NotTo(HaveOccurred())
 
-		// The gateway_name should be "bk-apigateway" (from init.sql test data)
-		Expect(containsMetricLine(metricsOutput, "bk_apigateway_mcp_proxy_mcp_requests_total", map[string]string{
-			"gateway_name":    "bk-apigateway",
-			"mcp_server_name": "test-http-server",
-			"method":          "tools/call",
-			"app_code":        "test-app",
-		})).To(BeTrue(), "should have gateway_name=bk-apigateway in mcp_requests_total")
+			// The gateway_name should be "bk-apigateway" (from init.sql test data)
+			Expect(containsMetricLine(metricsOutput, "bk_apigateway_mcp_proxy_mcp_requests_total", map[string]string{
+				"gateway_name":    "bk-apigateway",
+				"mcp_server_name": "test-http-server",
+				"method":          "tools/call",
+				"app_code":        "test-app",
+			})).To(BeTrue(), "should have gateway_name=bk-apigateway in mcp_requests_total")
 		})
 	})
 })

--- a/src/mcp-proxy/tests/integration/metrics_test.go
+++ b/src/mcp-proxy/tests/integration/metrics_test.go
@@ -182,17 +182,21 @@ var _ = Describe("MCP Protocol Metrics", func() {
 			metricsOutput, err := fetchMetrics(client.BaseURL)
 			Expect(err).NotTo(HaveOccurred())
 
-			Expect(containsMetricLine(metricsOutput, "bk_apigateway_mcp_proxy_mcp_requests_total", map[string]string{
-				"mcp_server_name": "test-http-server",
-				"method":          "initialize",
-				"error":           "0",
-			})).To(BeTrue(), "should have mcp_requests_total for initialize")
+		Expect(containsMetricLine(metricsOutput, "bk_apigateway_mcp_proxy_mcp_requests_total", map[string]string{
+			"gateway_name":    "bk-apigateway",
+			"mcp_server_name": "test-http-server",
+			"method":          "initialize",
+			"app_code":        "test-app",
+			"error":           "0",
+		})).To(BeTrue(), "should have mcp_requests_total for initialize")
 
-			Expect(containsMetricLine(metricsOutput, "bk_apigateway_mcp_proxy_mcp_requests_total", map[string]string{
-				"mcp_server_name": "test-http-server",
-				"method":          "tools/call",
-				"error":           "0",
-			})).To(BeTrue(), "should have mcp_requests_total for tools/call")
+		Expect(containsMetricLine(metricsOutput, "bk_apigateway_mcp_proxy_mcp_requests_total", map[string]string{
+			"gateway_name":    "bk-apigateway",
+			"mcp_server_name": "test-http-server",
+			"method":          "tools/call",
+			"app_code":        "test-app",
+			"error":           "0",
+		})).To(BeTrue(), "should have mcp_requests_total for tools/call")
 		})
 
 		It("should report mcp_request_duration_milliseconds after method calls", func() {
@@ -211,16 +215,18 @@ var _ = Describe("MCP Protocol Metrics", func() {
 			metricsOutput, err := fetchMetrics(client.BaseURL)
 			Expect(err).NotTo(HaveOccurred())
 
-			Expect(
-				containsMetricLine(
-					metricsOutput,
-					"bk_apigateway_mcp_proxy_mcp_request_duration_milliseconds_count",
-					map[string]string{
-						"mcp_server_name": "test-http-server",
-						"method":          "tools/call",
-					},
-				),
-			).To(BeTrue(), "should have mcp_request_duration_milliseconds for tools/call")
+		Expect(
+			containsMetricLine(
+				metricsOutput,
+				"bk_apigateway_mcp_proxy_mcp_request_duration_milliseconds_count",
+				map[string]string{
+					"gateway_name":    "bk-apigateway",
+					"mcp_server_name": "test-http-server",
+					"method":          "tools/call",
+					"app_code":        "test-app",
+				},
+			),
+		).To(BeTrue(), "should have mcp_request_duration_milliseconds for tools/call")
 		})
 
 		It("should report mcp_tool_calls_total with tool name", func() {
@@ -239,11 +245,13 @@ var _ = Describe("MCP Protocol Metrics", func() {
 			metricsOutput, err := fetchMetrics(client.BaseURL)
 			Expect(err).NotTo(HaveOccurred())
 
-			Expect(containsMetricLine(metricsOutput, "bk_apigateway_mcp_proxy_mcp_tool_calls_total", map[string]string{
-				"mcp_server_name": "test-http-server",
-				"tool_name":       "echo",
-				"error":           "0",
-			})).To(BeTrue(), "should have mcp_tool_calls_total for echo tool")
+		Expect(containsMetricLine(metricsOutput, "bk_apigateway_mcp_proxy_mcp_tool_calls_total", map[string]string{
+			"gateway_name":    "bk-apigateway",
+			"mcp_server_name": "test-http-server",
+			"tool_name":       "echo",
+			"app_code":        "test-app",
+			"error":           "0",
+		})).To(BeTrue(), "should have mcp_tool_calls_total for echo tool")
 		})
 
 		It("should report mcp_sessions_active after initialize", func() {
@@ -254,9 +262,11 @@ var _ = Describe("MCP Protocol Metrics", func() {
 			metricsOutput, err := fetchMetrics(client.BaseURL)
 			Expect(err).NotTo(HaveOccurred())
 
-			Expect(containsMetricLine(metricsOutput, "bk_apigateway_mcp_proxy_mcp_sessions_active", map[string]string{
-				"mcp_server_name": "test-http-server",
-			})).To(BeTrue(), "should have mcp_sessions_active for test-http-server")
+		Expect(containsMetricLine(metricsOutput, "bk_apigateway_mcp_proxy_mcp_sessions_active", map[string]string{
+			"gateway_name":    "bk-apigateway",
+			"mcp_server_name": "test-http-server",
+			"app_code":        "test-app",
+		})).To(BeTrue(), "should have mcp_sessions_active for test-http-server")
 		})
 
 		It("should report mcp_errors_total when calling non-existent tool", func() {
@@ -273,16 +283,21 @@ var _ = Describe("MCP Protocol Metrics", func() {
 			metricsOutput, err := fetchMetrics(client.BaseURL)
 			Expect(err).NotTo(HaveOccurred())
 
-			Expect(containsMetricLine(metricsOutput, "bk_apigateway_mcp_proxy_mcp_errors_total", map[string]string{
-				"mcp_server_name": "test-http-server",
-				"method":          "tools/call",
-			})).To(BeTrue(), "should have mcp_errors_total for failed tools/call")
+		Expect(containsMetricLine(metricsOutput, "bk_apigateway_mcp_proxy_mcp_errors_total", map[string]string{
+			"gateway_name":    "bk-apigateway",
+			"mcp_server_name": "test-http-server",
+			"method":          "tools/call",
+			"app_code":        "test-app",
+			"error_code":      "invalid_params",
+		})).To(BeTrue(), "should have mcp_errors_total for failed tools/call")
 
-			Expect(containsMetricLine(metricsOutput, "bk_apigateway_mcp_proxy_mcp_requests_total", map[string]string{
-				"mcp_server_name": "test-http-server",
-				"method":          "tools/call",
-				"error":           "1",
-			})).To(BeTrue(), "should have mcp_requests_total with error for failed tools/call")
+		Expect(containsMetricLine(metricsOutput, "bk_apigateway_mcp_proxy_mcp_requests_total", map[string]string{
+			"gateway_name":    "bk-apigateway",
+			"mcp_server_name": "test-http-server",
+			"method":          "tools/call",
+			"app_code":        "test-app",
+			"error":           "1",
+		})).To(BeTrue(), "should have mcp_requests_total with error for failed tools/call")
 		})
 	})
 
@@ -304,27 +319,35 @@ var _ = Describe("MCP Protocol Metrics", func() {
 			metricsOutput, err := fetchMetrics(client.BaseURL)
 			Expect(err).NotTo(HaveOccurred())
 
-			Expect(containsMetricLine(metricsOutput, "bk_apigateway_mcp_proxy_mcp_requests_total", map[string]string{
-				"mcp_server_name": "test-sse-server",
-				"method":          "initialize",
-				"error":           "0",
-			})).To(BeTrue(), "should have mcp_requests_total for SSE initialize")
+		Expect(containsMetricLine(metricsOutput, "bk_apigateway_mcp_proxy_mcp_requests_total", map[string]string{
+			"gateway_name":    "bk-apigateway",
+			"mcp_server_name": "test-sse-server",
+			"method":          "initialize",
+			"app_code":        "test-app",
+			"error":           "0",
+		})).To(BeTrue(), "should have mcp_requests_total for SSE initialize")
 
-			Expect(containsMetricLine(metricsOutput, "bk_apigateway_mcp_proxy_mcp_requests_total", map[string]string{
-				"mcp_server_name": "test-sse-server",
-				"method":          "tools/call",
-				"error":           "0",
-			})).To(BeTrue(), "should have mcp_requests_total for SSE tools/call")
+		Expect(containsMetricLine(metricsOutput, "bk_apigateway_mcp_proxy_mcp_requests_total", map[string]string{
+			"gateway_name":    "bk-apigateway",
+			"mcp_server_name": "test-sse-server",
+			"method":          "tools/call",
+			"app_code":        "test-app",
+			"error":           "0",
+		})).To(BeTrue(), "should have mcp_requests_total for SSE tools/call")
 
-			Expect(containsMetricLine(metricsOutput, "bk_apigateway_mcp_proxy_mcp_tool_calls_total", map[string]string{
-				"mcp_server_name": "test-sse-server",
-				"tool_name":       "echo",
-				"error":           "0",
-			})).To(BeTrue(), "should have mcp_tool_calls_total for SSE echo tool")
+		Expect(containsMetricLine(metricsOutput, "bk_apigateway_mcp_proxy_mcp_tool_calls_total", map[string]string{
+			"gateway_name":    "bk-apigateway",
+			"mcp_server_name": "test-sse-server",
+			"tool_name":       "echo",
+			"app_code":        "test-app",
+			"error":           "0",
+		})).To(BeTrue(), "should have mcp_tool_calls_total for SSE echo tool")
 
-			Expect(containsMetricLine(metricsOutput, "bk_apigateway_mcp_proxy_mcp_sessions_active", map[string]string{
-				"mcp_server_name": "test-sse-server",
-			})).To(BeTrue(), "should have mcp_sessions_active for test-sse-server")
+		Expect(containsMetricLine(metricsOutput, "bk_apigateway_mcp_proxy_mcp_sessions_active", map[string]string{
+			"gateway_name":    "bk-apigateway",
+			"mcp_server_name": "test-sse-server",
+			"app_code":        "test-app",
+		})).To(BeTrue(), "should have mcp_sessions_active for test-sse-server")
 		})
 	})
 
@@ -345,12 +368,13 @@ var _ = Describe("MCP Protocol Metrics", func() {
 			metricsOutput, err := fetchMetrics(client.BaseURL)
 			Expect(err).NotTo(HaveOccurred())
 
-			// The gateway_name should be "bk-apigateway" (from init.sql test data)
-			Expect(containsMetricLine(metricsOutput, "bk_apigateway_mcp_proxy_mcp_requests_total", map[string]string{
-				"gateway_name":    "bk-apigateway",
-				"mcp_server_name": "test-http-server",
-				"method":          "tools/call",
-			})).To(BeTrue(), "should have gateway_name=bk-apigateway in mcp_requests_total")
+		// The gateway_name should be "bk-apigateway" (from init.sql test data)
+		Expect(containsMetricLine(metricsOutput, "bk_apigateway_mcp_proxy_mcp_requests_total", map[string]string{
+			"gateway_name":    "bk-apigateway",
+			"mcp_server_name": "test-http-server",
+			"method":          "tools/call",
+			"app_code":        "test-app",
+		})).To(BeTrue(), "should have gateway_name=bk-apigateway in mcp_requests_total")
 		})
 	})
 })


### PR DESCRIPTION
## Description

### feat(mcp): Add observability for MCP Server with log search and metrics

Add log search and Prometheus metrics monitoring capabilities for MCP Server to help users understand the running status of MCP Server.

#### Dashboard Backend

- **Log Search** (`apis/web/mcp_server_log`):
  - Support multi-dimensional log search by request_id, client_ip, tool_name, mcp_server_name, etc.
  - Support chain search (ChainSearch) to trace complete request flow
  - Support time range queries and ES log storage integration

- **Metrics Monitoring** (`apis/web/mcp_server_metrics`):
  - Provide Prometheus queries for core metrics: QPS, latency (P50/P95/P99), error rate
  - Support aggregation by mcp_server_name, tool_name, status_code dimensions
  - Provide metrics overview API

- **Config**: Add MCP metrics related Prometheus config in `conf/default.py`

#### MCP Proxy (Go)

- Add Prometheus push related config in `config.yaml.tpl`
- Adjust metric registration and push logic in `metric/init.go`
- Add integration tests

#### Frontend

- Add MCP Server log search API in `access-log.ts`

### chore(lint): Remove stale ESB ignore rules from import-linter config

Remove 8 obsolete ESB import ignore rules from `pyproject.toml` that no longer match any actual imports, fixing `No matches for ignored import` errors.

## Impact

- MCP Server management module (logs, metrics)
- MCP Proxy metrics push config
- import-linter config cleanup (no functional impact)
