### PR TITLE
fix: resource version export missing pluginConfigs

### DIFF
--- a/src/dashboard/apigateway/apigateway/biz/resource/importer/openapi.py
+++ b/src/dashboard/apigateway/apigateway/biz/resource/importer/openapi.py
@@ -40,7 +40,7 @@ if TYPE_CHECKING:
     from apigateway.biz.resource.models import ResourceData
 from apigateway.biz.resource_version import ResourceVersionHandler
 from apigateway.core.models import Gateway, ResourceVersion
-from apigateway.utils.yaml import yaml_loads
+from apigateway.utils.yaml import yaml_dumps, yaml_loads
 
 # 初始化openapi validator schema
 init_validator_schema()
@@ -211,6 +211,13 @@ class OpenAPIExportManager:
                 "name": backend_id_to_config[resource["proxy"]["backend_id"]].name,
                 "config": json.loads(resource["proxy"]["config"]),
             }
+            resource["plugin_configs"] = [
+                {
+                    "type": plugin["type"],
+                    "yaml": yaml_dumps(plugin["config"]).rstrip("\n"),
+                }
+                for plugin in resource.get("plugins", [])
+            ]
             resource_data_list.append(resource)
 
         return self.export_openapi(resource_data_list, file_type)

--- a/src/dashboard/apigateway/apigateway/biz/resource/importer/parser.py
+++ b/src/dashboard/apigateway/apigateway/biz/resource/importer/parser.py
@@ -606,10 +606,11 @@ class BaseExporter:
                 resource.get("proxy_type", ""),
                 resource.get("proxy_configs", {}),
             ),
+            # 单独导出资源时 plugin_config 是 PluginConfig 对象，资源版本导出时是 dict
             "pluginConfigs": [
                 {
-                    "type": plugin_config.type.code,
-                    "yaml": plugin_config.yaml,
+                    "type": plugin_config["type"] if isinstance(plugin_config, dict) else plugin_config.type.code,
+                    "yaml": plugin_config["yaml"] if isinstance(plugin_config, dict) else plugin_config.yaml,
                 }
                 for plugin_config in resource.get("plugin_configs", [])
             ],

--- a/src/dashboard/apigateway/apigateway/biz/resource/importer/parser.py
+++ b/src/dashboard/apigateway/apigateway/biz/resource/importer/parser.py
@@ -606,7 +606,7 @@ class BaseExporter:
                 resource.get("proxy_type", ""),
                 resource.get("proxy_configs", {}),
             ),
-            # 单独导出资源时 plugin_config 是 PluginConfig 对象，资源版本导出时是 dict
+            # 资源配置导出时 plugin_config 是 PluginConfig 对象，资源版本导出时是 dict
             "pluginConfigs": [
                 {
                     "type": plugin_config["type"] if isinstance(plugin_config, dict) else plugin_config.type.code,

--- a/src/dashboard/apigateway/apigateway/tests/biz/resource/importer/test_openapi.py
+++ b/src/dashboard/apigateway/apigateway/tests/biz/resource/importer/test_openapi.py
@@ -1085,3 +1085,54 @@ class TestOpenAPIExporter:
         exporter = BaseExporter()
         result = exporter._adapt_auth_config(auth_config)
         assert result == expected
+
+    def test_generate_paths__plugin_configs_dict(self, fake_resource_dict):
+        """plugin_configs 为 dict 列表时（资源版本导出路径），pluginConfigs 应正确填充。"""
+        resource = dict(
+            fake_resource_dict,
+            plugin_configs=[
+                {
+                    "type": "bk-header-rewrite",
+                    "yaml": "remove:\n- X-Bar\nset:\n- key: X-Foo\n  value: test",
+                },
+            ],
+        )
+        exporter = BaseExporter()
+        paths = exporter._gen_swagger_paths([resource])
+        operation = paths[resource["path"]][resource["method"].lower()]
+
+        plugin_configs = operation["x-bk-apigateway-resource"]["pluginConfigs"]
+        assert len(plugin_configs) == 1
+        assert plugin_configs[0]["type"] == "bk-header-rewrite"
+        # yaml_dumps 输出末尾不应有多余换行
+        assert not plugin_configs[0]["yaml"].endswith("\n")
+        assert "remove:" in plugin_configs[0]["yaml"]
+
+    def test_generate_paths__plugin_configs_orm_obj(self, fake_plugin_config):
+        """plugin_configs 为 PluginConfig ORM 对象列表时（资源配置导出路径），应兼容。"""
+        resource = {
+            "method": "GET",
+            "path": "/test",
+            "name": "test_api",
+            "description": "",
+            "description_en": None,
+            "labels": [],
+            "is_public": True,
+            "allow_apply_permission": True,
+            "match_subpath": False,
+            "enable_websocket": False,
+            "backend": {
+                "name": "default",
+                "config": {"method": "GET", "path": "/test", "timeout": 0},
+            },
+            "auth_config": {"auth_verified_required": True},
+            "plugin_configs": [fake_plugin_config],
+        }
+        exporter = BaseExporter()
+        paths = exporter._gen_swagger_paths([resource])
+        operation = paths["/test"]["get"]
+
+        plugin_configs = operation["x-bk-apigateway-resource"]["pluginConfigs"]
+        assert len(plugin_configs) == 1
+        assert plugin_configs[0]["type"] == "bk-cors"
+        assert "allow_origins" in plugin_configs[0]["yaml"]

--- a/src/dashboard/apigateway/apigateway/tests/conftest.py
+++ b/src/dashboard/apigateway/apigateway/tests/conftest.py
@@ -1254,6 +1254,16 @@ def fake_resource_dict():
 
 
 @pytest.fixture
+def fake_plugin_config(faker):
+    return PluginConfig(
+        pk=1,
+        name="cors",
+        type=PluginType(code="bk-cors"),
+        yaml="allow_origins:\n- '*'",
+    )
+
+
+@pytest.fixture
 def fake_resource_data(faker):
     return ResourceData(
         resource=None,


### PR DESCRIPTION
- 修复资源版本导出时 pluginConfigs 为空的问题。在 openapi.py 导出方法中补上 plugins → plugin_configs 字段映射转换，在 parser.py 中兼容两种数据源格式（资源版本导出传 dict，单独资源导出传 PluginConfig ORM 对象），并统一 yaml 输出末尾换行符。