### PR TITLE
fix(mcp): fix RawResponseEnabled hot reload not working

### DIFF
--- a/src/mcp-proxy/pkg/infra/proxy/proxy.go
+++ b/src/mcp-proxy/pkg/infra/proxy/proxy.go
@@ -238,7 +238,7 @@ func (m *MCPProxy) AddMCPServerFromConfigs(configs []*MCPServerConfig) error {
 
 		// register tool
 		for _, toolConfig := range config.Tools {
-			toolHandler := genToolHandler(toolConfig, config.Name, config.RawResponseEnabled)
+			toolHandler := genToolHandler(toolConfig, config.Name, mcpServer.RawResponseEnabled)
 			mcpServer.AddTool(buildMCPTool(toolConfig, config.Name), toolHandler)
 		}
 		m.AddMCPServer(config.Name, mcpServer)
@@ -285,7 +285,7 @@ func (m *MCPProxy) UpdateMCPServerFromOpenApiSpec(
 	}
 	// update tool
 	for _, toolConfig := range mcpServerConfig.Tools {
-		toolHandler := genToolHandler(toolConfig, name, rawResponseEnabled)
+		toolHandler := genToolHandler(toolConfig, name, mcpServer.RawResponseEnabled)
 		mcpServer.AddTool(buildMCPTool(toolConfig, name), toolHandler)
 	}
 	// 更新资源版本号
@@ -748,7 +748,7 @@ func handleToolCallError(
 	return result
 }
 
-func genToolHandler(toolApiConfig *ToolConfig, serverName string, rawResponseEnabled bool) ToolHandler {
+func genToolHandler(toolApiConfig *ToolConfig, serverName string, rawResponseEnabledGetter func() bool) ToolHandler {
 	// 生成handler
 	handler := func(ctx context.Context, req *mcp.CallToolRequest) (result *mcp.CallToolResult, err error) {
 		start := time.Now()
@@ -919,12 +919,12 @@ func genToolHandler(toolApiConfig *ToolConfig, serverName string, rawResponseEna
 						}
 					}
 
-					var responseResult any
-					if rawResponseEnabled {
-						// raw_response_enabled 模式：直接返回 API 响应结果，不添加 request_id 等额外信息。
-						// 注意：无论成功或失败（非 2xx）都直接透传原始响应，
-						// 由 MCP 协议层的 IsError 标记来区分调用方是否为错误场景。
-						responseResult = res
+				var responseResult any
+				if rawResponseEnabledGetter() {
+					// raw_response_enabled 模式：直接返回 API 响应结果，不添加 request_id 等额外信息。
+					// 注意：无论成功或失败（非 2xx）都直接透传原始响应，
+					// 由 MCP 协议层的 IsError 标记来区分调用方是否为错误场景。
+					responseResult = res
 					} else {
 						responseResult = buildToolResponseEnvelope(
 							response.Code(),

--- a/src/mcp-proxy/pkg/infra/proxy/server_test.go
+++ b/src/mcp-proxy/pkg/infra/proxy/server_test.go
@@ -87,6 +87,29 @@ var _ = Describe("MCPServer", func() {
 				server.SetRawResponseEnabled(false)
 				Expect(server.RawResponseEnabled()).To(BeFalse())
 			})
+
+			It("should dynamically update value for tool handler getter", func() {
+				// Simulate the scenario where tool handler uses RawResponseEnabled as a getter
+				// This tests the hot-reload scenario for raw_response_enabled
+
+				// Initial state: false
+				Expect(server.RawResponseEnabled()).To(BeFalse())
+
+				// Simulate getter function (like genToolHandler uses)
+				getter := server.RawResponseEnabled
+				Expect(getter()).To(BeFalse())
+
+				// Hot update: change raw_response_enabled to true
+				server.SetRawResponseEnabled(true)
+
+				// Getter should return new value without re-registering handler
+				Expect(getter()).To(BeTrue())
+				Expect(server.RawResponseEnabled()).To(BeTrue())
+
+				// Hot update: change back to false
+				server.SetRawResponseEnabled(false)
+				Expect(getter()).To(BeFalse())
+			})
 		})
 
 		Describe("GetTools", func() {


### PR DESCRIPTION
Why this change was needed:
When changing RawResponseEnabled configuration for an MCP server, the setting was not taking effect without restarting the service. This was because genToolHandler captured the rawResponseEnabled bool value at handler registration time, so subsequent changes via SetRawResponseEnabled had no effect on already-registered tool handlers.

What changed:
- Changed genToolHandler signature from rawResponseEnabled bool to rawResponseEnabledGetter func() bool to accept a getter function
- Updated tool handler to call rawResponseEnabledGetter() dynamically instead of using captured boolean value
- Changed call sites to pass mcpServer.RawResponseEnabled method value instead of config.RawResponseEnabled or rawResponseEnabled boolean
- Added unit test for dynamic getter behavior in hot-reload scenario

Problem solved:
RawResponseEnabled configuration changes now take effect immediately without requiring service restart. Tool handlers dynamically read the latest value from MCPServer on each execution.

### Description

<!-- 关联相关issue Please include a summary of the change and which issue is fixed. -->
<!-- 给出必要的上下文以及review需要的必要信息 Please also include relevant motivation and context. -->

Fixes # (issue)

### Checklist

- [ ] 填写 PR 描述及相关 issue (write PR description and related issue)
- [ ] 代码风格检查通过 (code style check passed)
- [ ] PR 中包含单元测试 (include unit test)
- [ ] 单元测试通过 (unit test passed)
- [ ] 本地开发联调环境验证通过 (local development environment verification passed)
