### PR TITLE
feat(permission): support applied_by display_name in /api/v1 and /api/v2/inner

### DIFF
--- a/src/dashboard/apigateway/apigateway/apis/open/permission/serializers.py
+++ b/src/dashboard/apigateway/apigateway/apis/open/permission/serializers.py
@@ -31,6 +31,7 @@ from apigateway.apps.permission.constants import (
 )
 from apigateway.apps.permission.models import AppPermissionRecord
 from apigateway.biz.permission import PermissionDimensionManager
+from apigateway.biz.permission.permission import ResourcePermissionHandler
 from apigateway.biz.validators import BKAppCodeValidator
 from apigateway.common.fields import TimestampField
 from apigateway.common.i18n.field import SerializerTranslatedField
@@ -265,6 +266,7 @@ class AppPermissionRecordSLZ(serializers.ModelSerializer):
     apply_status_display = serializers.SerializerMethodField()
     handled_by = serializers.SerializerMethodField()
     comment = serializers.SerializerMethodField()
+    applied_by = serializers.SerializerMethodField()
 
     class Meta:
         model = AppPermissionRecord
@@ -300,6 +302,14 @@ class AppPermissionRecordSLZ(serializers.ModelSerializer):
 
     def get_comment(self, obj):
         return obj.comment or ""
+
+    def get_applied_by(self, obj):
+        return ResourcePermissionHandler.convert_applied_by_to_display_name(
+            obj.bk_app_code,
+            obj.applied_by,
+            obj.gateway.tenant_mode,
+            obj.gateway.tenant_id,
+        )
 
 
 class AppPermissionRecordOutputSLZ(AppPermissionRecordSLZ):

--- a/src/dashboard/apigateway/apigateway/apis/v2/inner/serializers.py
+++ b/src/dashboard/apigateway/apigateway/apis/v2/inner/serializers.py
@@ -516,7 +516,12 @@ class MCPServerAppPermissionRecordBaseSLZ(serializers.Serializer):
         """获取申请人 display_name"""
         try:
             if isinstance(obj, dict):
-                return obj.get("applied_by", "")
+                return ResourcePermissionHandler.convert_applied_by_to_display_name(
+                    obj.get("bk_app_code", ""),
+                    obj.get("applied_by", ""),
+                    obj.get("tenant_mode", ""),
+                    obj.get("tenant_id", ""),
+                )
 
             if hasattr(obj, "mcp_server"):
                 return ResourcePermissionHandler.convert_applied_by_to_display_name(

--- a/src/dashboard/apigateway/apigateway/apis/v2/inner/serializers.py
+++ b/src/dashboard/apigateway/apigateway/apis/v2/inner/serializers.py
@@ -514,24 +514,29 @@ class MCPServerAppPermissionRecordBaseSLZ(serializers.Serializer):
 
     def get_applied_by(self, obj):
         """获取申请人 display_name"""
-        try:
-            if isinstance(obj, dict):
+        if isinstance(obj, dict):
+            try:
                 return ResourcePermissionHandler.convert_applied_by_to_display_name(
                     obj.get("bk_app_code", ""),
                     obj.get("applied_by", ""),
                     obj.get("tenant_mode", ""),
                     obj.get("tenant_id", ""),
                 )
+            except Exception:
+                logger.warning("Failed to convert applied_by for dict object: %s", obj, exc_info=True)
+                return obj.get("applied_by", "")
 
-            if hasattr(obj, "mcp_server"):
+        if hasattr(obj, "mcp_server"):
+            try:
                 return ResourcePermissionHandler.convert_applied_by_to_display_name(
                     obj.bk_app_code,
                     obj.applied_by,
                     obj.mcp_server.gateway.tenant_mode,
                     obj.mcp_server.gateway.tenant_id,
                 )
-        except Exception:
-            logger.warning("Failed to convert applied_by for object: %s", obj, exc_info=True)
+            except Exception:
+                logger.warning("Failed to convert applied_by for model object: %s", obj, exc_info=True)
+                return getattr(obj, "applied_by", "")
 
         return getattr(obj, "applied_by", "")
 

--- a/src/dashboard/apigateway/apigateway/apis/v2/inner/serializers.py
+++ b/src/dashboard/apigateway/apigateway/apis/v2/inner/serializers.py
@@ -531,7 +531,7 @@ class MCPServerAppPermissionRecordBaseSLZ(serializers.Serializer):
                     obj.mcp_server.gateway.tenant_id,
                 )
         except Exception:
-            logger.warning("Failed to convert applied_by for object: %s", obj)
+            logger.warning("Failed to convert applied_by for object: %s", obj, exc_info=True)
 
         return getattr(obj, "applied_by", "")
 

--- a/src/dashboard/apigateway/apigateway/apis/v2/inner/serializers.py
+++ b/src/dashboard/apigateway/apigateway/apis/v2/inner/serializers.py
@@ -35,6 +35,7 @@ from apigateway.apps.permission.constants import (
     PermissionStatusEnum,
 )
 from apigateway.apps.permission.models import AppPermissionRecord
+from apigateway.biz.permission.permission import ResourcePermissionHandler
 from apigateway.biz.validators import BKAppCodeValidator
 from apigateway.common.fields import TimestampField
 from apigateway.common.i18n.field import SerializerTranslatedField
@@ -247,6 +248,7 @@ class AppPermissionRecordBaseSLZ(serializers.ModelSerializer):
     apply_status_display = serializers.SerializerMethodField()
     handled_by = serializers.SerializerMethodField()
     comment = serializers.SerializerMethodField()
+    applied_by = serializers.SerializerMethodField()
 
     class Meta:
         model = AppPermissionRecord
@@ -283,6 +285,14 @@ class AppPermissionRecordBaseSLZ(serializers.ModelSerializer):
 
     def get_comment(self, obj):
         return obj.comment or ""
+
+    def get_applied_by(self, obj):
+        return ResourcePermissionHandler.convert_applied_by_to_display_name(
+            obj.bk_app_code,
+            obj.applied_by,
+            obj.gateway.tenant_mode,
+            obj.gateway.tenant_id,
+        )
 
 
 class AppPermissionRecordListOutputSLZ(AppPermissionRecordBaseSLZ):
@@ -471,7 +481,7 @@ class MCPServerAppPermissionRecordListInputSLZ(serializers.Serializer):
 
 class MCPServerAppPermissionRecordBaseSLZ(serializers.Serializer):
     id = serializers.IntegerField(read_only=True)
-    applied_by = serializers.CharField(read_only=True, help_text="申请人")
+    applied_by = serializers.SerializerMethodField(help_text="申请人")
     applied_time = serializers.DateTimeField(read_only=True, help_text="申请时间")
     handled_by = serializers.ListField(child=serializers.CharField(), help_text="处理人")
     handled_time = serializers.DateTimeField(read_only=True, help_text="处理时间")
@@ -501,6 +511,24 @@ class MCPServerAppPermissionRecordBaseSLZ(serializers.Serializer):
             logger.warning("Failed to build approval URL for object: %s", obj)
 
         return ""
+
+    def get_applied_by(self, obj):
+        """获取申请人 display_name"""
+        try:
+            if isinstance(obj, dict):
+                return obj.get("applied_by", "")
+
+            if hasattr(obj, "mcp_server"):
+                return ResourcePermissionHandler.convert_applied_by_to_display_name(
+                    obj.bk_app_code,
+                    obj.applied_by,
+                    obj.mcp_server.gateway.tenant_mode,
+                    obj.mcp_server.gateway.tenant_id,
+                )
+        except Exception:
+            logger.warning("Failed to convert applied_by for object: %s", obj)
+
+        return getattr(obj, "applied_by", "")
 
     class Meta:
         ref_name = "apigateway.apis.v2.inner.serializers.MCPServerAppPermissionRecordBaseSLZ"

--- a/src/dashboard/apigateway/apigateway/apis/v2/inner/serializers_esb.py
+++ b/src/dashboard/apigateway/apigateway/apis/v2/inner/serializers_esb.py
@@ -33,6 +33,7 @@ from apigateway.apps.permission.constants import (
     PermissionApplyExpireDaysEnum,
     PermissionStatusEnum,
 )
+from apigateway.biz.permission.permission import ResourcePermissionHandler
 from apigateway.biz.validators import BKAppCodeValidator
 from apigateway.common.constants import UserAuthTypeEnum
 from apigateway.common.fields import TimestampField
@@ -223,6 +224,7 @@ class AppPermissionApplyRecordBaseSLZ(serializers.ModelSerializer):
     comment = serializers.SerializerMethodField()
     tag = serializers.SerializerMethodField()
     components = serializers.ListField(child=ComponentInRecordSLZ())
+    applied_by = serializers.SerializerMethodField()
 
     class Meta:
         model = AppPermissionApplyRecord
@@ -256,6 +258,14 @@ class AppPermissionApplyRecordBaseSLZ(serializers.ModelSerializer):
 
     def get_tag(self, obj):
         return BoardConfigManager.get_optional_display_label(obj.board)
+
+    def get_applied_by(self, obj):
+        return ResourcePermissionHandler.convert_applied_by_to_display_name(
+            obj.bk_app_code,
+            obj.applied_by,
+            "",
+            "",
+        )
 
 
 class EsbAppPermissionApplyRecordListOutputSLZ(AppPermissionApplyRecordBaseSLZ):

--- a/src/dashboard/apigateway/apigateway/apis/v2/inner/views.py
+++ b/src/dashboard/apigateway/apigateway/apis/v2/inner/views.py
@@ -673,6 +673,7 @@ class MCPServerAppPermissionRecordListApi(generics.ListAPIView):
                 },
                 "record": {
                     "id": obj.id,
+                    "bk_app_code": obj.bk_app_code,
                     "applied_by": obj.applied_by,
                     "applied_time": obj.applied_time,
                     "handled_by": [obj.handled_by] if obj.handled_by else obj.mcp_server.gateway.maintainers,
@@ -684,6 +685,8 @@ class MCPServerAppPermissionRecordListApi(generics.ListAPIView):
                     "expire_days": obj.expire_days,
                     "mcp_server_id": obj.mcp_server_id,  # 添加 mcp_server_id 用于构建审批 URL
                     "gateway_id": obj.mcp_server.gateway_id,  # 在 record 中也添加 gateway_id
+                    "tenant_mode": obj.mcp_server.gateway.tenant_mode,
+                    "tenant_id": obj.mcp_server.gateway.tenant_id,
                 },
             }
             for obj in queryset

--- a/src/dashboard/apigateway/apigateway/apis/v2/open/serializers.py
+++ b/src/dashboard/apigateway/apigateway/apis/v2/open/serializers.py
@@ -30,6 +30,7 @@ from apigateway.apps.mcp_server.constants import (
 )
 from apigateway.apps.permission.constants import GrantDimensionEnum, PermissionApplyExpireDaysEnum
 from apigateway.biz.permission import PermissionDimensionManager
+from apigateway.biz.permission.permission import ResourcePermissionHandler
 from apigateway.biz.validators import BKAppCodeValidator
 from apigateway.common.i18n.field import SerializerTranslatedField
 from apigateway.service.mcp.mcp_server import (
@@ -309,7 +310,7 @@ class MCPServerAppPermissionApplyRecordListOutputSLZ(serializers.Serializer):
     mcp_server = MCPServerBaseSLZ()
     id = serializers.IntegerField(read_only=True, help_text="申请记录 ID")
     bk_app_code = serializers.CharField(read_only=True, help_text="蓝鲸应用 ID")
-    applied_by = serializers.CharField(read_only=True, help_text="申请人")
+    applied_by = serializers.SerializerMethodField(help_text="申请人")
     applied_time = serializers.DateTimeField(read_only=True, help_text="申请时间")
     handled_by = serializers.CharField(read_only=True, help_text="处理人")
     handled_time = serializers.DateTimeField(read_only=True, help_text="处理时间")
@@ -325,6 +326,14 @@ class MCPServerAppPermissionApplyRecordListOutputSLZ(serializers.Serializer):
 
     def get_approval_url(self, obj) -> str:
         return build_mcp_server_permission_approval_url(obj.mcp_server.gateway_id, obj.mcp_server_id)
+
+    def get_applied_by(self, obj):
+        return ResourcePermissionHandler.convert_applied_by_to_display_name(
+            obj.bk_app_code,
+            obj.applied_by,
+            obj.mcp_server.gateway.tenant_mode,
+            obj.mcp_server.gateway.tenant_id,
+        )
 
     class Meta:
         ref_name = "apigateway.apis.v2.open.serializers.MCPServerAppPermissionApplyRecordListOutputSLZ"


### PR DESCRIPTION
- 为 PaaS 平台调用的 /api/v1、/api/v2/inner、/api/v2/open 接口补充 applied_by 字段的多租户 display_name 转换。将相关 Serializer 的 applied_by 字段从 CharField 改为 SerializerMethodField，调用 ResourcePermissionHandler.convert_applied_by_to_display_name() 实现跨租户时从 bk-user 查询 display_name 返回。ESB 接口因无多租户场景返回空字符串。