### PR TITLE
feat(django): upgrade Django from 4.2.23 to 4.2.26

### DIFF
--- a/src/dashboard/pyproject.toml
+++ b/src/dashboard/pyproject.toml
@@ -5,7 +5,7 @@ description = ""
 authors = []
 requires-python = ">=3.11,<3.12"
 dependencies = [
-    "django==4.2.23",
+    "django==4.2.26",
     "djangorestframework==3.16.0",
     "pymysql==1.1.1",
     "celery==5.5.3",

--- a/src/dashboard/uv.lock
+++ b/src/dashboard/uv.lock
@@ -169,7 +169,7 @@ requires-dist = [
     { name = "concurrent-log-handler", specifier = "==0.9.28" },
     { name = "cryptography", specifier = "==45.0.5" },
     { name = "curlify", specifier = "==2.2.1" },
-    { name = "django", specifier = "==4.2.23" },
+    { name = "django", specifier = "==4.2.26" },
     { name = "django-add-default-value", specifier = "==0.10.0" },
     { name = "django-celery-beat", specifier = "==2.7.0" },
     { name = "django-cors-headers", specifier = "==4.7.0" },
@@ -753,16 +753,16 @@ wheels = [
 
 [[package]]
 name = "django"
-version = "4.2.23"
+version = "4.2.26"
 source = { registry = "https://pypi.org/simple/" }
 dependencies = [
     { name = "asgiref" },
     { name = "sqlparse" },
     { name = "tzdata", marker = "sys_platform == 'win32'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/b5/20/02242739714eb4e53933d6c0fe2c57f41feb449955b0aa39fc2da82b8f3c/django-4.2.23.tar.gz", hash = "sha256:42fdeaba6e6449d88d4f66de47871015097dc6f1b87910db00a91946295cfae4", size = 10448384, upload-time = "2025-06-10T10:06:34.574Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/bc/f2/5cab08b4174b46cd9d5b4d4439d211f5dd15bec256fb43e8287adbb79580/django-4.2.26.tar.gz", hash = "sha256:9398e487bcb55e3f142cb56d19fbd9a83e15bb03a97edc31f408361ee76d9d7a", size = 10433052, upload-time = "2025-11-05T14:08:23.522Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/cb/44/314e8e4612bd122dd0424c88b44730af68eafbee88cc887a86586b7a1f2a/django-4.2.23-py3-none-any.whl", hash = "sha256:dafbfaf52c2f289bd65f4ab935791cb4fb9a198f2a5ba9faf35d7338a77e9803", size = 7993904, upload-time = "2025-06-10T10:06:28.092Z" },
+    { url = "https://files.pythonhosted.org/packages/39/6f/873365d280002de462852c20bcf050564e2354770041bd950bfb4a16d91e/django-4.2.26-py3-none-any.whl", hash = "sha256:c96e64fc3c359d051a6306871bd26243db1bd02317472a62ffdbe6c3cae14280", size = 7994264, upload-time = "2025-11-05T14:08:20.328Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
- 将 Dashboard 后端的 Django 版本从 4.2.23 升级到 4.2.26，修改 src/dashboard/pyproject.toml 中的依赖声明。该变更属于补丁级安全升级，不涉及 API 兼容性破坏。