### PR TITLE
fix(conf): change ENABLE_RUN_DATA and ENABLE_RUN_DATA_METRICS defaults to False

### DIFF
--- a/src/dashboard/apigateway/apigateway/conf/default.py
+++ b/src/dashboard/apigateway/apigateway/conf/default.py
@@ -444,7 +444,7 @@ else:
         CELERY_BROKER_URL = broker_url
         CELERY_RESULT_BACKEND = broker_url
 
-if env.bool("FEATURE_FLAG_ENABLE_RUN_DATA_METRICS", True):
+if env.bool("FEATURE_FLAG_ENABLE_RUN_DATA_METRICS", False):
     CELERY_BEAT_SCHEDULE.update(
         {
             "apigateway.apps.metrics.tasks.statistics_request_by_day": {

--- a/src/dashboard/apigateway/apigateway/conf/utils.py
+++ b/src/dashboard/apigateway/apigateway/conf/utils.py
@@ -172,9 +172,9 @@ def get_default_feature_flags(
         # 是否展示"监控告警"子菜单
         "ENABLE_MONITOR": env.bool("FEATURE_FLAG_ENABLE_MONITOR", False),
         # 是否展示"运行数据"子菜单
-        "ENABLE_RUN_DATA": env.bool("FEATURE_FLAG_ENABLE_RUN_DATA", True),
+        "ENABLE_RUN_DATA": env.bool("FEATURE_FLAG_ENABLE_RUN_DATA", False),
         # 是否展示 "运行数据" => 仪表盘 子菜单
-        "ENABLE_RUN_DATA_METRICS": env.bool("FEATURE_FLAG_ENABLE_RUN_DATA_METRICS", True),
+        "ENABLE_RUN_DATA_METRICS": env.bool("FEATURE_FLAG_ENABLE_RUN_DATA_METRICS", False),
         # 是否展示"组件管理"菜单项，企业版展示，上云版不展示
         "MENU_ITEM_ESB_API": env.bool("FEATURE_FLAG_MENU_ITEM_ESB_API", True),
         # TODO: remove in the future, and remove in the helm-chart and te repo


### PR DESCRIPTION
## Summary

- Change `ENABLE_RUN_DATA` default from `True` to `False`
- Change `ENABLE_RUN_DATA_METRICS` default from `True` to `False`

These feature flags were opt-out (defaulting to `True`), meaning every new deployment would have the "运行数据" menu and metrics features enabled without any explicit configuration. Changing to opt-in (`False`) is safer for new deployments that may not have the underlying data infrastructure (metrics storage, Celery workers, etc.) ready.

Operators who want these features can still enable them explicitly via:
- `FEATURE_FLAG_ENABLE_RUN_DATA=True`
- `FEATURE_FLAG_ENABLE_RUN_DATA_METRICS=True`

Made with [Cursor](https://cursor.com)