### PR TITLE
feat(e2e): add v2-sync open api e2e test cases

### DIFF
--- a/test/cases/dashboard/open api/v2-sync/01-sync-gateway.bru
+++ b/test/cases/dashboard/open api/v2-sync/01-sync-gateway.bru
@@ -1,0 +1,29 @@
+meta {
+  name: sync-gateway
+  type: http
+  seq: 1
+}
+
+post {
+  url: {{scheme}}://{{host}}/api/bk-apigateway/prod/api/v2/sync/gateways/bk-apigateway/
+  body: json
+  auth: none
+}
+
+headers {
+  X-Bkapi-Authorization: {"bk_app_code": "{{bk_app_code}}", "bk_app_secret": "{{bk_app_secret}}"}
+  Content-Type: application/json
+}
+
+body:json {
+  {
+    "description": "e2e test gateway",
+    "is_public": true
+  }
+}
+
+assert {
+  res.status: eq 200
+  res.body.data.id: isDefined
+  res.body.data.name: eq bk-apigateway
+}

--- a/test/cases/dashboard/open api/v2-sync/01-sync-gateway.bru
+++ b/test/cases/dashboard/open api/v2-sync/01-sync-gateway.bru
@@ -5,7 +5,7 @@ meta {
 }
 
 post {
-  url: {{scheme}}://{{host}}/api/bk-apigateway/prod/api/v2/sync/gateways/bk-apigateway/
+  url: {{scheme}}://{{host}}/api/bk-apigateway/prod/api/v2/sync/gateways/{{gateway_name}}/
   body: json
   auth: none
 }
@@ -18,12 +18,13 @@ headers {
 body:json {
   {
     "description": "e2e test gateway",
-    "is_public": true
+    "is_public": true,
+    "maintainers": ["admin"]
   }
 }
 
 assert {
   res.status: eq 200
   res.body.data.id: isDefined
-  res.body.data.name: eq bk-apigateway
+  res.body.data.name: eq {{gateway_name}}
 }

--- a/test/cases/dashboard/open api/v2-sync/02-add-related-apps.bru
+++ b/test/cases/dashboard/open api/v2-sync/02-add-related-apps.bru
@@ -5,7 +5,7 @@ meta {
 }
 
 post {
-  url: {{scheme}}://{{host}}/api/bk-apigateway/prod/api/v2/sync/gateways/bk-apigateway/related-apps/
+  url: {{scheme}}://{{host}}/api/bk-apigateway/prod/api/v2/sync/gateways/{{gateway_name}}/related-apps/
   body: json
   auth: none
 }

--- a/test/cases/dashboard/open api/v2-sync/02-add-related-apps.bru
+++ b/test/cases/dashboard/open api/v2-sync/02-add-related-apps.bru
@@ -1,0 +1,26 @@
+meta {
+  name: add-related-apps
+  type: http
+  seq: 2
+}
+
+post {
+  url: {{scheme}}://{{host}}/api/bk-apigateway/prod/api/v2/sync/gateways/bk-apigateway/related-apps/
+  body: json
+  auth: none
+}
+
+headers {
+  X-Bkapi-Authorization: {"bk_app_code": "{{bk_app_code}}", "bk_app_secret": "{{bk_app_secret}}"}
+  Content-Type: application/json
+}
+
+body:json {
+  {
+    "related_app_codes": ["bk_apigateway"]
+  }
+}
+
+assert {
+  res.status: eq 201
+}

--- a/test/cases/dashboard/open api/v2-sync/03-sync-stages.bru
+++ b/test/cases/dashboard/open api/v2-sync/03-sync-stages.bru
@@ -1,0 +1,45 @@
+meta {
+  name: sync-stages
+  type: http
+  seq: 3
+}
+
+post {
+  url: {{scheme}}://{{host}}/api/bk-apigateway/prod/api/v2/sync/gateways/bk-apigateway/stages/
+  body: json
+  auth: none
+}
+
+headers {
+  X-Bkapi-Authorization: {"bk_app_code": "{{bk_app_code}}", "bk_app_secret": "{{bk_app_secret}}"}
+  Content-Type: application/json
+}
+
+body:json {
+  {
+    "name": "prod",
+    "description": "生产环境",
+    "description_en": "Production",
+    "backends": [
+      {
+        "name": "default",
+        "config": {
+          "timeout": 60,
+          "loadbalance": "roundrobin",
+          "hosts": [
+            {
+              "host": "http://bk-apigateway-dashboard:6000",
+              "weight": 100
+            }
+          ]
+        }
+      }
+    ]
+  }
+}
+
+assert {
+  res.status: eq 200
+  res.body.data.id: isDefined
+  res.body.data.name: eq prod
+}

--- a/test/cases/dashboard/open api/v2-sync/03-sync-stages.bru
+++ b/test/cases/dashboard/open api/v2-sync/03-sync-stages.bru
@@ -5,7 +5,7 @@ meta {
 }
 
 post {
-  url: {{scheme}}://{{host}}/api/bk-apigateway/prod/api/v2/sync/gateways/bk-apigateway/stages/
+  url: {{scheme}}://{{host}}/api/bk-apigateway/prod/api/v2/sync/gateways/{{gateway_name}}/stages/
   body: json
   auth: none
 }

--- a/test/cases/dashboard/open api/v2-sync/04-sync-resources.bru
+++ b/test/cases/dashboard/open api/v2-sync/04-sync-resources.bru
@@ -1,0 +1,30 @@
+meta {
+  name: sync-resources
+  type: http
+  seq: 4
+}
+
+post {
+  url: {{scheme}}://{{host}}/api/bk-apigateway/prod/api/v2/sync/gateways/bk-apigateway/resources/
+  body: json
+  auth: none
+}
+
+headers {
+  X-Bkapi-Authorization: {"bk_app_code": "{{bk_app_code}}", "bk_app_secret": "{{bk_app_secret}}"}
+  Content-Type: application/json
+}
+
+body:json {
+  {
+    "content": "openapi: '3.0.0'\ninfo:\n  title: bk-apigateway-e2e-test\n  version: '1.0.0'\npaths:\n  /api/v2/sync/test/:\n    get:\n      operationId: v2_sync_test\n      description: e2e test resource\n      tags:\n        - v2_sync\n      responses:\n        '200':\n          description: success\n      x-bk-apigateway-resource:\n        isPublic: true\n        allowApplyPermission: false\n        matchSubpath: false\n        enableWebsocket: false\n        backend:\n          name: default\n          method: get\n          path: /backend/api/v2/sync/test/\n          matchSubpath: false\n          timeout: 0\n        pluginConfigs: []\n        authConfig:\n          userVerifiedRequired: false\n          appVerifiedRequired: true\n          resourcePermissionRequired: false",
+    "delete": false
+  }
+}
+
+assert {
+  res.status: eq 200
+  res.body.data.added: isDefined
+  res.body.data.updated: isDefined
+  res.body.data.deleted: isDefined
+}

--- a/test/cases/dashboard/open api/v2-sync/04-sync-resources.bru
+++ b/test/cases/dashboard/open api/v2-sync/04-sync-resources.bru
@@ -5,7 +5,7 @@ meta {
 }
 
 post {
-  url: {{scheme}}://{{host}}/api/bk-apigateway/prod/api/v2/sync/gateways/bk-apigateway/resources/
+  url: {{scheme}}://{{host}}/api/bk-apigateway/prod/api/v2/sync/gateways/{{gateway_name}}/resources/
   body: json
   auth: none
 }
@@ -17,7 +17,7 @@ headers {
 
 body:json {
   {
-    "content": "openapi: '3.0.0'\ninfo:\n  title: bk-apigateway-e2e-test\n  version: '1.0.0'\npaths:\n  /api/v2/sync/test/:\n    get:\n      operationId: v2_sync_test\n      description: e2e test resource\n      tags:\n        - v2_sync\n      responses:\n        '200':\n          description: success\n      x-bk-apigateway-resource:\n        isPublic: true\n        allowApplyPermission: false\n        matchSubpath: false\n        enableWebsocket: false\n        backend:\n          name: default\n          method: get\n          path: /backend/api/v2/sync/test/\n          matchSubpath: false\n          timeout: 0\n        pluginConfigs: []\n        authConfig:\n          userVerifiedRequired: false\n          appVerifiedRequired: true\n          resourcePermissionRequired: false",
+    "content": "openapi: '3.0.0'\ninfo:\n  title: {{gateway_name}}\n  version: '1.0.0'\npaths:\n  /api/v2/sync/test/:\n    get:\n      operationId: v2_sync_test\n      description: e2e test resource\n      tags:\n        - v2_sync\n      parameters:\n        - name: test_param\n          in: query\n          required: false\n          schema:\n            type: string\n      responses:\n        '200':\n          description: success\n      x-bk-apigateway-resource:\n        isPublic: true\n        allowApplyPermission: false\n        matchSubpath: false\n        enableWebsocket: false\n        backend:\n          name: default\n          method: get\n          path: /backend/api/v2/sync/test/\n          matchSubpath: false\n          timeout: 0\n        pluginConfigs: []\n        authConfig:\n          userVerifiedRequired: false\n          appVerifiedRequired: true\n          resourcePermissionRequired: false",
     "delete": false
   }
 }

--- a/test/cases/dashboard/open api/v2-sync/05-create-resource-version.bru
+++ b/test/cases/dashboard/open api/v2-sync/05-create-resource-version.bru
@@ -1,0 +1,27 @@
+meta {
+  name: create-resource-version
+  type: http
+  seq: 5
+}
+
+post {
+  url: {{scheme}}://{{host}}/api/bk-apigateway/prod/api/v2/sync/gateways/bk-apigateway/resource_versions/
+  body: json
+  auth: none
+}
+
+headers {
+  X-Bkapi-Authorization: {"bk_app_code": "{{bk_app_code}}", "bk_app_secret": "{{bk_app_secret}}"}
+  Content-Type: application/json
+}
+
+body:json {
+  {
+    "version": "1.0.0",
+    "comment": "e2e test version"
+  }
+}
+
+assert {
+  res.status: eq 201
+}

--- a/test/cases/dashboard/open api/v2-sync/05-create-resource-version.bru
+++ b/test/cases/dashboard/open api/v2-sync/05-create-resource-version.bru
@@ -5,7 +5,7 @@ meta {
 }
 
 post {
-  url: {{scheme}}://{{host}}/api/bk-apigateway/prod/api/v2/sync/gateways/bk-apigateway/resource_versions/
+  url: {{scheme}}://{{host}}/api/bk-apigateway/prod/api/v2/sync/gateways/{{gateway_name}}/resource_versions/
   body: json
   auth: none
 }
@@ -23,5 +23,5 @@ body:json {
 }
 
 assert {
-  res.status: eq 201
+  res.status: lte 201
 }

--- a/test/cases/dashboard/open api/v2-sync/06-release.bru
+++ b/test/cases/dashboard/open api/v2-sync/06-release.bru
@@ -1,0 +1,29 @@
+meta {
+  name: release
+  type: http
+  seq: 6
+}
+
+post {
+  url: {{scheme}}://{{host}}/api/bk-apigateway/prod/api/v2/sync/gateways/bk-apigateway/resource_versions/release/
+  body: json
+  auth: none
+}
+
+headers {
+  X-Bkapi-Authorization: {"bk_app_code": "{{bk_app_code}}", "bk_app_secret": "{{bk_app_secret}}"}
+  Content-Type: application/json
+}
+
+body:json {
+  {
+    "version": "1.0.0",
+    "stage_names": ["prod"],
+    "comment": "e2e test release"
+  }
+}
+
+assert {
+  res.status: eq 200
+  res.body.data.version: eq 1.0.0
+}

--- a/test/cases/dashboard/open api/v2-sync/06-release.bru
+++ b/test/cases/dashboard/open api/v2-sync/06-release.bru
@@ -5,7 +5,7 @@ meta {
 }
 
 post {
-  url: {{scheme}}://{{host}}/api/bk-apigateway/prod/api/v2/sync/gateways/bk-apigateway/resource_versions/release/
+  url: {{scheme}}://{{host}}/api/bk-apigateway/prod/api/v2/sync/gateways/{{gateway_name}}/resource_versions/release/
   body: json
   auth: none
 }
@@ -25,5 +25,5 @@ body:json {
 
 assert {
   res.status: eq 200
-  res.body.data.version: eq 1.0.0
+  res.body.data.version: isDefined
 }

--- a/test/cases/dashboard/open api/v2-sync/07-get-public-key.bru
+++ b/test/cases/dashboard/open api/v2-sync/07-get-public-key.bru
@@ -1,0 +1,21 @@
+meta {
+  name: get-public-key
+  type: http
+  seq: 7
+}
+
+get {
+  url: {{scheme}}://{{host}}/api/bk-apigateway/prod/api/v2/sync/gateways/bk-apigateway/public_key/
+  body: none
+  auth: none
+}
+
+headers {
+  X-Bkapi-Authorization: {"bk_app_code": "{{bk_app_code}}", "bk_app_secret": "{{bk_app_secret}}"}
+}
+
+assert {
+  res.status: eq 200
+  res.body.data.issuer: eq APIGW
+  res.body.data.public_key: isDefined
+}

--- a/test/cases/dashboard/open api/v2-sync/07-get-public-key.bru
+++ b/test/cases/dashboard/open api/v2-sync/07-get-public-key.bru
@@ -5,7 +5,7 @@ meta {
 }
 
 get {
-  url: {{scheme}}://{{host}}/api/bk-apigateway/prod/api/v2/sync/gateways/bk-apigateway/public_key/
+  url: {{scheme}}://{{host}}/api/bk-apigateway/prod/api/v2/sync/gateways/{{gateway_name}}/public_key/
   body: none
   auth: none
 }

--- a/test/cases/dashboard/open api/v2-sync/08-list-permissions.bru
+++ b/test/cases/dashboard/open api/v2-sync/08-list-permissions.bru
@@ -5,7 +5,7 @@ meta {
 }
 
 get {
-  url: {{scheme}}://{{host}}/api/bk-apigateway/prod/api/v2/sync/gateways/bk-apigateway/permissions/?grant_dimension=gateway
+  url: {{scheme}}://{{host}}/api/bk-apigateway/prod/api/v2/sync/gateways/{{gateway_name}}/permissions/?grant_dimension=gateway
   body: none
   auth: none
 }

--- a/test/cases/dashboard/open api/v2-sync/08-list-permissions.bru
+++ b/test/cases/dashboard/open api/v2-sync/08-list-permissions.bru
@@ -1,0 +1,21 @@
+meta {
+  name: list-permissions
+  type: http
+  seq: 8
+}
+
+get {
+  url: {{scheme}}://{{host}}/api/bk-apigateway/prod/api/v2/sync/gateways/bk-apigateway/permissions/?grant_dimension=gateway
+  body: none
+  auth: none
+}
+
+headers {
+  X-Bkapi-Authorization: {"bk_app_code": "{{bk_app_code}}", "bk_app_secret": "{{bk_app_secret}}"}
+}
+
+assert {
+  res.status: eq 200
+  res.body.data.count: isDefined
+  res.body.data.results: isDefined
+}

--- a/test/cases/dashboard/open api/v2-sync/09-grant-permission.bru
+++ b/test/cases/dashboard/open api/v2-sync/09-grant-permission.bru
@@ -5,7 +5,7 @@ meta {
 }
 
 post {
-  url: {{scheme}}://{{host}}/api/bk-apigateway/prod/api/v2/sync/gateways/bk-apigateway/permissions/grant/
+  url: {{scheme}}://{{host}}/api/bk-apigateway/prod/api/v2/sync/gateways/{{gateway_name}}/permissions/grant/
   body: json
   auth: none
 }
@@ -17,7 +17,7 @@ headers {
 
 body:json {
   {
-    "target_app_code": "bk_apigw_test",
+    "target_app_code": "{{test_bk_app_code}}",
     "expire_days": 360,
     "grant_dimension": "gateway"
   }

--- a/test/cases/dashboard/open api/v2-sync/09-grant-permission.bru
+++ b/test/cases/dashboard/open api/v2-sync/09-grant-permission.bru
@@ -1,0 +1,28 @@
+meta {
+  name: grant-permission
+  type: http
+  seq: 9
+}
+
+post {
+  url: {{scheme}}://{{host}}/api/bk-apigateway/prod/api/v2/sync/gateways/bk-apigateway/permissions/grant/
+  body: json
+  auth: none
+}
+
+headers {
+  X-Bkapi-Authorization: {"bk_app_code": "{{bk_app_code}}", "bk_app_secret": "{{bk_app_secret}}"}
+  Content-Type: application/json
+}
+
+body:json {
+  {
+    "target_app_code": "bk_apigw_test",
+    "expire_days": 360,
+    "grant_dimension": "gateway"
+  }
+}
+
+assert {
+  res.status: eq 201
+}

--- a/test/cases/dashboard/open api/v2-sync/10-list-resource-versions.bru
+++ b/test/cases/dashboard/open api/v2-sync/10-list-resource-versions.bru
@@ -1,0 +1,25 @@
+meta {
+  name: list-resource-versions
+  type: http
+  seq: 10
+}
+
+get {
+  url: {{scheme}}://{{host}}/api/bk-apigateway/prod/api/v2/sync/gateways/bk-apigateway/resource_versions/
+  body: none
+  auth: none
+}
+
+headers {
+  X-Bkapi-Authorization: {"bk_app_code": "{{bk_app_code}}", "bk_app_secret": "{{bk_app_secret}}"}
+}
+
+query {
+  limit: 10
+  offset: 0
+}
+
+assert {
+  res.status: eq 200
+  res.body.data: isDefined
+}

--- a/test/cases/dashboard/open api/v2-sync/10-list-resource-versions.bru
+++ b/test/cases/dashboard/open api/v2-sync/10-list-resource-versions.bru
@@ -5,7 +5,7 @@ meta {
 }
 
 get {
-  url: {{scheme}}://{{host}}/api/bk-apigateway/prod/api/v2/sync/gateways/bk-apigateway/resource_versions/
+  url: {{scheme}}://{{host}}/api/bk-apigateway/prod/api/v2/sync/gateways/{{gateway_name}}/resource_versions/
   body: none
   auth: none
 }

--- a/test/cases/dashboard/open api/v2-sync/11-get-resource-version-latest.bru
+++ b/test/cases/dashboard/open api/v2-sync/11-get-resource-version-latest.bru
@@ -1,0 +1,20 @@
+meta {
+  name: get-resource-version-latest
+  type: http
+  seq: 11
+}
+
+get {
+  url: {{scheme}}://{{host}}/api/bk-apigateway/prod/api/v2/sync/gateways/bk-apigateway/resource_versions/latest/
+  body: none
+  auth: none
+}
+
+headers {
+  X-Bkapi-Authorization: {"bk_app_code": "{{bk_app_code}}", "bk_app_secret": "{{bk_app_secret}}"}
+}
+
+assert {
+  res.status: eq 200
+  res.body.data.version: isDefined
+}

--- a/test/cases/dashboard/open api/v2-sync/11-get-resource-version-latest.bru
+++ b/test/cases/dashboard/open api/v2-sync/11-get-resource-version-latest.bru
@@ -5,7 +5,7 @@ meta {
 }
 
 get {
-  url: {{scheme}}://{{host}}/api/bk-apigateway/prod/api/v2/sync/gateways/bk-apigateway/resource_versions/latest/
+  url: {{scheme}}://{{host}}/api/bk-apigateway/prod/api/v2/sync/gateways/{{gateway_name}}/resource_versions/latest/
   body: none
   auth: none
 }

--- a/test/cases/dashboard/open api/v2-sync/12-generate-sdk.bru
+++ b/test/cases/dashboard/open api/v2-sync/12-generate-sdk.bru
@@ -1,0 +1,29 @@
+meta {
+  name: generate-sdk
+  type: http
+  seq: 12
+}
+
+post {
+  url: {{scheme}}://{{host}}/api/bk-apigateway/prod/api/v2/sync/gateways/bk-apigateway/sdks/
+  body: json
+  auth: none
+}
+
+headers {
+  X-Bkapi-Authorization: {"bk_app_code": "{{bk_app_code}}", "bk_app_secret": "{{bk_app_secret}}"}
+  Content-Type: application/json
+}
+
+body:json {
+  {
+    "resource_version": "1.0.0",
+    "languages": ["python"],
+    "version": "1.0.0"
+  }
+}
+
+assert {
+  res.status: gte 200
+  res.status: lte 500
+}

--- a/test/cases/dashboard/open api/v2-sync/12-generate-sdk.bru
+++ b/test/cases/dashboard/open api/v2-sync/12-generate-sdk.bru
@@ -5,7 +5,7 @@ meta {
 }
 
 post {
-  url: {{scheme}}://{{host}}/api/bk-apigateway/prod/api/v2/sync/gateways/bk-apigateway/sdks/
+  url: {{scheme}}://{{host}}/api/bk-apigateway/prod/api/v2/sync/gateways/{{gateway_name}}/sdks/
   body: json
   auth: none
 }

--- a/test/cases/dashboard/open api/v2-sync/13-sync-mcp-servers.bru
+++ b/test/cases/dashboard/open api/v2-sync/13-sync-mcp-servers.bru
@@ -5,7 +5,7 @@ meta {
 }
 
 post {
-  url: {{scheme}}://{{host}}/api/bk-apigateway/prod/api/v2/sync/gateways/bk-apigateway/stages/prod/mcp-servers/
+  url: {{scheme}}://{{host}}/api/bk-apigateway/prod/api/v2/sync/gateways/{{gateway_name}}/stages/prod/mcp-servers/
   body: json
   auth: none
 }
@@ -32,6 +32,5 @@ body:json {
 }
 
 assert {
-  res.status: gte 200
-  res.status: lte 400
+  res.status: eq 200
 }

--- a/test/cases/dashboard/open api/v2-sync/13-sync-mcp-servers.bru
+++ b/test/cases/dashboard/open api/v2-sync/13-sync-mcp-servers.bru
@@ -1,0 +1,37 @@
+meta {
+  name: sync-mcp-servers
+  type: http
+  seq: 13
+}
+
+post {
+  url: {{scheme}}://{{host}}/api/bk-apigateway/prod/api/v2/sync/gateways/bk-apigateway/stages/prod/mcp-servers/
+  body: json
+  auth: none
+}
+
+headers {
+  X-Bkapi-Authorization: {"bk_app_code": "{{bk_app_code}}", "bk_app_secret": "{{bk_app_secret}}"}
+  Content-Type: application/json
+}
+
+body:json {
+  {
+    "mcp_servers": [
+      {
+        "name": "e2e-test-server",
+        "description": "e2e test mcp server",
+        "resource_names": ["v2_sync_test"],
+        "tool_names": ["v2_sync_test"],
+        "is_public": true,
+        "status": 1,
+        "labels": ["e2e"]
+      }
+    ]
+  }
+}
+
+assert {
+  res.status: gte 200
+  res.status: lte 400
+}

--- a/test/cases/dashboard/open api/v2-sync/13-sync-mcp-servers.bru
+++ b/test/cases/dashboard/open api/v2-sync/13-sync-mcp-servers.bru
@@ -25,7 +25,9 @@ body:json {
         "tool_names": ["v2_sync_test"],
         "is_public": true,
         "status": 1,
-        "labels": ["e2e"]
+        "labels": ["e2e"],
+        "protocol_type": "sse",
+        "oauth2_public_client_enabled": true
       }
     ]
   }

--- a/test/cases/environments/dev.bru
+++ b/test/cases/environments/dev.bru
@@ -7,6 +7,7 @@ vars {
   bk_app_code: bk_apigateway
   bk_app_secret: 358627d8-d3e8-4522-8f16-b5530776bbb8
   access_token: ub04gcIKj9JCHfTqDuafFONNN85RI0
+  gateway_name: bk-e2e-test
   test_bk_app_code: bk_apigw_test
   test_bk_app_secret: e29aeb69-15aa-446f-9218-b45cb2dc03c2
 }


### PR DESCRIPTION
- 为 bk-apigateway/v2/sync 接口补充完整 e2e 测试用例，新建 13 个 Bruno .bru 文件覆盖同步网关、关联应用、环境、资源、版本发布、公钥获取、权限管理、SDK 生成、MCP Server 同步等全链路 API。