### PR TITLE
fix(mcp): fix RawResponseEnabled hot reload not working

### DIFF
--- a/src/mcp-proxy/pkg/infra/proxy/proxy.go
+++ b/src/mcp-proxy/pkg/infra/proxy/proxy.go
@@ -270,7 +270,7 @@ func (m *MCPProxy) AddMCPServerFromConfigs(configs []*MCPServerConfig) error {
 
 		// register tool
 		for _, toolConfig := range config.Tools {
-			toolHandler := genToolHandler(toolConfig, config.Name, config.RawResponseEnabled)
+			toolHandler := genToolHandler(toolConfig, config.Name, mcpServer.RawResponseEnabled)
 			mcpServer.AddTool(buildMCPTool(toolConfig, config.Name), toolHandler)
 		}
 		m.AddMCPServer(config.Name, mcpServer)
@@ -317,7 +317,7 @@ func (m *MCPProxy) UpdateMCPServerFromOpenApiSpec(
 	}
 	// update tool
 	for _, toolConfig := range mcpServerConfig.Tools {
-		toolHandler := genToolHandler(toolConfig, name, mcpServer.RawResponseEnabled())
+		toolHandler := genToolHandler(toolConfig, name, mcpServer.RawResponseEnabled)
 		mcpServer.AddTool(buildMCPTool(toolConfig, name), toolHandler)
 	}
 	// 更新资源版本号
@@ -508,7 +508,7 @@ func (t *loggingTransport) RoundTrip(req *http.Request) (*http.Response, error) 
 	return resp, nil
 }
 
-func genToolHandler(toolApiConfig *ToolConfig, serverName string, rawResponse bool) ToolHandler {
+func genToolHandler(toolApiConfig *ToolConfig, serverName string, rawResponseGetter func() bool) ToolHandler {
 	// 生成handler
 	handler := func(ctx context.Context, req *mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 		auditLog := logging.GetAuditLoggerWithContext(ctx)
@@ -664,7 +664,7 @@ func genToolHandler(toolApiConfig *ToolConfig, serverName string, rawResponse bo
 					}
 
 					var responseResult any
-					if rawResponse {
+					if rawResponseGetter() {
 						// raw_response 模式：直接返回 API 响应结果，不添加 request_id 等额外信息
 						responseResult = res
 					} else {

--- a/src/mcp-proxy/pkg/infra/proxy/server_test.go
+++ b/src/mcp-proxy/pkg/infra/proxy/server_test.go
@@ -65,6 +65,72 @@ var _ = Describe("MCPServer", func() {
 			})
 		})
 
+		Describe("RawResponseEnabled", func() {
+			It("should return default false when not set", func() {
+				Expect(server.RawResponseEnabled()).To(BeFalse())
+			})
+
+			It("should return true when set to true", func() {
+				server.SetRawResponseEnabled(true)
+				Expect(server.RawResponseEnabled()).To(BeTrue())
+			})
+
+			It("should return false when set to false", func() {
+				server.SetRawResponseEnabled(true)
+				Expect(server.RawResponseEnabled()).To(BeTrue())
+
+				server.SetRawResponseEnabled(false)
+				Expect(server.RawResponseEnabled()).To(BeFalse())
+			})
+
+			It("should handle concurrent reads and writes", func() {
+				var wg sync.WaitGroup
+
+				// Concurrent reads
+				for i := 0; i < 50; i++ {
+					wg.Add(1)
+					go func() {
+						defer wg.Done()
+						_ = server.RawResponseEnabled()
+					}()
+				}
+
+				// Concurrent writes
+				for i := 0; i < 50; i++ {
+					wg.Add(1)
+					go func(idx int) {
+						defer wg.Done()
+						server.SetRawResponseEnabled(idx%2 == 0)
+					}(i)
+				}
+
+				wg.Wait()
+			})
+
+			It("should dynamically update value for tool handler getter", func() {
+				// Simulate the scenario where tool handler uses RawResponseEnabled as a getter
+				// This tests the hot-reload scenario for raw_response_enabled
+
+				// Initial state: false
+				Expect(server.RawResponseEnabled()).To(BeFalse())
+
+				// Simulate getter function (like genToolHandler uses)
+				getter := server.RawResponseEnabled
+				Expect(getter()).To(BeFalse())
+
+				// Hot update: change raw_response_enabled to true
+				server.SetRawResponseEnabled(true)
+
+				// Getter should return new value without re-registering handler
+				Expect(getter()).To(BeTrue())
+				Expect(server.RawResponseEnabled()).To(BeTrue())
+
+				// Hot update: change back to false
+				server.SetRawResponseEnabled(false)
+				Expect(getter()).To(BeFalse())
+			})
+		})
+
 		Describe("GetTools", func() {
 			It("should return empty slice when no tools", func() {
 				Expect(server.GetTools()).To(BeEmpty())


### PR DESCRIPTION
Why this change was needed:
When changing RawResponseEnabled configuration for an MCP server, the setting was not taking effect without restarting the service. This was because genToolHandler captured the rawResponse bool value at handler registration time, so subsequent changes via SetRawResponseEnabled had no effect on already-registered tool handlers.

What changed:
- Changed genToolHandler signature from rawResponse bool to rawResponseGetter func() bool to accept a getter function
- Updated tool handler to call rawResponseGetter() dynamically instead of using captured boolean value
- Changed call sites to pass mcpServer.RawResponseEnabled method value instead of config.RawResponseEnabled boolean
- Added unit tests for RawResponseEnabled getter behavior and concurrent access safety

Problem solved:
RawResponseEnabled configuration changes now take effect immediately without requiring service restart. Tool handlers dynamically read the latest value from MCPServer on each execution.

### Description

<!-- 关联相关issue Please include a summary of the change and which issue is fixed. -->
<!-- 给出必要的上下文以及review需要的必要信息 Please also include relevant motivation and context. -->

Fixes # (issue)

### Checklist

- [ ] 填写 PR 描述及相关 issue (write PR description and related issue)
- [ ] 代码风格检查通过 (code style check passed)
- [ ] PR 中包含单元测试 (include unit test)
- [ ] 单元测试通过 (unit test passed)
- [ ] 本地开发联调环境验证通过 (local development environment verification passed)
