### PR TITLE
feat(mcp-proxy): add BKAIDev Agent Trace for MCP Gateway observability

### DIFF
--- a/src/mcp-proxy/cmd/init.go
+++ b/src/mcp-proxy/cmd/init.go
@@ -24,6 +24,7 @@ import (
 	"github.com/spf13/viper"
 
 	"mcp_proxy/pkg/config"
+	"mcp_proxy/pkg/infra/bkaidevtrace"
 	"mcp_proxy/pkg/infra/database"
 	"mcp_proxy/pkg/infra/logging"
 	sty "mcp_proxy/pkg/infra/sentry"
@@ -92,4 +93,18 @@ func initTracing() {
 		return
 	}
 	logging.GetLogger().Info("init tracing success")
+}
+
+func initBkAIDevTrace() {
+	if !globalConfig.BkAIDevTrace.Enable {
+		logging.GetLogger().Info("bkai dev trace is not enabled, will not init it")
+		return
+	}
+	logging.GetLogger().Info("enabling bkai dev trace")
+	err := bkaidevtrace.Init(globalConfig.BkAIDevTrace)
+	if err != nil {
+		logging.GetLogger().Errorf("init bkai dev trace fail: %+v", err)
+		return
+	}
+	logging.GetLogger().Info("init bkai dev trace success")
 }

--- a/src/mcp-proxy/cmd/root.go
+++ b/src/mcp-proxy/cmd/root.go
@@ -89,6 +89,7 @@ func Start() {
 	initLogger()
 	initDatabase()
 	initTracing()
+	initBkAIDevTrace()
 	initSentry()
 	initMetrics()
 

--- a/src/mcp-proxy/pkg/config/config.go
+++ b/src/mcp-proxy/pkg/config/config.go
@@ -155,6 +155,15 @@ type Instrument struct {
 	McpAPI bool
 }
 
+// BkAIDevTrace is the config for BKAIDev agent trace reporting.
+// It uses an independent OTLP/HTTP endpoint, fully isolated from the project's own tracing.
+type BkAIDevTrace struct {
+	Enable      bool
+	Endpoint    string
+	ServiceName string
+	Token       string
+}
+
 // Transport is the config for the shared HTTP transport used by tool calls.
 type Transport struct {
 	InsecureSkipVerify    bool
@@ -306,9 +315,10 @@ type Config struct {
 	Databases   []Database
 	DatabaseMap map[string]Database
 
-	Logger  Logger
-	Tracing Tracing
-	Metric  Metric
+	Logger       Logger
+	Tracing      Tracing
+	Metric       Metric
+	BkAIDevTrace BkAIDevTrace
 
 	McpServer McpServer
 	PProf     Pprof

--- a/src/mcp-proxy/pkg/constant/system.go
+++ b/src/mcp-proxy/pkg/constant/system.go
@@ -35,6 +35,9 @@ const (
 	// BkApiAllowedHeadersKey is a key to set the allowed headers in header
 	BkApiAllowedHeadersKey = "X-Bkapi-Allowed-Headers"
 
+	// BkApiItsmFlexKey is a key to set the itsm flex info in header
+	BkApiItsmFlexKey = "X-Bkapi-ItsmFlex"
+
 	// BkApiMCPServerIDKey is a key to set the mcp server id in header
 	BkApiMCPServerIDKey = "X-Bkapi-Mcp-Server-Id"
 	// BkApiMCPServerNameKey is a key to set the mcp server name in header
@@ -60,6 +63,7 @@ const (
 	TraceID             CtxKey = "trace_id"
 	BkApiTimeout        CtxKey = "bk_api_timeout"
 	BkApiAllowedHeaders CtxKey = "bk_api_allowed_headers"
+	BkApiItsmFlexData   CtxKey = "bk_api_itsm_flex_data"
 	ClientIP            CtxKey = "client_ip"
 	ClientID            CtxKey = "client_id"
 )

--- a/src/mcp-proxy/pkg/entity/model/mcp.go
+++ b/src/mcp-proxy/pkg/entity/model/mcp.go
@@ -40,16 +40,16 @@ const ToolNameSeparator = "@"
 
 // MCPServer ...
 type MCPServer struct {
-	ID            int         `gorm:"primaryKey;autoIncrement;column:id"`
-	Name          string      `gorm:"column:name;size:64;uniqueIndex"`
-	Description   string      `gorm:"column:description;size:512"`
-	IsPublic      bool        `gorm:"column:is_public"`
-	Labels        ArrayString `gorm:"column:labels"`
-	ResourceNames ArrayString `gorm:"column:resource_names"`
-	Status        int         `gorm:"column:status"`
-	GatewayID     int         `gorm:"column:gateway_id"`
-	StageID       int         `gorm:"column:stage_id"`
-	ProtocolType  string      `gorm:"column:protocol_type;size:32;default:sse"`
+	ID                 int         `gorm:"primaryKey;autoIncrement;column:id"`
+	Name               string      `gorm:"column:name;size:64;uniqueIndex"`
+	Description        string      `gorm:"column:description;size:512"`
+	IsPublic           bool        `gorm:"column:is_public"`
+	Labels             ArrayString `gorm:"column:labels"`
+	ResourceNames      ArrayString `gorm:"column:resource_names"`
+	Status             int         `gorm:"column:status"`
+	GatewayID          int         `gorm:"column:gateway_id"`
+	StageID            int         `gorm:"column:stage_id"`
+	ProtocolType       string      `gorm:"column:protocol_type;size:32;default:sse"`
 	RawResponseEnabled bool        `gorm:"column:raw_response_enabled;default:false"`
 }
 

--- a/src/mcp-proxy/pkg/infra/bkaidevtrace/export.go
+++ b/src/mcp-proxy/pkg/infra/bkaidevtrace/export.go
@@ -16,39 +16,29 @@
  * to the current version of the project delivered to anyone in the future.
  */
 
-package middleware
+package bkaidevtrace
 
 import (
-	"encoding/json"
+	"sync"
 
-	"github.com/gin-gonic/gin"
-	"github.com/spf13/cast"
-
-	"mcp_proxy/pkg/constant"
-	"mcp_proxy/pkg/util"
+	"go.opentelemetry.io/otel/propagation"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
 )
 
-// MCPServerHeaderMiddleware ... 用于处理mcp server的header参数
-func MCPServerHeaderMiddleware() func(c *gin.Context) {
-	return func(c *gin.Context) {
-		// 设置 timeout
-		util.SetBkApiTimeout(c, cast.ToInt(c.Request.Header.Get(constant.BkApiTimeoutHeaderKey)))
-		// 处理 AllowedHeaders
-		util.SetBkApiAllowedHeaders(c, c.Request.Header.Get(constant.BkApiAllowedHeadersKey))
-		// 解析 ItsmFlex header
-		parseBkApiItsmFlex(c)
-		c.Next()
-	}
+// ResetForTest resets all global state so that Init can be called again in tests.
+// NOTE: This function is exported for cross-package test usage (e.g., middleware_test).
+// It is only intended for use in test code; production callers should never invoke it.
+func ResetForTest() {
+	globalProvider = nil
+	globalTracer = nil
+	propagator = nil
+	once = sync.Once{}
 }
 
-func parseBkApiItsmFlex(c *gin.Context) {
-	itsmFlexStr := c.Request.Header.Get(constant.BkApiItsmFlexKey)
-	if itsmFlexStr == "" {
-		return
-	}
-	var data util.ItsmFlexData
-	if err := json.Unmarshal([]byte(itsmFlexStr), &data); err != nil {
-		return
-	}
-	util.SetBkApiItsmFlexData(c, &data)
+// SetTestProvider injects a test TracerProvider and propagator directly.
+// NOTE: This function is exported for cross-package test usage only.
+func SetTestProvider(tp *sdktrace.TracerProvider, p propagation.TextMapPropagator) {
+	globalProvider = tp
+	globalTracer = tp.Tracer("test")
+	propagator = p
 }

--- a/src/mcp-proxy/pkg/infra/bkaidevtrace/init.go
+++ b/src/mcp-proxy/pkg/infra/bkaidevtrace/init.go
@@ -1,0 +1,187 @@
+/*
+ * TencentBlueKing is pleased to support the open source community by making
+ * 蓝鲸智云 - API 网关(BlueKing - APIGateway) available.
+ * Copyright (C) 2025 Tencent. All rights reserved.
+ * Licensed under the MIT License (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ *     http://opensource.org/licenses/MIT
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * We undertake not to change the open source license (MIT license) applicable
+ * to the current version of the project delivered to anyone in the future.
+ */
+
+// Package bkaidevtrace provides an independent OpenTelemetry trace pipeline
+// for BKAIDev Agent trace reporting. It is fully isolated from the project's
+// own global tracing to avoid interference.
+package bkaidevtrace
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/binary"
+	"fmt"
+	mrand "math/rand"
+	"sync"
+	"time"
+
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/exporters/otlp/otlptrace"
+	"go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp"
+	"go.opentelemetry.io/otel/propagation"
+	"go.opentelemetry.io/otel/sdk/resource"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	semconv "go.opentelemetry.io/otel/semconv/v1.10.0"
+	tc "go.opentelemetry.io/otel/trace"
+
+	"mcp_proxy/pkg/config"
+)
+
+var (
+	globalProvider *sdktrace.TracerProvider
+	globalTracer   tc.Tracer
+	propagator     propagation.TextMapPropagator
+	once           sync.Once
+)
+
+// Init initializes the independent BKAIDev trace pipeline.
+func Init(cfg config.BkAIDevTrace) error {
+	var initErr error
+	once.Do(func() {
+		// WithInsecure uses HTTP instead of HTTPS for the OTLP exporter.
+		// This is intentional: the BKAIDev trace collector runs in the same
+		// internal network, so TLS is not required. The bk.data.token in the
+		// resource attributes provides authentication.
+		client := otlptracehttp.NewClient(
+			otlptracehttp.WithEndpoint(cfg.Endpoint),
+			otlptracehttp.WithInsecure(),
+		)
+		exporter, err := otlptrace.New(context.Background(), client)
+		if err != nil {
+			initErr = fmt.Errorf("create bkaidevtrace exporter: %w", err)
+			return
+		}
+
+		tp := sdktrace.NewTracerProvider(
+			sdktrace.WithBatcher(exporter),
+			sdktrace.WithResource(resource.NewWithAttributes(
+				semconv.SchemaURL,
+				semconv.ServiceNameKey.String(cfg.ServiceName),
+				attribute.Key("bk.data.token").String(cfg.Token),
+			)),
+			sdktrace.WithSampler(sdktrace.AlwaysSample()),
+		)
+
+		globalProvider = tp
+		globalTracer = tp.Tracer(cfg.ServiceName)
+		propagator = propagation.NewCompositeTextMapPropagator(
+			propagation.TraceContext{},
+			propagation.Baggage{},
+		)
+	})
+	return initErr
+}
+
+// Enabled returns whether the BKAIDev trace pipeline is initialized.
+func Enabled() bool {
+	return globalTracer != nil
+}
+
+// StartSpan starts a new span using the independent tracer.
+func StartSpan(ctx context.Context, name string, opts ...tc.SpanStartOption) (context.Context, tc.Span) {
+	if globalTracer == nil {
+		return ctx, nil
+	}
+	return globalTracer.Start(ctx, name, opts...)
+}
+
+// Extract extracts trace context from carrier using the independent propagator.
+func Extract(ctx context.Context, carrier propagation.TextMapCarrier) context.Context {
+	if propagator == nil {
+		return ctx
+	}
+	return propagator.Extract(ctx, carrier)
+}
+
+// Inject injects trace context into carrier using the independent propagator.
+func Inject(ctx context.Context, carrier propagation.TextMapCarrier) {
+	if propagator == nil {
+		return
+	}
+	propagator.Inject(ctx, carrier)
+}
+
+// GetTraceIDFromContext extracts the trace ID from the active span in context.
+func GetTraceIDFromContext(ctx context.Context) string {
+	span := tc.SpanFromContext(ctx)
+	if span == nil {
+		return ""
+	}
+	sc := span.SpanContext()
+	if !sc.TraceID().IsValid() {
+		return ""
+	}
+	return sc.TraceID().String()
+}
+
+// GetSpanIDFromContext extracts the span ID from the active span in context.
+func GetSpanIDFromContext(ctx context.Context) string {
+	span := tc.SpanFromContext(ctx)
+	if span == nil {
+		return ""
+	}
+	sc := span.SpanContext()
+	if !sc.SpanID().IsValid() {
+		return ""
+	}
+	return sc.SpanID().String()
+}
+
+// NewSpanContext creates a span context with a randomly-generated trace ID and span ID.
+// This is used to carry a valid trace context without creating an actual span.
+func NewSpanContext() tc.SpanContext {
+	var traceID tc.TraceID
+	var spanID tc.SpanID
+
+	// Try crypto/rand first for both traceID and spanID.
+	// If crypto/rand fails (extremely rare), fallback to a single math/rand instance
+	// to avoid seed collision when two separate instances are created with the same
+	// time-based seed under high concurrency.
+	traceOK := true
+	if _, err := rand.Read(traceID[:]); err != nil {
+		traceOK = false
+	}
+	if _, err := rand.Read(spanID[:]); err != nil {
+		if traceOK {
+			// Only traceID succeeded via crypto/rand; generate spanID with math/rand
+			r := mrand.New(mrand.NewSource(time.Now().UnixNano()))
+			binary.BigEndian.PutUint64(spanID[:], uint64(r.Int63()))
+		}
+	}
+	if !traceOK {
+		// crypto/rand failed for traceID; use a single math/rand instance for both
+		r := mrand.New(mrand.NewSource(time.Now().UnixNano()))
+		binary.BigEndian.PutUint64(traceID[:8], uint64(r.Int63()))
+		binary.BigEndian.PutUint64(traceID[8:], uint64(r.Int63()))
+		binary.BigEndian.PutUint64(spanID[:], uint64(r.Int63()))
+	}
+
+	return tc.NewSpanContext(tc.SpanContextConfig{
+		TraceID:    traceID,
+		SpanID:     spanID,
+		TraceFlags: tc.FlagsSampled,
+	})
+}
+
+// Shutdown flushes and shuts down the tracer provider.
+func Shutdown(ctx context.Context) error {
+	if globalProvider == nil {
+		return nil
+	}
+	return globalProvider.Shutdown(ctx)
+}

--- a/src/mcp-proxy/pkg/infra/bkaidevtrace/init_test.go
+++ b/src/mcp-proxy/pkg/infra/bkaidevtrace/init_test.go
@@ -1,0 +1,293 @@
+/*
+ * TencentBlueKing is pleased to support the open source community by making
+ * 蓝鲸智云 - API 网关(BlueKing - APIGateway) available.
+ * Copyright (C) 2025 Tencent. All rights reserved.
+ * Licensed under the MIT License (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ *     http://opensource.org/licenses/MIT
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * We undertake not to change the open source license (MIT license) applicable
+ * to the current version of the project delivered to anyone in the future.
+ */
+
+package bkaidevtrace
+
+import (
+	"context"
+	"net/http"
+	"testing"
+
+	"go.opentelemetry.io/otel/propagation"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
+
+	"mcp_proxy/pkg/config"
+)
+
+func setupTestProvider(t *testing.T) (*sdktrace.TracerProvider, *tracetest.InMemoryExporter) {
+	t.Helper()
+	exporter := tracetest.NewInMemoryExporter()
+	tp := sdktrace.NewTracerProvider(sdktrace.WithSyncer(exporter))
+	return tp, exporter
+}
+
+func TestInit(t *testing.T) {
+	ResetForTest()
+	defer ResetForTest()
+
+	err := Init(config.BkAIDevTrace{
+		Enable:      true,
+		Endpoint:    "localhost:4318",
+		ServiceName: "test-service",
+		Token:       "test-token",
+	})
+	if err != nil {
+		t.Fatalf("Init failed: %v", err)
+	}
+
+	if !Enabled() {
+		t.Error("expected Enabled() to be true after Init")
+	}
+
+	if globalProvider == nil {
+		t.Error("expected globalProvider to be set")
+	}
+
+	if globalTracer == nil {
+		t.Error("expected globalTracer to be set")
+	}
+
+	if propagator == nil {
+		t.Error("expected propagator to be set")
+	}
+}
+
+func TestEnabled(t *testing.T) {
+	ResetForTest()
+	defer ResetForTest()
+
+	if Enabled() {
+		t.Error("expected Enabled() to be false before Init")
+	}
+
+	tp, _ := setupTestProvider(t)
+	defer func() { _ = tp.Shutdown(context.Background()) }()
+
+	SetTestProvider(tp, propagation.TraceContext{})
+
+	if !Enabled() {
+		t.Error("expected Enabled() to be true after setting test provider")
+	}
+}
+
+func TestStartSpan(t *testing.T) {
+	ResetForTest()
+	defer ResetForTest()
+
+	tp, exporter := setupTestProvider(t)
+	defer func() { _ = tp.Shutdown(context.Background()) }()
+
+	SetTestProvider(tp, propagation.TraceContext{})
+
+	ctx, span := StartSpan(context.Background(), "test-span")
+	if span == nil {
+		t.Fatal("expected non-nil span")
+	}
+	span.End()
+
+	spans := exporter.GetSpans()
+	if len(spans) != 1 {
+		t.Fatalf("expected 1 span, got %d", len(spans))
+	}
+	if spans[0].Name != "test-span" {
+		t.Errorf("expected span name 'test-span', got %q", spans[0].Name)
+	}
+
+	if ctx == nil {
+		t.Error("expected non-nil context")
+	}
+}
+
+func TestStartSpanNotInitialized(t *testing.T) {
+	ResetForTest()
+	defer ResetForTest()
+
+	ctx, span := StartSpan(context.Background(), "test-span")
+	if span != nil {
+		t.Error("expected nil span when not initialized")
+	}
+	if ctx == nil {
+		t.Error("expected non-nil context")
+	}
+}
+
+func TestGetTraceIDFromContext(t *testing.T) {
+	ResetForTest()
+	defer ResetForTest()
+
+	tp, _ := setupTestProvider(t)
+	defer func() { _ = tp.Shutdown(context.Background()) }()
+
+	SetTestProvider(tp, propagation.TraceContext{})
+
+	t.Run("returns empty when no span", func(t *testing.T) {
+		traceID := GetTraceIDFromContext(context.Background())
+		if traceID != "" {
+			t.Errorf("expected empty trace ID, got %q", traceID)
+		}
+	})
+
+	t.Run("returns valid trace ID from active span", func(t *testing.T) {
+		ctx, span := StartSpan(context.Background(), "test-span")
+		defer span.End()
+
+		traceID := GetTraceIDFromContext(ctx)
+		if traceID == "" {
+			t.Error("expected non-empty trace ID")
+		}
+		if len(traceID) != 32 {
+			t.Errorf("expected 32-char trace ID, got %d chars: %s", len(traceID), traceID)
+		}
+	})
+}
+
+func TestGetSpanIDFromContext(t *testing.T) {
+	ResetForTest()
+	defer ResetForTest()
+
+	tp, _ := setupTestProvider(t)
+	defer func() { _ = tp.Shutdown(context.Background()) }()
+
+	SetTestProvider(tp, propagation.TraceContext{})
+
+	t.Run("returns empty when no span", func(t *testing.T) {
+		spanID := GetSpanIDFromContext(context.Background())
+		if spanID != "" {
+			t.Errorf("expected empty span ID, got %q", spanID)
+		}
+	})
+
+	t.Run("returns valid span ID from active span", func(t *testing.T) {
+		ctx, span := StartSpan(context.Background(), "test-span")
+		defer span.End()
+
+		spanID := GetSpanIDFromContext(ctx)
+		if spanID == "" {
+			t.Error("expected non-empty span ID")
+		}
+		if len(spanID) != 16 {
+			t.Errorf("expected 16-char span ID, got %d chars: %s", len(spanID), spanID)
+		}
+	})
+}
+
+func TestExtract(t *testing.T) {
+	ResetForTest()
+	defer ResetForTest()
+
+	tp, _ := setupTestProvider(t)
+	defer func() { _ = tp.Shutdown(context.Background()) }()
+
+	SetTestProvider(tp, propagation.NewCompositeTextMapPropagator(
+		propagation.TraceContext{},
+		propagation.Baggage{},
+	))
+
+	// Create a span and inject into headers
+	ctx, span := StartSpan(context.Background(), "parent-span")
+	defer span.End()
+
+	parentTraceID := GetTraceIDFromContext(ctx)
+
+	headers := http.Header{}
+	Inject(ctx, propagation.HeaderCarrier(headers))
+
+	traceparent := headers.Get("Traceparent")
+	if traceparent == "" {
+		t.Fatal("expected traceparent header to be injected")
+	}
+
+	// Extract into a new context and start a child span
+	newCtx := Extract(context.Background(), propagation.HeaderCarrier(headers))
+	childCtx, childSpan := StartSpan(newCtx, "child-span")
+	defer childSpan.End()
+
+	childTraceID := GetTraceIDFromContext(childCtx)
+	if childTraceID != parentTraceID {
+		t.Errorf("expected trace IDs to match: parent=%s, child=%s", parentTraceID, childTraceID)
+	}
+}
+
+func TestExtractNoPropagator(t *testing.T) {
+	ResetForTest()
+	defer ResetForTest()
+
+	// No propagator set
+	ctx := Extract(context.Background(), propagation.HeaderCarrier(http.Header{}))
+	if ctx == nil {
+		t.Error("expected non-nil context")
+	}
+}
+
+func TestNewSpanContext(t *testing.T) {
+	ResetForTest()
+	defer ResetForTest()
+
+	spanCtx := NewSpanContext()
+
+	if !spanCtx.IsValid() {
+		t.Error("expected valid span context")
+	}
+	if !spanCtx.HasTraceID() {
+		t.Error("expected span context to have trace ID")
+	}
+	if !spanCtx.HasSpanID() {
+		t.Error("expected span context to have span ID")
+	}
+	if !spanCtx.IsSampled() {
+		t.Error("expected span context to be sampled")
+	}
+
+	traceIDStr := spanCtx.TraceID().String()
+	if len(traceIDStr) != 32 {
+		t.Errorf("expected 32-char trace ID, got %d chars: %s", len(traceIDStr), traceIDStr)
+	}
+
+	spanIDStr := spanCtx.SpanID().String()
+	if len(spanIDStr) != 16 {
+		t.Errorf("expected 16-char span ID, got %d chars: %s", len(spanIDStr), spanIDStr)
+	}
+
+	// Ensure two calls produce different IDs
+	spanCtx2 := NewSpanContext()
+	if spanCtx.TraceID() == spanCtx2.TraceID() {
+		t.Error("expected different trace IDs for two calls")
+	}
+	if spanCtx.SpanID() == spanCtx2.SpanID() {
+		t.Error("expected different span IDs for two calls")
+	}
+}
+
+func TestShutdown(t *testing.T) {
+	ResetForTest()
+	defer ResetForTest()
+
+	tp, _ := setupTestProvider(t)
+	SetTestProvider(tp, nil)
+
+	if err := Shutdown(context.Background()); err != nil {
+		t.Errorf("unexpected shutdown error: %v", err)
+	}
+
+	// Shutdown with nil provider should not panic
+	ResetForTest()
+	if err := Shutdown(context.Background()); err != nil {
+		t.Errorf("unexpected shutdown error with nil provider: %v", err)
+	}
+}

--- a/src/mcp-proxy/pkg/infra/proxy/config.go
+++ b/src/mcp-proxy/pkg/infra/proxy/config.go
@@ -27,12 +27,12 @@ import (
 
 // MCPServerConfig ...
 type MCPServerConfig struct {
-	Name              string        `json:"name"`  // 唯一标识name，可以是：gateway_name+stage或者其他id
-	Title             string        `json:"title"` // 标题
-	ResourceVersionID int           `json:"resource_version_id"`
-	Tools             []*ToolConfig `json:"tools"`
-	ProtocolType      string        `json:"protocol_type"` // 协议类型: sse 或 streamable_http
-	RawResponseEnabled bool `json:"raw_response_enabled"` // 是否返回原始响应，开启后直接返回 API 响应结果，不添加 request_id 等额外信息
+	Name               string        `json:"name"`  // 唯一标识name，可以是：gateway_name+stage或者其他id
+	Title              string        `json:"title"` // 标题
+	ResourceVersionID  int           `json:"resource_version_id"`
+	Tools              []*ToolConfig `json:"tools"`
+	ProtocolType       string        `json:"protocol_type"`        // 协议类型: sse 或 streamable_http
+	RawResponseEnabled bool          `json:"raw_response_enabled"` // 是否返回原始响应，开启后直接返回 API 响应结果，不添加 request_id 等额外信息
 }
 
 // ToolConfig ...

--- a/src/mcp-proxy/pkg/infra/proxy/config_test.go
+++ b/src/mcp-proxy/pkg/infra/proxy/config_test.go
@@ -81,8 +81,8 @@ var _ = Describe("Config", func() {
 	Describe("MCPServerConfig", func() {
 		It("should have correct fields", func() {
 			config := proxy.MCPServerConfig{
-				Name:              "test-server",
-				ResourceVersionID: 123,
+				Name:               "test-server",
+				ResourceVersionID:  123,
 				RawResponseEnabled: true,
 				Tools: []*proxy.ToolConfig{
 					{

--- a/src/mcp-proxy/pkg/infra/proxy/proxy.go
+++ b/src/mcp-proxy/pkg/infra/proxy/proxy.go
@@ -258,10 +258,10 @@ func (m *MCPProxy) AddMCPServerFromOpenAPISpec(name string,
 		operationIDMap[operationID] = struct{}{}
 	}
 	mcpServerConfig := &MCPServerConfig{
-		Name:              name,
-		Tools:             OpenapiToMcpToolConfig(openAPISpec, operationIDMap, toolNameMap),
-		ResourceVersionID: resourceVersionID,
-		ProtocolType:      protocolType,
+		Name:               name,
+		Tools:              OpenapiToMcpToolConfig(openAPISpec, operationIDMap, toolNameMap),
+		ResourceVersionID:  resourceVersionID,
+		ProtocolType:       protocolType,
 		RawResponseEnabled: rawResponseEnabled,
 	}
 	return m.AddMCPServerFromConfigs([]*MCPServerConfig{mcpServerConfig})
@@ -279,8 +279,8 @@ func (m *MCPProxy) UpdateMCPServerFromOpenApiSpec(
 		operationIDMap[operationID] = struct{}{}
 	}
 	mcpServerConfig := &MCPServerConfig{
-		Name:        name,
-		Tools:       OpenapiToMcpToolConfig(openAPISpec, operationIDMap, toolNameMap),
+		Name:               name,
+		Tools:              OpenapiToMcpToolConfig(openAPISpec, operationIDMap, toolNameMap),
 		RawResponseEnabled: rawResponseEnabled,
 	}
 	// update tool
@@ -919,12 +919,12 @@ func genToolHandler(toolApiConfig *ToolConfig, serverName string, rawResponseEna
 						}
 					}
 
-				var responseResult any
-				if rawResponseEnabledGetter() {
-					// raw_response_enabled 模式：直接返回 API 响应结果，不添加 request_id 等额外信息。
-					// 注意：无论成功或失败（非 2xx）都直接透传原始响应，
-					// 由 MCP 协议层的 IsError 标记来区分调用方是否为错误场景。
-					responseResult = res
+					var responseResult any
+					if rawResponseEnabledGetter() {
+						// raw_response_enabled 模式：直接返回 API 响应结果，不添加 request_id 等额外信息。
+						// 注意：无论成功或失败（非 2xx）都直接透传原始响应，
+						// 由 MCP 协议层的 IsError 标记来区分调用方是否为错误场景。
+						responseResult = res
 					} else {
 						responseResult = buildToolResponseEnvelope(
 							response.Code(),

--- a/src/mcp-proxy/pkg/infra/proxy/server.go
+++ b/src/mcp-proxy/pkg/infra/proxy/server.go
@@ -42,11 +42,11 @@ type MCPServer struct {
 	protocolType          string                     // 协议类型: sse 或 streamable_http
 	name                  string
 	// 生效的资源版本号
-	resourceVersionID int
+	resourceVersionID  int
 	rawResponseEnabled bool // 是否返回原始响应，开启后直接返回 API 响应结果，不添加 request_id 等额外信息
-	tools             map[string]struct{}
-	prompts           map[string]struct{}
-	rwLock            *sync.RWMutex
+	tools              map[string]struct{}
+	prompts            map[string]struct{}
+	rwLock             *sync.RWMutex
 }
 
 // NewMCPServer 创建 SSE 协议的 MCP Server
@@ -58,14 +58,14 @@ func NewMCPServer(
 	rawResponseEnabled bool,
 ) *MCPServer {
 	return &MCPServer{
-		Server:            server,
-		SSEHandler:        handler,
-		protocolType:      constant.MCPServerProtocolTypeSSE,
-		tools:             make(map[string]struct{}),
-		prompts:           make(map[string]struct{}),
-		rwLock:            &sync.RWMutex{},
-		name:              name,
-		resourceVersionID: resourceVersion,
+		Server:             server,
+		SSEHandler:         handler,
+		protocolType:       constant.MCPServerProtocolTypeSSE,
+		tools:              make(map[string]struct{}),
+		prompts:            make(map[string]struct{}),
+		rwLock:             &sync.RWMutex{},
+		name:               name,
+		resourceVersionID:  resourceVersion,
 		rawResponseEnabled: rawResponseEnabled,
 	}
 }

--- a/src/mcp-proxy/pkg/mcp/mcp.go
+++ b/src/mcp-proxy/pkg/mcp/mcp.go
@@ -33,6 +33,7 @@ import (
 	"mcp_proxy/pkg/cacheimpls"
 	"mcp_proxy/pkg/config"
 	"mcp_proxy/pkg/entity/model"
+	"mcp_proxy/pkg/infra/bkaidevtrace"
 	"mcp_proxy/pkg/infra/logging"
 	"mcp_proxy/pkg/infra/proxy"
 	"mcp_proxy/pkg/util"
@@ -357,6 +358,10 @@ func addMCPServer(
 		// Add tracing middleware if MCP tracing is enabled
 		if config.G.Tracing.McpAPIEnabled() {
 			AddTracingMiddleware(mcpServer.GetServer(), svr.Name)
+		}
+		// Add BKAIDev trace middleware if enabled
+		if bkaidevtrace.Enabled() {
+			AddBkAIDevTraceMiddleware(mcpServer.GetServer(), svr.Name)
 		}
 	}
 

--- a/src/mcp-proxy/pkg/mcp/mcp_load_test.go
+++ b/src/mcp-proxy/pkg/mcp/mcp_load_test.go
@@ -151,9 +151,9 @@ var _ = Describe("MCP Load Functions", func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			server := &model.MCPServer{
-				Name:                "test-server",
-				ProtocolType:        constant.MCPServerProtocolTypeSSE,
-				RawResponseEnabled:  true, // Changed raw_response_enabled
+				Name:               "test-server",
+				ProtocolType:       constant.MCPServerProtocolTypeSSE,
+				RawResponseEnabled: true, // Changed raw_response_enabled
 			}
 			release := &model.Release{ResourceVersionID: 1}
 

--- a/src/mcp-proxy/pkg/mcp/mcp_test.go
+++ b/src/mcp-proxy/pkg/mcp/mcp_test.go
@@ -154,45 +154,48 @@ var _ = Describe("MCP", func() {
 		})
 
 		Describe("UpdateMCPServerFromOpenApiSpec", func() {
-			It("should update raw_response_enabled and rebuild tool handlers when raw_response_enabled changes with same version", func() {
-				openapiSpec := &openapi3.T{
-					OpenAPI: "3.0.0",
-					Info:    &openapi3.Info{Title: "Test API", Version: "1.0.0"},
-					Servers: []*openapi3.Server{{URL: "https://api.example.com"}},
-					Paths:   &openapi3.Paths{},
-				}
+			It(
+				"should update raw_response_enabled and rebuild tool handlers when raw_response_enabled changes with same version",
+				func() {
+					openapiSpec := &openapi3.T{
+						OpenAPI: "3.0.0",
+						Info:    &openapi3.Info{Title: "Test API", Version: "1.0.0"},
+						Servers: []*openapi3.Server{{URL: "https://api.example.com"}},
+						Paths:   &openapi3.Paths{},
+					}
 
-				pathItem := &openapi3.PathItem{
-					Get: &openapi3.Operation{
-						OperationID: "getUsers",
-						Summary:     "Get users",
-						Responses:   &openapi3.Responses{},
-					},
-				}
-				openapiSpec.Paths.Set("/users", pathItem)
+					pathItem := &openapi3.PathItem{
+						Get: &openapi3.Operation{
+							OperationID: "getUsers",
+							Summary:     "Get users",
+							Responses:   &openapi3.Responses{},
+						},
+					}
+					openapiSpec.Paths.Set("/users", pathItem)
 
-				// 创建 server，raw_response_enabled=false
-				err := mcpProxy.AddMCPServerFromOpenAPISpec(
-					"raw-switch-server", 1, openapiSpec,
-					[]string{"getUsers"}, nil, constant.MCPServerProtocolTypeSSE, false,
-				)
-				Expect(err).NotTo(HaveOccurred())
+					// 创建 server，raw_response_enabled=false
+					err := mcpProxy.AddMCPServerFromOpenAPISpec(
+						"raw-switch-server", 1, openapiSpec,
+						[]string{"getUsers"}, nil, constant.MCPServerProtocolTypeSSE, false,
+					)
+					Expect(err).NotTo(HaveOccurred())
 
-				server := mcpProxy.GetMCPServer("raw-switch-server")
-				Expect(server).NotTo(BeNil())
-				Expect(server.RawResponseEnabled()).To(BeFalse())
-				Expect(server.GetResourceVersionID()).To(Equal(1))
+					server := mcpProxy.GetMCPServer("raw-switch-server")
+					Expect(server).NotTo(BeNil())
+					Expect(server.RawResponseEnabled()).To(BeFalse())
+					Expect(server.GetResourceVersionID()).To(Equal(1))
 
-				// 更新 server，仅切换 raw_response_enabled=true，resourceVersionID 不变
-				err = mcpProxy.UpdateMCPServerFromOpenApiSpec(
-					server, "raw-switch-server", 1, openapiSpec,
-					[]string{"getUsers"}, nil, true,
-				)
-				Expect(err).NotTo(HaveOccurred())
-				Expect(server.RawResponseEnabled()).To(BeTrue())
-				// resourceVersionID 应保持不变
-				Expect(server.GetResourceVersionID()).To(Equal(1))
-			})
+					// 更新 server，仅切换 raw_response_enabled=true，resourceVersionID 不变
+					err = mcpProxy.UpdateMCPServerFromOpenApiSpec(
+						server, "raw-switch-server", 1, openapiSpec,
+						[]string{"getUsers"}, nil, true,
+					)
+					Expect(err).NotTo(HaveOccurred())
+					Expect(server.RawResponseEnabled()).To(BeTrue())
+					// resourceVersionID 应保持不变
+					Expect(server.GetResourceVersionID()).To(Equal(1))
+				},
+			)
 
 			It("should update server with new version", func() {
 				openapiSpec := &openapi3.T{

--- a/src/mcp-proxy/pkg/mcp/middleware.go
+++ b/src/mcp-proxy/pkg/mcp/middleware.go
@@ -37,6 +37,7 @@ import (
 	"mcp_proxy/pkg/cacheimpls"
 	"mcp_proxy/pkg/config"
 	"mcp_proxy/pkg/constant"
+	"mcp_proxy/pkg/infra/bkaidevtrace"
 	"mcp_proxy/pkg/infra/logging"
 	"mcp_proxy/pkg/infra/sentry"
 	"mcp_proxy/pkg/infra/trace"
@@ -561,4 +562,85 @@ func TracingMiddleware(serverName string) mcp.Middleware {
 // AddTracingMiddleware adds tracing middleware to the MCP server.
 func AddTracingMiddleware(server *mcp.Server, serverName string) {
 	server.AddReceivingMiddleware(TracingMiddleware(serverName))
+}
+
+// BkAIDevTraceMiddleware returns a middleware that creates independent BKAIDev Agent
+// trace spans for MCP method calls. It uses the isolated bkaidevtrace provider.
+func BkAIDevTraceMiddleware(serverName string) mcp.Middleware {
+	return func(next mcp.MethodHandler) mcp.MethodHandler {
+		return func(ctx context.Context, method string, req mcp.Request) (result mcp.Result, err error) {
+			if !bkaidevtrace.Enabled() {
+				return next(ctx, method, req)
+			}
+
+			spanName := fmt.Sprintf("mcp_gw.%s.%s", serverName, method)
+			start := time.Now()
+
+			ctx, span := bkaidevtrace.StartSpan(ctx, spanName)
+			defer span.End()
+
+			// Collect attributes
+			appCode := util.GetAppCodeFromContext(ctx)
+			username := util.GetUsernameFromContext(ctx)
+			clientIP := util.GetClientIPFromContext(ctx)
+			clientID := util.GetClientIDFromContext(ctx)
+			gatewayName := util.GetGatewayNameFromContext(ctx)
+			requestID := util.GetRequestIDFromContext(ctx)
+			xRequestID := util.GetXRequestIDFromContext(ctx)
+			traceID := bkaidevtrace.GetTraceIDFromContext(ctx)
+
+			span.SetAttributes(
+				attribute.String("app_code", appCode),
+				attribute.String("bk_username", username),
+				attribute.String("client_ip", clientIP),
+				attribute.String("client_id", clientID),
+				attribute.String("gateway_name", gatewayName),
+				attribute.String("mcp_server_name", serverName),
+				attribute.String("request_id", requestID),
+				attribute.String("x_request_id", xRequestID),
+				attribute.String("trace_id", traceID),
+			)
+
+			// ItsmFlex fields
+			if itsmFlex := util.GetBkApiItsmFlexData(ctx); itsmFlex != nil {
+				span.SetAttributes(
+					attribute.String("caller_executor", itsmFlex.CallerExecutor),
+					attribute.String("agent_code", itsmFlex.AgentCode),
+				)
+			}
+
+			// Tool name
+			if method == "tools/call" {
+				toolName := extractToolName(req)
+				if toolName != "" {
+					span.SetAttributes(attribute.String("tool_name", toolName))
+				}
+			}
+
+			result, err = next(ctx, method, req)
+
+			// Status and latency
+			latency := time.Since(start)
+			status := "success"
+			if err != nil {
+				status = "failed"
+				span.SetStatus(codes.Error, err.Error())
+				var jsonrpcErr *jsonrpc.Error
+				if errors.As(err, &jsonrpcErr) {
+					span.SetAttributes(attribute.Int64("error_code", jsonrpcErr.Code))
+				}
+			}
+			span.SetAttributes(
+				attribute.String("status", status),
+				attribute.Float64("latency_ms", latency.Seconds()*1000),
+			)
+
+			return result, err
+		}
+	}
+}
+
+// AddBkAIDevTraceMiddleware adds BKAIDev trace middleware to the MCP server.
+func AddBkAIDevTraceMiddleware(server *mcp.Server, serverName string) {
+	server.AddReceivingMiddleware(BkAIDevTraceMiddleware(serverName))
 }

--- a/src/mcp-proxy/pkg/mcp/middleware_test.go
+++ b/src/mcp-proxy/pkg/mcp/middleware_test.go
@@ -30,10 +30,16 @@ import (
 	. "github.com/onsi/gomega"
 	"github.com/prometheus/client_golang/prometheus"
 	dto "github.com/prometheus/client_model/go"
+	"go.opentelemetry.io/otel/codes"
+	"go.opentelemetry.io/otel/propagation"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
 
 	"mcp_proxy/pkg/constant"
+	"mcp_proxy/pkg/infra/bkaidevtrace"
 	mcppkg "mcp_proxy/pkg/mcp"
 	"mcp_proxy/pkg/metric"
+	"mcp_proxy/pkg/util"
 )
 
 // getCounterValue extracts the float64 value from a CounterVec for the given labels
@@ -424,6 +430,162 @@ var _ = Describe("Middleware", func() {
 		It("should return string representation for unknown codes", func() {
 			Expect(mcppkg.MatchErrorCodeNameForTest(-32000)).To(Equal("-32000"))
 			Expect(mcppkg.MatchErrorCodeNameForTest(42)).To(Equal("42"))
+		})
+	})
+
+	Describe("BkAIDevTraceMiddleware", func() {
+		var exporter *tracetest.InMemoryExporter
+
+		BeforeEach(func() {
+			bkaidevtrace.ResetForTest()
+			exporter = tracetest.NewInMemoryExporter()
+			tp := sdktrace.NewTracerProvider(sdktrace.WithSyncer(exporter))
+			bkaidevtrace.SetTestProvider(tp, propagation.NewCompositeTextMapPropagator(
+				propagation.TraceContext{},
+				propagation.Baggage{},
+			))
+		})
+
+		AfterEach(func() {
+			bkaidevtrace.ResetForTest()
+		})
+
+		It("should pass through when not initialized", func() {
+			bkaidevtrace.ResetForTest()
+			middleware := mcppkg.BkAIDevTraceMiddleware(serverName)
+			handler := middleware(func(ctx context.Context, method string, req sdkmcp.Request) (sdkmcp.Result, error) {
+				return successResult, nil
+			})
+			result, err := handler(ctx, "initialize", nil)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result).To(Equal(successResult))
+		})
+
+		It("should create span with correct name and attributes on success", func() {
+			testCtx := context.WithValue(ctx, constant.BkAppCode, "test-app")
+			testCtx = context.WithValue(testCtx, constant.BkUsername, "test-user")
+			testCtx = context.WithValue(testCtx, constant.ClientIP, "127.0.0.1")
+			testCtx = context.WithValue(testCtx, constant.ClientID, "test-client")
+			testCtx = context.WithValue(testCtx, constant.GatewayName, "test-gateway")
+			testCtx = context.WithValue(testCtx, constant.RequestID, "req-123")
+			testCtx = context.WithValue(testCtx, constant.XRequestID, "x-req-456")
+
+			middleware := mcppkg.BkAIDevTraceMiddleware(serverName)
+			handler := middleware(func(ctx context.Context, method string, req sdkmcp.Request) (sdkmcp.Result, error) {
+				return successResult, nil
+			})
+			_, err := handler(testCtx, "tools/list", nil)
+			Expect(err).NotTo(HaveOccurred())
+
+			spans := exporter.GetSpans()
+			Expect(len(spans)).To(Equal(1))
+			span := spans[0]
+			Expect(span.Name).To(Equal("mcp_gw.test-server.tools/list"))
+			Expect(span.Status.Code).NotTo(Equal(codes.Error))
+
+			attrs := make(map[string]any)
+			for _, attr := range span.Attributes {
+				attrs[string(attr.Key)] = attr.Value.AsInterface()
+			}
+			Expect(attrs["app_code"]).To(Equal("test-app"))
+			Expect(attrs["bk_username"]).To(Equal("test-user"))
+			Expect(attrs["client_ip"]).To(Equal("127.0.0.1"))
+			Expect(attrs["client_id"]).To(Equal("test-client"))
+			Expect(attrs["gateway_name"]).To(Equal("test-gateway"))
+			Expect(attrs["mcp_server_name"]).To(Equal("test-server"))
+			Expect(attrs["request_id"]).To(Equal("req-123"))
+			Expect(attrs["x_request_id"]).To(Equal("x-req-456"))
+			Expect(attrs["status"]).To(Equal("success"))
+			Expect(attrs["latency_ms"]).To(BeNumerically(">=", 0))
+			Expect(attrs["trace_id"]).NotTo(BeEmpty())
+		})
+
+		It("should create span with error status and error_code on failure", func() {
+			middleware := mcppkg.BkAIDevTraceMiddleware(serverName)
+			handler := middleware(func(ctx context.Context, method string, req sdkmcp.Request) (sdkmcp.Result, error) {
+				return nil, &jsonrpc.Error{
+					Code:    jsonrpc.CodeMethodNotFound,
+					Message: "method not found",
+				}
+			})
+			_, err := handler(ctx, "tools/call", nil)
+			Expect(err).To(HaveOccurred())
+
+			spans := exporter.GetSpans()
+			Expect(len(spans)).To(Equal(1))
+			span := spans[0]
+			Expect(span.Name).To(Equal("mcp_gw.test-server.tools/call"))
+			Expect(span.Status.Code).To(Equal(codes.Error))
+
+			attrs := make(map[string]any)
+			for _, attr := range span.Attributes {
+				attrs[string(attr.Key)] = attr.Value.AsInterface()
+			}
+			Expect(attrs["status"]).To(Equal("failed"))
+			Expect(attrs["error_code"]).To(Equal(int64(jsonrpc.CodeMethodNotFound)))
+		})
+
+		It("should include tool_name for tools/call", func() {
+			req := &sdkmcp.ServerRequest[*sdkmcp.CallToolParamsRaw]{
+				Params: &sdkmcp.CallToolParamsRaw{Name: "test-tool"},
+			}
+
+			middleware := mcppkg.BkAIDevTraceMiddleware(serverName)
+			handler := middleware(func(ctx context.Context, method string, req sdkmcp.Request) (sdkmcp.Result, error) {
+				return successResult, nil
+			})
+			_, err := handler(ctx, "tools/call", req)
+			Expect(err).NotTo(HaveOccurred())
+
+			spans := exporter.GetSpans()
+			Expect(len(spans)).To(Equal(1))
+			attrs := make(map[string]any)
+			for _, attr := range spans[0].Attributes {
+				attrs[string(attr.Key)] = attr.Value.AsInterface()
+			}
+			Expect(attrs["tool_name"]).To(Equal("test-tool"))
+		})
+
+		It("should include caller_executor and agent_code when ItsmFlex is present", func() {
+			testCtx := context.WithValue(ctx, constant.BkApiItsmFlexData, &util.ItsmFlexData{
+				CallerExecutor: "judge-caller",
+				AgentCode:      "ai-test-appcode",
+			})
+
+			middleware := mcppkg.BkAIDevTraceMiddleware(serverName)
+			handler := middleware(func(ctx context.Context, method string, req sdkmcp.Request) (sdkmcp.Result, error) {
+				return successResult, nil
+			})
+			_, err := handler(testCtx, "initialize", nil)
+			Expect(err).NotTo(HaveOccurred())
+
+			spans := exporter.GetSpans()
+			Expect(len(spans)).To(Equal(1))
+			attrs := make(map[string]any)
+			for _, attr := range spans[0].Attributes {
+				attrs[string(attr.Key)] = attr.Value.AsInterface()
+			}
+			Expect(attrs["caller_executor"]).To(Equal("judge-caller"))
+			Expect(attrs["agent_code"]).To(Equal("ai-test-appcode"))
+		})
+
+		It("should record latency_ms as float with sub-millisecond precision", func() {
+			middleware := mcppkg.BkAIDevTraceMiddleware(serverName)
+			handler := middleware(func(ctx context.Context, method string, req sdkmcp.Request) (sdkmcp.Result, error) {
+				return successResult, nil
+			})
+			_, err := handler(ctx, "initialize", nil)
+			Expect(err).NotTo(HaveOccurred())
+
+			spans := exporter.GetSpans()
+			Expect(len(spans)).To(Equal(1))
+			attrs := make(map[string]any)
+			for _, attr := range spans[0].Attributes {
+				attrs[string(attr.Key)] = attr.Value.AsInterface()
+			}
+			latency, ok := attrs["latency_ms"].(float64)
+			Expect(ok).To(BeTrue())
+			Expect(latency).To(BeNumerically(">=", 0))
 		})
 	})
 })

--- a/src/mcp-proxy/pkg/middleware/bkaidevtrace.go
+++ b/src/mcp-proxy/pkg/middleware/bkaidevtrace.go
@@ -1,0 +1,75 @@
+/*
+ * TencentBlueKing is pleased to support the open source community by making
+ * 蓝鲸智云 - API 网关(BlueKing - APIGateway) available.
+ * Copyright (C) 2025 Tencent. All rights reserved.
+ * Licensed under the MIT License (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ *     http://opensource.org/licenses/MIT
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * We undertake not to change the open source license (MIT license) applicable
+ * to the current version of the project delivered to anyone in the future.
+ */
+
+package middleware
+
+import (
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+	tc "go.opentelemetry.io/otel/trace"
+
+	"mcp_proxy/pkg/infra/bkaidevtrace"
+)
+
+// BkAIDevTraceContextMiddleware extracts traceparent from the incoming HTTP request
+// and injects the trace context into the request context using BKAIDev's isolated
+// trace propagator (separate from the project's global OTEL tracing). If no
+// traceparent is present, a new trace context is created so that downstream MCP
+// spans always have a valid trace ID.
+func BkAIDevTraceContextMiddleware() gin.HandlerFunc {
+	return func(c *gin.Context) {
+		ctx := c.Request.Context()
+		traceparent := c.GetHeader("traceparent")
+
+		if traceparent != "" {
+			// Extract existing trace context from headers
+			carrier := headerCarrier(c.Request.Header)
+			ctx = bkaidevtrace.Extract(ctx, &carrier)
+		} else {
+			// No traceparent provided: create a span context with random trace/span IDs
+			// without creating an actual span, so that downstream MCP spans have a valid parent.
+			spanCtx := bkaidevtrace.NewSpanContext()
+			ctx = tc.ContextWithSpanContext(ctx, spanCtx)
+		}
+
+		c.Request = c.Request.WithContext(ctx)
+		c.Next()
+	}
+}
+
+type headerCarrier http.Header
+
+// Get returns the value associated with the passed key.
+func (h headerCarrier) Get(key string) string {
+	return http.Header(h).Get(key)
+}
+
+// Set stores the key-value pair.
+func (h headerCarrier) Set(key string, value string) {
+	http.Header(h).Set(key, value)
+}
+
+// Keys lists the keys stored in this carrier.
+func (h headerCarrier) Keys() []string {
+	keys := make([]string, 0, len(h))
+	for k := range h {
+		keys = append(keys, k)
+	}
+	return keys
+}

--- a/src/mcp-proxy/pkg/middleware/bkaidevtrace_test.go
+++ b/src/mcp-proxy/pkg/middleware/bkaidevtrace_test.go
@@ -1,0 +1,104 @@
+/*
+ * TencentBlueKing is pleased to support the open source community by making
+ * 蓝鲸智云 - API 网关(BlueKing - APIGateway) available.
+ * Copyright (C) 2025 Tencent. All rights reserved.
+ * Licensed under the MIT License (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ *     http://opensource.org/licenses/MIT
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * We undertake not to change the open source license (MIT license) applicable
+ * to the current version of the project delivered to anyone in the future.
+ */
+
+package middleware_test
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+
+	"github.com/gin-gonic/gin"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"go.opentelemetry.io/otel/propagation"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	tc "go.opentelemetry.io/otel/trace"
+
+	"mcp_proxy/pkg/infra/bkaidevtrace"
+	"mcp_proxy/pkg/middleware"
+)
+
+var _ = Describe("BkAIDevTraceContextMiddleware", func() {
+	BeforeEach(func() {
+		gin.SetMode(gin.TestMode)
+		bkaidevtrace.ResetForTest()
+	})
+
+	AfterEach(func() {
+		bkaidevtrace.ResetForTest()
+	})
+
+	It("should extract trace context from traceparent header", func() {
+		// Set up test provider
+		exporter := sdktrace.NewTracerProvider(sdktrace.WithSyncer(&testSpanExporter{}))
+		defer func() { _ = exporter.Shutdown(context.Background()) }()
+		bkaidevtrace.SetTestProvider(exporter, propagation.NewCompositeTextMapPropagator(
+			propagation.TraceContext{},
+			propagation.Baggage{},
+		))
+
+		w := httptest.NewRecorder()
+		c, _ := gin.CreateTestContext(w)
+		c.Request = httptest.NewRequest(http.MethodGet, "/test", nil)
+		c.Request.Header.Set("traceparent", "00-11223344556677889900aabbccddeeff-aabbccddeeff0011-01")
+
+		called := false
+		middleware.BkAIDevTraceContextMiddleware()(c)
+		called = true
+
+		Expect(called).To(BeTrue())
+		spanCtx := tc.SpanFromContext(c.Request.Context()).SpanContext()
+		Expect(spanCtx.IsValid()).To(BeTrue())
+		Expect(spanCtx.TraceID().String()).To(Equal("11223344556677889900aabbccddeeff"))
+	})
+
+	It("should create new span context when no traceparent header", func() {
+		w := httptest.NewRecorder()
+		c, _ := gin.CreateTestContext(w)
+		c.Request = httptest.NewRequest(http.MethodGet, "/test", nil)
+
+		middleware.BkAIDevTraceContextMiddleware()(c)
+
+		spanCtx := tc.SpanFromContext(c.Request.Context()).SpanContext()
+		Expect(spanCtx.IsValid()).To(BeTrue())
+		Expect(spanCtx.TraceID().String()).NotTo(BeEmpty())
+		Expect(spanCtx.SpanID().String()).NotTo(BeEmpty())
+	})
+
+	It("should pass through Next handler", func() {
+		w := httptest.NewRecorder()
+		c, _ := gin.CreateTestContext(w)
+		c.Request = httptest.NewRequest(http.MethodGet, "/test", nil)
+
+		mw := middleware.BkAIDevTraceContextMiddleware()
+		mw(c)
+
+		Expect(c.Request.Context()).NotTo(BeNil())
+	})
+})
+
+type testSpanExporter struct{}
+
+func (t *testSpanExporter) ExportSpans(ctx context.Context, spans []sdktrace.ReadOnlySpan) error {
+	return nil
+}
+
+func (t *testSpanExporter) Shutdown(ctx context.Context) error {
+	return nil
+}

--- a/src/mcp-proxy/pkg/middleware/mcp_header_test.go
+++ b/src/mcp-proxy/pkg/middleware/mcp_header_test.go
@@ -87,5 +87,50 @@ var _ = Describe("MCPHeader", func() {
 			Expect(headers["X-Custom-Header"]).To(Equal("custom-value"))
 			Expect(headers["X-Another-Header"]).To(Equal("another-value"))
 		})
+
+		It("should parse X-Bkapi-ItsmFlex header", func() {
+			w := httptest.NewRecorder()
+			c, _ := gin.CreateTestContext(w)
+			c.Request = httptest.NewRequest(http.MethodGet, "/test", nil)
+
+			itsmFlexJSON := `{"agent.info.code":"ai-test-appcode","agent.info.name":"AgentName","agent.session.caller_executor":"judge-caller","agent.session.executor":"judge-executor"}`
+			c.Request.Header.Set(constant.BkApiItsmFlexKey, itsmFlexJSON)
+
+			mw := middleware.MCPServerHeaderMiddleware()
+			mw(c)
+
+			data := util.GetBkApiItsmFlexData(c.Request.Context())
+			Expect(data).NotTo(BeNil())
+			Expect(data.AgentCode).To(Equal("ai-test-appcode"))
+			Expect(data.AgentName).To(Equal("AgentName"))
+			Expect(data.CallerExecutor).To(Equal("judge-caller"))
+			Expect(data.Executor).To(Equal("judge-executor"))
+		})
+
+		It("should ignore invalid X-Bkapi-ItsmFlex header", func() {
+			w := httptest.NewRecorder()
+			c, _ := gin.CreateTestContext(w)
+			c.Request = httptest.NewRequest(http.MethodGet, "/test", nil)
+
+			c.Request.Header.Set(constant.BkApiItsmFlexKey, "not-json")
+
+			mw := middleware.MCPServerHeaderMiddleware()
+			mw(c)
+
+			data := util.GetBkApiItsmFlexData(c.Request.Context())
+			Expect(data).To(BeNil())
+		})
+
+		It("should handle missing X-Bkapi-ItsmFlex header", func() {
+			w := httptest.NewRecorder()
+			c, _ := gin.CreateTestContext(w)
+			c.Request = httptest.NewRequest(http.MethodGet, "/test", nil)
+
+			mw := middleware.MCPServerHeaderMiddleware()
+			mw(c)
+
+			data := util.GetBkApiItsmFlexData(c.Request.Context())
+			Expect(data).To(BeNil())
+		})
 	})
 })

--- a/src/mcp-proxy/pkg/server/router.go
+++ b/src/mcp-proxy/pkg/server/router.go
@@ -28,6 +28,7 @@ import (
 	"go.opentelemetry.io/contrib/instrumentation/github.com/gin-gonic/gin/otelgin"
 
 	"mcp_proxy/pkg/config"
+	"mcp_proxy/pkg/infra/bkaidevtrace"
 	"mcp_proxy/pkg/infra/logging"
 	"mcp_proxy/pkg/infra/proxy"
 	sty "mcp_proxy/pkg/infra/sentry"
@@ -109,11 +110,16 @@ func NewRouter(cfg *config.Config) *gin.Engine {
 	logging.GetLogger().Infof("mcp proxy init complete, duration=%s", time.Since(mcpInitStart))
 
 	// 用户态路由
+	// BkAIDevTraceContextMiddleware is registered at the group level, so it covers
+	// both SSE (/sse) and Streamable HTTP (/mcp) routes within this group.
 	seeRouter := router.Group("/:name")
 	seeRouter.Use(middleware.APILogger())
 	seeRouter.Use(middleware.BkGatewayJWTAuthMiddleware())
 	seeRouter.Use(middleware.MCPServerPermissionMiddleware())
 	seeRouter.Use(middleware.MCPServerHeaderMiddleware())
+	if bkaidevtrace.Enabled() {
+		seeRouter.Use(middleware.BkAIDevTraceContextMiddleware())
+	}
 	// SSE 协议路由 - 官方 SDK 的 SSEHandler 同时处理 GET 和 POST 请求
 	seeRouter.GET("/sse", mcpProxy.SseHandler())
 	seeRouter.POST("/sse", mcpProxy.SseHandler())
@@ -122,11 +128,15 @@ func NewRouter(cfg *config.Config) *gin.Engine {
 	seeRouter.POST("/mcp", mcpProxy.StreamableHTTPHandler())
 
 	// 应用态路由（共享 MCPProxy 实例）
+	// BkAIDevTraceContextMiddleware covers both /sse and /mcp routes in this group as well.
 	seeAppRouter := router.Group("/:name/application")
 	seeAppRouter.Use(middleware.APILogger())
 	seeAppRouter.Use(middleware.BkGatewayJWTAuthMiddleware())
 	seeAppRouter.Use(middleware.MCPServerPermissionMiddleware())
 	seeAppRouter.Use(middleware.MCPServerHeaderMiddleware())
+	if bkaidevtrace.Enabled() {
+		seeAppRouter.Use(middleware.BkAIDevTraceContextMiddleware())
+	}
 	// SSE 协议路由 - 官方 SDK 的 SSEHandler 同时处理 GET 和 POST 请求
 	seeAppRouter.GET("/sse", mcpProxy.SseHandlerApplication())
 	seeAppRouter.POST("/sse", mcpProxy.SseHandlerApplication())

--- a/src/mcp-proxy/pkg/server/server.go
+++ b/src/mcp-proxy/pkg/server/server.go
@@ -29,6 +29,7 @@ import (
 	"time"
 
 	"mcp_proxy/pkg/config"
+	"mcp_proxy/pkg/infra/bkaidevtrace"
 	"mcp_proxy/pkg/infra/logging"
 	sty "mcp_proxy/pkg/infra/sentry"
 )
@@ -64,16 +65,26 @@ func Run(cfg *config.Config) {
 	<-quit
 	logging.GetLogger().Info("Shutdown Server ...")
 
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-	defer cancel()
 	// Flush buffered sentry events before exit (defer ensures this runs even on fatal paths)
 	defer sty.Flush(2 * time.Second)
 
-	if err := srv.Shutdown(ctx); err != nil {
-		logging.GetLogger().Fatalf("Server Shutdown: %s", err)
+	// Shutdown HTTP server with a 5-second timeout
+	srvCtx, srvCancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer srvCancel()
+
+	if err := srv.Shutdown(srvCtx); err != nil {
+		logging.GetLogger().Errorf("Server Shutdown: %s", err)
 	}
-	// catching ctx.Done(). timeout of 5 seconds.
-	<-ctx.Done()
-	logging.GetLogger().Info("timeout of 5 seconds.")
+
+	// Shutdown BkAIDev trace provider with its own independent context,
+	// so it has a full 3 seconds to flush buffered spans regardless of
+	// how long srv.Shutdown took.
+	traceCtx, traceCancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer traceCancel()
+
+	if err := bkaidevtrace.Shutdown(traceCtx); err != nil {
+		logging.GetLogger().Errorf("BkAIDev trace shutdown error: %s", err)
+	}
+
 	logging.GetLogger().Info("Server exiting")
 }

--- a/src/mcp-proxy/pkg/util/context.go
+++ b/src/mcp-proxy/pkg/util/context.go
@@ -294,6 +294,29 @@ func GetBkApiAllowedHeaders(ctx context.Context) map[string]string {
 	return allowedHeaders
 }
 
+// ItsmFlexData holds fields extracted from X-Bkapi-ItsmFlex header.
+type ItsmFlexData struct {
+	AgentCode      string `json:"agent.info.code"`
+	AgentName      string `json:"agent.info.name"`
+	CallerExecutor string `json:"agent.session.caller_executor"`
+	Executor       string `json:"agent.session.executor"`
+}
+
+// SetBkApiItsmFlexData stores the parsed ItsmFlex data into context.
+func SetBkApiItsmFlexData(c *gin.Context, data *ItsmFlexData) {
+	if c.Request != nil {
+		c.Request = c.Request.WithContext(context.WithValue(c.Request.Context(), constant.BkApiItsmFlexData, data))
+	}
+}
+
+// GetBkApiItsmFlexData retrieves the parsed ItsmFlex data from context.
+func GetBkApiItsmFlexData(ctx context.Context) *ItsmFlexData {
+	if data, ok := ctx.Value(constant.BkApiItsmFlexData).(*ItsmFlexData); ok {
+		return data
+	}
+	return nil
+}
+
 // JWTClaimsForLazySigning 用于延迟签发 JWT 的 claims 信息
 type JWTClaimsForLazySigning struct {
 	AppCode      string
@@ -331,5 +354,3 @@ func GetPrivateKeyFromContext(ctx context.Context) []byte {
 	}
 	return nil
 }
-
-

--- a/src/mcp-proxy/pkg/util/context_test.go
+++ b/src/mcp-proxy/pkg/util/context_test.go
@@ -369,4 +369,44 @@ var _ = Describe("Context", func() {
 			Expect(headers["X-Header-2"]).To(Equal("value2"))
 		})
 	})
+
+	Describe("BkApiItsmFlexData", func() {
+		It("should set and get ItsmFlex data", func() {
+			w := httptest.NewRecorder()
+			c, _ := gin.CreateTestContext(w)
+			c.Request = httptest.NewRequest(http.MethodGet, "/test", nil)
+
+			data := &util.ItsmFlexData{
+				AgentCode:      "ai-test-appcode",
+				AgentName:      "AgentName",
+				CallerExecutor: "judge-caller",
+				Executor:       "judge-executor",
+			}
+			util.SetBkApiItsmFlexData(c, data)
+
+			retrieved := util.GetBkApiItsmFlexData(c.Request.Context())
+			Expect(retrieved).NotTo(BeNil())
+			Expect(retrieved.AgentCode).To(Equal("ai-test-appcode"))
+			Expect(retrieved.AgentName).To(Equal("AgentName"))
+			Expect(retrieved.CallerExecutor).To(Equal("judge-caller"))
+			Expect(retrieved.Executor).To(Equal("judge-executor"))
+		})
+
+		It("should return nil when not set", func() {
+			ctx := context.Background()
+			data := util.GetBkApiItsmFlexData(ctx)
+			Expect(data).To(BeNil())
+		})
+
+		It("should return nil when set to nil", func() {
+			w := httptest.NewRecorder()
+			c, _ := gin.CreateTestContext(w)
+			c.Request = httptest.NewRequest(http.MethodGet, "/test", nil)
+
+			util.SetBkApiItsmFlexData(c, nil)
+
+			retrieved := util.GetBkApiItsmFlexData(c.Request.Context())
+			Expect(retrieved).To(BeNil())
+		})
+	})
 })


### PR DESCRIPTION
## What changed

- Added independent OTLP/HTTP trace provider in `pkg/infra/bkaidtrace` with its own TracerProvider, propagator, and lifecycle management, fully isolated from the project's existing tracing infrastructure
- Added Gin middleware (`BkAIDevTraceContextMiddleware`) to extract W3C traceparent from incoming requests or generate fresh span contexts when absent
- Added MCP-level middleware (`BkAIDevTraceMiddleware`) that creates spans per MCP method call with rich attributes: app_code, bk_username, client_ip, client_id, gateway_name, mcp_server_name, tool_name, request_id, x_request_id, trace_id, caller_executor, agent_code, latency_ms, status, and error_code
- Added `X-Bkapi-ItsmFlex` header parsing to extract agent identity fields (agent code, agent name, caller executor, executor)
- Added `BkAIDevTrace` config struct with enable/endpoint/token/service name fields
- Added graceful shutdown of bkaidtrace provider in server shutdown
- Comprehensive unit tests covering all new modules (25+ test cases)
- Applied gofumpt/goimports-reviser formatting fixes to existing files

## Why this change was needed

The MCP Gateway lacked independent observability for BKAIDev Agent interactions. Operations teams needed a way to trace agent-to-tool call flows, including caller identity, latency, error codes, and upstream agent metadata (via X-Bkapi-ItsmFlex header), without interfering with the existing project-level OpenTelemetry tracing.

## Problem solved

BKAIDev Agent trace spans are now independently reported to a dedicated OTLP endpoint, enabling full observability of agent-driven MCP tool calls without coupling to or polluting the project's own tracing pipeline.