### PR TITLE
feat: add raw_response field to MCPServer

### DIFF
--- a/src/dashboard/apigateway/apigateway/apis/v2/sync/serializers.py
+++ b/src/dashboard/apigateway/apigateway/apis/v2/sync/serializers.py
@@ -857,6 +857,11 @@ class MCPServerSLZ(ExtensibleFieldMixin, serializers.ModelSerializer):
         default=False,
         help_text="是否开启 OAuth2 公开客户端模式，开启后将会对 bk_app_code=public 的应用进行授权",
     )
+    raw_response_enabled = serializers.BooleanField(
+        required=False,
+        default=False,
+        help_text="是否返回原始响应，开启后 mcp-proxy 将直接返回 API 响应结果，不添加 request_id 等额外信息",
+    )
     category_names = serializers.ListField(
         child=serializers.CharField(),
         required=False,
@@ -879,6 +884,7 @@ class MCPServerSLZ(ExtensibleFieldMixin, serializers.ModelSerializer):
             "protocol_type",
             "target_app_codes",
             "oauth2_public_client_enabled",
+            "raw_response_enabled",
             "category_names",
         )
         lookup_field = "id"

--- a/src/dashboard/apigateway/apigateway/apis/web/mcp_server/serializers.py
+++ b/src/dashboard/apigateway/apigateway/apis/web/mcp_server/serializers.py
@@ -228,6 +228,11 @@ class MCPServerCreateInputSLZ(serializers.ModelSerializer):
         default=False,
         help_text="是否开启 OAuth2 公开客户端模式，开启后将会对 bk_app_code=public 的应用进行授权",
     )
+    raw_response_enabled = serializers.BooleanField(
+        required=False,
+        default=False,
+        help_text="是否返回原始响应，开启后 mcp-proxy 将直接返回 API 响应结果，不添加 request_id 等额外信息",
+    )
 
     class Meta:
         ref_name = "apigateway.apis.web.mcp_server.serializers.MCPServerCreateInputSLZ"
@@ -245,6 +250,7 @@ class MCPServerCreateInputSLZ(serializers.ModelSerializer):
             "protocol_type",
             "category_ids",
             "oauth2_public_client_enabled",
+            "raw_response_enabled",
         )
         lookup_field = "id"
         validators = [MCPServerValidator()]
@@ -350,6 +356,11 @@ class MCPServerBaseOutputSLZ(serializers.Serializer):
         read_only=True, help_text="是否开启 OAuth2 公开客户端模式，开启后将会对 bk_app_code=public 的应用进行授权"
     )
 
+    raw_response_enabled = serializers.BooleanField(
+        read_only=True,
+        help_text="是否返回原始响应，开启后 mcp-proxy 将直接返回 API 响应结果，不添加 request_id 等额外信息",
+    )
+
     stage = serializers.SerializerMethodField(help_text="MCPServer 环境")
 
     updated_time = serializers.DateTimeField(read_only=True, help_text="MCPServer 更新时间")
@@ -448,6 +459,10 @@ class MCPServerUpdateInputSLZ(serializers.ModelSerializer):
         required=False,
         help_text="是否开启 OAuth2 公开客户端模式，开启后将会对 bk_app_code=public 的应用进行授权",
     )
+    raw_response_enabled = serializers.BooleanField(
+        required=False,
+        help_text="是否返回原始响应，开启后 mcp-proxy 将直接返回 API 响应结果，不添加 request_id 等额外信息",
+    )
 
     def validate_resource_names(self, resource_names):
         """验证资源名称列表"""
@@ -497,6 +512,7 @@ class MCPServerUpdateInputSLZ(serializers.ModelSerializer):
             "protocol_type",
             "category_ids",
             "oauth2_public_client_enabled",
+            "raw_response_enabled",
         )
         lookup_field = "id"
 

--- a/src/dashboard/apigateway/apigateway/apps/mcp_server/migrations/0013_mcpserver_raw_response.py
+++ b/src/dashboard/apigateway/apigateway/apps/mcp_server/migrations/0013_mcpserver_raw_response.py
@@ -1,0 +1,21 @@
+# Generated manually
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("mcp_server", "0012_mcpserver_oauth2_public_client_enabled"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="mcpserver",
+            name="raw_response_enabled",
+            field=models.BooleanField(
+                default=False,
+                help_text="是否返回原始响应，开启后 mcp-proxy 将直接返回 API 响应结果，不添加 request_id 等额外信息",
+            ),
+        ),
+    ]

--- a/src/dashboard/apigateway/apigateway/apps/mcp_server/models.py
+++ b/src/dashboard/apigateway/apigateway/apps/mcp_server/models.py
@@ -107,6 +107,11 @@ class MCPServer(TimestampedModelMixin, OperatorModelMixin):
         help_text=_("是否开启 OAuth2 公开客户端模式，开启后将会对 bk_app_code=public 的应用进行授权"),
     )
 
+    raw_response_enabled = models.BooleanField(
+        default=False,
+        help_text=_("是否返回原始响应，开启后 mcp-proxy 将直接返回 API 响应结果，不添加 request_id 等额外信息"),
+    )
+
     # 分类关联（多对多关系）
     categories = models.ManyToManyField(
         MCPServerCategory,

--- a/src/dashboard/apigateway/apigateway/data/apidocs/zh/v2_sync_stage_mcp_servers.md
+++ b/src/dashboard/apigateway/apigateway/data/apidocs/zh/v2_sync_stage_mcp_servers.md
@@ -35,6 +35,7 @@ mcp_servers 参数说明
 | `protocol_type` | string       | 否  | MCP 协议类型：sse（默认）、streamable_http                                       |
 | `target_app_codes`   | array[string]          | 否  | 主动授权的应用列表                                                              |
 | `oauth2_public_client_enabled`     | bool                   | 否  | 是否开启 OAuth2 公开客户端模式，开启后将会对 bk_app_code=public 的应用进行授权，默认不开启                     |
+| `raw_response_enabled`     | bool                   | 否  | 是否返回原始响应，开启后 mcp-proxy 将直接返回 API 响应结果，不添加 request_id 等额外信息，默认不开启                     |
 | `category_names`   | array[string]          | 否  | MCP Server 分类名称列表，不传则不更新分类。当前支持的分类：`Uncategorized`（未分类）、`Official`（官方资源）、`Featured`（精选推荐）、`Monitoring`（监控告警）、`ConfigManagement`（配置管理）、`DevOps`（持续交付）、`Emergency`（故障管理）、`Database`（数据服务）、`Automation`（运维自动化）、`Observability`（可观测性）、`Security`（安全合规）、`ResourceOptimize`（资源优化）、`ChaosEngineering`（混沌工程）、`Network`（网络管理）                                                              |
 
 
@@ -67,6 +68,7 @@ mcp_servers 参数说明
         "app2"
       ],
       "oauth2_public_client_enabled": false,
+      "raw_response_enabled": false,
       "category_names": [
         "Official"
       ]

--- a/src/mcp-proxy/pkg/entity/model/mcp.go
+++ b/src/mcp-proxy/pkg/entity/model/mcp.go
@@ -50,6 +50,7 @@ type MCPServer struct {
 	GatewayID     int         `gorm:"column:gateway_id"`
 	StageID       int         `gorm:"column:stage_id"`
 	ProtocolType  string      `gorm:"column:protocol_type;size:32;default:sse"`
+	RawResponseEnabled bool        `gorm:"column:raw_response_enabled;default:false"`
 }
 
 // GetProtocolType 获取协议类型，默认返回 SSE

--- a/src/mcp-proxy/pkg/entity/model/mcp_test.go
+++ b/src/mcp-proxy/pkg/entity/model/mcp_test.go
@@ -53,6 +53,7 @@ var _ = Describe("MCP Models", func() {
 				IsPublic: true, Labels: model.ArrayString{"label1", "label2"},
 				ResourceNames: model.ArrayString{"resource1", "resource2"},
 				Status:        model.McpServerStatusActive, GatewayID: 100, StageID: 200,
+				RawResponseEnabled: true,
 			}
 			Expect(server.ID).To(Equal(1))
 			Expect(server.Name).To(Equal("test-server"))
@@ -63,6 +64,12 @@ var _ = Describe("MCP Models", func() {
 			Expect(server.Status).To(Equal(model.McpServerStatusActive))
 			Expect(server.GatewayID).To(Equal(100))
 			Expect(server.StageID).To(Equal(200))
+			Expect(server.RawResponseEnabled).To(BeTrue())
+		})
+
+		It("should default RawResponseEnabled to false", func() {
+			server := &model.MCPServer{}
+			Expect(server.RawResponseEnabled).To(BeFalse())
 		})
 
 		Describe("GetProtocolType", func() {

--- a/src/mcp-proxy/pkg/infra/proxy/config.go
+++ b/src/mcp-proxy/pkg/infra/proxy/config.go
@@ -32,6 +32,7 @@ type MCPServerConfig struct {
 	ResourceVersionID int           `json:"resource_version_id"`
 	Tools             []*ToolConfig `json:"tools"`
 	ProtocolType      string        `json:"protocol_type"` // 协议类型: sse 或 streamable_http
+	RawResponseEnabled bool `json:"raw_response_enabled"` // 是否返回原始响应，开启后直接返回 API 响应结果，不添加 request_id 等额外信息
 }
 
 // ToolConfig ...

--- a/src/mcp-proxy/pkg/infra/proxy/config_test.go
+++ b/src/mcp-proxy/pkg/infra/proxy/config_test.go
@@ -83,6 +83,7 @@ var _ = Describe("Config", func() {
 			config := proxy.MCPServerConfig{
 				Name:              "test-server",
 				ResourceVersionID: 123,
+				RawResponseEnabled: true,
 				Tools: []*proxy.ToolConfig{
 					{
 						Name: "tool1", Description: "Test tool 1",
@@ -94,8 +95,18 @@ var _ = Describe("Config", func() {
 
 			Expect(config.Name).To(Equal("test-server"))
 			Expect(config.ResourceVersionID).To(Equal(123))
+			Expect(config.RawResponseEnabled).To(BeTrue())
 			Expect(config.Tools).To(HaveLen(1))
 			Expect(config.Tools[0].Name).To(Equal("tool1"))
+		})
+
+		It("should default RawResponseEnabled to false", func() {
+			config := proxy.MCPServerConfig{
+				Name:              "test-server",
+				ResourceVersionID: 1,
+			}
+
+			Expect(config.RawResponseEnabled).To(BeFalse())
 		})
 	})
 

--- a/src/mcp-proxy/pkg/infra/proxy/proxy.go
+++ b/src/mcp-proxy/pkg/infra/proxy/proxy.go
@@ -225,18 +225,20 @@ func (m *MCPProxy) AddMCPServerFromConfigs(configs []*MCPServerConfig) error {
 			}, &mcp.StreamableHTTPOptions{
 				Stateless: true,
 			})
-			mcpServer = NewStreamableHTTPMCPServer(server, httpHandler, config.Name, config.ResourceVersionID)
+			mcpServer = NewStreamableHTTPMCPServer(
+				server, httpHandler, config.Name, config.ResourceVersionID, config.RawResponseEnabled,
+			)
 		} else {
 			// 默认使用 SSE Handler
 			sseHandler := mcp.NewSSEHandler(func(r *http.Request) *mcp.Server {
 				return server
 			}, nil)
-			mcpServer = NewMCPServer(server, sseHandler, config.Name, config.ResourceVersionID)
+			mcpServer = NewMCPServer(server, sseHandler, config.Name, config.ResourceVersionID, config.RawResponseEnabled)
 		}
 
 		// register tool
 		for _, toolConfig := range config.Tools {
-			toolHandler := genToolHandler(toolConfig, config.Name)
+			toolHandler := genToolHandler(toolConfig, config.Name, config.RawResponseEnabled)
 			mcpServer.AddTool(buildMCPTool(toolConfig, config.Name), toolHandler)
 		}
 		m.AddMCPServer(config.Name, mcpServer)
@@ -249,7 +251,7 @@ func (m *MCPProxy) AddMCPServerFromConfigs(configs []*MCPServerConfig) error {
 // toolNameMap: 资源名到工具名的映射，如果为 nil 则使用资源名作为工具名
 func (m *MCPProxy) AddMCPServerFromOpenAPISpec(name string,
 	resourceVersionID int, openAPISpec *openapi3.T, operationIDList []string,
-	toolNameMap map[string]string, protocolType string,
+	toolNameMap map[string]string, protocolType string, rawResponseEnabled bool,
 ) error {
 	operationIDMap := make(map[string]struct{})
 	for _, operationID := range operationIDList {
@@ -260,6 +262,7 @@ func (m *MCPProxy) AddMCPServerFromOpenAPISpec(name string,
 		Tools:             OpenapiToMcpToolConfig(openAPISpec, operationIDMap, toolNameMap),
 		ResourceVersionID: resourceVersionID,
 		ProtocolType:      protocolType,
+		RawResponseEnabled: rawResponseEnabled,
 	}
 	return m.AddMCPServerFromConfigs([]*MCPServerConfig{mcpServerConfig})
 }
@@ -269,23 +272,26 @@ func (m *MCPProxy) AddMCPServerFromOpenAPISpec(name string,
 // toolNameMap: 资源名到工具名的映射，如果为 nil 则使用资源名作为工具名
 func (m *MCPProxy) UpdateMCPServerFromOpenApiSpec(
 	mcpServer *MCPServer, name string, resourceVersionID int, openAPISpec *openapi3.T,
-	operationIDList []string, toolNameMap map[string]string,
+	operationIDList []string, toolNameMap map[string]string, rawResponseEnabled bool,
 ) error {
 	operationIDMap := make(map[string]struct{})
 	for _, operationID := range operationIDList {
 		operationIDMap[operationID] = struct{}{}
 	}
 	mcpServerConfig := &MCPServerConfig{
-		Name:  name,
-		Tools: OpenapiToMcpToolConfig(openAPISpec, operationIDMap, toolNameMap),
+		Name:        name,
+		Tools:       OpenapiToMcpToolConfig(openAPISpec, operationIDMap, toolNameMap),
+		RawResponseEnabled: rawResponseEnabled,
 	}
 	// update tool
 	for _, toolConfig := range mcpServerConfig.Tools {
-		toolHandler := genToolHandler(toolConfig, name)
+		toolHandler := genToolHandler(toolConfig, name, rawResponseEnabled)
 		mcpServer.AddTool(buildMCPTool(toolConfig, name), toolHandler)
 	}
 	// 更新资源版本号
 	mcpServer.SetResourceVersionID(resourceVersionID)
+	// 更新 rawResponseEnabled 状态
+	mcpServer.SetRawResponseEnabled(rawResponseEnabled)
 	return nil
 }
 
@@ -742,7 +748,7 @@ func handleToolCallError(
 	return result
 }
 
-func genToolHandler(toolApiConfig *ToolConfig, serverName string) ToolHandler {
+func genToolHandler(toolApiConfig *ToolConfig, serverName string, rawResponseEnabled bool) ToolHandler {
 	// 生成handler
 	handler := func(ctx context.Context, req *mcp.CallToolRequest) (result *mcp.CallToolResult, err error) {
 		start := time.Now()
@@ -913,13 +919,21 @@ func genToolHandler(toolApiConfig *ToolConfig, serverName string) ToolHandler {
 						}
 					}
 
-					responseResult := buildToolResponseEnvelope(
-						response.Code(),
-						response.GetHeader(constant.BkGatewayRequestIDKey),
-						trace.GetTraceIDFromContext(ctx),
-						xRequestID,
-						res,
-					)
+					var responseResult any
+					if rawResponseEnabled {
+						// raw_response_enabled 模式：直接返回 API 响应结果，不添加 request_id 等额外信息。
+						// 注意：无论成功或失败（非 2xx）都直接透传原始响应，
+						// 由 MCP 协议层的 IsError 标记来区分调用方是否为错误场景。
+						responseResult = res
+					} else {
+						responseResult = buildToolResponseEnvelope(
+							response.Code(),
+							response.GetHeader(constant.BkGatewayRequestIDKey),
+							trace.GetTraceIDFromContext(ctx),
+							xRequestID,
+							res,
+						)
+					}
 					if response.Code() < 200 || response.Code() > 299 {
 						return nil, runtime.NewAPIError("call tool err", responseResult, response.Code())
 					}

--- a/src/mcp-proxy/pkg/infra/proxy/proxy_test.go
+++ b/src/mcp-proxy/pkg/infra/proxy/proxy_test.go
@@ -484,6 +484,33 @@ var _ = Describe("MCPProxy", func() {
 				result.Content[0].(*mcp.TextContent).Text,
 			).To(MatchJSON(`{"status_code":200,"request_id":"req-1","trace_id":"trace-1","x_request_id":"x-req-1","response_body":["a","b"]}`))
 		})
+
+		It("should return raw API response directly when rawResponseEnabled is enabled", func() {
+			// When rawResponseEnabled is true, the response result is the raw API response (not wrapped in envelope)
+			rawBody := map[string]any{
+				"timezone": "Asia/Shanghai",
+				"datetime": "2026-03-19T15:04:05+08:00",
+			}
+			result := buildToolResult(rawBody)
+
+			Expect(result).NotTo(BeNil())
+			Expect(result.Content).To(HaveLen(1))
+			Expect(result.Content[0]).To(BeAssignableToTypeOf(&mcp.TextContent{}))
+			// Raw response should NOT contain status_code, request_id, trace_id, x_request_id wrapper
+			Expect(
+				result.Content[0].(*mcp.TextContent).Text,
+			).To(MatchJSON(`{"timezone":"Asia/Shanghai","datetime":"2026-03-19T15:04:05+08:00"}`))
+		})
+
+		It("should return raw string response directly when rawResponseEnabled is enabled", func() {
+			rawBody := "plain text response"
+			result := buildToolResult(rawBody)
+
+			Expect(result).NotTo(BeNil())
+			Expect(result.Content).To(HaveLen(1))
+			Expect(result.Content[0]).To(BeAssignableToTypeOf(&mcp.TextContent{}))
+			Expect(result.Content[0].(*mcp.TextContent).Text).To(Equal(`"plain text response"`))
+		})
 	})
 
 	Describe("buildLoggingTransport", func() {

--- a/src/mcp-proxy/pkg/infra/proxy/server.go
+++ b/src/mcp-proxy/pkg/infra/proxy/server.go
@@ -43,6 +43,7 @@ type MCPServer struct {
 	name                  string
 	// 生效的资源版本号
 	resourceVersionID int
+	rawResponseEnabled bool // 是否返回原始响应，开启后直接返回 API 响应结果，不添加 request_id 等额外信息
 	tools             map[string]struct{}
 	prompts           map[string]struct{}
 	rwLock            *sync.RWMutex
@@ -54,6 +55,7 @@ func NewMCPServer(
 	handler *mcp.SSEHandler,
 	name string,
 	resourceVersion int,
+	rawResponseEnabled bool,
 ) *MCPServer {
 	return &MCPServer{
 		Server:            server,
@@ -64,6 +66,7 @@ func NewMCPServer(
 		rwLock:            &sync.RWMutex{},
 		name:              name,
 		resourceVersionID: resourceVersion,
+		rawResponseEnabled: rawResponseEnabled,
 	}
 }
 
@@ -73,6 +76,7 @@ func NewStreamableHTTPMCPServer(
 	handler *mcp.StreamableHTTPHandler,
 	name string,
 	resourceVersion int,
+	rawResponseEnabled bool,
 ) *MCPServer {
 	return &MCPServer{
 		Server:                server,
@@ -83,6 +87,7 @@ func NewStreamableHTTPMCPServer(
 		rwLock:                &sync.RWMutex{},
 		name:                  name,
 		resourceVersionID:     resourceVersion,
+		rawResponseEnabled:    rawResponseEnabled,
 	}
 }
 
@@ -94,6 +99,20 @@ func (s *MCPServer) GetProtocolType() string {
 // IsStreamableHTTP 判断是否为 Streamable HTTP 协议
 func (s *MCPServer) IsStreamableHTTP() bool {
 	return s.protocolType == constant.MCPServerProtocolTypeStreamableHTTP
+}
+
+// RawResponseEnabled 是否返回原始响应
+func (s *MCPServer) RawResponseEnabled() bool {
+	s.rwLock.RLock()
+	defer s.rwLock.RUnlock()
+	return s.rawResponseEnabled
+}
+
+// SetRawResponseEnabled 设置是否返回原始响应
+func (s *MCPServer) SetRawResponseEnabled(rawResponseEnabled bool) {
+	s.rwLock.Lock()
+	defer s.rwLock.Unlock()
+	s.rawResponseEnabled = rawResponseEnabled
 }
 
 // HandleSSE 返回 SSE 连接 Handler

--- a/src/mcp-proxy/pkg/infra/proxy/server_test.go
+++ b/src/mcp-proxy/pkg/infra/proxy/server_test.go
@@ -65,6 +65,30 @@ var _ = Describe("MCPServer", func() {
 			})
 		})
 
+		Describe("RawResponseEnabled", func() {
+			It("should return false by default", func() {
+				Expect(server.RawResponseEnabled()).To(BeFalse())
+			})
+
+			It("should return true when rawResponseEnabled is set", func() {
+				server.rawResponseEnabled = true
+				Expect(server.RawResponseEnabled()).To(BeTrue())
+			})
+		})
+
+		Describe("SetRawResponseEnabled", func() {
+			It("should set rawResponseEnabled to true", func() {
+				server.SetRawResponseEnabled(true)
+				Expect(server.RawResponseEnabled()).To(BeTrue())
+			})
+
+			It("should set rawResponseEnabled to false", func() {
+				server.rawResponseEnabled = true
+				server.SetRawResponseEnabled(false)
+				Expect(server.RawResponseEnabled()).To(BeFalse())
+			})
+		})
+
 		Describe("GetTools", func() {
 			It("should return empty slice when no tools", func() {
 				Expect(server.GetTools()).To(BeEmpty())

--- a/src/mcp-proxy/pkg/mcp/mcp.go
+++ b/src/mcp-proxy/pkg/mcp/mcp.go
@@ -261,6 +261,14 @@ func checkNeedLoad(mcpProxy *proxy.MCPProxy, s *model.MCPServer, release *model.
 		}
 	}
 
+	// raw_response_enabled 变化，需要重建 tool handler
+	if mcpServer.RawResponseEnabled() != s.RawResponseEnabled {
+		logging.GetLogger().Infof(
+			"mcp server[%s] raw_response_enabled changed from %v to %v, will reload",
+			s.Name, mcpServer.RawResponseEnabled(), s.RawResponseEnabled)
+		return true
+	}
+
 	logging.GetLogger().Debugf("mcp server[%s] version unchanged, skip reload", s.Name)
 	return false
 }
@@ -331,8 +339,10 @@ func addMCPServer(
 	addStart := time.Now()
 	resourceNames := svr.GetResourceNames()
 
-	err := mcpProxy.AddMCPServerFromOpenAPISpec(svr.Name,
-		conf.resourceVersion, conf.openapiFileData, resourceNames, svr.GetToolNameMap(), svr.GetProtocolType())
+	err := mcpProxy.AddMCPServerFromOpenAPISpec(
+		svr.Name, conf.resourceVersion, conf.openapiFileData,
+		resourceNames, svr.GetToolNameMap(), svr.GetProtocolType(), svr.RawResponseEnabled,
+	)
 	if err != nil {
 		logging.GetLogger().Errorf("add mcp server[name:%s] error: %v", svr.Name, err)
 		return false
@@ -385,8 +395,11 @@ func updateMCPServer(
 
 	var resourceVersionUpdated bool
 	if conf != nil {
-		err := mcpProxy.UpdateMCPServerFromOpenApiSpec(mcpServer, svr.Name, conf.resourceVersion,
-			conf.openapiFileData, svr.GetResourceNames(), svr.GetToolNameMap())
+		err := mcpProxy.UpdateMCPServerFromOpenApiSpec(
+			mcpServer, svr.Name, conf.resourceVersion,
+			conf.openapiFileData, svr.GetResourceNames(),
+			svr.GetToolNameMap(), svr.RawResponseEnabled,
+		)
 		if err != nil {
 			logging.GetLogger().Errorf("update mcp server[%s] from openapi spec error: %v", svr.Name, err)
 			return false

--- a/src/mcp-proxy/pkg/mcp/mcp_benchmark_test.go
+++ b/src/mcp-proxy/pkg/mcp/mcp_benchmark_test.go
@@ -88,7 +88,15 @@ func setupProxyWithServers(count, toolsPerServer, resourceVersion int) *proxy.MC
 	ops := operationIDs(toolsPerServer)
 	for i := 0; i < count; i++ {
 		name := fmt.Sprintf("server_%d", i)
-		_ = p.AddMCPServerFromOpenAPISpec(name, resourceVersion, spec, ops, nil, constant.MCPServerProtocolTypeSSE)
+		_ = p.AddMCPServerFromOpenAPISpec(
+			name,
+			resourceVersion,
+			spec,
+			ops,
+			nil,
+			constant.MCPServerProtocolTypeSSE,
+			false,
+		)
 	}
 	return p
 }
@@ -190,6 +198,7 @@ func BenchmarkAddMCPServerFromOpenAPISpec(b *testing.B) {
 				p := proxy.NewMCPProxy("", "")
 				_ = p.AddMCPServerFromOpenAPISpec(
 					"bench-server", 1, spec, ops, nil, constant.MCPServerProtocolTypeSSE,
+					false,
 				)
 			}
 		})
@@ -208,6 +217,7 @@ func BenchmarkAddMCPServerFromOpenAPISpec_StreamableHTTP(b *testing.B) {
 				p := proxy.NewMCPProxy("", "")
 				_ = p.AddMCPServerFromOpenAPISpec(
 					"bench-server", 1, spec, ops, nil, constant.MCPServerProtocolTypeStreamableHTTP,
+					false,
 				)
 			}
 		})
@@ -228,7 +238,7 @@ func BenchmarkUpdateMCPServerFromOpenApiSpec(b *testing.B) {
 			b.ResetTimer()
 			for i := 0; i < b.N; i++ {
 				_ = p.UpdateMCPServerFromOpenApiSpec(
-					server, "server_0", i+2, newSpec, newOps, nil,
+					server, "server_0", i+2, newSpec, newOps, nil, false,
 				)
 			}
 		})
@@ -386,6 +396,7 @@ func BenchmarkAddMultipleServers(b *testing.B) {
 				for j := 0; j < numServers; j++ {
 					_ = p.AddMCPServerFromOpenAPISpec(
 						fmt.Sprintf("server_%d", j), 1, spec, ops, nil, constant.MCPServerProtocolTypeSSE,
+						false,
 					)
 				}
 			}
@@ -411,6 +422,7 @@ func BenchmarkAddMCPServerWithToolNameMap(b *testing.B) {
 				p := proxy.NewMCPProxy("", "")
 				_ = p.AddMCPServerFromOpenAPISpec(
 					"bench-server", 1, spec, ops, toolNameMap, constant.MCPServerProtocolTypeSSE,
+					false,
 				)
 			}
 		})

--- a/src/mcp-proxy/pkg/mcp/mcp_load_test.go
+++ b/src/mcp-proxy/pkg/mcp/mcp_load_test.go
@@ -76,6 +76,7 @@ var _ = Describe("MCP Load Functions", func() {
 			// Add an existing server with version 1
 			err := mcpProxy.AddMCPServerFromOpenAPISpec(
 				"test-server", 1, openapiSpec, []string{"getUsers"}, nil, constant.MCPServerProtocolTypeSSE,
+				false,
 			)
 			Expect(err).NotTo(HaveOccurred())
 
@@ -92,6 +93,7 @@ var _ = Describe("MCP Load Functions", func() {
 		It("should return false when version unchanged and all tools present", func() {
 			err := mcpProxy.AddMCPServerFromOpenAPISpec(
 				"test-server", 1, openapiSpec, []string{"getUsers"}, nil, constant.MCPServerProtocolTypeSSE,
+				false,
 			)
 			Expect(err).NotTo(HaveOccurred())
 
@@ -109,6 +111,7 @@ var _ = Describe("MCP Load Functions", func() {
 		It("should return true when new tool is added (resource_names changed)", func() {
 			err := mcpProxy.AddMCPServerFromOpenAPISpec(
 				"test-server", 1, openapiSpec, []string{"getUsers"}, nil, constant.MCPServerProtocolTypeSSE,
+				false,
 			)
 			Expect(err).NotTo(HaveOccurred())
 
@@ -126,12 +129,31 @@ var _ = Describe("MCP Load Functions", func() {
 		It("should return true when protocol type changed", func() {
 			err := mcpProxy.AddMCPServerFromOpenAPISpec(
 				"test-server", 1, openapiSpec, []string{"getUsers"}, nil, constant.MCPServerProtocolTypeSSE,
+				false,
 			)
 			Expect(err).NotTo(HaveOccurred())
 
 			server := &model.MCPServer{
 				Name:         "test-server",
 				ProtocolType: constant.MCPServerProtocolTypeStreamableHTTP, // Changed protocol
+			}
+			release := &model.Release{ResourceVersionID: 1}
+
+			needLoad := mcppkg.CheckNeedLoadForTest(mcpProxy, server, release)
+			Expect(needLoad).To(BeTrue())
+		})
+
+		It("should return true when raw_response_enabled changed", func() {
+			err := mcpProxy.AddMCPServerFromOpenAPISpec(
+				"test-server", 1, openapiSpec, []string{"getUsers"}, nil,
+				constant.MCPServerProtocolTypeSSE, false,
+			)
+			Expect(err).NotTo(HaveOccurred())
+
+			server := &model.MCPServer{
+				Name:                "test-server",
+				ProtocolType:        constant.MCPServerProtocolTypeSSE,
+				RawResponseEnabled:  true, // Changed raw_response_enabled
 			}
 			release := &model.Release{ResourceVersionID: 1}
 
@@ -145,10 +167,12 @@ var _ = Describe("MCP Load Functions", func() {
 			// Add two servers
 			err := mcpProxy.AddMCPServerFromOpenAPISpec(
 				"server-1", 1, openapiSpec, []string{"getUsers"}, nil, constant.MCPServerProtocolTypeSSE,
+				false,
 			)
 			Expect(err).NotTo(HaveOccurred())
 			err = mcpProxy.AddMCPServerFromOpenAPISpec(
 				"server-2", 1, openapiSpec, []string{"getUsers"}, nil, constant.MCPServerProtocolTypeSSE,
+				false,
 			)
 			Expect(err).NotTo(HaveOccurred())
 			mcpProxy.Run(ctx)
@@ -172,10 +196,12 @@ var _ = Describe("MCP Load Functions", func() {
 		It("should delete servers not in active set", func() {
 			err := mcpProxy.AddMCPServerFromOpenAPISpec(
 				"server-1", 1, openapiSpec, []string{"getUsers"}, nil, constant.MCPServerProtocolTypeSSE,
+				false,
 			)
 			Expect(err).NotTo(HaveOccurred())
 			err = mcpProxy.AddMCPServerFromOpenAPISpec(
 				"server-2", 1, openapiSpec, []string{"getUsers"}, nil, constant.MCPServerProtocolTypeSSE,
+				false,
 			)
 			Expect(err).NotTo(HaveOccurred())
 			mcpProxy.Run(ctx)
@@ -195,6 +221,7 @@ var _ = Describe("MCP Load Functions", func() {
 		It("should return 0 when all servers are active", func() {
 			err := mcpProxy.AddMCPServerFromOpenAPISpec(
 				"server-1", 1, openapiSpec, []string{"getUsers"}, nil, constant.MCPServerProtocolTypeSSE,
+				false,
 			)
 			Expect(err).NotTo(HaveOccurred())
 			mcpProxy.Run(ctx)

--- a/src/mcp-proxy/pkg/mcp/mcp_test.go
+++ b/src/mcp-proxy/pkg/mcp/mcp_test.go
@@ -75,6 +75,7 @@ var _ = Describe("MCP", func() {
 					[]string{"getUsers"},
 					nil,
 					constant.MCPServerProtocolTypeSSE,
+					false,
 				)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(mcpProxy.IsMCPServerExist("test-server")).To(BeTrue())
@@ -82,6 +83,41 @@ var _ = Describe("MCP", func() {
 				server := mcpProxy.GetMCPServer("test-server")
 				Expect(server).NotTo(BeNil())
 				Expect(server.GetResourceVersionID()).To(Equal(1))
+				Expect(server.RawResponseEnabled()).To(BeFalse())
+			})
+
+			It("should add server with raw_response_enabled enabled", func() {
+				openapiSpec := &openapi3.T{
+					OpenAPI: "3.0.0",
+					Info:    &openapi3.Info{Title: "Test API", Version: "1.0.0"},
+					Servers: []*openapi3.Server{{URL: "https://api.example.com"}},
+					Paths:   &openapi3.Paths{},
+				}
+
+				pathItem := &openapi3.PathItem{
+					Get: &openapi3.Operation{
+						OperationID: "getUsers",
+						Summary:     "Get users",
+						Responses:   &openapi3.Responses{},
+					},
+				}
+				openapiSpec.Paths.Set("/users", pathItem)
+
+				err := mcpProxy.AddMCPServerFromOpenAPISpec(
+					"raw-response-server",
+					1,
+					openapiSpec,
+					[]string{"getUsers"},
+					nil,
+					constant.MCPServerProtocolTypeSSE,
+					true,
+				)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(mcpProxy.IsMCPServerExist("raw-response-server")).To(BeTrue())
+
+				server := mcpProxy.GetMCPServer("raw-response-server")
+				Expect(server).NotTo(BeNil())
+				Expect(server.RawResponseEnabled()).To(BeTrue())
 			})
 		})
 
@@ -101,6 +137,7 @@ var _ = Describe("MCP", func() {
 					[]string{},
 					nil,
 					constant.MCPServerProtocolTypeSSE,
+					false,
 				)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(mcpProxy.IsMCPServerExist("test-server")).To(BeTrue())
@@ -117,6 +154,46 @@ var _ = Describe("MCP", func() {
 		})
 
 		Describe("UpdateMCPServerFromOpenApiSpec", func() {
+			It("should update raw_response_enabled and rebuild tool handlers when raw_response_enabled changes with same version", func() {
+				openapiSpec := &openapi3.T{
+					OpenAPI: "3.0.0",
+					Info:    &openapi3.Info{Title: "Test API", Version: "1.0.0"},
+					Servers: []*openapi3.Server{{URL: "https://api.example.com"}},
+					Paths:   &openapi3.Paths{},
+				}
+
+				pathItem := &openapi3.PathItem{
+					Get: &openapi3.Operation{
+						OperationID: "getUsers",
+						Summary:     "Get users",
+						Responses:   &openapi3.Responses{},
+					},
+				}
+				openapiSpec.Paths.Set("/users", pathItem)
+
+				// 创建 server，raw_response_enabled=false
+				err := mcpProxy.AddMCPServerFromOpenAPISpec(
+					"raw-switch-server", 1, openapiSpec,
+					[]string{"getUsers"}, nil, constant.MCPServerProtocolTypeSSE, false,
+				)
+				Expect(err).NotTo(HaveOccurred())
+
+				server := mcpProxy.GetMCPServer("raw-switch-server")
+				Expect(server).NotTo(BeNil())
+				Expect(server.RawResponseEnabled()).To(BeFalse())
+				Expect(server.GetResourceVersionID()).To(Equal(1))
+
+				// 更新 server，仅切换 raw_response_enabled=true，resourceVersionID 不变
+				err = mcpProxy.UpdateMCPServerFromOpenApiSpec(
+					server, "raw-switch-server", 1, openapiSpec,
+					[]string{"getUsers"}, nil, true,
+				)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(server.RawResponseEnabled()).To(BeTrue())
+				// resourceVersionID 应保持不变
+				Expect(server.GetResourceVersionID()).To(Equal(1))
+			})
+
 			It("should update server with new version", func() {
 				openapiSpec := &openapi3.T{
 					OpenAPI: "3.0.0",
@@ -141,6 +218,7 @@ var _ = Describe("MCP", func() {
 					[]string{"getUsers"},
 					nil,
 					constant.MCPServerProtocolTypeSSE,
+					false,
 				)
 				Expect(err).NotTo(HaveOccurred())
 
@@ -170,7 +248,7 @@ var _ = Describe("MCP", func() {
 				newOpenapiSpec.Paths.Set("/users", newPathItem)
 
 				err = mcpProxy.UpdateMCPServerFromOpenApiSpec(
-					server, "test-server", 2, newOpenapiSpec, []string{"getUsers", "createUser"}, nil,
+					server, "test-server", 2, newOpenapiSpec, []string{"getUsers", "createUser"}, nil, false,
 				)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(server.GetResourceVersionID()).To(Equal(2))
@@ -193,6 +271,7 @@ var _ = Describe("MCP", func() {
 					[]string{},
 					nil,
 					constant.MCPServerProtocolTypeSSE,
+					false,
 				)
 				Expect(err).NotTo(HaveOccurred())
 
@@ -217,6 +296,7 @@ var _ = Describe("MCP", func() {
 					[]string{},
 					nil,
 					constant.MCPServerProtocolTypeStreamableHTTP,
+					false,
 				)
 				Expect(err).NotTo(HaveOccurred())
 
@@ -242,6 +322,7 @@ var _ = Describe("MCP", func() {
 					[]string{},
 					nil,
 					constant.MCPServerProtocolTypeSSE,
+					false,
 				)
 				Expect(err).NotTo(HaveOccurred())
 
@@ -260,6 +341,7 @@ var _ = Describe("MCP", func() {
 					[]string{},
 					nil,
 					constant.MCPServerProtocolTypeStreamableHTTP,
+					false,
 				)
 				Expect(err).NotTo(HaveOccurred())
 
@@ -286,6 +368,7 @@ var _ = Describe("MCP", func() {
 					[]string{},
 					nil,
 					constant.MCPServerProtocolTypeStreamableHTTP,
+					false,
 				)
 				Expect(err).NotTo(HaveOccurred())
 
@@ -304,6 +387,7 @@ var _ = Describe("MCP", func() {
 					[]string{},
 					nil,
 					constant.MCPServerProtocolTypeSSE,
+					false,
 				)
 				Expect(err).NotTo(HaveOccurred())
 
@@ -340,6 +424,7 @@ var _ = Describe("MCP", func() {
 					[]string{"getUsers"},
 					nil,
 					constant.MCPServerProtocolTypeSSE,
+					false,
 				)
 				Expect(err).NotTo(HaveOccurred())
 
@@ -379,6 +464,7 @@ var _ = Describe("MCP", func() {
 					[]string{"getUsers", "createUser"},
 					nil,
 					constant.MCPServerProtocolTypeSSE,
+					false,
 				)
 				Expect(err).NotTo(HaveOccurred())
 
@@ -431,6 +517,7 @@ var _ = Describe("MCP", func() {
 					[]string{"getUsers"},
 					nil,
 					constant.MCPServerProtocolTypeSSE,
+					false,
 				)
 				Expect(err).NotTo(HaveOccurred())
 
@@ -466,7 +553,7 @@ var _ = Describe("MCP", func() {
 
 				// 使用相同的 resourceVersionID 更新（模拟 resource_names 变化但版本不变的场景）
 				err = mcpProxy.UpdateMCPServerFromOpenApiSpec(
-					server, "test-server", 1, openapiSpec, newResourceNames, nil,
+					server, "test-server", 1, openapiSpec, newResourceNames, nil, false,
 				)
 				Expect(err).NotTo(HaveOccurred())
 
@@ -507,6 +594,7 @@ var _ = Describe("MCP", func() {
 					[]string{"getUsers", "createUser"},
 					nil,
 					constant.MCPServerProtocolTypeSSE,
+					false,
 				)
 				Expect(err).NotTo(HaveOccurred())
 
@@ -565,6 +653,7 @@ var _ = Describe("MCP", func() {
 					[]string{"getUsers"},
 					nil,
 					constant.MCPServerProtocolTypeSSE,
+					false,
 				)
 				Expect(err).NotTo(HaveOccurred())
 
@@ -631,6 +720,7 @@ var _ = Describe("MCP", func() {
 					[]string{"getUsers", "createUser"},
 					toolNameMap,
 					constant.MCPServerProtocolTypeSSE,
+					false,
 				)
 				Expect(err).NotTo(HaveOccurred())
 
@@ -669,6 +759,7 @@ var _ = Describe("MCP", func() {
 					[]string{"getUsers"},
 					nil,
 					constant.MCPServerProtocolTypeSSE,
+					false,
 				)
 				Expect(err).NotTo(HaveOccurred())
 
@@ -710,6 +801,7 @@ var _ = Describe("MCP", func() {
 					[]string{"getUsers"},
 					nil,
 					constant.MCPServerProtocolTypeSSE,
+					false,
 				)
 				Expect(err).NotTo(HaveOccurred())
 
@@ -724,7 +816,7 @@ var _ = Describe("MCP", func() {
 				}
 
 				err = mcpProxy.UpdateMCPServerFromOpenApiSpec(
-					server, "test-server", 2, openapiSpec, []string{"getUsers", "createUser"}, toolNameMap,
+					server, "test-server", 2, openapiSpec, []string{"getUsers", "createUser"}, toolNameMap, false,
 				)
 				Expect(err).NotTo(HaveOccurred())
 
@@ -769,6 +861,7 @@ var _ = Describe("MCP", func() {
 					[]string{"getUsers", "createUser"},
 					toolNameMap,
 					constant.MCPServerProtocolTypeSSE,
+					false,
 				)
 				Expect(err).NotTo(HaveOccurred())
 


### PR DESCRIPTION
## Summary

- Add `raw_response` boolean field to MCPServer Django model with migration
- Add `raw_response` to web/mcp_server serializers (create, update, output)
- Add `raw_response` to v2/sync serializer
- Add `RawResponse` field to Go MCPServer model and MCPServerConfig
- Support `rawResponse` in proxy server and tool handler
- When `raw_response` is enabled, mcp-proxy returns raw API response without wrapping in envelope (status_code, request_id, trace_id, etc.)
- Add unit tests for `raw_response` in Go (model, config, server, proxy, mcp)
- Update apidocs for sync API

## Test Plan

- [x] Go unit tests for model, config, server, proxy, mcp packages
- [x] Python model migration verified
- [ ] Integration test with actual MCP server