### PR TITLE
feat(mcp): add categories field to MCP server APIs and optimize query performance

### DIFF
--- a/src/dashboard/apigateway/apigateway/apis/v2/inner/serializers.py
+++ b/src/dashboard/apigateway/apigateway/apis/v2/inner/serializers.py
@@ -18,10 +18,12 @@
 #
 import logging
 import math
+from typing import Dict, List
 
 from django.utils.translation import gettext as _
 from rest_framework import serializers
 
+from apigateway.apis.v2.mcp_server import get_categories_from_context
 from apigateway.apps.mcp_server.constants import (
     MCPServerAppPermissionApplyStatusEnum,
     MCPServerProtocolTypeEnum,
@@ -357,6 +359,7 @@ class MCPServerBaseSLZ(serializers.Serializer):
         help_text="MCPServer 协议类型",
         choices=MCPServerProtocolTypeEnum.get_choices(),
     )
+    categories = serializers.SerializerMethodField(help_text="MCPServer 分类列表")
 
     def get_title(self, obj) -> str:
         title = obj.get("title", "") if isinstance(obj, dict) else getattr(obj, "title", "")
@@ -366,6 +369,9 @@ class MCPServerBaseSLZ(serializers.Serializer):
     def get_doc_link(self, obj):
         obj_id = obj.get("id") if isinstance(obj, dict) else obj.id
         return build_mcp_server_detail_url(obj_id)
+
+    def get_categories(self, obj) -> List[Dict[str, str]]:
+        return get_categories_from_context(self.context, obj)
 
     class Meta:
         ref_name = "apigateway.apis.v2.inner.serializers.MCPServerBaseSLZ"
@@ -568,6 +574,8 @@ class MCPServerListOutputSLZ(serializers.Serializer):
         read_only=True, help_text="是否开启 OAuth2 公开客户端模式，开启后将会对 bk_app_code=public 的应用进行授权"
     )
 
+    categories = serializers.SerializerMethodField(help_text="MCPServer 分类列表")
+
     stage = serializers.SerializerMethodField(help_text="MCPServer 环境")
     gateway = serializers.SerializerMethodField(help_text="MCPServer 网关")
 
@@ -583,6 +591,9 @@ class MCPServerListOutputSLZ(serializers.Serializer):
 
     def get_title(self, obj) -> str:
         return obj.title if obj.title else obj.name
+
+    def get_categories(self, obj) -> List[Dict[str, str]]:
+        return get_categories_from_context(self.context, obj)
 
     def get_stage(self, obj):
         return self.context["stages"][obj.stage.id]

--- a/src/dashboard/apigateway/apigateway/apis/v2/inner/views.py
+++ b/src/dashboard/apigateway/apigateway/apis/v2/inner/views.py
@@ -30,7 +30,10 @@ from drf_yasg.utils import swagger_auto_schema
 from rest_framework import generics, status
 from rest_framework.exceptions import ValidationError
 
-from apigateway.apis.v2.mcp_server import build_mcp_server_list_context, build_mcp_server_list_queryset
+from apigateway.apis.v2.mcp_server import (
+    build_mcp_server_list_context,
+    build_mcp_server_list_queryset,
+)
 from apigateway.apis.v2.permissions import OpenAPIV2GatewayNamePermission, OpenAPIV2Permission
 from apigateway.apps.mcp_server.constants import (
     MCPServerAppPermissionApplyStatusEnum,
@@ -506,6 +509,9 @@ class MCPServerPermissionListApi(generics.ListAPIView):
                 mcp_server_permission_status[obj["mcp_server_id"]] = obj["status"]
 
         mcp_server_permissions = []
+        # Build categories map for queryset
+        categories_map = MCPServerHandler.build_categories_map([obj.id for obj in queryset])
+
         for obj in queryset:
             permission_status = mcp_server_permission_status.get(
                 obj.id, MCPServerPermissionStatusEnum.NEED_APPLY.value
@@ -542,7 +548,9 @@ class MCPServerPermissionListApi(generics.ListAPIView):
                 }
             )
 
-        slz = serializers.MCPServerPermissionListOutputSLZ(mcp_server_permissions, many=True)
+        slz = serializers.MCPServerPermissionListOutputSLZ(
+            mcp_server_permissions, many=True, context={"categories": categories_map}
+        )
         return OKJsonResponse(data=slz.data)
 
 
@@ -627,7 +635,12 @@ class MCPServerAppPermissionListApi(generics.ListAPIView):
             for obj in queryset
         ]
 
-        slz = serializers.MCPServerAppPermissionListOutputSLZ(mcp_server_permissions, many=True)
+        # Build categories map
+        categories_map = MCPServerHandler.build_categories_map([obj.mcp_server_id for obj in queryset])
+
+        slz = serializers.MCPServerAppPermissionListOutputSLZ(
+            mcp_server_permissions, many=True, context={"categories": categories_map}
+        )
         return OKJsonResponse(data=slz.data)
 
 
@@ -689,7 +702,12 @@ class MCPServerAppPermissionRecordListApi(generics.ListAPIView):
             for obj in queryset
         ]
 
-        slz = serializers.MCPServerAppPermissionRecordListOutputSLZ(mcp_server_permission_records, many=True)
+        # Build categories map
+        categories_map = MCPServerHandler.build_categories_map([obj.mcp_server_id for obj in queryset])
+
+        slz = serializers.MCPServerAppPermissionRecordListOutputSLZ(
+            mcp_server_permission_records, many=True, context={"categories": categories_map}
+        )
 
         return OKJsonResponse(data=slz.data)
 
@@ -753,7 +771,11 @@ class MCPServerAppPermissionRecordRetrieveApi(generics.RetrieveAPIView):
             },
         }
 
-        slz = self.get_serializer(mcp_server_permission_record)
+        # Build categories map
+        categories_map = MCPServerHandler.build_categories_map([instance.mcp_server_id])
+
+        context = {**self.get_serializer_context(), "categories": categories_map}
+        slz = self.get_serializer(mcp_server_permission_record, context=context)
         return OKJsonResponse(data=slz.data)
 
 
@@ -790,6 +812,9 @@ class MCPServerListApi(generics.ListAPIView):
 
         mcp_server_ids = [mcp_server.id for mcp_server in page]
         context["prompts_count_map"] = MCPServerHandler.get_prompts_count_map(mcp_server_ids)
+
+        # Add categories map
+        context["categories"] = MCPServerHandler.build_categories_map([mcp_server.id for mcp_server in page])
 
         output_slz = serializers.MCPServerListOutputSLZ(page, many=True, context=context)
         return self.get_paginated_response(output_slz.data)

--- a/src/dashboard/apigateway/apigateway/apis/v2/mcp_server.py
+++ b/src/dashboard/apigateway/apigateway/apis/v2/mcp_server.py
@@ -26,12 +26,28 @@ v2 MCP Server 公共函数模块
     - validate_and_enrich_mcp_server_for_retrieve -> MCPServerHandler.build_retrieve_context
 """
 
-from typing import Any, Dict, Optional, Sequence
+from typing import Any, Dict, List, Optional, Sequence, Union
 
 from django.db.models import QuerySet
 
 from apigateway.apps.mcp_server.models import MCPServer
 from apigateway.biz.mcp_server import MCPServerHandler
+
+
+def get_categories_from_context(context: dict, obj: Union[dict, MCPServer]) -> List[Dict[str, str]]:
+    """从 serializer context 中获取 obj 对应的 categories 列表
+
+    支持 dict 和 model 实例两种 obj 格式，统一 inner/open 序列化器中的 categories 获取逻辑。
+
+    Args:
+        context: serializer 的 context 字典，应包含 "categories" 键
+        obj: MCPServer 数据，可以是 dict（含 "id" 键）或 model 实例（含 id 属性）
+
+    Returns:
+        categories 列表，如 [{"name": "official", "display_name": "官方"}]
+    """
+    obj_id = obj.get("id") if isinstance(obj, dict) else obj.id
+    return context.get("categories", {}).get(obj_id, [])
 
 
 def build_mcp_server_list_queryset(

--- a/src/dashboard/apigateway/apigateway/apis/v2/open/serializers.py
+++ b/src/dashboard/apigateway/apigateway/apis/v2/open/serializers.py
@@ -21,6 +21,7 @@ from typing import Any, Dict, List, Optional
 from django.utils.translation import gettext as _
 from rest_framework import serializers
 
+from apigateway.apis.v2.mcp_server import get_categories_from_context
 from apigateway.apps.mcp_server.constants import (
     MCPServerAppPermissionApplyStatusEnum,
     MCPServerAppPermissionGrantTypeEnum,
@@ -217,6 +218,11 @@ class MCPServerBaseSLZ(serializers.Serializer):
     def get_title(self, obj) -> str:
         return obj.title if obj.title else obj.name
 
+    categories = serializers.SerializerMethodField(help_text="MCPServer 分类列表")
+
+    def get_categories(self, obj) -> List[Dict[str, str]]:
+        return get_categories_from_context(self.context, obj)
+
     class Meta:
         ref_name = "apigateway.apis.v2.open.serializers.MCPServerBaseSLZ"
 
@@ -262,6 +268,8 @@ class MCPServerBaseOutputSLZ(serializers.Serializer):
         read_only=True, help_text="是否开启 OAuth2 公开客户端模式，开启后将会对 bk_app_code=public 的应用进行授权"
     )
 
+    categories = serializers.SerializerMethodField(help_text="MCPServer 分类列表")
+
     stage = serializers.SerializerMethodField(help_text="MCPServer 环境")
     gateway = serializers.SerializerMethodField(help_text="MCPServer 网关")
 
@@ -273,6 +281,9 @@ class MCPServerBaseOutputSLZ(serializers.Serializer):
     created_by = serializers.CharField(read_only=True, help_text="创建人")
     updated_time = serializers.DateTimeField(read_only=True, help_text="更新时间")
     created_time = serializers.DateTimeField(read_only=True, help_text="创建时间")
+
+    def get_categories(self, obj) -> List[Dict[str, str]]:
+        return get_categories_from_context(self.context, obj)
 
     def get_stage(self, obj) -> Dict[str, Any]:
         return self.context["stages"][obj.stage.id]
@@ -793,8 +804,8 @@ class MCPServerBatchQueryOutputSLZ(serializers.Serializer):
     def get_title(self, obj) -> str:
         return obj.title if obj.title else obj.name
 
-    def get_categories(self, obj) -> list:
-        return self.context.get("categories", {}).get(obj.id, [])
+    def get_categories(self, obj) -> List[Dict[str, str]]:
+        return get_categories_from_context(self.context, obj)
 
 
 class OAuthProtectedResourceInputSLZ(serializers.Serializer):

--- a/src/dashboard/apigateway/apigateway/apis/v2/open/views.py
+++ b/src/dashboard/apigateway/apigateway/apis/v2/open/views.py
@@ -277,6 +277,9 @@ class MCPServerListApi(generics.ListAPIView):
         page = self.paginate_queryset(queryset)
         context = build_mcp_server_list_context(page)
 
+        # Add categories map
+        context["categories"] = MCPServerHandler.build_categories_map([mcp_server.id for mcp_server in page])
+
         output_slz = MCPServerListOutputSLZ(page, many=True, context=context)
         return self.get_paginated_response(output_slz.data)
 
@@ -319,7 +322,11 @@ class MCPServerAppPermissionListApi(generics.ListAPIView):
 
         queryset = MCPServerAppPermission.objects.filter(bk_app_code=slz.validated_data["bk_app_code"])
         page = self.paginate_queryset(queryset)
-        output_slz = MCPServerAppPermissionListOutputSLZ(page, many=True)
+
+        # Build categories map
+        categories_map = MCPServerHandler.build_categories_map([perm.mcp_server_id for perm in page])
+
+        output_slz = MCPServerAppPermissionListOutputSLZ(page, many=True, context={"categories": categories_map})
 
         return self.get_paginated_response(output_slz.data)
 
@@ -342,7 +349,11 @@ class MCPServerPermissionListApi(generics.ListAPIView):
 
         queryset = MCPServerAppPermission.objects.filter(mcp_server=instance)
         page = self.paginate_queryset(queryset)
-        output_slz = MCPServerPermissionListOutputSLZ(page, many=True)
+
+        # Build categories map
+        categories_map = MCPServerHandler.build_categories_map([instance.id])
+
+        output_slz = MCPServerPermissionListOutputSLZ(page, many=True, context={"categories": categories_map})
 
         return self.get_paginated_response(output_slz.data)
 
@@ -416,7 +427,12 @@ class MCPServerAppPermissionRecordListApi(generics.ListAPIView):
             if obj.mcp_server.id not in output_data:
                 output_data[obj.mcp_server.id] = obj
 
-        output_slz = MCPServerAppPermissionApplyRecordListOutputSLZ(output_data.values(), many=True)
+        # Build categories map
+        categories_map = MCPServerHandler.build_categories_map(list(output_data.keys()))
+
+        output_slz = MCPServerAppPermissionApplyRecordListOutputSLZ(
+            output_data.values(), many=True, context={"categories": categories_map}
+        )
         return OKJsonResponse(data=output_slz.data)
 
 
@@ -501,6 +517,9 @@ class UserMCPServerListApi(generics.ListAPIView):
 
         least_privileges = MCPServerHandler.get_least_privileges(page)
 
+        # Add categories map
+        categories_map = MCPServerHandler.build_categories_map([mcp_server.id for mcp_server in page])
+
         output_slz = UserMCPServerListOutputSLZ(
             page,
             many=True,
@@ -508,6 +527,7 @@ class UserMCPServerListApi(generics.ListAPIView):
                 "gateways": gateways,
                 "stages": stages,
                 "least_privileges": least_privileges,
+                "categories": categories_map,
             },
         )
 

--- a/src/dashboard/apigateway/apigateway/biz/mcp_server/mcp_server.py
+++ b/src/dashboard/apigateway/apigateway/biz/mcp_server/mcp_server.py
@@ -640,6 +640,33 @@ class MCPServerHandler:
         return queryset.select_related("gateway", "stage").order_by(order_by)
 
     @staticmethod
+    def build_categories_map(mcp_server_ids: List[int]) -> Dict[int, List[Dict[str, str]]]:
+        """批量查询 MCPServer 的分类信息，返回 {mcp_server_id: [{"name": ..., "display_name": ...}]} 映射
+
+        使用单次查询替代 N+1 的 categories.filter() 调用。
+
+        Args:
+            mcp_server_ids: MCPServer ID 列表
+
+        Returns:
+            以 mcp_server_id 为 key 的分类字典映射
+        """
+        if not mcp_server_ids:
+            return {}
+
+        categories_qs = MCPServerCategory.objects.filter(
+            mcp_servers__id__in=mcp_server_ids,
+            is_active=True,
+        ).values("mcp_servers__id", "name", "display_name")
+
+        categories_map: Dict[int, List[Dict[str, str]]] = {}
+        for cat in categories_qs:
+            categories_map.setdefault(cat["mcp_servers__id"], []).append(
+                {"name": cat["name"], "display_name": cat["display_name"]}
+            )
+        return categories_map
+
+    @staticmethod
     def build_list_context(
         mcp_servers: Sequence,
         include_prompts_count: bool = False,

--- a/src/dashboard/apigateway/apigateway/data/apidocs/zh/v2_inner_list_mcp_server.md
+++ b/src/dashboard/apigateway/apigateway/data/apidocs/zh/v2_inner_list_mcp_server.md
@@ -34,6 +34,10 @@
         "status": "active",
         "protocol_type": "sse",
         "oauth2_public_client_enabled": false,
+        "categories": [
+          {"name": "official", "display_name": "官方"},
+          {"name": "ai", "display_name": "AI"}
+        ],
         "stage": {
           "id": 1,
           "name": "prod"
@@ -88,6 +92,7 @@
 | status       | string | MCPServer 状态          |
 | protocol_type | string | MCPServer 协议类型        |
 | oauth2_public_client_enabled | bool   | 是否开启 OAuth2 公开客户端模式，开启后将会对 bk_app_code=public 的应用进行授权       |
+| categories   | array  | MCPServer 分类列表，每项包含 name（英文标识）和 display_name（显示名称） |
 | stage        | object | MCPServer 环境信息        |
 | gateway      | object | MCPServer 网关信息        |
 | tools_count  | int    | MCPServer 工具数量        |

--- a/src/dashboard/apigateway/apigateway/data/apidocs/zh/v2_inner_list_mcp_server_app_permissions.md
+++ b/src/dashboard/apigateway/apigateway/data/apidocs/zh/v2_inner_list_mcp_server_app_permissions.md
@@ -24,7 +24,11 @@ mcp_server 已申请权限列表
         "title": "测试服务",
         "description": "test",
         "tools_count": "1",
-        "doc_link": ""
+        "doc_link": "",
+        "categories": [
+          {"name": "official", "display_name": "官方"},
+          {"name": "ai", "display_name": "AI"}
+        ]
       },
       "permission": {
         "status": "owned",
@@ -60,6 +64,7 @@ mcp_server 已申请权限列表
 | description     | string | mcp_server 描述     |
 | tools_count     | int    | mcp_server 工具数量   |
 | doc_link        | string | mcp_server 文档访问地址 |
+| categories      | array  | mcp_server 分类列表，每项包含 name（英文标识）和 display_name（显示名称） |
 
 
 #### data.permission

--- a/src/dashboard/apigateway/apigateway/data/apidocs/zh/v2_inner_list_mcp_server_permission_apply_records.md
+++ b/src/dashboard/apigateway/apigateway/data/apidocs/zh/v2_inner_list_mcp_server_permission_apply_records.md
@@ -30,7 +30,11 @@ mcp_server 申请记录列表
         "title": "测试服务",
         "description": "test",
         "tools_count": "1",
-        "doc_link": ""
+        "doc_link": "",
+        "categories": [
+          {"name": "official", "display_name": "官方"},
+          {"name": "ai", "display_name": "AI"}
+        ]
       },
       "record": {
         "id": 1,
@@ -73,6 +77,7 @@ mcp_server 申请记录列表
 | description     | string | mcp_server 描述        |
 | tools_count     | int    | mcp_server 工具数量      |
 | doc_link        | string | mcp_server 文档访问地址    |
+| categories      | array  | mcp_server 分类列表，每项包含 name（英文标识）和 display_name（显示名称） |
 
 
 #### data.record

--- a/src/dashboard/apigateway/apigateway/data/apidocs/zh/v2_inner_list_mcp_server_permissions.md
+++ b/src/dashboard/apigateway/apigateway/data/apidocs/zh/v2_inner_list_mcp_server_permissions.md
@@ -26,7 +26,11 @@ mcp_server 申请权限列表
         "title": "测试服务1",
         "description": "test",
         "tools_count": "1",
-        "doc_link": ""
+        "doc_link": "",
+        "categories": [
+          {"name": "official", "display_name": "官方"},
+          {"name": "ai", "display_name": "AI"}
+        ]
       },
       "permission": {
         "status": "approved",
@@ -41,7 +45,8 @@ mcp_server 申请权限列表
         "title": "测试服务2",
         "description": "test",
         "tools_count": "1",
-        "doc_link": ""
+        "doc_link": "",
+        "categories": []
       },
       "permission": {
         "status": "need_apply",
@@ -77,6 +82,7 @@ mcp_server 申请权限列表
 | description     | string | mcp_server 描述     |
 | tools_count     | int    | mcp_server 工具数量   |
 | doc_link        | string | mcp_server 文档访问地址 |
+| categories      | array  | mcp_server 分类列表，每项包含 name（英文标识）和 display_name（显示名称） |
 
 
 #### data.permission

--- a/src/dashboard/apigateway/apigateway/data/apidocs/zh/v2_inner_retrieve_mcp_server_permission_apply_record.md
+++ b/src/dashboard/apigateway/apigateway/data/apidocs/zh/v2_inner_retrieve_mcp_server_permission_apply_record.md
@@ -28,7 +28,11 @@ mcp_server 申请记录详情
       "title": "测试服务",
       "description": "test",
       "tools_count": "1",
-      "doc_link": ""
+      "doc_link": "",
+      "categories": [
+        {"name": "official", "display_name": "官方"},
+        {"name": "ai", "display_name": "AI"}
+      ]
     },
     "record": {
       "applied_by": "admin",
@@ -73,6 +77,7 @@ mcp_server 申请记录详情
 | description     | string | mcp_server 描述        |
 | tools_count     | int    | mcp_server 工具数量      |
 | doc_link        | string | mcp_server 文档访问地址    |
+| categories      | array  | mcp_server 分类列表，每项包含 name（英文标识）和 display_name（显示名称） |
 
 
 #### data.record

--- a/src/dashboard/apigateway/apigateway/data/apidocs/zh/v2_open_list_mcp_server.md
+++ b/src/dashboard/apigateway/apigateway/data/apidocs/zh/v2_open_list_mcp_server.md
@@ -32,6 +32,10 @@
         "status": 1,
         "protocol_type": "sse",
         "oauth2_public_client_enabled": false,
+        "categories": [
+          {"name": "official", "display_name": "官方"},
+          {"name": "ai", "display_name": "AI"}
+        ],
         "stage": {
           "id": 3,
           "name": "prod"
@@ -78,6 +82,7 @@
 | status           | int     | mcp_server 状态（0：已停用，1：启用中）                             |
 | protocol_type    | string  | MCP 协议类型（sse：SSE 协议，streamable_http：Streamable HTTP 协议） |
 | oauth2_public_client_enabled   | boolean | 是否开启 OAuth2 公开客户端模式，开启后将会对 bk_app_code=public 的应用进行授权                                         |
+| categories      | array  | mcp_server 分类列表，每项包含 name（英文标识）和 display_name（显示名称） |
 | tools_count      | int     | mcp_server 工具数量                                        |
 | url              | string  | mcp_server 访问地址                                        |
 | detail_url       | string  | mcp_server 网关站点详情地址                                    |

--- a/src/dashboard/apigateway/apigateway/data/apidocs/zh/v2_open_list_mcp_server_app_permissions.md
+++ b/src/dashboard/apigateway/apigateway/data/apidocs/zh/v2_open_list_mcp_server_app_permissions.md
@@ -29,7 +29,11 @@
           "id": 1,
           "name": "mcp_1",
           "title": "MCP服务1",
-          "description": null
+          "description": null,
+          "categories": [
+            {"name": "official", "display_name": "官方"},
+            {"name": "ai", "display_name": "AI"}
+          ]
         }
       }
     ]
@@ -63,3 +67,4 @@
 | name          | string  | mcp_server 名称        |
 | title         | string  | mcp_server 中文名/显示名称  |
 | description   | string  | mcp_server 描述        |
+| categories    | array   | mcp_server 分类列表，每项包含 name（英文标识）和 display_name（显示名称） |

--- a/src/dashboard/apigateway/apigateway/data/apidocs/zh/v2_open_list_mcp_server_app_permissions_apply_records.md
+++ b/src/dashboard/apigateway/apigateway/data/apidocs/zh/v2_open_list_mcp_server_app_permissions_apply_records.md
@@ -25,7 +25,11 @@
         "id": 1,
         "name": "test",
         "title": "测试服务",
-        "description": null
+        "description": null,
+        "categories": [
+          {"name": "official", "display_name": "官方"},
+          {"name": "ai", "display_name": "AI"}
+        ]
       },
       "id": 1,
       "bk_app_code": "bk-001",
@@ -78,3 +82,4 @@
 | name          | string  | mcp_server 名称        |
 | title         | string  | mcp_server 中文名/显示名称  |
 | description   | string  | mcp_server 描述        |
+| categories    | array   | mcp_server 分类列表，每项包含 name（英文标识）和 display_name（显示名称） |

--- a/src/dashboard/apigateway/apigateway/data/apidocs/zh/v2_open_list_mcp_server_permissions.md
+++ b/src/dashboard/apigateway/apigateway/data/apidocs/zh/v2_open_list_mcp_server_permissions.md
@@ -35,7 +35,11 @@
           "id": 1,
           "name": "mcp_1",
           "title": "MCP服务1",
-          "description": null
+          "description": null,
+          "categories": [
+            {"name": "official", "display_name": "官方"},
+            {"name": "ai", "display_name": "AI"}
+          ]
         }
       }
     ]
@@ -69,3 +73,4 @@
 | name          | string  | mcp_server 名称        |
 | title         | string  | mcp_server 中文名/显示名称  |
 | description   | string  | mcp_server 描述        |
+| categories    | array   | mcp_server 分类列表，每项包含 name（英文标识）和 display_name（显示名称） |

--- a/src/dashboard/apigateway/apigateway/data/apidocs/zh/v2_open_list_user_mcp_server.md
+++ b/src/dashboard/apigateway/apigateway/data/apidocs/zh/v2_open_list_user_mcp_server.md
@@ -32,6 +32,10 @@
         "status": 1,
         "protocol_type": "sse",
         "oauth2_public_client_enabled": false,
+        "categories": [
+          {"name": "official", "display_name": "官方"},
+          {"name": "ai", "display_name": "AI"}
+        ],
         "stage": {
           "id": 3,
           "name": "prod"
@@ -80,6 +84,7 @@
 | status              | int     | mcp_server 状态（0：已停用，1：启用中）                             |
 | protocol_type       | string  | MCP 协议类型（sse：SSE 协议，streamable_http：Streamable HTTP 协议） |
 | oauth2_public_client_enabled      | boolean | 是否开启 OAuth2 公开客户端模式，开启后将会对 bk_app_code=public 的应用进行授权                                         |
+| categories          | array  | mcp_server 分类列表，每项包含 name（英文标识）和 display_name（显示名称） |
 | tools_count         | int     | mcp_server 工具数量                                        |
 | url                 | string  | mcp_server 访问地址                                        |
 | detail_url          | string  | mcp_server 网关站点详情地址                                    |

--- a/src/dashboard/apigateway/apigateway/tests/apis/v2/open/test_views.py
+++ b/src/dashboard/apigateway/apigateway/tests/apis/v2/open/test_views.py
@@ -1525,3 +1525,87 @@ class TestMCPServerBatchQueryApi:
             content_type="application/json",
         )
         assert resp.status_code == 400
+
+
+class TestMCPServerListCategories:
+    """测试 MCP Server 列表接口的 categories 字段"""
+
+    def test_list_with_categories(self, request_view, fake_gateway):
+        """有分类的 MCP Server 返回 categories 字段"""
+        stage = G(Stage, gateway=fake_gateway, status=StageStatusEnum.ACTIVE.value)
+        cat1, _ = MCPServerCategory.objects.get_or_create(name="official", defaults={"display_name": "Official"})
+        cat2, _ = MCPServerCategory.objects.get_or_create(name="ai", defaults={"display_name": "AI"})
+        mcp_server = G(
+            MCPServer,
+            gateway=fake_gateway,
+            stage=stage,
+            status=MCPServerStatusEnum.ACTIVE.value,
+            is_public=True,
+            protocol_type=MCPServerProtocolTypeEnum.SSE.value,
+        )
+        mcp_server.categories.add(cat1, cat2)
+
+        resp = request_view(
+            method="GET",
+            view_name="openapi.v2.open.mcp_server.list",
+            app=mock.MagicMock(app_code="test"),
+        )
+
+        assert resp.status_code == 200
+        result = resp.json()
+        assert len(result["data"]["results"]) >= 1
+
+        mcp_data = next(r for r in result["data"]["results"] if r["id"] == mcp_server.id)
+        assert len(mcp_data["categories"]) == 2
+        cat_names = {c["name"] for c in mcp_data["categories"]}
+        assert cat_names == {"official", "ai"}
+
+    def test_list_without_categories(self, request_view, fake_gateway):
+        """无分类的 MCP Server 返回空 categories"""
+        stage = G(Stage, gateway=fake_gateway, status=StageStatusEnum.ACTIVE.value)
+        mcp_server = G(
+            MCPServer,
+            gateway=fake_gateway,
+            stage=stage,
+            status=MCPServerStatusEnum.ACTIVE.value,
+            is_public=True,
+            protocol_type=MCPServerProtocolTypeEnum.SSE.value,
+        )
+
+        resp = request_view(
+            method="GET",
+            view_name="openapi.v2.open.mcp_server.list",
+            app=mock.MagicMock(app_code="test"),
+        )
+
+        assert resp.status_code == 200
+        result = resp.json()
+        mcp_data = next(r for r in result["data"]["results"] if r["id"] == mcp_server.id)
+        assert mcp_data["categories"] == []
+
+    def test_list_filters_inactive_categories(self, request_view, fake_gateway):
+        """不活跃的分类不出现在 categories 中"""
+        stage = G(Stage, gateway=fake_gateway, status=StageStatusEnum.ACTIVE.value)
+        cat_active, _ = MCPServerCategory.objects.get_or_create(name="official", defaults={"display_name": "Official"})
+        cat_inactive = G(MCPServerCategory, name="inactive_cat", display_name="Inactive", is_active=False)
+        mcp_server = G(
+            MCPServer,
+            gateway=fake_gateway,
+            stage=stage,
+            status=MCPServerStatusEnum.ACTIVE.value,
+            is_public=True,
+            protocol_type=MCPServerProtocolTypeEnum.SSE.value,
+        )
+        mcp_server.categories.add(cat_active, cat_inactive)
+
+        resp = request_view(
+            method="GET",
+            view_name="openapi.v2.open.mcp_server.list",
+            app=mock.MagicMock(app_code="test"),
+        )
+
+        assert resp.status_code == 200
+        result = resp.json()
+        mcp_data = next(r for r in result["data"]["results"] if r["id"] == mcp_server.id)
+        assert len(mcp_data["categories"]) == 1
+        assert mcp_data["categories"][0]["name"] == "official"

--- a/src/dashboard/apigateway/apigateway/tests/biz/mcp_server/test_mcp_server.py
+++ b/src/dashboard/apigateway/apigateway/tests/biz/mcp_server/test_mcp_server.py
@@ -1624,3 +1624,46 @@ class TestMCPServerHandler:
         MCPServerHandler._sync_mcp_server_categories(mcp_server, None)
 
         assert mcp_server.categories.count() == 1
+
+
+class TestBuildCategoriesMap:
+    """测试 MCPServerHandler.build_categories_map 批量查询分类"""
+
+    def test_build_categories_map_with_categories(self, fake_gateway, fake_stage):
+        """有分类的 MCP Server 返回正确的分类映射"""
+        cat1, _ = MCPServerCategory.objects.get_or_create(name="official", defaults={"display_name": "Official"})
+        cat2, _ = MCPServerCategory.objects.get_or_create(name="ai", defaults={"display_name": "AI"})
+        mcp_server = G(MCPServer, gateway=fake_gateway, stage=fake_stage)
+        mcp_server.categories.add(cat1, cat2)
+
+        result = MCPServerHandler.build_categories_map([mcp_server.id])
+
+        assert mcp_server.id in result
+        categories = result[mcp_server.id]
+        assert len(categories) == 2
+        cat_names = {c["name"] for c in categories}
+        assert cat_names == {"official", "ai"}
+
+    def test_build_categories_map_no_categories(self, fake_gateway, fake_stage):
+        """无分类的 MCP Server 不出现在映射中"""
+        mcp_server = G(MCPServer, gateway=fake_gateway, stage=fake_stage)
+
+        result = MCPServerHandler.build_categories_map([mcp_server.id])
+
+        assert mcp_server.id not in result
+
+    def test_build_categories_map_empty_ids(self):
+        """空 ID 列表返回空映射"""
+        result = MCPServerHandler.build_categories_map([])
+
+        assert result == {}
+
+    def test_build_categories_map_filters_inactive(self, fake_gateway, fake_stage):
+        """不活跃的分类被过滤"""
+        cat_inactive = G(MCPServerCategory, name="inactive_cat", display_name="Inactive", is_active=False)
+        mcp_server = G(MCPServer, gateway=fake_gateway, stage=fake_stage)
+        mcp_server.categories.add(cat_inactive)
+
+        result = MCPServerHandler.build_categories_map([mcp_server.id])
+
+        assert mcp_server.id not in result


### PR DESCRIPTION
## 变更内容

1. **新增 categories 字段**：为 MCP Server 相关 API 响应添加 `categories` 分类字段
2. **N+1 查询优化**：提取 `build_categories_map` 批量查询方法，解决列表接口中的 N+1 查询问题
3. **DRY 重构**：将 10 处重复的 categories_map 构建逻辑统一为共享函数调用
4. **类型注解改进**：`get_categories` 返回类型从 `list` 改为 `List[Dict[str, str]]`
5. **API 文档更新**：更新 10 个 API 文档中的 categories 示例为多分类格式