### PR TITLE
feat(plugin): make three OAuth2 plugins public in fixtures

### DIFF
--- a/src/dashboard/apigateway/apigateway/fixtures/plugins.yaml
+++ b/src/dashboard/apigateway/apigateway/fixtures/plugins.yaml
@@ -1339,7 +1339,7 @@
     name_en: OAuth2 Protected Resource
     description: OAuth2 protected resource plugin
     description_en: OAuth2 protected resource plugin
-    is_public: false
+    is_public: true
     scope: resource
     priority: 18740
     _tags: "认证,Authentication"
@@ -1366,7 +1366,7 @@
     name_en: OAuth2 Verify
     description: OAuth2 verify plugin
     description_en: OAuth2 verify plugin
-    is_public: false
+    is_public: true
     scope: resource
     priority: 18732
     _tags: "认证,Authentication"
@@ -1393,7 +1393,7 @@
     name_en: OAuth2 Audience Validate
     description: OAuth2 audience validate plugin
     description_en: OAuth2 audience validate plugin
-    is_public: false
+    is_public: true
     scope: resource
     priority: 17678
     _tags: "认证,Authentication"


### PR DESCRIPTION
- 将 plugins.yaml 中三个 bk-oauth2 系列插件（bk-oauth2-protected-resource、bk-oauth2-verify、bk-oauth2-audience-validate）的 is_public 属性从 false 改为 true，使这些 OAuth2 认证相关插件变为公开可用状态。