### PR TITLE
feat(mcp-servers): support gateway-level applicant list when mcp_server_id is absent

### DIFF
--- a/src/dashboard/apigateway/apigateway/apis/web/mcp_server/urls.py
+++ b/src/dashboard/apigateway/apigateway/apis/web/mcp_server/urls.py
@@ -45,23 +45,39 @@ urlpatterns = [
     path("", MCPServerListCreateApi.as_view(), name="mcp_server.list_create"),
     path("-/categories/", MCPServerCategoriesListApi.as_view(), name="mcp_server.categories_list"),
     path("-/filter-options/", MCPServerFilterOptionsApi.as_view(), name="mcp_server.filter_options"),
-    # 有权限的 bk_app_code 列表（网关级别）
+    # permissions（网关级别）
     path(
-        "-/app-permission-app-codes/",
-        MCPServerAppPermissionAppCodeListApi.as_view(),
-        name="mcp_server.app-permission.app_code_list",
-    ),
-    # 授权审批列表（网关级别，支持按 mcp_server_id 筛选）
-    path(
-        "-/app-permission-apply/",
-        MCPServerAppPermissionApplyListApi.as_view(),
-        name="mcp_server.app-permission-apply.list",
-    ),
-    # 授权审批申请人列表（网关级别，返回网关下所有申请人）
-    path(
-        "-/permissions/app-permission-apply/applicant/",
-        MCPServerAppPermissionApplyApplicantListApi.as_view(),
-        name="mcp_server.app-permission-apply.gateway_applicant_list",
+        "-/permissions/",
+        include(
+            [
+                # 有权限的 bk_app_code 列表（网关级别）
+                path(
+                    "app-permission-app-codes/",
+                    MCPServerAppPermissionAppCodeListApi.as_view(),
+                    name="mcp_server.app-permission.app_code_list",
+                ),
+                # 授权审批（网关级别）
+                path(
+                    "app-permission-apply/",
+                    include(
+                        [
+                            # 审批列表（支持按 mcp_server_id 筛选）
+                            path(
+                                "",
+                                MCPServerAppPermissionApplyListApi.as_view(),
+                                name="mcp_server.app-permission-apply.list",
+                            ),
+                            # 审批申请人列表
+                            path(
+                                "applicant/",
+                                MCPServerAppPermissionApplyApplicantListApi.as_view(),
+                                name="mcp_server.app-permission-apply.gateway_applicant_list",
+                            ),
+                        ]
+                    ),
+                ),
+            ]
+        ),
     ),
     path(
         "<int:mcp_server_id>/",

--- a/src/dashboard/apigateway/apigateway/apis/web/mcp_server/urls.py
+++ b/src/dashboard/apigateway/apigateway/apis/web/mcp_server/urls.py
@@ -61,7 +61,7 @@ urlpatterns = [
     path(
         "-/permissions/app-permission-apply/applicant/",
         MCPServerAppPermissionApplyApplicantListApi.as_view(),
-        name="mcp_server.app-permission-apply.applicant_list",
+        name="mcp_server.app-permission-apply.gateway_applicant_list",
     ),
     path(
         "<int:mcp_server_id>/",

--- a/src/dashboard/apigateway/apigateway/apis/web/mcp_server/urls.py
+++ b/src/dashboard/apigateway/apigateway/apis/web/mcp_server/urls.py
@@ -57,6 +57,12 @@ urlpatterns = [
         MCPServerAppPermissionApplyListApi.as_view(),
         name="mcp_server.app-permission-apply.list",
     ),
+    # 授权审批申请人列表（网关级别，返回网关下所有申请人）
+    path(
+        "-/permissions/app-permission-apply/applicant/",
+        MCPServerAppPermissionApplyApplicantListApi.as_view(),
+        name="mcp_server.app-permission-apply.applicant_list",
+    ),
     path(
         "<int:mcp_server_id>/",
         include(

--- a/src/dashboard/apigateway/apigateway/apis/web/mcp_server/views.py
+++ b/src/dashboard/apigateway/apigateway/apis/web/mcp_server/views.py
@@ -818,7 +818,16 @@ class MCPServerAppPermissionApplyListApi(generics.ListAPIView):
         tags=["WebAPI.MCPServer"],
     ),
 )
-class MCPServerAppPermissionApplyApplicantListApi(MCPServerAppPermissionApplyQuerySetMixin, generics.ListAPIView):
+class MCPServerAppPermissionApplyApplicantListApi(generics.ListAPIView):
+    def get_queryset(self):
+        queryset = MCPServerAppPermissionApply.objects.filter(
+            mcp_server__gateway=self.request.gateway,
+        )
+        mcp_server_id = self.kwargs.get("mcp_server_id")
+        if mcp_server_id is not None:
+            queryset = queryset.filter(mcp_server_id=mcp_server_id)
+        return queryset
+
     def list(self, request, *args, **kwargs):
         queryset = self.get_queryset()
         applied_by_list = list(queryset.values_list("applied_by", flat=True).distinct().order_by("applied_by"))

--- a/src/dashboard/apigateway/apigateway/apis/web/mcp_server/views.py
+++ b/src/dashboard/apigateway/apigateway/apis/web/mcp_server/views.py
@@ -669,10 +669,13 @@ class MCPServerAppPermissionQuerySetMixin:
 
 class MCPServerAppPermissionApplyQuerySetMixin:
     def get_queryset(self):
-        return MCPServerAppPermissionApply.objects.filter(
-            mcp_server_id=self.kwargs["mcp_server_id"],
+        queryset = MCPServerAppPermissionApply.objects.filter(
             mcp_server__gateway=self.request.gateway,
         )
+        mcp_server_id = self.kwargs.get("mcp_server_id")
+        if mcp_server_id is not None:
+            queryset = queryset.filter(mcp_server_id=mcp_server_id)
+        return queryset
 
 
 @method_decorator(
@@ -818,16 +821,7 @@ class MCPServerAppPermissionApplyListApi(generics.ListAPIView):
         tags=["WebAPI.MCPServer"],
     ),
 )
-class MCPServerAppPermissionApplyApplicantListApi(generics.ListAPIView):
-    def get_queryset(self):
-        queryset = MCPServerAppPermissionApply.objects.filter(
-            mcp_server__gateway=self.request.gateway,
-        )
-        mcp_server_id = self.kwargs.get("mcp_server_id")
-        if mcp_server_id is not None:
-            queryset = queryset.filter(mcp_server_id=mcp_server_id)
-        return queryset
-
+class MCPServerAppPermissionApplyApplicantListApi(MCPServerAppPermissionApplyQuerySetMixin, generics.ListAPIView):
     def list(self, request, *args, **kwargs):
         queryset = self.get_queryset()
         applied_by_list = list(queryset.values_list("applied_by", flat=True).distinct().order_by("applied_by"))

--- a/src/dashboard/apigateway/apigateway/tests/apis/web/mcp_server/test_views.py
+++ b/src/dashboard/apigateway/apigateway/tests/apis/web/mcp_server/test_views.py
@@ -1391,6 +1391,35 @@ class TestMCPServerAppPermissionApplyApplicantListApi:
         assert resp.status_code == 200
         assert len(result["data"]["applicants"]) == 2
 
+    def test_gateway_level_list(self, request_view, fake_gateway, fake_mcp_server):
+        G(
+            MCPServerAppPermissionApply,
+            mcp_server=fake_mcp_server,
+            bk_app_code="test-app",
+            applied_by="user1",
+            applied_time=now_datetime(),
+            status=MCPServerAppPermissionApplyStatusEnum.PENDING.value,
+        )
+        G(
+            MCPServerAppPermissionApply,
+            mcp_server=fake_mcp_server,
+            bk_app_code="test-app2",
+            applied_by="user2",
+            applied_time=now_datetime(),
+            status=MCPServerAppPermissionApplyStatusEnum.PENDING.value,
+        )
+
+        resp = request_view(
+            method="GET",
+            view_name="mcp_server.app-permission-apply.gateway_applicant_list",
+            path_params={"gateway_id": fake_gateway.id},
+            gateway=fake_gateway,
+        )
+        result = resp.json()
+
+        assert resp.status_code == 200
+        assert result["data"]["applicants"] == ["user1", "user2"]
+
 
 class TestMCPServerAppPermissionApplyUpdateStatusApi:
     def test_approve(self, mocker, request_view, fake_gateway, fake_mcp_server):


### PR DESCRIPTION
- 支持 MCP Server 权限审批申请人列表的网关级别查询，当 mcp_server_id 为 - 时返回网关下所有申请人。