### PR TITLE
feat: add batch MCP Server config API

### DIFF
--- a/src/dashboard/apigateway/apigateway/apis/web/mcp_marketplace/serializers.py
+++ b/src/dashboard/apigateway/apigateway/apis/web/mcp_marketplace/serializers.py
@@ -18,6 +18,8 @@
 
 from typing import Any, Dict, List
 
+from django.conf import settings
+from django.utils.translation import gettext as _
 from rest_framework import serializers
 
 from apigateway.apps.mcp_server.constants import (
@@ -274,6 +276,7 @@ class MCPServerBatchConfigInputSLZ(serializers.Serializer):
         child=serializers.IntegerField(),
         required=True,
         min_length=1,
+        max_length=100,
         help_text="MCPServer ID 列表",
     )
     client_type = serializers.CharField(
@@ -283,6 +286,16 @@ class MCPServerBatchConfigInputSLZ(serializers.Serializer):
 
     class Meta:
         ref_name = "apigateway.apis.web.mcp_marketplace.serializers.MCPServerBatchConfigInputSLZ"
+
+    def validate_client_type(self, value):
+        """校验 client_type 必须在 MCP_CONFIG_AGENT_CLIENTS 中"""
+        valid_client_types = [client["name"] for client in settings.MCP_CONFIG_AGENT_CLIENTS]
+        if value not in valid_client_types:
+            raise serializers.ValidationError(
+                _("不支持的客户端类型：%(value)s，支持的类型：%(valid_types)s")
+                % {"value": value, "valid_types": ", ".join(valid_client_types)}
+            )
+        return value
 
 
 class MCPServerBatchConfigOutputSLZ(serializers.Serializer):

--- a/src/dashboard/apigateway/apigateway/apis/web/mcp_marketplace/serializers.py
+++ b/src/dashboard/apigateway/apigateway/apis/web/mcp_marketplace/serializers.py
@@ -18,11 +18,11 @@
 
 from typing import Any, Dict, List
 
-from django.conf import settings
 from rest_framework import serializers
 
 from apigateway.apps.mcp_server.constants import (
     FEATURED_MCP_CATEGORY_NAME,
+    MCP_AGENT_CLIENT_CHOICES_WITHOUT_AIDEV,
     OFFICIAL_MCP_CATEGORY_NAME,
     MCPServerProtocolTypeEnum,
     MCPServerStatusEnum,
@@ -280,7 +280,7 @@ class MCPServerBatchConfigInputSLZ(serializers.Serializer):
     )
     client_type = serializers.ChoiceField(
         required=True,
-        choices=[(client["name"], client["display_name"]) for client in settings.MCP_CONFIG_AGENT_CLIENTS],
+        choices=MCP_AGENT_CLIENT_CHOICES_WITHOUT_AIDEV,
         help_text="客户端类型",
     )
 

--- a/src/dashboard/apigateway/apigateway/apis/web/mcp_marketplace/serializers.py
+++ b/src/dashboard/apigateway/apigateway/apis/web/mcp_marketplace/serializers.py
@@ -265,3 +265,32 @@ class MCPServerToolDocOutputSLZ(serializers.Serializer):
 
     class Meta:
         ref_name = "apigateway.apis.web.mcp_marketplace.serializers.MCPServerToolDocOutputSLZ"
+
+
+class MCPServerBatchConfigInputSLZ(serializers.Serializer):
+    """批量获取 MCPServer 配置输入序列化器"""
+
+    mcp_server_ids = serializers.ListField(
+        child=serializers.IntegerField(),
+        required=True,
+        min_length=1,
+        help_text="MCPServer ID 列表",
+    )
+    client_type = serializers.CharField(
+        required=True,
+        help_text="客户端类型（cursor, codebuddy, claude, vscode, aidev 等）",
+    )
+
+    class Meta:
+        ref_name = "apigateway.apis.web.mcp_marketplace.serializers.MCPServerBatchConfigInputSLZ"
+
+
+class MCPServerBatchConfigOutputSLZ(serializers.Serializer):
+    """批量获取 MCPServer 配置输出序列化器"""
+
+    client_type = serializers.CharField(read_only=True, help_text="客户端类型")
+    display_name = serializers.CharField(read_only=True, help_text="客户端显示名称")
+    config = serializers.DictField(read_only=True, help_text="客户端配置（JSON 格式）")
+
+    class Meta:
+        ref_name = "apigateway.apis.web.mcp_marketplace.serializers.MCPServerBatchConfigOutputSLZ"

--- a/src/dashboard/apigateway/apigateway/apis/web/mcp_marketplace/serializers.py
+++ b/src/dashboard/apigateway/apigateway/apis/web/mcp_marketplace/serializers.py
@@ -278,7 +278,7 @@ class MCPServerBatchConfigInputSLZ(serializers.Serializer):
     )
     client_type = serializers.CharField(
         required=True,
-        help_text="客户端类型（cursor, codebuddy, claude, vscode, aidev 等）",
+        help_text="客户端类型（cursor, codebuddy, claude, vscode 等）",
     )
 
     class Meta:

--- a/src/dashboard/apigateway/apigateway/apis/web/mcp_marketplace/serializers.py
+++ b/src/dashboard/apigateway/apigateway/apis/web/mcp_marketplace/serializers.py
@@ -19,7 +19,6 @@
 from typing import Any, Dict, List
 
 from django.conf import settings
-from django.utils.translation import gettext as _
 from rest_framework import serializers
 
 from apigateway.apps.mcp_server.constants import (
@@ -279,23 +278,14 @@ class MCPServerBatchConfigInputSLZ(serializers.Serializer):
         max_length=100,
         help_text="MCPServer ID 列表",
     )
-    client_type = serializers.CharField(
+    client_type = serializers.ChoiceField(
         required=True,
-        help_text="客户端类型（cursor, codebuddy, claude, vscode 等）",
+        choices=[(client["name"], client["display_name"]) for client in settings.MCP_CONFIG_AGENT_CLIENTS],
+        help_text="客户端类型",
     )
 
     class Meta:
         ref_name = "apigateway.apis.web.mcp_marketplace.serializers.MCPServerBatchConfigInputSLZ"
-
-    def validate_client_type(self, value):
-        """校验 client_type 必须在 MCP_CONFIG_AGENT_CLIENTS 中"""
-        valid_client_types = [client["name"] for client in settings.MCP_CONFIG_AGENT_CLIENTS]
-        if value not in valid_client_types:
-            raise serializers.ValidationError(
-                _("不支持的客户端类型：%(value)s，支持的类型：%(valid_types)s")
-                % {"value": value, "valid_types": ", ".join(valid_client_types)}
-            )
-        return value
 
 
 class MCPServerBatchConfigOutputSLZ(serializers.Serializer):

--- a/src/dashboard/apigateway/apigateway/apis/web/mcp_marketplace/urls.py
+++ b/src/dashboard/apigateway/apigateway/apis/web/mcp_marketplace/urls.py
@@ -19,6 +19,7 @@
 from django.urls import include, path
 
 from .views import (
+    MCPMarketplaceBatchConfigApi,
     MCPMarketplaceCategoryListApi,
     MCPMarketplaceServerConfigListApi,
     MCPMarketplaceServerListApi,
@@ -29,6 +30,8 @@ from .views import (
 urlpatterns = [
     # 分类列表
     path("categories/", MCPMarketplaceCategoryListApi.as_view(), name="mcp_marketplace.category.list"),
+    # 批量获取配置
+    path("batch-config/", MCPMarketplaceBatchConfigApi.as_view(), name="mcp_marketplace.batch_config"),
     path(
         "servers/",
         include(

--- a/src/dashboard/apigateway/apigateway/apis/web/mcp_marketplace/urls.py
+++ b/src/dashboard/apigateway/apigateway/apis/web/mcp_marketplace/urls.py
@@ -31,7 +31,7 @@ urlpatterns = [
     # 分类列表
     path("categories/", MCPMarketplaceCategoryListApi.as_view(), name="mcp_marketplace.category.list"),
     # 批量获取配置
-    path("batch-config/", MCPMarketplaceBatchConfigApi.as_view(), name="mcp_marketplace.batch_config"),
+    path("batch-configs/", MCPMarketplaceBatchConfigApi.as_view(), name="mcp_marketplace.batch_configs"),
     path(
         "servers/",
         include(

--- a/src/dashboard/apigateway/apigateway/apis/web/mcp_marketplace/views.py
+++ b/src/dashboard/apigateway/apigateway/apis/web/mcp_marketplace/views.py
@@ -15,8 +15,10 @@
 # We undertake not to change the open source license (MIT license) applicable
 # to the current version of the project delivered to anyone in the future.
 #
+from django.conf import settings
 from django.db.models import Count, Q
 from django.utils.decorators import method_decorator
+from django.utils.translation import gettext as _
 from drf_yasg.utils import swagger_auto_schema
 from rest_framework import generics, status
 
@@ -28,6 +30,7 @@ from apigateway.apps.mcp_server.constants import (
 )
 from apigateway.apps.mcp_server.models import MCPServer, MCPServerCategory
 from apigateway.biz.mcp_server import MCPServerHandler
+from apigateway.common.error_codes import error_codes
 from apigateway.common.tenant.constants import TENANT_ID_OPERATION, TenantModeEnum
 from apigateway.common.tenant.query import gateway_mcp_server_filter_by_user_tenant_id
 from apigateway.common.tenant.request import get_user_tenant_id
@@ -36,6 +39,8 @@ from apigateway.core.constants import GatewayStatusEnum, StageStatusEnum
 from apigateway.utils.responses import OKJsonResponse
 
 from .serializers import (
+    MCPServerBatchConfigInputSLZ,
+    MCPServerBatchConfigOutputSLZ,
     MCPServerCategoryOutputSLZ,
     MCPServerListInputSLZ,
     MCPServerListOutputSLZ,
@@ -289,3 +294,70 @@ class MCPMarketplaceCategoryListApi(generics.ListAPIView):
 
         serializer = self.get_serializer(queryset, many=True, context={"category_stats": category_stats})
         return OKJsonResponse(data=serializer.data)
+
+
+@method_decorator(
+    name="post",
+    decorator=swagger_auto_schema(
+        operation_description="批量获取 MCP 市场 MCPServer 配置（支持指定客户端类型：cursor, codebuddy, claude, vscode, aidev 等）",
+        request_body=MCPServerBatchConfigInputSLZ,
+        responses={status.HTTP_200_OK: MCPServerBatchConfigOutputSLZ()},
+        tags=["WebAPI.MCPServer"],
+    ),
+)
+class MCPMarketplaceBatchConfigApi(generics.CreateAPIView):
+    """批量获取 MCP 市场 MCPServer 配置，支持指定客户端类型"""
+
+    def create(self, request, *args, **kwargs):
+        slz = MCPServerBatchConfigInputSLZ(data=request.data)
+        slz.is_valid(raise_exception=True)
+
+        mcp_server_ids = slz.validated_data["mcp_server_ids"]
+        client_type = slz.validated_data["client_type"]
+
+        # 查询 MCPServer 列表（只查询公开的）
+        queryset = MCPServer.objects.filter(
+            id__in=mcp_server_ids,
+            is_public=True,
+            status=MCPServerStatusEnum.ACTIVE.value,
+            gateway__status=GatewayStatusEnum.ACTIVE.value,
+            stage__status=StageStatusEnum.ACTIVE.value,
+        ).select_related("gateway", "stage")
+
+        # 租户过滤
+        user_tenant_id = get_user_tenant_id(request)
+        if user_tenant_id:
+            queryset = gateway_mcp_server_filter_by_user_tenant_id(queryset, user_tenant_id)
+
+        instances = list(queryset)
+
+        if not instances:
+            raise error_codes.NOT_FOUND.format(_("未找到有效的 MCPServer"), replace=True)
+
+        # 校验访问权限
+        for instance in instances:
+            check_user_can_access_gateway(instance.gateway.tenant_mode, instance.gateway.tenant_id, user_tenant_id)
+
+        # 获取最低权限信息
+        least_privileges = MCPServerHandler.get_least_privileges(instances)
+
+        # 构建批量配置
+        config = MCPServerHandler.build_batch_agent_client_config(
+            instances, client_type, least_privileges, user_tenant_id=user_tenant_id
+        )
+
+        # 查找客户端显示名称
+        display_name = client_type
+        for client in settings.MCP_CONFIG_AGENT_CLIENTS:
+            if client["name"] == client_type:
+                display_name = client["display_name"]
+                break
+
+        result = {
+            "client_type": client_type,
+            "display_name": display_name,
+            "config": config,
+        }
+
+        output_slz = MCPServerBatchConfigOutputSLZ(result)
+        return OKJsonResponse(data=output_slz.data)

--- a/src/dashboard/apigateway/apigateway/apis/web/mcp_marketplace/views.py
+++ b/src/dashboard/apigateway/apigateway/apis/web/mcp_marketplace/views.py
@@ -15,7 +15,6 @@
 # We undertake not to change the open source license (MIT license) applicable
 # to the current version of the project delivered to anyone in the future.
 #
-from django.conf import settings
 from django.db.models import Count, Q
 from django.utils.decorators import method_decorator
 from django.utils.translation import gettext as _
@@ -185,7 +184,7 @@ class MCPMarketplaceServerToolDocRetrieveApi(generics.RetrieveAPIView):
 @method_decorator(
     name="get",
     decorator=swagger_auto_schema(
-        operation_description="获取 MCP 市场中某个 Server 的配置列表（支持 Cursor、CodeBuddy、Claude、AIDev 等工具的配置）",
+        operation_description="获取 MCP 市场中某个 Server 的配置列表（支持 Cursor、CodeBuddy、Claude、VSCode 等工具的配置）",
         responses={status.HTTP_200_OK: MCPServerConfigListOutputSLZ()},
         tags=["WebAPI.MCPServer"],
     ),
@@ -299,7 +298,7 @@ class MCPMarketplaceCategoryListApi(generics.ListAPIView):
 @method_decorator(
     name="post",
     decorator=swagger_auto_schema(
-        operation_description="批量获取 MCP 市场 MCPServer 配置（支持指定客户端类型：cursor, codebuddy, claude, vscode, aidev 等）",
+        operation_description="批量获取 MCP 市场 MCPServer 配置（支持指定客户端类型：cursor, codebuddy, claude, vscode 等）",
         request_body=MCPServerBatchConfigInputSLZ,
         responses={status.HTTP_200_OK: MCPServerBatchConfigOutputSLZ()},
         tags=["WebAPI.MCPServer"],
@@ -338,8 +337,8 @@ class MCPMarketplaceBatchConfigApi(generics.CreateAPIView):
         for instance in instances:
             check_user_can_access_gateway(instance.gateway.tenant_mode, instance.gateway.tenant_id, user_tenant_id)
 
-        # 获取最低权限信息
-        least_privileges = MCPServerHandler.get_least_privileges(instances)
+        # 获取最低权限信息（按 mcp_server.id 为 key）
+        least_privileges = MCPServerHandler.get_least_privileges_by_server(instances)
 
         # 构建批量配置
         config = MCPServerHandler.build_batch_agent_client_config(
@@ -347,11 +346,7 @@ class MCPMarketplaceBatchConfigApi(generics.CreateAPIView):
         )
 
         # 查找客户端显示名称
-        display_name = client_type
-        for client in settings.MCP_CONFIG_AGENT_CLIENTS:
-            if client["name"] == client_type:
-                display_name = client["display_name"]
-                break
+        display_name = MCPServerHandler.get_client_display_name(client_type)
 
         result = {
             "client_type": client_type,

--- a/src/dashboard/apigateway/apigateway/apis/web/mcp_server/serializers.py
+++ b/src/dashboard/apigateway/apigateway/apis/web/mcp_server/serializers.py
@@ -19,6 +19,7 @@
 import logging
 from typing import Any, Dict, List
 
+from django.conf import settings
 from django.utils.translation import gettext_lazy as _
 from rest_framework import serializers
 
@@ -832,7 +833,7 @@ class MCPServerFilterOptionsOutputSLZ(serializers.Serializer):
 class MCPServerConfigItemOutputSLZ(serializers.Serializer):
     """MCPServer 单个配置项输出序列化器"""
 
-    name = serializers.CharField(read_only=True, help_text="配置名称（如 cursor, codebuddy, claude, aidev）")
+    name = serializers.CharField(read_only=True, help_text="配置名称（如 cursor, codebuddy, claude, vscode 等）")
     display_name = serializers.CharField(read_only=True, help_text="配置显示名称")
     content = serializers.CharField(read_only=True, help_text="配置内容（markdown 格式）")
     install_url = serializers.CharField(
@@ -887,6 +888,7 @@ class MCPServerBatchConfigInputSLZ(serializers.Serializer):
         child=serializers.IntegerField(),
         required=True,
         min_length=1,
+        max_length=100,
         help_text="MCPServer ID 列表",
     )
     client_type = serializers.CharField(
@@ -896,6 +898,16 @@ class MCPServerBatchConfigInputSLZ(serializers.Serializer):
 
     class Meta:
         ref_name = "apigateway.apis.web.mcp_server.serializers.MCPServerBatchConfigInputSLZ"
+
+    def validate_client_type(self, value):
+        """校验 client_type 必须在 MCP_CONFIG_AGENT_CLIENTS 中"""
+        valid_client_types = [client["name"] for client in settings.MCP_CONFIG_AGENT_CLIENTS]
+        if value not in valid_client_types:
+            raise serializers.ValidationError(
+                _("不支持的客户端类型：%(value)s，支持的类型：%(valid_types)s")
+                % {"value": value, "valid_types": ", ".join(valid_client_types)}
+            )
+        return value
 
 
 class MCPServerBatchConfigOutputSLZ(serializers.Serializer):

--- a/src/dashboard/apigateway/apigateway/apis/web/mcp_server/serializers.py
+++ b/src/dashboard/apigateway/apigateway/apis/web/mcp_server/serializers.py
@@ -19,12 +19,12 @@
 import logging
 from typing import Any, Dict, List
 
-from django.conf import settings
 from django.utils.translation import gettext_lazy as _
 from rest_framework import serializers
 
 from apigateway.apps.mcp_server.constants import (
     FEATURED_MCP_CATEGORY_NAME,
+    MCP_AGENT_CLIENT_CHOICES_WITHOUT_AIDEV,
     OFFICIAL_MCP_CATEGORY_NAME,
     MCPServerAppPermissionApplyProcessedStateEnum,
     MCPServerAppPermissionApplyStatusEnum,
@@ -893,7 +893,7 @@ class MCPServerBatchConfigInputSLZ(serializers.Serializer):
     )
     client_type = serializers.ChoiceField(
         required=True,
-        choices=[(client["name"], client["display_name"]) for client in settings.MCP_CONFIG_AGENT_CLIENTS],
+        choices=MCP_AGENT_CLIENT_CHOICES_WITHOUT_AIDEV,
         help_text="客户端类型",
     )
 

--- a/src/dashboard/apigateway/apigateway/apis/web/mcp_server/serializers.py
+++ b/src/dashboard/apigateway/apigateway/apis/web/mcp_server/serializers.py
@@ -891,23 +891,14 @@ class MCPServerBatchConfigInputSLZ(serializers.Serializer):
         max_length=100,
         help_text="MCPServer ID 列表",
     )
-    client_type = serializers.CharField(
+    client_type = serializers.ChoiceField(
         required=True,
-        help_text="客户端类型（cursor, codebuddy, claude, vscode 等）",
+        choices=[(client["name"], client["display_name"]) for client in settings.MCP_CONFIG_AGENT_CLIENTS],
+        help_text="客户端类型",
     )
 
     class Meta:
         ref_name = "apigateway.apis.web.mcp_server.serializers.MCPServerBatchConfigInputSLZ"
-
-    def validate_client_type(self, value):
-        """校验 client_type 必须在 MCP_CONFIG_AGENT_CLIENTS 中"""
-        valid_client_types = [client["name"] for client in settings.MCP_CONFIG_AGENT_CLIENTS]
-        if value not in valid_client_types:
-            raise serializers.ValidationError(
-                _("不支持的客户端类型：%(value)s，支持的类型：%(valid_types)s")
-                % {"value": value, "valid_types": ", ".join(valid_client_types)}
-            )
-        return value
 
 
 class MCPServerBatchConfigOutputSLZ(serializers.Serializer):

--- a/src/dashboard/apigateway/apigateway/apis/web/mcp_server/serializers.py
+++ b/src/dashboard/apigateway/apigateway/apis/web/mcp_server/serializers.py
@@ -891,7 +891,7 @@ class MCPServerBatchConfigInputSLZ(serializers.Serializer):
     )
     client_type = serializers.CharField(
         required=True,
-        help_text="客户端类型（cursor, codebuddy, claude, vscode, aidev 等）",
+        help_text="客户端类型（cursor, codebuddy, claude, vscode 等）",
     )
 
     class Meta:

--- a/src/dashboard/apigateway/apigateway/apis/web/mcp_server/serializers.py
+++ b/src/dashboard/apigateway/apigateway/apis/web/mcp_server/serializers.py
@@ -878,3 +878,32 @@ class MCPServerAppPermissionAppCodeListOutputSLZ(serializers.Serializer):
 
     class Meta:
         ref_name = "apigateway.apis.web.mcp_server.serializers.MCPServerAppPermissionAppCodeListOutputSLZ"
+
+
+class MCPServerBatchConfigInputSLZ(serializers.Serializer):
+    """批量获取 MCPServer 配置输入序列化器"""
+
+    mcp_server_ids = serializers.ListField(
+        child=serializers.IntegerField(),
+        required=True,
+        min_length=1,
+        help_text="MCPServer ID 列表",
+    )
+    client_type = serializers.CharField(
+        required=True,
+        help_text="客户端类型（cursor, codebuddy, claude, vscode, aidev 等）",
+    )
+
+    class Meta:
+        ref_name = "apigateway.apis.web.mcp_server.serializers.MCPServerBatchConfigInputSLZ"
+
+
+class MCPServerBatchConfigOutputSLZ(serializers.Serializer):
+    """批量获取 MCPServer 配置输出序列化器"""
+
+    client_type = serializers.CharField(read_only=True, help_text="客户端类型")
+    display_name = serializers.CharField(read_only=True, help_text="客户端显示名称")
+    config = serializers.DictField(read_only=True, help_text="客户端配置（JSON 格式）")
+
+    class Meta:
+        ref_name = "apigateway.apis.web.mcp_server.serializers.MCPServerBatchConfigOutputSLZ"

--- a/src/dashboard/apigateway/apigateway/apis/web/mcp_server/urls.py
+++ b/src/dashboard/apigateway/apigateway/apis/web/mcp_server/urls.py
@@ -126,5 +126,5 @@ urlpatterns = [
     path("-/stage-release-check/", MCPServerStageReleaseCheckApi.as_view(), name="mcp_server.stage_release_check"),
     path("-/remote-prompts/", MCPServerRemotePromptsListApi.as_view(), name="mcp_server.remote_prompts_list"),
     path("-/remote-prompts/batch/", MCPServerRemotePromptsBatchApi.as_view(), name="mcp_server.remote_prompts_batch"),
-    path("-/batch-config/", MCPServerBatchConfigApi.as_view(), name="mcp_server.batch_config"),
+    path("-/batch-configs/", MCPServerBatchConfigApi.as_view(), name="mcp_server.batch_configs"),
 ]

--- a/src/dashboard/apigateway/apigateway/apis/web/mcp_server/urls.py
+++ b/src/dashboard/apigateway/apigateway/apis/web/mcp_server/urls.py
@@ -25,6 +25,7 @@ from .views import (
     MCPServerAppPermissionApplyUpdateStatusApi,
     MCPServerAppPermissionDestroyApi,
     MCPServerAppPermissionListCreateApi,
+    MCPServerBatchConfigApi,
     MCPServerCategoriesListApi,
     MCPServerConfigListApi,
     MCPServerFilterOptionsApi,
@@ -125,4 +126,5 @@ urlpatterns = [
     path("-/stage-release-check/", MCPServerStageReleaseCheckApi.as_view(), name="mcp_server.stage_release_check"),
     path("-/remote-prompts/", MCPServerRemotePromptsListApi.as_view(), name="mcp_server.remote_prompts_list"),
     path("-/remote-prompts/batch/", MCPServerRemotePromptsBatchApi.as_view(), name="mcp_server.remote_prompts_batch"),
+    path("-/batch-config/", MCPServerBatchConfigApi.as_view(), name="mcp_server.batch_config"),
 ]

--- a/src/dashboard/apigateway/apigateway/apis/web/mcp_server/views.py
+++ b/src/dashboard/apigateway/apigateway/apis/web/mcp_server/views.py
@@ -17,7 +17,6 @@
 #
 
 
-from django.conf import settings
 from django.db import transaction
 from django.db.models import Q
 from django.utils.decorators import method_decorator
@@ -449,7 +448,7 @@ class MCPServerGuidelineRetrieveApi(generics.RetrieveAPIView):
 @method_decorator(
     name="get",
     decorator=swagger_auto_schema(
-        operation_description="获取 MCPServer 配置列表（支持 Cursor、CodeBuddy、Claude、AIDev 等工具的配置）",
+        operation_description="获取 MCPServer 配置列表（支持 Cursor、CodeBuddy、Claude、VSCode 等工具的配置）",
         responses={status.HTTP_200_OK: MCPServerConfigListOutputSLZ()},
         tags=["WebAPI.MCPServer"],
     ),
@@ -1022,7 +1021,7 @@ class MCPServerAppPermissionAppCodeListApi(generics.ListAPIView):
 @method_decorator(
     name="post",
     decorator=swagger_auto_schema(
-        operation_description="批量获取 MCPServer 配置（支持指定客户端类型：cursor, codebuddy, claude, vscode, aidev 等）",
+        operation_description="批量获取 MCPServer 配置（支持指定客户端类型：cursor, codebuddy, claude, vscode 等）",
         request_body=MCPServerBatchConfigInputSLZ,
         responses={status.HTTP_200_OK: MCPServerBatchConfigOutputSLZ()},
         tags=["WebAPI.MCPServer"],
@@ -1050,8 +1049,8 @@ class MCPServerBatchConfigApi(generics.CreateAPIView):
         if not instances:
             raise error_codes.NOT_FOUND.format(_("未找到有效的 MCPServer"), replace=True)
 
-        # 获取最低权限信息
-        least_privileges = MCPServerHandler.get_least_privileges(instances)
+        # 获取最低权限信息（按 mcp_server.id 为 key）
+        least_privileges = MCPServerHandler.get_least_privileges_by_server(instances)
 
         # 获取用户租户 ID
         user_tenant_id = get_user_tenant_id(request)
@@ -1062,11 +1061,7 @@ class MCPServerBatchConfigApi(generics.CreateAPIView):
         )
 
         # 查找客户端显示名称
-        display_name = client_type
-        for client in settings.MCP_CONFIG_AGENT_CLIENTS:
-            if client["name"] == client_type:
-                display_name = client["display_name"]
-                break
+        display_name = MCPServerHandler.get_client_display_name(client_type)
 
         result = {
             "client_type": client_type,

--- a/src/dashboard/apigateway/apigateway/apis/web/mcp_server/views.py
+++ b/src/dashboard/apigateway/apigateway/apis/web/mcp_server/views.py
@@ -17,6 +17,7 @@
 #
 
 
+from django.conf import settings
 from django.db import transaction
 from django.db.models import Q
 from django.utils.decorators import method_decorator
@@ -63,6 +64,8 @@ from .serializers import (
     MCPServerAppPermissionCreateInputSLZ,
     MCPServerAppPermissionListInputSLZ,
     MCPServerAppPermissionListOutputSLZ,
+    MCPServerBatchConfigInputSLZ,
+    MCPServerBatchConfigOutputSLZ,
     MCPServerCategoryOutputSLZ,
     MCPServerConfigListOutputSLZ,
     MCPServerCreateInputSLZ,
@@ -1013,4 +1016,63 @@ class MCPServerAppPermissionAppCodeListApi(generics.ListAPIView):
 
         output_slz = MCPServerAppPermissionAppCodeListOutputSLZ(data={"bk_app_codes": list(bk_app_codes)})
         output_slz.is_valid(raise_exception=True)
+        return OKJsonResponse(data=output_slz.data)
+
+
+@method_decorator(
+    name="post",
+    decorator=swagger_auto_schema(
+        operation_description="批量获取 MCPServer 配置（支持指定客户端类型：cursor, codebuddy, claude, vscode, aidev 等）",
+        request_body=MCPServerBatchConfigInputSLZ,
+        responses={status.HTTP_200_OK: MCPServerBatchConfigOutputSLZ()},
+        tags=["WebAPI.MCPServer"],
+    ),
+)
+class MCPServerBatchConfigApi(generics.CreateAPIView):
+    """批量获取 MCPServer 配置，支持指定客户端类型"""
+
+    def create(self, request, *args, **kwargs):
+        slz = MCPServerBatchConfigInputSLZ(data=request.data)
+        slz.is_valid(raise_exception=True)
+
+        mcp_server_ids = slz.validated_data["mcp_server_ids"]
+        client_type = slz.validated_data["client_type"]
+
+        # 查询 MCPServer 列表
+        instances = list(
+            MCPServer.objects.filter(
+                id__in=mcp_server_ids,
+                gateway=request.gateway,
+                status=MCPServerStatusEnum.ACTIVE.value,
+            ).select_related("gateway", "stage")
+        )
+
+        if not instances:
+            raise error_codes.NOT_FOUND.format(_("未找到有效的 MCPServer"), replace=True)
+
+        # 获取最低权限信息
+        least_privileges = MCPServerHandler.get_least_privileges(instances)
+
+        # 获取用户租户 ID
+        user_tenant_id = get_user_tenant_id(request)
+
+        # 构建批量配置
+        config = MCPServerHandler.build_batch_agent_client_config(
+            instances, client_type, least_privileges, user_tenant_id=user_tenant_id
+        )
+
+        # 查找客户端显示名称
+        display_name = client_type
+        for client in settings.MCP_CONFIG_AGENT_CLIENTS:
+            if client["name"] == client_type:
+                display_name = client["display_name"]
+                break
+
+        result = {
+            "client_type": client_type,
+            "display_name": display_name,
+            "config": config,
+        }
+
+        output_slz = MCPServerBatchConfigOutputSLZ(result)
         return OKJsonResponse(data=output_slz.data)

--- a/src/dashboard/apigateway/apigateway/apps/mcp_server/constants.py
+++ b/src/dashboard/apigateway/apigateway/apps/mcp_server/constants.py
@@ -104,11 +104,17 @@ _MCP_CONFIG_DEFAULT_CLIENT_TYPES = [
 
 def get_mcp_config_agent_clients() -> list:
     """获取 MCP Server 配置工具的客户端列表，根据 AIDEV_AGENT_CREATE_URL 动态决定是否包含 AIDev"""
-    clients = [{"name": member.value, "display_name": member.label} for member in _MCP_CONFIG_DEFAULT_CLIENT_TYPES]
+    clients = [
+        {"name": member.value, "display_name": MCPAgentClientTypeEnum.get_choice_label(member)}
+        for member in _MCP_CONFIG_DEFAULT_CLIENT_TYPES
+    ]
 
     if getattr(settings, "AIDEV_AGENT_CREATE_URL", ""):
         clients.append(
-            {"name": MCPAgentClientTypeEnum.AIDEV.value, "display_name": MCPAgentClientTypeEnum.AIDEV.label}
+            {
+                "name": MCPAgentClientTypeEnum.AIDEV.value,
+                "display_name": MCPAgentClientTypeEnum.get_choice_label(MCPAgentClientTypeEnum.AIDEV),
+            }
         )
 
     return clients

--- a/src/dashboard/apigateway/apigateway/apps/mcp_server/constants.py
+++ b/src/dashboard/apigateway/apigateway/apps/mcp_server/constants.py
@@ -77,6 +77,22 @@ class MCPServerProtocolTypeEnum(StructuredEnum):
     STREAMABLE_HTTP = EnumField("streamable_http", label=_("Streamable HTTP"))
 
 
+class MCPAgentClientTypeEnum(StructuredEnum):
+    """MCP Agent 客户端类型"""
+
+    CODEBUDDY = EnumField("codebuddy", label="CodeBuddy")
+    CURSOR = EnumField("cursor", label="Cursor")
+    CLAUDE = EnumField("claude", label="Claude")
+    VSCODE = EnumField("vscode", label="VSCode")
+    AIDEV = EnumField("aidev", label="AIDev")
+
+
+# MCP Agent 客户端 choices（不含 AIDev），供批量配置序列化器校验使用
+MCP_AGENT_CLIENT_CHOICES_WITHOUT_AIDEV = [
+    choice for choice in MCPAgentClientTypeEnum.get_choices() if choice[0] != MCPAgentClientTypeEnum.AIDEV.value
+]
+
+
 # MCPServer 分类名称常量 - 用于判断特殊分类
 OFFICIAL_MCP_CATEGORY_NAME = "Official"
 FEATURED_MCP_CATEGORY_NAME = "Featured"

--- a/src/dashboard/apigateway/apigateway/apps/mcp_server/constants.py
+++ b/src/dashboard/apigateway/apigateway/apps/mcp_server/constants.py
@@ -78,6 +78,14 @@ class MCPServerProtocolTypeEnum(StructuredEnum):
     STREAMABLE_HTTP = EnumField("streamable_http", label=_("Streamable HTTP"))
 
 
+class MCPTransportTypeEnum(StructuredEnum):
+    """MCP 传输协议类型（客户端配置中使用）"""
+
+    SSE = EnumField("sse", label="SSE")
+    HTTP = EnumField("http", label="HTTP")
+    STREAMABLE_HTTP = EnumField("streamable-http", label="Streamable HTTP")
+
+
 class MCPAgentClientTypeEnum(StructuredEnum):
     """MCP Agent 客户端类型"""
 

--- a/src/dashboard/apigateway/apigateway/apps/mcp_server/constants.py
+++ b/src/dashboard/apigateway/apigateway/apps/mcp_server/constants.py
@@ -17,6 +17,7 @@
 #
 
 from blue_krill.data_types.enum import EnumField, StructuredEnum
+from django.conf import settings
 from django.utils.translation import gettext_lazy as _
 
 
@@ -91,6 +92,26 @@ class MCPAgentClientTypeEnum(StructuredEnum):
 MCP_AGENT_CLIENT_CHOICES_WITHOUT_AIDEV = [
     choice for choice in MCPAgentClientTypeEnum.get_choices() if choice[0] != MCPAgentClientTypeEnum.AIDEV.value
 ]
+
+# MCP Server 配置工具的默认客户端类型列表（不含 AIDev）
+_MCP_CONFIG_DEFAULT_CLIENT_TYPES = [
+    MCPAgentClientTypeEnum.CODEBUDDY,
+    MCPAgentClientTypeEnum.CURSOR,
+    MCPAgentClientTypeEnum.CLAUDE,
+    MCPAgentClientTypeEnum.VSCODE,
+]
+
+
+def get_mcp_config_agent_clients() -> list:
+    """获取 MCP Server 配置工具的客户端列表，根据 AIDEV_AGENT_CREATE_URL 动态决定是否包含 AIDev"""
+    clients = [{"name": member.value, "display_name": member.label} for member in _MCP_CONFIG_DEFAULT_CLIENT_TYPES]
+
+    if getattr(settings, "AIDEV_AGENT_CREATE_URL", ""):
+        clients.append(
+            {"name": MCPAgentClientTypeEnum.AIDEV.value, "display_name": MCPAgentClientTypeEnum.AIDEV.label}
+        )
+
+    return clients
 
 
 # MCPServer 分类名称常量 - 用于判断特殊分类

--- a/src/dashboard/apigateway/apigateway/apps/permission/tasks.py
+++ b/src/dashboard/apigateway/apigateway/apps/permission/tasks.py
@@ -248,9 +248,7 @@ class AppPermissionExpiringSoonAlerter:
             )
 
         # 过滤掉已拥有永久网关维度权限的应用，网关维度权限可以覆盖资源维度权限，无需告警
-        permissions_by_resource = AppResourcePermission.objects.filter(
-            expires__range=(now, expire_end_time)
-        ).filter(
+        permissions_by_resource = AppResourcePermission.objects.filter(expires__range=(now, expire_end_time)).filter(
             ~Exists(
                 AppGatewayPermission.objects.filter(
                     gateway_id=OuterRef("gateway_id"),

--- a/src/dashboard/apigateway/apigateway/biz/mcp_server/mcp_server.py
+++ b/src/dashboard/apigateway/apigateway/biz/mcp_server/mcp_server.py
@@ -36,6 +36,7 @@ from apigateway.apps.mcp_server.constants import (
     MCPServerLeastPrivilegeEnum,
     MCPServerProtocolTypeEnum,
     MCPServerStatusEnum,
+    MCPTransportTypeEnum,
     get_mcp_config_agent_clients,
 )
 from apigateway.apps.mcp_server.models import (
@@ -1021,12 +1022,14 @@ class MCPServerHandler:
             template_name = f"mcp_server/{language_code}/config/{client['name']}.md"
 
             # 根据 protocol_type 和客户端类型确定 transport_type
-            if instance.protocol_type == "streamable_http":
+            if instance.protocol_type == MCPServerProtocolTypeEnum.STREAMABLE_HTTP.value:
                 transport_type = (
-                    "streamable-http" if client["name"] == MCPAgentClientTypeEnum.CODEBUDDY.value else "http"
+                    MCPTransportTypeEnum.STREAMABLE_HTTP.value
+                    if client["name"] == MCPAgentClientTypeEnum.CODEBUDDY.value
+                    else MCPTransportTypeEnum.HTTP.value
                 )
             else:
-                transport_type = "sse"
+                transport_type = MCPTransportTypeEnum.SSE.value
 
             # 构建模板上下文
             context = {
@@ -1161,9 +1164,13 @@ class MCPServerHandler:
 
             # 根据 protocol_type 和客户端类型确定 transport_type
             if instance.protocol_type == MCPServerProtocolTypeEnum.STREAMABLE_HTTP.value:
-                transport_type = "streamable-http" if client_type == MCPAgentClientTypeEnum.CODEBUDDY.value else "http"
+                transport_type = (
+                    MCPTransportTypeEnum.STREAMABLE_HTTP.value
+                    if client_type == MCPAgentClientTypeEnum.CODEBUDDY.value
+                    else MCPTransportTypeEnum.HTTP.value
+                )
             else:
-                transport_type = "sse"
+                transport_type = MCPTransportTypeEnum.SSE.value
 
             # 构建单个 server 配置
             server_config: Dict[str, Any] = {}

--- a/src/dashboard/apigateway/apigateway/biz/mcp_server/mcp_server.py
+++ b/src/dashboard/apigateway/apigateway/biz/mcp_server/mcp_server.py
@@ -33,6 +33,7 @@ from apigateway.apps.mcp_server.constants import (
     MCPServerAppPermissionGrantTypeEnum,
     MCPServerExtendTypeEnum,
     MCPServerLeastPrivilegeEnum,
+    MCPServerProtocolTypeEnum,
     MCPServerStatusEnum,
 )
 from apigateway.apps.mcp_server.models import (
@@ -1060,6 +1061,14 @@ class MCPServerHandler:
         return configs
 
     @staticmethod
+    def get_client_display_name(client_type: str) -> str:
+        """获取客户端类型的显示名称"""
+        for client in settings.MCP_CONFIG_AGENT_CLIENTS:
+            if client["name"] == client_type:
+                return client["display_name"]
+        return client_type
+
+    @staticmethod
     def build_batch_agent_client_config(
         instances: List[MCPServer],
         client_type: str,
@@ -1071,7 +1080,7 @@ class MCPServerHandler:
 
         Args:
             instances: MCPServer 实例列表
-            client_type: 客户端类型（cursor, codebuddy, claude, vscode, aidev 等）
+            client_type: 客户端类型（cursor, codebuddy, claude, vscode 等）
             least_privileges: 最低权限字典，key 为 (gateway_id, stage_id)
             user_tenant_id: 用户租户 ID（多租户模式下使用）
 
@@ -1090,7 +1099,7 @@ class MCPServerHandler:
             )
 
             # 根据 protocol_type 和客户端类型确定 transport_type
-            if instance.protocol_type == "streamable_http":
+            if instance.protocol_type == MCPServerProtocolTypeEnum.STREAMABLE_HTTP.value:
                 transport_type = "streamable-http" if client_type == "codebuddy" else "http"
             else:
                 transport_type = "sse"
@@ -1109,9 +1118,9 @@ class MCPServerHandler:
             if not instance.oauth2_public_client_enabled:
                 headers["X-Bkapi-Authorization"] = json.dumps(
                     {
-                        "bk_app_code": "your_app_code",
-                        "bk_app_secret": "your_app_secret",
-                        settings.BK_LOGIN_TICKET_KEY: "your_ticket",
+                        "bk_app_code": "<your_app_code>",
+                        "bk_app_secret": "<your_app_secret>",
+                        settings.BK_LOGIN_TICKET_KEY: "<your_ticket>",
                     }
                 )
             if enable_multi_tenant_mode and user_tenant_id:

--- a/src/dashboard/apigateway/apigateway/biz/mcp_server/mcp_server.py
+++ b/src/dashboard/apigateway/apigateway/biz/mcp_server/mcp_server.py
@@ -1069,34 +1069,91 @@ class MCPServerHandler:
         return client_type
 
     @staticmethod
+    def get_least_privileges_by_server(
+        mcp_servers,
+        releases: Optional[Dict[Tuple[int, int], Release]] = None,
+    ) -> Dict[int, str]:
+        """按 MCPServer ID 计算最低权限级别
+
+        与 get_least_privileges 不同，此方法以 mcp_server.id 为 key，
+        避免同 gateway+stage 下多个 server 的 least_privilege 互相覆盖。
+
+        Args:
+            mcp_servers: MCPServer 实例列表（需已 select_related gateway/stage）
+            releases: 可选，预查询的 Release 映射，避免重复查询
+
+        Returns:
+            {mcp_server_id: least_privilege} 映射
+        """
+        if not mcp_servers:
+            return {}
+
+        if releases is None:
+            releases = MCPServerHandler._get_releases_for_mcp_servers(mcp_servers)
+
+        # 先按 (gateway_id, stage_id) 计算每个 server 的 tool_names
+        server_tool_names: Dict[int, List[str]] = {}
+        for mcp_server in mcp_servers:
+            server_tool_names[mcp_server.id] = mcp_server.resource_names
+
+        least_privileges: Dict[int, str] = {}
+        # 按 (gateway_id, stage_id) 分组计算，然后映射到每个 server
+        for mcp_server in mcp_servers:
+            gateway_stage_key = (mcp_server.gateway_id, mcp_server.stage_id)
+            release = releases.get(gateway_stage_key)
+            if not release:
+                least_privileges[mcp_server.id] = ""
+                continue
+
+            tool_names = server_tool_names.get(mcp_server.id, [])
+            least_privilege = MCPServerLeastPrivilegeEnum.APPLICATION.value
+            for resource in release.resource_version.data:
+                if resource["name"] not in tool_names:
+                    continue
+                auth_config = json.loads(resource.get("contexts", {}).get("resource_auth", {}).get("config", "{}"))
+                verified_user_required = not auth_config.get("skip_auth_verification", False) and bool(
+                    auth_config.get("auth_verified_required", False)
+                )
+                if verified_user_required:
+                    least_privilege = MCPServerLeastPrivilegeEnum.APPLICATION_AND_USER.value
+                    break
+            least_privileges[mcp_server.id] = least_privilege
+
+        return least_privileges
+
+    @staticmethod
     def build_batch_agent_client_config(
         instances: List[MCPServer],
         client_type: str,
-        least_privileges: Dict[Tuple[int, int], str],
+        least_privileges: Dict[int, str],
         user_tenant_id: str = "",
     ) -> Dict[str, Any]:
         """
         批量构建指定客户端类型的 MCP Server 配置
 
+        不同客户端类型有不同的 JSON schema：
+        - cursor: {"mcpServers": {name: {url, headers}}}
+        - codebuddy: {"mcpServers": {name: {url, transportType, headers}}}
+        - claude: {"mcpServers": {name: {type, url, headers}}}
+        - vscode: {"servers": {name: {type, url, headers}}}
+
         Args:
             instances: MCPServer 实例列表
             client_type: 客户端类型（cursor, codebuddy, claude, vscode 等）
-            least_privileges: 最低权限字典，key 为 (gateway_id, stage_id)
+            least_privileges: 最低权限字典，key 为 mcp_server_id
             user_tenant_id: 用户租户 ID（多租户模式下使用）
 
         Returns:
-            对应客户端类型的 JSON 配置，包含所有 mcpServers
+            对应客户端类型的 JSON 配置
         """
         if not instances:
             return {"mcpServers": {}}
 
         enable_multi_tenant_mode = settings.ENABLE_MULTI_TENANT_MODE
-        mcp_servers_config = {}
+        servers_config = {}
 
         for instance in instances:
-            mcp_url = MCPServerHandler.get_mcp_server_url(
-                instance, least_privileges.get((instance.gateway.id, instance.stage.id), "")
-            )
+            mcp_url = MCPServerHandler.get_mcp_server_url(instance, least_privileges.get(instance.id, ""))
 
             # 根据 protocol_type 和客户端类型确定 transport_type
             if instance.protocol_type == MCPServerProtocolTypeEnum.STREAMABLE_HTTP.value:
@@ -1105,9 +1162,13 @@ class MCPServerHandler:
                 transport_type = "sse"
 
             # 构建单个 server 配置
-            server_config: Dict[str, Any] = {
-                "url": mcp_url,
-            }
+            server_config: Dict[str, Any] = {}
+
+            # claude 和 vscode 需要 type 字段
+            if client_type in ("claude", "vscode"):
+                server_config["type"] = transport_type
+
+            server_config["url"] = mcp_url
 
             # CodeBuddy 需要 transportType
             if client_type == "codebuddy":
@@ -1130,6 +1191,8 @@ class MCPServerHandler:
             if headers:
                 server_config["headers"] = headers
 
-            mcp_servers_config[instance.name] = server_config
+            servers_config[instance.name] = server_config
 
-        return {"mcpServers": mcp_servers_config}
+        # vscode 顶层 key 是 servers，其他客户端用 mcpServers
+        top_level_key = "servers" if client_type == "vscode" else "mcpServers"
+        return {top_level_key: servers_config}

--- a/src/dashboard/apigateway/apigateway/biz/mcp_server/mcp_server.py
+++ b/src/dashboard/apigateway/apigateway/biz/mcp_server/mcp_server.py
@@ -1058,3 +1058,69 @@ class MCPServerHandler:
             )
 
         return configs
+
+    @staticmethod
+    def build_batch_agent_client_config(
+        instances: List[MCPServer],
+        client_type: str,
+        least_privileges: Dict[Tuple[int, int], str],
+        user_tenant_id: str = "",
+    ) -> Dict[str, Any]:
+        """
+        批量构建指定客户端类型的 MCP Server 配置
+
+        Args:
+            instances: MCPServer 实例列表
+            client_type: 客户端类型（cursor, codebuddy, claude, vscode, aidev 等）
+            least_privileges: 最低权限字典，key 为 (gateway_id, stage_id)
+            user_tenant_id: 用户租户 ID（多租户模式下使用）
+
+        Returns:
+            对应客户端类型的 JSON 配置，包含所有 mcpServers
+        """
+        if not instances:
+            return {"mcpServers": {}}
+
+        enable_multi_tenant_mode = settings.ENABLE_MULTI_TENANT_MODE
+        mcp_servers_config = {}
+
+        for instance in instances:
+            mcp_url = MCPServerHandler.get_mcp_server_url(
+                instance, least_privileges.get((instance.gateway.id, instance.stage.id), "")
+            )
+
+            # 根据 protocol_type 和客户端类型确定 transport_type
+            if instance.protocol_type == "streamable_http":
+                transport_type = "streamable-http" if client_type == "codebuddy" else "http"
+            else:
+                transport_type = "sse"
+
+            # 构建单个 server 配置
+            server_config: Dict[str, Any] = {
+                "url": mcp_url,
+            }
+
+            # CodeBuddy 需要 transportType
+            if client_type == "codebuddy":
+                server_config["transportType"] = transport_type
+
+            # 处理 headers
+            headers = {}
+            if not instance.oauth2_public_client_enabled:
+                headers["X-Bkapi-Authorization"] = json.dumps(
+                    {
+                        "bk_app_code": "your_app_code",
+                        "bk_app_secret": "your_app_secret",
+                        settings.BK_LOGIN_TICKET_KEY: "your_ticket",
+                    }
+                )
+            if enable_multi_tenant_mode and user_tenant_id:
+                headers["X-Bk-Tenant-Id"] = user_tenant_id
+                headers["X-Bkapi-Allowed-Headers"] = "X-Bk-Tenant-Id"
+
+            if headers:
+                server_config["headers"] = headers
+
+            mcp_servers_config[instance.name] = server_config
+
+        return {"mcpServers": mcp_servers_config}

--- a/src/dashboard/apigateway/apigateway/biz/mcp_server/mcp_server.py
+++ b/src/dashboard/apigateway/apigateway/biz/mcp_server/mcp_server.py
@@ -30,6 +30,7 @@ from django.utils.translation import gettext as _
 from apigateway.apps.mcp_server.constants import (
     FEATURED_MCP_CATEGORY_NAME,
     OFFICIAL_MCP_CATEGORY_NAME,
+    MCPAgentClientTypeEnum,
     MCPServerAppPermissionGrantTypeEnum,
     MCPServerExtendTypeEnum,
     MCPServerLeastPrivilegeEnum,
@@ -1020,7 +1021,9 @@ class MCPServerHandler:
 
             # 根据 protocol_type 和客户端类型确定 transport_type
             if instance.protocol_type == "streamable_http":
-                transport_type = "streamable-http" if client["name"] == "codebuddy" else "http"
+                transport_type = (
+                    "streamable-http" if client["name"] == MCPAgentClientTypeEnum.CODEBUDDY.value else "http"
+                )
             else:
                 transport_type = "sse"
 
@@ -1037,14 +1040,14 @@ class MCPServerHandler:
             }
 
             # AIDev 需要额外的创建链接
-            if client["name"] == "aidev":
+            if client["name"] == MCPAgentClientTypeEnum.AIDEV.value:
                 context["aidev_agent_create_url"] = settings.AIDEV_AGENT_CREATE_URL
 
             content = render_to_string(template_name, context=context)
 
             # 生成一键配置 URL（目前只有 Cursor 支持）
             install_url = ""
-            if client["name"] == "cursor":
+            if client["name"] == MCPAgentClientTypeEnum.CURSOR.value:
                 install_url = MCPServerHandler._build_cursor_install_url(
                     instance.name, mcp_url, instance.oauth2_public_client_enabled, user_tenant_id
                 )
@@ -1157,7 +1160,7 @@ class MCPServerHandler:
 
             # 根据 protocol_type 和客户端类型确定 transport_type
             if instance.protocol_type == MCPServerProtocolTypeEnum.STREAMABLE_HTTP.value:
-                transport_type = "streamable-http" if client_type == "codebuddy" else "http"
+                transport_type = "streamable-http" if client_type == MCPAgentClientTypeEnum.CODEBUDDY.value else "http"
             else:
                 transport_type = "sse"
 
@@ -1165,13 +1168,13 @@ class MCPServerHandler:
             server_config: Dict[str, Any] = {}
 
             # claude 和 vscode 需要 type 字段
-            if client_type in ("claude", "vscode"):
+            if client_type in (MCPAgentClientTypeEnum.CLAUDE.value, MCPAgentClientTypeEnum.VSCODE.value):
                 server_config["type"] = transport_type
 
             server_config["url"] = mcp_url
 
             # CodeBuddy 需要 transportType
-            if client_type == "codebuddy":
+            if client_type == MCPAgentClientTypeEnum.CODEBUDDY.value:
                 server_config["transportType"] = transport_type
 
             # 处理 headers
@@ -1194,5 +1197,5 @@ class MCPServerHandler:
             servers_config[instance.name] = server_config
 
         # vscode 顶层 key 是 servers，其他客户端用 mcpServers
-        top_level_key = "servers" if client_type == "vscode" else "mcpServers"
+        top_level_key = "servers" if client_type == MCPAgentClientTypeEnum.VSCODE.value else "mcpServers"
         return {top_level_key: servers_config}

--- a/src/dashboard/apigateway/apigateway/biz/mcp_server/mcp_server.py
+++ b/src/dashboard/apigateway/apigateway/biz/mcp_server/mcp_server.py
@@ -36,6 +36,7 @@ from apigateway.apps.mcp_server.constants import (
     MCPServerLeastPrivilegeEnum,
     MCPServerProtocolTypeEnum,
     MCPServerStatusEnum,
+    get_mcp_config_agent_clients,
 )
 from apigateway.apps.mcp_server.models import (
     MCPServer,
@@ -1016,7 +1017,7 @@ class MCPServerHandler:
         enable_multi_tenant_mode = settings.ENABLE_MULTI_TENANT_MODE
         configs = []
 
-        for client in settings.MCP_CONFIG_AGENT_CLIENTS:
+        for client in get_mcp_config_agent_clients():
             template_name = f"mcp_server/{language_code}/config/{client['name']}.md"
 
             # 根据 protocol_type 和客户端类型确定 transport_type
@@ -1066,7 +1067,7 @@ class MCPServerHandler:
     @staticmethod
     def get_client_display_name(client_type: str) -> str:
         """获取客户端类型的显示名称"""
-        for client in settings.MCP_CONFIG_AGENT_CLIENTS:
+        for client in get_mcp_config_agent_clients():
             if client["name"] == client_type:
                 return client["display_name"]
         return client_type

--- a/src/dashboard/apigateway/apigateway/conf/default.py
+++ b/src/dashboard/apigateway/apigateway/conf/default.py
@@ -562,21 +562,6 @@ AIDEV_AGENT_CREATE_URL = env.str("AIDEV_AGENT_CREATE_URL", "")
 # MCP Server OAuth2 公开客户端模式开启后自动授权的 bk_app_code
 MCP_SERVER_OAUTH2_PUBLIC_CLIENT_APP_CODE = env.str("MCP_SERVER_OAUTH2_PUBLIC_CLIENT_APP_CODE", "public")
 
-# MCP Server 配置工具列表
-# 注意：此处使用字面值而非枚举引用，因为 settings 加载阶段 Django app registry 尚未初始化，
-# 无法导入使用了 gettext_lazy 的 constants 模块。值需要与 MCPAgentClientTypeEnum 保持一致。
-MCP_CONFIG_AGENT_CLIENTS = [
-    {"name": "codebuddy", "display_name": "CodeBuddy"},
-    {"name": "cursor", "display_name": "Cursor"},
-    {"name": "claude", "display_name": "Claude"},
-    {"name": "vscode", "display_name": "VSCode"},
-]
-
-# 如果配置了 AIDEV_AGENT_CREATE_URL，则添加 AIDev 到配置列表
-if AIDEV_AGENT_CREATE_URL:
-    MCP_CONFIG_AGENT_CLIENTS.append({"name": "aidev", "display_name": "AIDev"})
-
-
 # ==============================================================================
 # 网关全局配置
 # ==============================================================================

--- a/src/dashboard/apigateway/apigateway/conf/default.py
+++ b/src/dashboard/apigateway/apigateway/conf/default.py
@@ -28,6 +28,7 @@ from django.core.exceptions import ImproperlyConfigured
 from django.db.backends.mysql.features import DatabaseFeatures
 from django.utils.encoding import force_bytes
 
+from apigateway.apps.mcp_server.constants import MCPAgentClientTypeEnum
 from apigateway.common.env import Env
 from apigateway.conf.celery_conf import *  # noqa
 from apigateway.conf.celery_conf import CELERY_BEAT_SCHEDULE
@@ -564,15 +565,17 @@ MCP_SERVER_OAUTH2_PUBLIC_CLIENT_APP_CODE = env.str("MCP_SERVER_OAUTH2_PUBLIC_CLI
 
 # MCP Server 配置工具列表
 MCP_CONFIG_AGENT_CLIENTS = [
-    {"name": "codebuddy", "display_name": "CodeBuddy"},
-    {"name": "cursor", "display_name": "Cursor"},
-    {"name": "claude", "display_name": "Claude"},
-    {"name": "vscode", "display_name": "VSCode"},
+    {"name": MCPAgentClientTypeEnum.CODEBUDDY.value, "display_name": MCPAgentClientTypeEnum.CODEBUDDY.label},
+    {"name": MCPAgentClientTypeEnum.CURSOR.value, "display_name": MCPAgentClientTypeEnum.CURSOR.label},
+    {"name": MCPAgentClientTypeEnum.CLAUDE.value, "display_name": MCPAgentClientTypeEnum.CLAUDE.label},
+    {"name": MCPAgentClientTypeEnum.VSCODE.value, "display_name": MCPAgentClientTypeEnum.VSCODE.label},
 ]
 
 # 如果配置了 AIDEV_AGENT_CREATE_URL，则添加 AIDev 到配置列表
 if AIDEV_AGENT_CREATE_URL:
-    MCP_CONFIG_AGENT_CLIENTS.append({"name": "aidev", "display_name": "AIDev"})
+    MCP_CONFIG_AGENT_CLIENTS.append(
+        {"name": MCPAgentClientTypeEnum.AIDEV.value, "display_name": MCPAgentClientTypeEnum.AIDEV.label}
+    )
 
 
 # ==============================================================================

--- a/src/dashboard/apigateway/apigateway/conf/default.py
+++ b/src/dashboard/apigateway/apigateway/conf/default.py
@@ -28,7 +28,6 @@ from django.core.exceptions import ImproperlyConfigured
 from django.db.backends.mysql.features import DatabaseFeatures
 from django.utils.encoding import force_bytes
 
-from apigateway.apps.mcp_server.constants import MCPAgentClientTypeEnum
 from apigateway.common.env import Env
 from apigateway.conf.celery_conf import *  # noqa
 from apigateway.conf.celery_conf import CELERY_BEAT_SCHEDULE
@@ -564,18 +563,18 @@ AIDEV_AGENT_CREATE_URL = env.str("AIDEV_AGENT_CREATE_URL", "")
 MCP_SERVER_OAUTH2_PUBLIC_CLIENT_APP_CODE = env.str("MCP_SERVER_OAUTH2_PUBLIC_CLIENT_APP_CODE", "public")
 
 # MCP Server 配置工具列表
+# 注意：此处使用字面值而非枚举引用，因为 settings 加载阶段 Django app registry 尚未初始化，
+# 无法导入使用了 gettext_lazy 的 constants 模块。值需要与 MCPAgentClientTypeEnum 保持一致。
 MCP_CONFIG_AGENT_CLIENTS = [
-    {"name": MCPAgentClientTypeEnum.CODEBUDDY.value, "display_name": MCPAgentClientTypeEnum.CODEBUDDY.label},
-    {"name": MCPAgentClientTypeEnum.CURSOR.value, "display_name": MCPAgentClientTypeEnum.CURSOR.label},
-    {"name": MCPAgentClientTypeEnum.CLAUDE.value, "display_name": MCPAgentClientTypeEnum.CLAUDE.label},
-    {"name": MCPAgentClientTypeEnum.VSCODE.value, "display_name": MCPAgentClientTypeEnum.VSCODE.label},
+    {"name": "codebuddy", "display_name": "CodeBuddy"},
+    {"name": "cursor", "display_name": "Cursor"},
+    {"name": "claude", "display_name": "Claude"},
+    {"name": "vscode", "display_name": "VSCode"},
 ]
 
 # 如果配置了 AIDEV_AGENT_CREATE_URL，则添加 AIDev 到配置列表
 if AIDEV_AGENT_CREATE_URL:
-    MCP_CONFIG_AGENT_CLIENTS.append(
-        {"name": MCPAgentClientTypeEnum.AIDEV.value, "display_name": MCPAgentClientTypeEnum.AIDEV.label}
-    )
+    MCP_CONFIG_AGENT_CLIENTS.append({"name": "aidev", "display_name": "AIDev"})
 
 
 # ==============================================================================

--- a/src/dashboard/apigateway/apigateway/tests/apis/web/mcp_marketplace/test_views.py
+++ b/src/dashboard/apigateway/apigateway/tests/apis/web/mcp_marketplace/test_views.py
@@ -1025,3 +1025,136 @@ class TestMCPServerCategoryModel:
         )
         fake_public_mcp_server.categories.add(featured_category)
         assert fake_public_mcp_server.is_featured() is True
+
+
+class TestMCPMarketplaceBatchConfigApi:
+    """测试 MCP 市场批量获取 MCPServer 配置 API"""
+
+    def test_batch_config_success(self, request_view, fake_public_mcp_server):
+        """测试批量获取配置成功"""
+        resp = request_view(
+            method="POST",
+            view_name="mcp_marketplace.batch_config",
+            data={
+                "mcp_server_ids": [fake_public_mcp_server.id],
+                "client_type": "cursor",
+            },
+        )
+        result = resp.json()
+
+        assert resp.status_code == 200
+        assert result["data"]["client_type"] == "cursor"
+        assert result["data"]["display_name"] == "Cursor"
+        assert "config" in result["data"]
+        assert "mcpServers" in result["data"]["config"]
+        assert fake_public_mcp_server.name in result["data"]["config"]["mcpServers"]
+
+    def test_batch_config_codebuddy(self, request_view, fake_public_mcp_server):
+        """测试批量获取 CodeBuddy 配置"""
+        resp = request_view(
+            method="POST",
+            view_name="mcp_marketplace.batch_config",
+            data={
+                "mcp_server_ids": [fake_public_mcp_server.id],
+                "client_type": "codebuddy",
+            },
+        )
+        result = resp.json()
+
+        assert resp.status_code == 200
+        assert result["data"]["client_type"] == "codebuddy"
+        assert result["data"]["display_name"] == "CodeBuddy"
+
+        # CodeBuddy 配置应该包含 transportType
+        server_config = result["data"]["config"]["mcpServers"][fake_public_mcp_server.name]
+        assert "transportType" in server_config
+
+    def test_batch_config_multiple_servers(self, request_view, fake_public_mcp_server):
+        """测试批量获取多个 MCPServer 配置"""
+        other_server = G(
+            MCPServer,
+            name="other-marketplace-server",
+            gateway=fake_public_mcp_server.gateway,
+            stage=fake_public_mcp_server.stage,
+            status=MCPServerStatusEnum.ACTIVE.value,
+            is_public=True,
+            _resource_names="resource3",
+        )
+
+        resp = request_view(
+            method="POST",
+            view_name="mcp_marketplace.batch_config",
+            data={
+                "mcp_server_ids": [fake_public_mcp_server.id, other_server.id],
+                "client_type": "cursor",
+            },
+        )
+        result = resp.json()
+
+        assert resp.status_code == 200
+        assert fake_public_mcp_server.name in result["data"]["config"]["mcpServers"]
+        assert other_server.name in result["data"]["config"]["mcpServers"]
+
+    def test_batch_config_not_public(self, request_view, fake_public_mcp_server):
+        """测试非公开的 MCPServer 不会被包含"""
+        fake_public_mcp_server.is_public = False
+        fake_public_mcp_server.save()
+
+        resp = request_view(
+            method="POST",
+            view_name="mcp_marketplace.batch_config",
+            data={
+                "mcp_server_ids": [fake_public_mcp_server.id],
+                "client_type": "cursor",
+            },
+        )
+
+        assert resp.status_code == 404
+
+    def test_batch_config_inactive(self, request_view, fake_public_mcp_server):
+        """测试未启用的 MCPServer 不会被包含"""
+        fake_public_mcp_server.status = MCPServerStatusEnum.INACTIVE.value
+        fake_public_mcp_server.save()
+
+        resp = request_view(
+            method="POST",
+            view_name="mcp_marketplace.batch_config",
+            data={
+                "mcp_server_ids": [fake_public_mcp_server.id],
+                "client_type": "cursor",
+            },
+        )
+
+        assert resp.status_code == 404
+
+    def test_batch_config_invalid_input(self, request_view):
+        """测试无效输入时返回 400"""
+        resp = request_view(
+            method="POST",
+            view_name="mcp_marketplace.batch_config",
+            data={
+                "mcp_server_ids": [],
+                "client_type": "cursor",
+            },
+        )
+        assert resp.status_code == 400
+
+    def test_batch_config_oauth2_public_client_enabled(self, request_view, fake_public_mcp_server):
+        """测试 OAuth2 公开客户端模式开启时配置中不包含认证请求头"""
+        fake_public_mcp_server.oauth2_public_client_enabled = True
+        fake_public_mcp_server.save()
+
+        resp = request_view(
+            method="POST",
+            view_name="mcp_marketplace.batch_config",
+            data={
+                "mcp_server_ids": [fake_public_mcp_server.id],
+                "client_type": "cursor",
+            },
+        )
+        result = resp.json()
+
+        assert resp.status_code == 200
+        server_config = result["data"]["config"]["mcpServers"][fake_public_mcp_server.name]
+        if "headers" in server_config:
+            assert "X-Bkapi-Authorization" not in server_config["headers"]

--- a/src/dashboard/apigateway/apigateway/tests/apis/web/mcp_marketplace/test_views.py
+++ b/src/dashboard/apigateway/apigateway/tests/apis/web/mcp_marketplace/test_views.py
@@ -1034,7 +1034,7 @@ class TestMCPMarketplaceBatchConfigApi:
         """测试批量获取配置成功"""
         resp = request_view(
             method="POST",
-            view_name="mcp_marketplace.batch_config",
+            view_name="mcp_marketplace.batch_configs",
             data={
                 "mcp_server_ids": [fake_public_mcp_server.id],
                 "client_type": "cursor",
@@ -1053,7 +1053,7 @@ class TestMCPMarketplaceBatchConfigApi:
         """测试批量获取 CodeBuddy 配置"""
         resp = request_view(
             method="POST",
-            view_name="mcp_marketplace.batch_config",
+            view_name="mcp_marketplace.batch_configs",
             data={
                 "mcp_server_ids": [fake_public_mcp_server.id],
                 "client_type": "codebuddy",
@@ -1083,7 +1083,7 @@ class TestMCPMarketplaceBatchConfigApi:
 
         resp = request_view(
             method="POST",
-            view_name="mcp_marketplace.batch_config",
+            view_name="mcp_marketplace.batch_configs",
             data={
                 "mcp_server_ids": [fake_public_mcp_server.id, other_server.id],
                 "client_type": "cursor",
@@ -1102,7 +1102,7 @@ class TestMCPMarketplaceBatchConfigApi:
 
         resp = request_view(
             method="POST",
-            view_name="mcp_marketplace.batch_config",
+            view_name="mcp_marketplace.batch_configs",
             data={
                 "mcp_server_ids": [fake_public_mcp_server.id],
                 "client_type": "cursor",
@@ -1118,7 +1118,7 @@ class TestMCPMarketplaceBatchConfigApi:
 
         resp = request_view(
             method="POST",
-            view_name="mcp_marketplace.batch_config",
+            view_name="mcp_marketplace.batch_configs",
             data={
                 "mcp_server_ids": [fake_public_mcp_server.id],
                 "client_type": "cursor",
@@ -1131,7 +1131,7 @@ class TestMCPMarketplaceBatchConfigApi:
         """测试无效输入时返回 400"""
         resp = request_view(
             method="POST",
-            view_name="mcp_marketplace.batch_config",
+            view_name="mcp_marketplace.batch_configs",
             data={
                 "mcp_server_ids": [],
                 "client_type": "cursor",
@@ -1146,7 +1146,7 @@ class TestMCPMarketplaceBatchConfigApi:
 
         resp = request_view(
             method="POST",
-            view_name="mcp_marketplace.batch_config",
+            view_name="mcp_marketplace.batch_configs",
             data={
                 "mcp_server_ids": [fake_public_mcp_server.id],
                 "client_type": "cursor",

--- a/src/dashboard/apigateway/apigateway/tests/apis/web/mcp_server/test_views.py
+++ b/src/dashboard/apigateway/apigateway/tests/apis/web/mcp_server/test_views.py
@@ -3062,7 +3062,7 @@ class TestMCPServerBatchConfigApi:
 
         resp = request_view(
             method="POST",
-            view_name="mcp_server.batch_config",
+            view_name="mcp_server.batch_configs",
             path_params={"gateway_id": fake_gateway.id},
             gateway=fake_gateway,
             data={
@@ -3096,7 +3096,7 @@ class TestMCPServerBatchConfigApi:
 
         resp = request_view(
             method="POST",
-            view_name="mcp_server.batch_config",
+            view_name="mcp_server.batch_configs",
             path_params={"gateway_id": fake_gateway.id},
             gateway=fake_gateway,
             data={
@@ -3138,7 +3138,7 @@ class TestMCPServerBatchConfigApi:
 
         resp = request_view(
             method="POST",
-            view_name="mcp_server.batch_config",
+            view_name="mcp_server.batch_configs",
             path_params={"gateway_id": fake_gateway.id},
             gateway=fake_gateway,
             data={
@@ -3156,7 +3156,7 @@ class TestMCPServerBatchConfigApi:
         """测试所有 MCPServer 都无效时返回 404"""
         resp = request_view(
             method="POST",
-            view_name="mcp_server.batch_config",
+            view_name="mcp_server.batch_configs",
             path_params={"gateway_id": fake_gateway.id},
             gateway=fake_gateway,
             data={
@@ -3171,7 +3171,7 @@ class TestMCPServerBatchConfigApi:
         """测试无效输入时返回 400"""
         resp = request_view(
             method="POST",
-            view_name="mcp_server.batch_config",
+            view_name="mcp_server.batch_configs",
             path_params={"gateway_id": fake_gateway.id},
             gateway=fake_gateway,
             data={
@@ -3197,7 +3197,7 @@ class TestMCPServerBatchConfigApi:
 
         resp = request_view(
             method="POST",
-            view_name="mcp_server.batch_config",
+            view_name="mcp_server.batch_configs",
             path_params={"gateway_id": fake_gateway.id},
             gateway=fake_gateway,
             data={
@@ -3230,7 +3230,7 @@ class TestMCPServerBatchConfigApi:
 
         resp = request_view(
             method="POST",
-            view_name="mcp_server.batch_config",
+            view_name="mcp_server.batch_configs",
             path_params={"gateway_id": fake_gateway.id},
             gateway=fake_gateway,
             data={

--- a/src/dashboard/apigateway/apigateway/tests/apis/web/mcp_server/test_views.py
+++ b/src/dashboard/apigateway/apigateway/tests/apis/web/mcp_server/test_views.py
@@ -870,12 +870,15 @@ class TestMCPServerConfigListApi:
             return_value="# Config Content",
         )
         # 模拟配置了 AIDEV_AGENT_CREATE_URL（AIDev 启用）
-        settings.MCP_CONFIG_AGENT_CLIENTS = [
-            {"name": "codebuddy", "display_name": "CodeBuddy"},
-            {"name": "cursor", "display_name": "Cursor"},
-            {"name": "claude", "display_name": "Claude"},
-            {"name": "aidev", "display_name": "AIDev"},
-        ]
+        mocker.patch(
+            "apigateway.biz.mcp_server.mcp_server.get_mcp_config_agent_clients",
+            return_value=[
+                {"name": "codebuddy", "display_name": "CodeBuddy"},
+                {"name": "cursor", "display_name": "Cursor"},
+                {"name": "claude", "display_name": "Claude"},
+                {"name": "aidev", "display_name": "AIDev"},
+            ],
+        )
 
         resp = request_view(
             method="GET",

--- a/src/dashboard/apigateway/apigateway/tests/apis/web/mcp_server/test_views.py
+++ b/src/dashboard/apigateway/apigateway/tests/apis/web/mcp_server/test_views.py
@@ -37,7 +37,9 @@ from apigateway.apps.mcp_server.models import (
     MCPServerCategory,
     MCPServerExtend,
 )
+from apigateway.core.constants import StageStatusEnum
 from apigateway.core.models import Release, ResourceVersion, Stage
+from apigateway.tests.utils.testing import create_gateway
 from apigateway.utils.time import now_datetime
 
 pytestmark = pytest.mark.django_db
@@ -3028,3 +3030,213 @@ class TestMCPServerListAppPermissionRisk:
         assert mcp_server_data is not None
         assert mcp_server_data["app_permission_risk"]["has_risk"] is False
         assert mcp_server_data["app_permission_risk"]["risk_tools"] == []
+
+
+class TestMCPServerBatchConfigApi:
+    """测试批量获取 MCPServer 配置 API"""
+
+    def test_batch_config_success(self, request_view, fake_gateway, fake_stage, faker):
+        """测试批量获取配置成功"""
+        server1 = G(
+            MCPServer,
+            name="test-server-1",
+            gateway=fake_gateway,
+            stage=fake_stage,
+            status=MCPServerStatusEnum.ACTIVE.value,
+            description=faker.pystr(),
+            is_public=True,
+            _resource_names="resource1",
+            oauth2_public_client_enabled=False,
+        )
+        server2 = G(
+            MCPServer,
+            name="test-server-2",
+            gateway=fake_gateway,
+            stage=fake_stage,
+            status=MCPServerStatusEnum.ACTIVE.value,
+            description=faker.pystr(),
+            is_public=True,
+            _resource_names="resource2",
+            oauth2_public_client_enabled=False,
+        )
+
+        resp = request_view(
+            method="POST",
+            view_name="mcp_server.batch_config",
+            path_params={"gateway_id": fake_gateway.id},
+            gateway=fake_gateway,
+            data={
+                "mcp_server_ids": [server1.id, server2.id],
+                "client_type": "cursor",
+            },
+        )
+        result = resp.json()
+
+        assert resp.status_code == 200
+        assert result["data"]["client_type"] == "cursor"
+        assert result["data"]["display_name"] == "Cursor"
+        assert "config" in result["data"]
+        assert "mcpServers" in result["data"]["config"]
+        assert "test-server-1" in result["data"]["config"]["mcpServers"]
+        assert "test-server-2" in result["data"]["config"]["mcpServers"]
+
+    def test_batch_config_codebuddy(self, request_view, fake_gateway, fake_stage, faker):
+        """测试批量获取 CodeBuddy 配置（包含 transportType）"""
+        server = G(
+            MCPServer,
+            name="test-server-codebuddy",
+            gateway=fake_gateway,
+            stage=fake_stage,
+            status=MCPServerStatusEnum.ACTIVE.value,
+            description=faker.pystr(),
+            is_public=True,
+            _resource_names="resource1",
+            oauth2_public_client_enabled=False,
+        )
+
+        resp = request_view(
+            method="POST",
+            view_name="mcp_server.batch_config",
+            path_params={"gateway_id": fake_gateway.id},
+            gateway=fake_gateway,
+            data={
+                "mcp_server_ids": [server.id],
+                "client_type": "codebuddy",
+            },
+        )
+        result = resp.json()
+
+        assert resp.status_code == 200
+        assert result["data"]["client_type"] == "codebuddy"
+        assert result["data"]["display_name"] == "CodeBuddy"
+
+        server_config = result["data"]["config"]["mcpServers"]["test-server-codebuddy"]
+        assert "transportType" in server_config
+
+    def test_batch_config_with_inactive_server(self, request_view, fake_gateway, fake_stage, faker):
+        """测试包含停用状态的 MCPServer 时会被过滤"""
+        active_server = G(
+            MCPServer,
+            name="active-server",
+            gateway=fake_gateway,
+            stage=fake_stage,
+            status=MCPServerStatusEnum.ACTIVE.value,
+            description=faker.pystr(),
+            is_public=True,
+            _resource_names="resource1",
+        )
+        inactive_server = G(
+            MCPServer,
+            name="inactive-server",
+            gateway=fake_gateway,
+            stage=fake_stage,
+            status=MCPServerStatusEnum.INACTIVE.value,
+            description=faker.pystr(),
+            is_public=True,
+            _resource_names="resource2",
+        )
+
+        resp = request_view(
+            method="POST",
+            view_name="mcp_server.batch_config",
+            path_params={"gateway_id": fake_gateway.id},
+            gateway=fake_gateway,
+            data={
+                "mcp_server_ids": [active_server.id, inactive_server.id],
+                "client_type": "cursor",
+            },
+        )
+        result = resp.json()
+
+        assert resp.status_code == 200
+        assert "active-server" in result["data"]["config"]["mcpServers"]
+        assert "inactive-server" not in result["data"]["config"]["mcpServers"]
+
+    def test_batch_config_not_found(self, request_view, fake_gateway):
+        """测试所有 MCPServer 都无效时返回 404"""
+        resp = request_view(
+            method="POST",
+            view_name="mcp_server.batch_config",
+            path_params={"gateway_id": fake_gateway.id},
+            gateway=fake_gateway,
+            data={
+                "mcp_server_ids": [99999, 99998],
+                "client_type": "cursor",
+            },
+        )
+
+        assert resp.status_code == 404
+
+    def test_batch_config_invalid_input(self, request_view, fake_gateway):
+        """测试无效输入时返回 400"""
+        resp = request_view(
+            method="POST",
+            view_name="mcp_server.batch_config",
+            path_params={"gateway_id": fake_gateway.id},
+            gateway=fake_gateway,
+            data={
+                "mcp_server_ids": [],
+                "client_type": "cursor",
+            },
+        )
+        assert resp.status_code == 400
+
+    def test_batch_config_oauth2_public_client_enabled(self, request_view, fake_gateway, fake_stage, faker):
+        """测试 OAuth2 公开客户端模式开启时配置中不包含认证请求头"""
+        server = G(
+            MCPServer,
+            name="oauth2-server",
+            gateway=fake_gateway,
+            stage=fake_stage,
+            status=MCPServerStatusEnum.ACTIVE.value,
+            description=faker.pystr(),
+            is_public=True,
+            _resource_names="resource1",
+            oauth2_public_client_enabled=True,
+        )
+
+        resp = request_view(
+            method="POST",
+            view_name="mcp_server.batch_config",
+            path_params={"gateway_id": fake_gateway.id},
+            gateway=fake_gateway,
+            data={
+                "mcp_server_ids": [server.id],
+                "client_type": "cursor",
+            },
+        )
+        result = resp.json()
+
+        assert resp.status_code == 200
+        server_config = result["data"]["config"]["mcpServers"]["oauth2-server"]
+        if "headers" in server_config:
+            assert "X-Bkapi-Authorization" not in server_config["headers"]
+
+    def test_batch_config_other_gateway_server(self, request_view, fake_gateway, faker):
+        """测试不能获取其他网关的 MCPServer 配置"""
+        other_gateway = create_gateway()
+        other_stage = G(Stage, gateway=other_gateway, name="prod", status=StageStatusEnum.ACTIVE.value)
+
+        other_server = G(
+            MCPServer,
+            name="other-server",
+            gateway=other_gateway,
+            stage=other_stage,
+            status=MCPServerStatusEnum.ACTIVE.value,
+            description=faker.pystr(),
+            is_public=True,
+            _resource_names="resource1",
+        )
+
+        resp = request_view(
+            method="POST",
+            view_name="mcp_server.batch_config",
+            path_params={"gateway_id": fake_gateway.id},
+            gateway=fake_gateway,
+            data={
+                "mcp_server_ids": [other_server.id],
+                "client_type": "cursor",
+            },
+        )
+
+        assert resp.status_code == 404

--- a/src/dashboard/apigateway/apigateway/tests/biz/mcp_server/test_mcp_server.py
+++ b/src/dashboard/apigateway/apigateway/tests/biz/mcp_server/test_mcp_server.py
@@ -1625,45 +1625,138 @@ class TestMCPServerHandler:
 
         assert mcp_server.categories.count() == 1
 
+    def test_build_batch_agent_client_config_empty_list(self):
+        """测试空列表返回空配置"""
+        result = MCPServerHandler.build_batch_agent_client_config([], "cursor", {}, user_tenant_id="")
+        assert result == {"mcpServers": {}}
 
-class TestBuildCategoriesMap:
-    """测试 MCPServerHandler.build_categories_map 批量查询分类"""
+    def test_build_batch_agent_client_config_cursor(self, fake_gateway, fake_stage):
+        """测试批量生成 Cursor 配置"""
+        server1 = G(
+            MCPServer,
+            name="server-1",
+            gateway=fake_gateway,
+            stage=fake_stage,
+            status=MCPServerStatusEnum.ACTIVE.value,
+            _resource_names="resource1",
+            oauth2_public_client_enabled=False,
+        )
+        server2 = G(
+            MCPServer,
+            name="server-2",
+            gateway=fake_gateway,
+            stage=fake_stage,
+            status=MCPServerStatusEnum.ACTIVE.value,
+            _resource_names="resource2",
+            oauth2_public_client_enabled=False,
+        )
 
-    def test_build_categories_map_with_categories(self, fake_gateway, fake_stage):
-        """有分类的 MCP Server 返回正确的分类映射"""
-        cat1, _ = MCPServerCategory.objects.get_or_create(name="official", defaults={"display_name": "Official"})
-        cat2, _ = MCPServerCategory.objects.get_or_create(name="ai", defaults={"display_name": "AI"})
-        mcp_server = G(MCPServer, gateway=fake_gateway, stage=fake_stage)
-        mcp_server.categories.add(cat1, cat2)
+        least_privileges = {(fake_gateway.id, fake_stage.id): ""}
 
-        result = MCPServerHandler.build_categories_map([mcp_server.id])
+        result = MCPServerHandler.build_batch_agent_client_config(
+            [server1, server2], "cursor", least_privileges, user_tenant_id=""
+        )
 
-        assert mcp_server.id in result
-        categories = result[mcp_server.id]
-        assert len(categories) == 2
-        cat_names = {c["name"] for c in categories}
-        assert cat_names == {"official", "ai"}
+        assert "mcpServers" in result
+        assert "server-1" in result["mcpServers"]
+        assert "server-2" in result["mcpServers"]
 
-    def test_build_categories_map_no_categories(self, fake_gateway, fake_stage):
-        """无分类的 MCP Server 不出现在映射中"""
-        mcp_server = G(MCPServer, gateway=fake_gateway, stage=fake_stage)
+        # 验证 Cursor 配置结构
+        config1 = result["mcpServers"]["server-1"]
+        assert "url" in config1
+        assert "headers" in config1
+        assert "X-Bkapi-Authorization" in config1["headers"]
 
-        result = MCPServerHandler.build_categories_map([mcp_server.id])
+    def test_build_batch_agent_client_config_codebuddy(self, fake_gateway, fake_stage):
+        """测试批量生成 CodeBuddy 配置（包含 transportType）"""
+        server = G(
+            MCPServer,
+            name="codebuddy-server",
+            gateway=fake_gateway,
+            stage=fake_stage,
+            status=MCPServerStatusEnum.ACTIVE.value,
+            _resource_names="resource1",
+            oauth2_public_client_enabled=False,
+            protocol_type="streamable_http",
+        )
 
-        assert mcp_server.id not in result
+        least_privileges = {(fake_gateway.id, fake_stage.id): ""}
 
-    def test_build_categories_map_empty_ids(self):
-        """空 ID 列表返回空映射"""
-        result = MCPServerHandler.build_categories_map([])
+        result = MCPServerHandler.build_batch_agent_client_config(
+            [server], "codebuddy", least_privileges, user_tenant_id=""
+        )
 
-        assert result == {}
+        config = result["mcpServers"]["codebuddy-server"]
+        assert "url" in config
+        assert "transportType" in config
+        assert config["transportType"] == "streamable-http"
 
-    def test_build_categories_map_filters_inactive(self, fake_gateway, fake_stage):
-        """不活跃的分类被过滤"""
-        cat_inactive = G(MCPServerCategory, name="inactive_cat", display_name="Inactive", is_active=False)
-        mcp_server = G(MCPServer, gateway=fake_gateway, stage=fake_stage)
-        mcp_server.categories.add(cat_inactive)
+    def test_build_batch_agent_client_config_oauth2_public_client_enabled(self, fake_gateway, fake_stage, settings):
+        """测试 OAuth2 公开客户端模式开启时不包含认证请求头"""
+        server = G(
+            MCPServer,
+            name="oauth2-server",
+            gateway=fake_gateway,
+            stage=fake_stage,
+            status=MCPServerStatusEnum.ACTIVE.value,
+            _resource_names="resource1",
+            oauth2_public_client_enabled=True,
+        )
 
-        result = MCPServerHandler.build_categories_map([mcp_server.id])
+        least_privileges = {(fake_gateway.id, fake_stage.id): ""}
 
-        assert mcp_server.id not in result
+        result = MCPServerHandler.build_batch_agent_client_config(
+            [server], "cursor", least_privileges, user_tenant_id=""
+        )
+
+        config = result["mcpServers"]["oauth2-server"]
+        # OAuth2 公开客户端模式下不应该有 headers
+        assert "headers" not in config or "X-Bkapi-Authorization" not in config.get("headers", {})
+
+    def test_build_batch_agent_client_config_with_tenant(self, fake_gateway, fake_stage, settings):
+        """测试多租户模式下包含租户 ID"""
+        settings.ENABLE_MULTI_TENANT_MODE = True
+
+        server = G(
+            MCPServer,
+            name="tenant-server",
+            gateway=fake_gateway,
+            stage=fake_stage,
+            status=MCPServerStatusEnum.ACTIVE.value,
+            _resource_names="resource1",
+            oauth2_public_client_enabled=False,
+        )
+
+        least_privileges = {(fake_gateway.id, fake_stage.id): ""}
+
+        result = MCPServerHandler.build_batch_agent_client_config(
+            [server], "cursor", least_privileges, user_tenant_id="tenant-123"
+        )
+
+        config = result["mcpServers"]["tenant-server"]
+        assert "headers" in config
+        assert "X-Bk-Tenant-Id" in config["headers"]
+        assert config["headers"]["X-Bk-Tenant-Id"] == "tenant-123"
+
+    def test_build_batch_agent_client_config_sse_protocol(self, fake_gateway, fake_stage):
+        """测试 SSE 协议类型"""
+        server = G(
+            MCPServer,
+            name="sse-server",
+            gateway=fake_gateway,
+            stage=fake_stage,
+            status=MCPServerStatusEnum.ACTIVE.value,
+            _resource_names="resource1",
+            oauth2_public_client_enabled=False,
+            protocol_type="sse",
+        )
+
+        least_privileges = {(fake_gateway.id, fake_stage.id): ""}
+
+        result = MCPServerHandler.build_batch_agent_client_config(
+            [server], "codebuddy", least_privileges, user_tenant_id=""
+        )
+
+        config = result["mcpServers"]["sse-server"]
+        # SSE 协议下 CodeBuddy 的 transportType 应为 sse
+        assert config["transportType"] == "sse"

--- a/src/dashboard/apigateway/apigateway/tests/biz/mcp_server/test_mcp_server.py
+++ b/src/dashboard/apigateway/apigateway/tests/biz/mcp_server/test_mcp_server.py
@@ -1651,7 +1651,7 @@ class TestMCPServerHandler:
             oauth2_public_client_enabled=False,
         )
 
-        least_privileges = {(fake_gateway.id, fake_stage.id): ""}
+        least_privileges = {server1.id: "", server2.id: ""}
 
         result = MCPServerHandler.build_batch_agent_client_config(
             [server1, server2], "cursor", least_privileges, user_tenant_id=""
@@ -1661,9 +1661,10 @@ class TestMCPServerHandler:
         assert "server-1" in result["mcpServers"]
         assert "server-2" in result["mcpServers"]
 
-        # 验证 Cursor 配置结构
+        # 验证 Cursor 配置结构（不带 type 字段）
         config1 = result["mcpServers"]["server-1"]
         assert "url" in config1
+        assert "type" not in config1
         assert "headers" in config1
         assert "X-Bkapi-Authorization" in config1["headers"]
 
@@ -1680,7 +1681,7 @@ class TestMCPServerHandler:
             protocol_type="streamable_http",
         )
 
-        least_privileges = {(fake_gateway.id, fake_stage.id): ""}
+        least_privileges = {server.id: ""}
 
         result = MCPServerHandler.build_batch_agent_client_config(
             [server], "codebuddy", least_privileges, user_tenant_id=""
@@ -1690,6 +1691,61 @@ class TestMCPServerHandler:
         assert "url" in config
         assert "transportType" in config
         assert config["transportType"] == "streamable-http"
+        assert "type" not in config
+
+    def test_build_batch_agent_client_config_claude(self, fake_gateway, fake_stage):
+        """测试批量生成 Claude 配置（包含 type 字段，顶层 key 为 mcpServers）"""
+        server = G(
+            MCPServer,
+            name="claude-server",
+            gateway=fake_gateway,
+            stage=fake_stage,
+            status=MCPServerStatusEnum.ACTIVE.value,
+            _resource_names="resource1",
+            oauth2_public_client_enabled=False,
+            protocol_type="streamable_http",
+        )
+
+        least_privileges = {server.id: ""}
+
+        result = MCPServerHandler.build_batch_agent_client_config(
+            [server], "claude", least_privileges, user_tenant_id=""
+        )
+
+        # Claude 顶层 key 为 mcpServers
+        assert "mcpServers" in result
+        config = result["mcpServers"]["claude-server"]
+        assert "url" in config
+        assert "type" in config
+        assert config["type"] == "http"
+        assert "transportType" not in config
+
+    def test_build_batch_agent_client_config_vscode(self, fake_gateway, fake_stage):
+        """测试批量生成 VSCode 配置（包含 type 字段，顶层 key 为 servers）"""
+        server = G(
+            MCPServer,
+            name="vscode-server",
+            gateway=fake_gateway,
+            stage=fake_stage,
+            status=MCPServerStatusEnum.ACTIVE.value,
+            _resource_names="resource1",
+            oauth2_public_client_enabled=False,
+            protocol_type="streamable_http",
+        )
+
+        least_privileges = {server.id: ""}
+
+        result = MCPServerHandler.build_batch_agent_client_config(
+            [server], "vscode", least_privileges, user_tenant_id=""
+        )
+
+        # VSCode 顶层 key 为 servers
+        assert "servers" in result
+        assert "mcpServers" not in result
+        config = result["servers"]["vscode-server"]
+        assert "url" in config
+        assert "type" in config
+        assert config["type"] == "http"
 
     def test_build_batch_agent_client_config_oauth2_public_client_enabled(self, fake_gateway, fake_stage, settings):
         """测试 OAuth2 公开客户端模式开启时不包含认证请求头"""
@@ -1703,7 +1759,7 @@ class TestMCPServerHandler:
             oauth2_public_client_enabled=True,
         )
 
-        least_privileges = {(fake_gateway.id, fake_stage.id): ""}
+        least_privileges = {server.id: ""}
 
         result = MCPServerHandler.build_batch_agent_client_config(
             [server], "cursor", least_privileges, user_tenant_id=""
@@ -1727,7 +1783,7 @@ class TestMCPServerHandler:
             oauth2_public_client_enabled=False,
         )
 
-        least_privileges = {(fake_gateway.id, fake_stage.id): ""}
+        least_privileges = {server.id: ""}
 
         result = MCPServerHandler.build_batch_agent_client_config(
             [server], "cursor", least_privileges, user_tenant_id="tenant-123"
@@ -1751,7 +1807,7 @@ class TestMCPServerHandler:
             protocol_type="sse",
         )
 
-        least_privileges = {(fake_gateway.id, fake_stage.id): ""}
+        least_privileges = {server.id: ""}
 
         result = MCPServerHandler.build_batch_agent_client_config(
             [server], "codebuddy", least_privileges, user_tenant_id=""
@@ -1760,3 +1816,37 @@ class TestMCPServerHandler:
         config = result["mcpServers"]["sse-server"]
         # SSE 协议下 CodeBuddy 的 transportType 应为 sse
         assert config["transportType"] == "sse"
+
+    def test_build_batch_agent_client_config_per_server_least_privilege(self, fake_gateway, fake_stage):
+        """测试同一 gateway+stage 下不同 server 的 least_privilege 独立计算"""
+        server1 = G(
+            MCPServer,
+            name="server-app",
+            gateway=fake_gateway,
+            stage=fake_stage,
+            status=MCPServerStatusEnum.ACTIVE.value,
+            _resource_names="resource1",
+            oauth2_public_client_enabled=False,
+        )
+        server2 = G(
+            MCPServer,
+            name="server-user",
+            gateway=fake_gateway,
+            stage=fake_stage,
+            status=MCPServerStatusEnum.ACTIVE.value,
+            _resource_names="resource2",
+            oauth2_public_client_enabled=False,
+        )
+
+        # 不同的 least_privilege（按 mcp_server.id 为 key）
+        least_privileges = {
+            server1.id: MCPServerLeastPrivilegeEnum.APPLICATION.value,
+            server2.id: MCPServerLeastPrivilegeEnum.APPLICATION_AND_USER.value,
+        }
+
+        result = MCPServerHandler.build_batch_agent_client_config(
+            [server1, server2], "cursor", least_privileges, user_tenant_id=""
+        )
+
+        assert "server-app" in result["mcpServers"]
+        assert "server-user" in result["mcpServers"]


### PR DESCRIPTION
## Summary

- Add `MCPServerBatchConfigApi` and `MCPMarketplaceBatchConfigApi` endpoints
- Support generating JSON config based on agent client type (cursor, codebuddy, claude, vscode)
- Handle transport type mapping, OAuth2 public client mode, and multi-tenant headers
- Add `get_client_display_name` helper and `validate_client_type` validation
- Use `MCPServerProtocolTypeEnum` constant instead of magic string
- Add comprehensive tests for both APIs

## Changes

### APIs
- `POST /gateways/{gateway_id}/mcp_servers/batch_config/` — batch config for gateway MCP servers
- `POST /mcp_marketplace/mcp_servers/batch_config/` — batch config for marketplace MCP servers

### Biz Layer
- `MCPServerHandler.build_batch_agent_client_config()` — build batch JSON config
- `MCPServerHandler.get_client_display_name()` — get display name for client type

### Security
- `mcp_server_ids` limited to max 100 items
- `client_type` validated against `MCP_CONFIG_AGENT_CLIENTS`
- Placeholder credentials use explicit `<your_xxx>` format