### PR TITLE
fix: return empty data when backend not found in metrics query

### DIFF
--- a/src/dashboard/apigateway/apigateway/service/prometheus/dimension.py
+++ b/src/dashboard/apigateway/apigateway/service/prometheus/dimension.py
@@ -55,6 +55,7 @@ class BaseMetrics(BasePrometheusMetrics):
         resource_id: Optional[int],
         resource_name: Optional[str],
     ) -> str:
+        # 返回空字符串表示 backend 不存在，无需查询
         pass
 
     def query_range(
@@ -348,6 +349,7 @@ class IngressMetrics(BaseMetrics):
             logger.warning(
                 "backend (gateway_name=%s, name=%s) does not exist, skip query.", gateway_name, backend_name
             )
+            # backend 不存在，无需查询
             return ""
 
         label_list = [
@@ -386,6 +388,7 @@ class EgressMetrics(BaseMetrics):
             logger.warning(
                 "backend (gateway_name=%s, name=%s) does not exist, skip query.", gateway_name, backend_name
             )
+            # backend 不存在，无需查询
             return ""
 
         label_list = [

--- a/src/dashboard/apigateway/apigateway/service/prometheus/dimension.py
+++ b/src/dashboard/apigateway/apigateway/service/prometheus/dimension.py
@@ -71,6 +71,9 @@ class BaseMetrics(BasePrometheusMetrics):
             gateway_name, stage_name, backend_name, step, stage_id, resource_id, resource_name
         )
 
+        if not promql:
+            return {"series": []}
+
         # request prometheus http api to get metrics data
         return query_range(
             bk_biz_id=getattr(settings, "BCS_CLUSTER_BK_BIZ_ID", ""),
@@ -96,6 +99,10 @@ class BaseMetrics(BasePrometheusMetrics):
         promql = self._get_query_promql(
             gateway_name, stage_name, backend_name, step, stage_id, resource_id, resource_name
         )
+
+        if not promql:
+            return {"instant": 0}
+
         result: Dict[str, Any] = {}
         data = query_range(
             bk_biz_id=getattr(settings, "BCS_CLUSTER_BK_BIZ_ID", ""),
@@ -333,7 +340,10 @@ class IngressMetrics(BaseMetrics):
     ) -> str:
         # 因为 route 的参数结果不能使用 self._get_labels_expression 方法去去除空参数
         # 查询 backend_id
-        backend = Backend.objects.get(gateway__name=gateway_name, name=backend_name)
+        backend = Backend.objects.filter(gateway__name=gateway_name, name=backend_name).first()
+        if not backend:
+            return ""
+
         label_list = [
             *self.default_labels,
             ("type", "=", "ingress"),
@@ -365,7 +375,10 @@ class EgressMetrics(BaseMetrics):
     ) -> str:
         # 因为 route 的参数结果不能使用 self._get_labels_expression 方法去去除空参数
         # 查询 backend_id
-        backend = Backend.objects.get(gateway__name=gateway_name, name=backend_name)
+        backend = Backend.objects.filter(gateway__name=gateway_name, name=backend_name).first()
+        if not backend:
+            return ""
+
         label_list = [
             *self.default_labels,
             ("type", "=", "egress"),

--- a/src/dashboard/apigateway/apigateway/service/prometheus/dimension.py
+++ b/src/dashboard/apigateway/apigateway/service/prometheus/dimension.py
@@ -16,6 +16,7 @@
 # We undertake not to change the open source license (MIT license) applicable
 # to the current version of the project delivered to anyone in the future.
 #
+import logging
 from abc import abstractmethod
 from typing import Any, ClassVar, Dict, Optional, Type
 
@@ -36,6 +37,8 @@ from apigateway.components.bkmonitor import query_range
 from apigateway.core.models import Backend
 
 from .base import BasePrometheusMetrics
+
+logger = logging.getLogger(__name__)
 
 
 class BaseMetrics(BasePrometheusMetrics):
@@ -342,6 +345,9 @@ class IngressMetrics(BaseMetrics):
         # 查询 backend_id
         backend = Backend.objects.filter(gateway__name=gateway_name, name=backend_name).first()
         if not backend:
+            logger.warning(
+                "backend (gateway_name=%s, name=%s) does not exist, skip query.", gateway_name, backend_name
+            )
             return ""
 
         label_list = [
@@ -377,6 +383,9 @@ class EgressMetrics(BaseMetrics):
         # 查询 backend_id
         backend = Backend.objects.filter(gateway__name=gateway_name, name=backend_name).first()
         if not backend:
+            logger.warning(
+                "backend (gateway_name=%s, name=%s) does not exist, skip query.", gateway_name, backend_name
+            )
             return ""
 
         label_list = [

--- a/src/dashboard/apigateway/apigateway/tests/service/prometheus/test_dimension.py
+++ b/src/dashboard/apigateway/apigateway/tests/service/prometheus/test_dimension.py
@@ -367,6 +367,24 @@ class TestResponseTime99thMetrics:
 
 
 class TestIngressMetrics:
+    def test_get_query_promql_backend_not_found(self, mocker):
+        mocker.patch("apigateway.service.prometheus.dimension.BaseMetrics.default_labels", return_value=[])
+        mocker.patch(
+            "apigateway.service.prometheus.dimension.Backend.objects.filter"
+        ).return_value.first.return_value = None
+
+        metrics = dimension.IngressMetrics()
+        result = metrics._get_query_promql(
+            gateway_name="not_exist",
+            stage_name="prod",
+            backend_name="not_exist",
+            step="1m",
+            stage_id=1,
+            resource_id=1,
+            resource_name="get_foo",
+        )
+        assert result == ""
+
     def test_get_query_promql(self, mocker, fake_default_backend):
         mocker.patch("apigateway.service.prometheus.dimension.BaseMetrics.default_labels", return_value=[])
 
@@ -413,6 +431,24 @@ class TestIngressMetrics:
 
 
 class TestEgressMetrics:
+    def test_get_query_promql_backend_not_found(self, mocker):
+        mocker.patch("apigateway.service.prometheus.dimension.BaseMetrics.default_labels", return_value=[])
+        mocker.patch(
+            "apigateway.service.prometheus.dimension.Backend.objects.filter"
+        ).return_value.first.return_value = None
+
+        metrics = dimension.EgressMetrics()
+        result = metrics._get_query_promql(
+            gateway_name="not_exist",
+            stage_name="prod",
+            backend_name="not_exist",
+            step="1m",
+            stage_id=1,
+            resource_id=1,
+            resource_name="get_foo",
+        )
+        assert result == ""
+
     def test_get_query_promql(self, mocker, fake_default_backend):
         mocker.patch("apigateway.service.prometheus.dimension.BaseMetrics.default_labels", return_value=[])
 


### PR DESCRIPTION
- 修复 Prometheus 指标查询中 backend_name 为空或不存在时因 Backend.objects.get() 抛出 DoesNotExist 导致 500 错误的问题。将 IngressMetrics 和 EgressMetrics 中的 .get() 替换为 .filter().first()，并在 BaseMetrics.query_range/query_instant 中增加 promql 空值检查，返回空数据而非异常。