### PR TITLE
feat(e2e): add v2 open api e2e test cases

### DIFF
--- a/test/cases/dashboard/open api/v2-open/01-gateway-list.bru
+++ b/test/cases/dashboard/open api/v2-open/01-gateway-list.bru
@@ -1,0 +1,20 @@
+meta {
+  name: openapi-v2-gateway-list
+  type: http
+  seq: 1
+}
+
+get {
+  url: {{scheme}}://{{host}}/backend/api/v2/open/gateways/
+  body: none
+  auth: none
+}
+
+headers {
+  X-Bkapi-Authorization: {"bk_app_code": "{{bk_app_code}}", "bk_app_secret": "{{bk_app_secret}}"}
+}
+
+assert {
+  res.status: eq 200
+  res.body.data: isDefined
+}

--- a/test/cases/dashboard/open api/v2-open/01-gateway-list.bru
+++ b/test/cases/dashboard/open api/v2-open/01-gateway-list.bru
@@ -5,7 +5,7 @@ meta {
 }
 
 get {
-  url: {{scheme}}://{{host}}/backend/api/v2/open/gateways/
+  url: {{scheme}}://{{host}}/api/{{gateway_name}}/prod/api/v2/open/gateways/
   body: none
   auth: none
 }

--- a/test/cases/dashboard/open api/v2-open/01-gateway-list.bru
+++ b/test/cases/dashboard/open api/v2-open/01-gateway-list.bru
@@ -5,7 +5,7 @@ meta {
 }
 
 get {
-  url: {{scheme}}://{{host}}/api/{{gateway_name}}/prod/api/v2/open/gateways/
+  url: {{scheme}}://{{host}}/api/bk-apigateway/prod/api/v2/open/gateways/
   body: none
   auth: none
 }

--- a/test/cases/dashboard/open api/v2-open/02-gateway-batch-query.bru
+++ b/test/cases/dashboard/open api/v2-open/02-gateway-batch-query.bru
@@ -5,7 +5,7 @@ meta {
 }
 
 post {
-  url: {{scheme}}://{{host}}/backend/api/v2/open/gateways/batch-query/
+  url: {{scheme}}://{{host}}/api/{{gateway_name}}/prod/api/v2/open/gateways/batch-query/
   body: json
   auth: none
 }

--- a/test/cases/dashboard/open api/v2-open/02-gateway-batch-query.bru
+++ b/test/cases/dashboard/open api/v2-open/02-gateway-batch-query.bru
@@ -5,7 +5,7 @@ meta {
 }
 
 post {
-  url: {{scheme}}://{{host}}/api/{{gateway_name}}/prod/api/v2/open/gateways/batch-query/
+  url: {{scheme}}://{{host}}/api/bk-apigateway/prod/api/v2/open/gateways/batch-query/
   body: json
   auth: none
 }

--- a/test/cases/dashboard/open api/v2-open/02-gateway-batch-query.bru
+++ b/test/cases/dashboard/open api/v2-open/02-gateway-batch-query.bru
@@ -1,0 +1,28 @@
+meta {
+  name: openapi-v2-gateway-batch-query
+  type: http
+  seq: 2
+}
+
+post {
+  url: {{scheme}}://{{host}}/backend/api/v2/open/gateways/batch-query/
+  body: json
+  auth: none
+}
+
+headers {
+  Content-Type: application/json
+  X-Bkapi-Authorization: {"bk_app_code": "{{bk_app_code}}", "bk_app_secret": "{{bk_app_secret}}"}
+}
+
+body:json {
+  {
+    "names": ["{{gateway_name}}"],
+    "fields": "id,name,description"
+  }
+}
+
+assert {
+  res.status: eq 200
+  res.body.data: isDefined
+}

--- a/test/cases/dashboard/open api/v2-open/03-gateway-retrieve.bru
+++ b/test/cases/dashboard/open api/v2-open/03-gateway-retrieve.bru
@@ -1,0 +1,24 @@
+meta {
+  name: openapi-v2-gateway-retrieve
+  type: http
+  seq: 3
+}
+
+get {
+  url: {{scheme}}://{{host}}/backend/api/v2/open/gateways/{{gateway_name}}/
+  body: none
+  auth: none
+}
+
+headers {
+  X-Bkapi-Authorization: {"bk_app_code": "{{bk_app_code}}", "bk_app_secret": "{{bk_app_secret}}"}
+}
+
+assert {
+  res.status: eq 200
+  res.body.data.id: isDefined
+  res.body.data.name: isDefined
+  res.body.data.description: isDefined
+  res.body.data.maintainers: isDefined
+  res.body.data.doc_maintainers: isDefined
+}

--- a/test/cases/dashboard/open api/v2-open/03-gateway-retrieve.bru
+++ b/test/cases/dashboard/open api/v2-open/03-gateway-retrieve.bru
@@ -5,7 +5,7 @@ meta {
 }
 
 get {
-  url: {{scheme}}://{{host}}/api/{{gateway_name}}/prod/api/v2/open/gateways/{{gateway_name}}/
+  url: {{scheme}}://{{host}}/api/bk-apigateway/prod/api/v2/open/gateways/{{gateway_name}}/
   body: none
   auth: none
 }

--- a/test/cases/dashboard/open api/v2-open/03-gateway-retrieve.bru
+++ b/test/cases/dashboard/open api/v2-open/03-gateway-retrieve.bru
@@ -5,7 +5,7 @@ meta {
 }
 
 get {
-  url: {{scheme}}://{{host}}/backend/api/v2/open/gateways/{{gateway_name}}/
+  url: {{scheme}}://{{host}}/api/{{gateway_name}}/prod/api/v2/open/gateways/{{gateway_name}}/
   body: none
   auth: none
 }

--- a/test/cases/dashboard/open api/v2-open/04-gateway-resources-list.bru
+++ b/test/cases/dashboard/open api/v2-open/04-gateway-resources-list.bru
@@ -23,5 +23,7 @@ script:post-response {
   const data = res.body.data;
   if (Array.isArray(data) && data.length > 0) {
     bru.setVar('resource_name', data[0].name);
+  } else {
+    throw new Error('No gateway resources found, cannot set resource_name for downstream tests');
   }
 }

--- a/test/cases/dashboard/open api/v2-open/04-gateway-resources-list.bru
+++ b/test/cases/dashboard/open api/v2-open/04-gateway-resources-list.bru
@@ -5,7 +5,7 @@ meta {
 }
 
 get {
-  url: {{scheme}}://{{host}}/api/{{gateway_name}}/prod/api/v2/open/gateways/{{gateway_name}}/resources/?fields=id,name,method,path
+  url: {{scheme}}://{{host}}/api/bk-apigateway/prod/api/v2/open/gateways/{{gateway_name}}/resources/?fields=id,name,method,path
   body: none
   auth: none
 }

--- a/test/cases/dashboard/open api/v2-open/04-gateway-resources-list.bru
+++ b/test/cases/dashboard/open api/v2-open/04-gateway-resources-list.bru
@@ -1,0 +1,27 @@
+meta {
+  name: openapi-v2-gateway-resources-list
+  type: http
+  seq: 4
+}
+
+get {
+  url: {{scheme}}://{{host}}/backend/api/v2/open/gateways/{{gateway_name}}/resources/?fields=id,name,method,path
+  body: none
+  auth: none
+}
+
+headers {
+  X-Bkapi-Authorization: {"bk_app_code": "{{bk_app_code}}", "bk_app_secret": "{{bk_app_secret}}"}
+}
+
+assert {
+  res.status: eq 200
+  res.body.data: isDefined
+}
+
+script:post-response {
+  const data = res.body.data;
+  if (Array.isArray(data) && data.length > 0) {
+    bru.setVar('resource_name', data[0].name);
+  }
+}

--- a/test/cases/dashboard/open api/v2-open/04-gateway-resources-list.bru
+++ b/test/cases/dashboard/open api/v2-open/04-gateway-resources-list.bru
@@ -5,7 +5,7 @@ meta {
 }
 
 get {
-  url: {{scheme}}://{{host}}/backend/api/v2/open/gateways/{{gateway_name}}/resources/?fields=id,name,method,path
+  url: {{scheme}}://{{host}}/api/{{gateway_name}}/prod/api/v2/open/gateways/{{gateway_name}}/resources/?fields=id,name,method,path
   body: none
   auth: none
 }

--- a/test/cases/dashboard/open api/v2-open/05-gateway-resource-detail.bru
+++ b/test/cases/dashboard/open api/v2-open/05-gateway-resource-detail.bru
@@ -5,7 +5,7 @@ meta {
 }
 
 get {
-  url: {{scheme}}://{{host}}/api/{{gateway_name}}/prod/api/v2/open/gateways/{{gateway_name}}/resources/{{resource_name}}/?stage_name=prod
+  url: {{scheme}}://{{host}}/api/bk-apigateway/prod/api/v2/open/gateways/{{gateway_name}}/resources/{{resource_name}}/?stage_name=prod
   body: none
   auth: none
 }

--- a/test/cases/dashboard/open api/v2-open/05-gateway-resource-detail.bru
+++ b/test/cases/dashboard/open api/v2-open/05-gateway-resource-detail.bru
@@ -1,0 +1,26 @@
+meta {
+  name: openapi-v2-gateway-resource-detail
+  type: http
+  seq: 5
+}
+
+get {
+  url: {{scheme}}://{{host}}/backend/api/v2/open/gateways/{{gateway_name}}/resources/{{resource_name}}/?stage_name=prod
+  body: none
+  auth: none
+}
+
+headers {
+  X-Bkapi-Authorization: {"bk_app_code": "{{bk_app_code}}", "bk_app_secret": "{{bk_app_secret}}"}
+}
+
+assert {
+  res.status: eq 200
+  res.body.data.id: isDefined
+  res.body.data.name: isDefined
+  res.body.data.description: isDefined
+  res.body.data.method: isDefined
+  res.body.data.path: isDefined
+  res.body.data.schema: isDefined
+  res.body.data.auth_config: isDefined
+}

--- a/test/cases/dashboard/open api/v2-open/05-gateway-resource-detail.bru
+++ b/test/cases/dashboard/open api/v2-open/05-gateway-resource-detail.bru
@@ -5,7 +5,7 @@ meta {
 }
 
 get {
-  url: {{scheme}}://{{host}}/backend/api/v2/open/gateways/{{gateway_name}}/resources/{{resource_name}}/?stage_name=prod
+  url: {{scheme}}://{{host}}/api/{{gateway_name}}/prod/api/v2/open/gateways/{{gateway_name}}/resources/{{resource_name}}/?stage_name=prod
   body: none
   auth: none
 }

--- a/test/cases/dashboard/open api/v2-open/06-gateway-resource-info.bru
+++ b/test/cases/dashboard/open api/v2-open/06-gateway-resource-info.bru
@@ -1,0 +1,26 @@
+meta {
+  name: openapi-v2-gateway-resource-info
+  type: http
+  seq: 6
+}
+
+get {
+  url: {{scheme}}://{{host}}/backend/api/v2/open/gateways/{{gateway_name}}/resources/{{resource_name}}/info/
+  body: none
+  auth: none
+}
+
+headers {
+  X-Bkapi-Authorization: {"bk_app_code": "{{bk_app_code}}", "bk_app_secret": "{{bk_app_secret}}"}
+}
+
+assert {
+  res.status: eq 200
+  res.body.data.id: isDefined
+  res.body.data.name: isDefined
+  res.body.data.description: isDefined
+  res.body.data.method: isDefined
+  res.body.data.path: isDefined
+  res.body.data.match_subpath: isDefined
+  res.body.data.is_public: isDefined
+}

--- a/test/cases/dashboard/open api/v2-open/06-gateway-resource-info.bru
+++ b/test/cases/dashboard/open api/v2-open/06-gateway-resource-info.bru
@@ -5,7 +5,7 @@ meta {
 }
 
 get {
-  url: {{scheme}}://{{host}}/api/{{gateway_name}}/prod/api/v2/open/gateways/{{gateway_name}}/resources/{{resource_name}}/info/
+  url: {{scheme}}://{{host}}/api/bk-apigateway/prod/api/v2/open/gateways/{{gateway_name}}/resources/{{resource_name}}/info/
   body: none
   auth: none
 }

--- a/test/cases/dashboard/open api/v2-open/06-gateway-resource-info.bru
+++ b/test/cases/dashboard/open api/v2-open/06-gateway-resource-info.bru
@@ -5,7 +5,7 @@ meta {
 }
 
 get {
-  url: {{scheme}}://{{host}}/backend/api/v2/open/gateways/{{gateway_name}}/resources/{{resource_name}}/info/
+  url: {{scheme}}://{{host}}/api/{{gateway_name}}/prod/api/v2/open/gateways/{{gateway_name}}/resources/{{resource_name}}/info/
   body: none
   auth: none
 }

--- a/test/cases/dashboard/open api/v2-open/07-mcp-server-list.bru
+++ b/test/cases/dashboard/open api/v2-open/07-mcp-server-list.bru
@@ -1,11 +1,11 @@
 meta {
   name: openapi-v2-mcp-server-list
   type: http
-  seq: 8
+  seq: 7
 }
 
 get {
-  url: {{scheme}}://{{host}}/backend/api/v2/open/mcp-servers/
+  url: {{scheme}}://{{host}}/api/{{gateway_name}}/prod/api/v2/open/mcp-servers/
   body: none
   auth: none
 }

--- a/test/cases/dashboard/open api/v2-open/07-mcp-server-list.bru
+++ b/test/cases/dashboard/open api/v2-open/07-mcp-server-list.bru
@@ -5,7 +5,7 @@ meta {
 }
 
 get {
-  url: {{scheme}}://{{host}}/api/{{gateway_name}}/prod/api/v2/open/mcp-servers/
+  url: {{scheme}}://{{host}}/api/bk-apigateway/prod/api/v2/open/mcp-servers/
   body: none
   auth: none
 }

--- a/test/cases/dashboard/open api/v2-open/07-mcp-server-list.bru
+++ b/test/cases/dashboard/open api/v2-open/07-mcp-server-list.bru
@@ -1,0 +1,28 @@
+meta {
+  name: openapi-v2-mcp-server-list
+  type: http
+  seq: 8
+}
+
+get {
+  url: {{scheme}}://{{host}}/backend/api/v2/open/mcp-servers/
+  body: none
+  auth: none
+}
+
+headers {
+  X-Bkapi-Authorization: {"bk_app_code": "{{bk_app_code}}", "bk_app_secret": "{{bk_app_secret}}"}
+}
+
+assert {
+  res.status: eq 200
+  res.body.data.count: isDefined
+  res.body.data.results: isDefined
+}
+
+script:post-response {
+  const results = res.body.data.results;
+  if (Array.isArray(results) && results.length > 0) {
+    bru.setVar('mcp_server_id', results[0].id);
+  }
+}

--- a/test/cases/dashboard/open api/v2-open/07-mcp-server-list.bru
+++ b/test/cases/dashboard/open api/v2-open/07-mcp-server-list.bru
@@ -24,5 +24,7 @@ script:post-response {
   const results = res.body.data.results;
   if (Array.isArray(results) && results.length > 0) {
     bru.setVar('mcp_server_id', results[0].id);
+  } else {
+    throw new Error('No MCP servers found, cannot set mcp_server_id for downstream tests');
   }
 }

--- a/test/cases/dashboard/open api/v2-open/08-mcp-server-categories-list.bru
+++ b/test/cases/dashboard/open api/v2-open/08-mcp-server-categories-list.bru
@@ -5,7 +5,7 @@ meta {
 }
 
 get {
-  url: {{scheme}}://{{host}}/api/{{gateway_name}}/prod/api/v2/open/mcp-servers/categories/
+  url: {{scheme}}://{{host}}/api/bk-apigateway/prod/api/v2/open/mcp-servers/categories/
   body: none
   auth: none
 }

--- a/test/cases/dashboard/open api/v2-open/08-mcp-server-categories-list.bru
+++ b/test/cases/dashboard/open api/v2-open/08-mcp-server-categories-list.bru
@@ -1,11 +1,11 @@
 meta {
   name: openapi-v2-mcp-server-categories-list
   type: http
-  seq: 9
+  seq: 8
 }
 
 get {
-  url: {{scheme}}://{{host}}/backend/api/v2/open/mcp-servers/categories/
+  url: {{scheme}}://{{host}}/api/{{gateway_name}}/prod/api/v2/open/mcp-servers/categories/
   body: none
   auth: none
 }

--- a/test/cases/dashboard/open api/v2-open/08-mcp-server-categories-list.bru
+++ b/test/cases/dashboard/open api/v2-open/08-mcp-server-categories-list.bru
@@ -1,0 +1,20 @@
+meta {
+  name: openapi-v2-mcp-server-categories-list
+  type: http
+  seq: 9
+}
+
+get {
+  url: {{scheme}}://{{host}}/backend/api/v2/open/mcp-servers/categories/
+  body: none
+  auth: none
+}
+
+headers {
+  X-Bkapi-Authorization: {"bk_app_code": "{{bk_app_code}}", "bk_app_secret": "{{bk_app_secret}}"}
+}
+
+assert {
+  res.status: eq 200
+  res.body.data: isDefined
+}

--- a/test/cases/dashboard/open api/v2-open/09-mcp-server-batch-query.bru
+++ b/test/cases/dashboard/open api/v2-open/09-mcp-server-batch-query.bru
@@ -1,11 +1,11 @@
 meta {
   name: openapi-v2-mcp-server-batch-query
   type: http
-  seq: 10
+  seq: 9
 }
 
 post {
-  url: {{scheme}}://{{host}}/backend/api/v2/open/mcp-servers/batch-query/
+  url: {{scheme}}://{{host}}/api/{{gateway_name}}/prod/api/v2/open/mcp-servers/batch-query/
   body: json
   auth: none
 }

--- a/test/cases/dashboard/open api/v2-open/09-mcp-server-batch-query.bru
+++ b/test/cases/dashboard/open api/v2-open/09-mcp-server-batch-query.bru
@@ -1,0 +1,28 @@
+meta {
+  name: openapi-v2-mcp-server-batch-query
+  type: http
+  seq: 10
+}
+
+post {
+  url: {{scheme}}://{{host}}/backend/api/v2/open/mcp-servers/batch-query/
+  body: json
+  auth: none
+}
+
+headers {
+  Content-Type: application/json
+  X-Bkapi-Authorization: {"bk_app_code": "{{bk_app_code}}", "bk_app_secret": "{{bk_app_secret}}"}
+}
+
+body:json {
+  {
+    "ids": [{{mcp_server_id}}],
+    "fields": "id,name,title,description,categories"
+  }
+}
+
+assert {
+  res.status: eq 200
+  res.body.data: isDefined
+}

--- a/test/cases/dashboard/open api/v2-open/09-mcp-server-batch-query.bru
+++ b/test/cases/dashboard/open api/v2-open/09-mcp-server-batch-query.bru
@@ -5,7 +5,7 @@ meta {
 }
 
 post {
-  url: {{scheme}}://{{host}}/api/{{gateway_name}}/prod/api/v2/open/mcp-servers/batch-query/
+  url: {{scheme}}://{{host}}/api/bk-apigateway/prod/api/v2/open/mcp-servers/batch-query/
   body: json
   auth: none
 }

--- a/test/cases/dashboard/open api/v2-open/10-mcp-server-retrieve.bru
+++ b/test/cases/dashboard/open api/v2-open/10-mcp-server-retrieve.bru
@@ -1,0 +1,33 @@
+meta {
+  name: openapi-v2-mcp-server-retrieve
+  type: http
+  seq: 11
+}
+
+get {
+  url: {{scheme}}://{{host}}/backend/api/v2/open/mcp-servers/{{mcp_server_id}}/
+  body: none
+  auth: none
+}
+
+headers {
+  X-Bkapi-Authorization: {"bk_app_code": "{{bk_app_code}}", "bk_app_secret": "{{bk_app_secret}}"}
+}
+
+assert {
+  res.status: eq 200
+  res.body.data.id: isDefined
+  res.body.data.name: isDefined
+  res.body.data.title: isDefined
+  res.body.data.description: isDefined
+  res.body.data.is_public: isDefined
+  res.body.data.status: isDefined
+  res.body.data.protocol_type: isDefined
+  res.body.data.oauth2_public_client_enabled: isDefined
+  res.body.data.url: isDefined
+  res.body.data.guideline: isDefined
+  res.body.data.tools: isDefined
+  res.body.data.maintainers: isDefined
+  res.body.data.updated_time: isDefined
+  res.body.data.created_time: isDefined
+}

--- a/test/cases/dashboard/open api/v2-open/10-mcp-server-retrieve.bru
+++ b/test/cases/dashboard/open api/v2-open/10-mcp-server-retrieve.bru
@@ -5,7 +5,7 @@ meta {
 }
 
 get {
-  url: {{scheme}}://{{host}}/api/{{gateway_name}}/prod/api/v2/open/mcp-servers/{{mcp_server_id}}/
+  url: {{scheme}}://{{host}}/api/bk-apigateway/prod/api/v2/open/mcp-servers/{{mcp_server_id}}/
   body: none
   auth: none
 }

--- a/test/cases/dashboard/open api/v2-open/10-mcp-server-retrieve.bru
+++ b/test/cases/dashboard/open api/v2-open/10-mcp-server-retrieve.bru
@@ -1,17 +1,17 @@
 meta {
   name: openapi-v2-mcp-server-retrieve
   type: http
-  seq: 11
+  seq: 10
 }
 
 get {
-  url: {{scheme}}://{{host}}/backend/api/v2/open/mcp-servers/{{mcp_server_id}}/
+  url: {{scheme}}://{{host}}/api/{{gateway_name}}/prod/api/v2/open/mcp-servers/{{mcp_server_id}}/
   body: none
   auth: none
 }
 
 headers {
-  X-Bkapi-Authorization: {"bk_app_code": "{{bk_app_code}}", "bk_app_secret": "{{bk_app_secret}}"}
+  X-Bkapi-Authorization: {"bk_app_code": "{{bk_app_code}}", "bk_app_secret": "{{bk_app_secret}}", "access_token": "{{access_token}}"}
 }
 
 assert {

--- a/test/cases/dashboard/open api/v2-open/11-mcp-server-permission-list.bru
+++ b/test/cases/dashboard/open api/v2-open/11-mcp-server-permission-list.bru
@@ -1,11 +1,11 @@
 meta {
   name: openapi-v2-mcp-server-permission-list
   type: http
-  seq: 12
+  seq: 11
 }
 
 get {
-  url: {{scheme}}://{{host}}/backend/api/v2/open/mcp-servers/{{mcp_server_id}}/permissions/
+  url: {{scheme}}://{{host}}/api/{{gateway_name}}/prod/api/v2/open/mcp-servers/{{mcp_server_id}}/permissions/
   body: none
   auth: none
 }

--- a/test/cases/dashboard/open api/v2-open/11-mcp-server-permission-list.bru
+++ b/test/cases/dashboard/open api/v2-open/11-mcp-server-permission-list.bru
@@ -1,0 +1,21 @@
+meta {
+  name: openapi-v2-mcp-server-permission-list
+  type: http
+  seq: 12
+}
+
+get {
+  url: {{scheme}}://{{host}}/backend/api/v2/open/mcp-servers/{{mcp_server_id}}/permissions/
+  body: none
+  auth: none
+}
+
+headers {
+  X-Bkapi-Authorization: {"bk_app_code": "{{bk_app_code}}", "bk_app_secret": "{{bk_app_secret}}"}
+}
+
+assert {
+  res.status: eq 200
+  res.body.data.count: isDefined
+  res.body.data.results: isDefined
+}

--- a/test/cases/dashboard/open api/v2-open/11-mcp-server-permission-list.bru
+++ b/test/cases/dashboard/open api/v2-open/11-mcp-server-permission-list.bru
@@ -5,7 +5,7 @@ meta {
 }
 
 get {
-  url: {{scheme}}://{{host}}/api/{{gateway_name}}/prod/api/v2/open/mcp-servers/{{mcp_server_id}}/permissions/
+  url: {{scheme}}://{{host}}/api/bk-apigateway/prod/api/v2/open/mcp-servers/{{mcp_server_id}}/permissions/
   body: none
   auth: none
 }

--- a/test/cases/dashboard/open api/v2-open/12-mcp-app-permission-list.bru
+++ b/test/cases/dashboard/open api/v2-open/12-mcp-app-permission-list.bru
@@ -5,7 +5,7 @@ meta {
 }
 
 get {
-  url: {{scheme}}://{{host}}/api/{{gateway_name}}/prod/api/v2/open/mcp-servers/permissions/?bk_app_code={{bk_app_code}}
+  url: {{scheme}}://{{host}}/api/bk-apigateway/prod/api/v2/open/mcp-servers/permissions/?bk_app_code={{bk_app_code}}
   body: none
   auth: none
 }

--- a/test/cases/dashboard/open api/v2-open/12-mcp-app-permission-list.bru
+++ b/test/cases/dashboard/open api/v2-open/12-mcp-app-permission-list.bru
@@ -1,11 +1,11 @@
 meta {
   name: openapi-v2-mcp-app-permission-list
   type: http
-  seq: 13
+  seq: 12
 }
 
 get {
-  url: {{scheme}}://{{host}}/backend/api/v2/open/mcp-servers/permissions/?bk_app_code={{bk_app_code}}
+  url: {{scheme}}://{{host}}/api/{{gateway_name}}/prod/api/v2/open/mcp-servers/permissions/?bk_app_code={{bk_app_code}}
   body: none
   auth: none
 }

--- a/test/cases/dashboard/open api/v2-open/12-mcp-app-permission-list.bru
+++ b/test/cases/dashboard/open api/v2-open/12-mcp-app-permission-list.bru
@@ -1,0 +1,21 @@
+meta {
+  name: openapi-v2-mcp-app-permission-list
+  type: http
+  seq: 13
+}
+
+get {
+  url: {{scheme}}://{{host}}/backend/api/v2/open/mcp-servers/permissions/?bk_app_code={{bk_app_code}}
+  body: none
+  auth: none
+}
+
+headers {
+  X-Bkapi-Authorization: {"bk_app_code": "{{bk_app_code}}", "bk_app_secret": "{{bk_app_secret}}"}
+}
+
+assert {
+  res.status: eq 200
+  res.body.data.count: isDefined
+  res.body.data.results: isDefined
+}

--- a/test/cases/dashboard/open api/v2-open/13-mcp-app-permission-apply-records.bru
+++ b/test/cases/dashboard/open api/v2-open/13-mcp-app-permission-apply-records.bru
@@ -5,7 +5,7 @@ meta {
 }
 
 get {
-  url: {{scheme}}://{{host}}/api/{{gateway_name}}/prod/api/v2/open/mcp-servers/permissions/apply-records/?bk_app_code={{bk_app_code}}
+  url: {{scheme}}://{{host}}/api/bk-apigateway/prod/api/v2/open/mcp-servers/permissions/apply-records/?bk_app_code={{bk_app_code}}
   body: none
   auth: none
 }

--- a/test/cases/dashboard/open api/v2-open/13-mcp-app-permission-apply-records.bru
+++ b/test/cases/dashboard/open api/v2-open/13-mcp-app-permission-apply-records.bru
@@ -1,11 +1,11 @@
 meta {
   name: openapi-v2-mcp-app-permission-apply-records
   type: http
-  seq: 15
+  seq: 13
 }
 
 get {
-  url: {{scheme}}://{{host}}/backend/api/v2/open/mcp-servers/permissions/apply-records/?bk_app_code={{bk_app_code}}
+  url: {{scheme}}://{{host}}/api/{{gateway_name}}/prod/api/v2/open/mcp-servers/permissions/apply-records/?bk_app_code={{bk_app_code}}
   body: none
   auth: none
 }

--- a/test/cases/dashboard/open api/v2-open/13-mcp-app-permission-apply-records.bru
+++ b/test/cases/dashboard/open api/v2-open/13-mcp-app-permission-apply-records.bru
@@ -1,0 +1,20 @@
+meta {
+  name: openapi-v2-mcp-app-permission-apply-records
+  type: http
+  seq: 15
+}
+
+get {
+  url: {{scheme}}://{{host}}/backend/api/v2/open/mcp-servers/permissions/apply-records/?bk_app_code={{bk_app_code}}
+  body: none
+  auth: none
+}
+
+headers {
+  X-Bkapi-Authorization: {"bk_app_code": "{{bk_app_code}}", "bk_app_secret": "{{bk_app_secret}}"}
+}
+
+assert {
+  res.status: eq 200
+  res.body.data: isDefined
+}

--- a/test/cases/dashboard/open api/v2-open/14-user-mcp-server-list.bru
+++ b/test/cases/dashboard/open api/v2-open/14-user-mcp-server-list.bru
@@ -5,7 +5,7 @@ meta {
 }
 
 get {
-  url: {{scheme}}://{{host}}/api/{{gateway_name}}/prod/api/v2/open/user/mcp-servers/
+  url: {{scheme}}://{{host}}/api/bk-apigateway/prod/api/v2/open/user/mcp-servers/
   body: none
   auth: none
 }

--- a/test/cases/dashboard/open api/v2-open/14-user-mcp-server-list.bru
+++ b/test/cases/dashboard/open api/v2-open/14-user-mcp-server-list.bru
@@ -1,0 +1,21 @@
+meta {
+  name: openapi-v2-user-mcp-server-list
+  type: http
+  seq: 16
+}
+
+get {
+  url: {{scheme}}://{{host}}/backend/api/v2/open/user/mcp-servers/
+  body: none
+  auth: none
+}
+
+headers {
+  X-Bkapi-Authorization: {"bk_app_code": "{{bk_app_code}}", "bk_app_secret": "{{bk_app_secret}}"}
+}
+
+assert {
+  res.status: eq 200
+  res.body.data.count: isDefined
+  res.body.data.results: isDefined
+}

--- a/test/cases/dashboard/open api/v2-open/14-user-mcp-server-list.bru
+++ b/test/cases/dashboard/open api/v2-open/14-user-mcp-server-list.bru
@@ -1,17 +1,17 @@
 meta {
   name: openapi-v2-user-mcp-server-list
   type: http
-  seq: 16
+  seq: 14
 }
 
 get {
-  url: {{scheme}}://{{host}}/backend/api/v2/open/user/mcp-servers/
+  url: {{scheme}}://{{host}}/api/{{gateway_name}}/prod/api/v2/open/user/mcp-servers/
   body: none
   auth: none
 }
 
 headers {
-  X-Bkapi-Authorization: {"bk_app_code": "{{bk_app_code}}", "bk_app_secret": "{{bk_app_secret}}"}
+  X-Bkapi-Authorization: {"bk_app_code": "{{bk_app_code}}", "bk_app_secret": "{{bk_app_secret}}", "access_token": "{{access_token}}"}
 }
 
 assert {

--- a/test/cases/dashboard/open api/v2-open/15-tools-time-get-datetime.bru
+++ b/test/cases/dashboard/open api/v2-open/15-tools-time-get-datetime.bru
@@ -1,11 +1,11 @@
 meta {
   name: openapi-v2-tools-time-get-datetime
   type: http
-  seq: 17
+  seq: 15
 }
 
 get {
-  url: {{scheme}}://{{host}}/backend/api/v2/open/tools/time/get_datetime/?tz_name=Asia/Shanghai
+  url: {{scheme}}://{{host}}/api/{{gateway_name}}/prod/api/v2/open/tools/time/get_datetime/?tz_name=Asia/Shanghai
   body: none
   auth: none
 }

--- a/test/cases/dashboard/open api/v2-open/15-tools-time-get-datetime.bru
+++ b/test/cases/dashboard/open api/v2-open/15-tools-time-get-datetime.bru
@@ -1,0 +1,20 @@
+meta {
+  name: openapi-v2-tools-time-get-datetime
+  type: http
+  seq: 17
+}
+
+get {
+  url: {{scheme}}://{{host}}/backend/api/v2/open/tools/time/get_datetime/?tz_name=Asia/Shanghai
+  body: none
+  auth: none
+}
+
+headers {
+  X-Bkapi-Authorization: {"bk_app_code": "{{bk_app_code}}", "bk_app_secret": "{{bk_app_secret}}"}
+}
+
+assert {
+  res.status: eq 200
+  res.body.data.datetime: isDefined
+}

--- a/test/cases/dashboard/open api/v2-open/15-tools-time-get-datetime.bru
+++ b/test/cases/dashboard/open api/v2-open/15-tools-time-get-datetime.bru
@@ -5,7 +5,7 @@ meta {
 }
 
 get {
-  url: {{scheme}}://{{host}}/api/{{gateway_name}}/prod/api/v2/open/tools/time/get_datetime/?tz_name=Asia/Shanghai
+  url: {{scheme}}://{{host}}/api/bk-apigateway/prod/api/v2/open/tools/time/get_datetime/?tz_name=Asia/Shanghai
   body: none
   auth: none
 }

--- a/test/cases/dashboard/open api/v2-open/16-tools-time-get-current-unix-timestamp.bru
+++ b/test/cases/dashboard/open api/v2-open/16-tools-time-get-current-unix-timestamp.bru
@@ -1,11 +1,11 @@
 meta {
   name: openapi-v2-tools-time-get-current-unix-timestamp
   type: http
-  seq: 18
+  seq: 16
 }
 
 get {
-  url: {{scheme}}://{{host}}/backend/api/v2/open/tools/time/get_current_unix_timestamp/
+  url: {{scheme}}://{{host}}/api/{{gateway_name}}/prod/api/v2/open/tools/time/get_current_unix_timestamp/
   body: none
   auth: none
 }

--- a/test/cases/dashboard/open api/v2-open/16-tools-time-get-current-unix-timestamp.bru
+++ b/test/cases/dashboard/open api/v2-open/16-tools-time-get-current-unix-timestamp.bru
@@ -1,0 +1,20 @@
+meta {
+  name: openapi-v2-tools-time-get-current-unix-timestamp
+  type: http
+  seq: 18
+}
+
+get {
+  url: {{scheme}}://{{host}}/backend/api/v2/open/tools/time/get_current_unix_timestamp/
+  body: none
+  auth: none
+}
+
+headers {
+  X-Bkapi-Authorization: {"bk_app_code": "{{bk_app_code}}", "bk_app_secret": "{{bk_app_secret}}"}
+}
+
+assert {
+  res.status: eq 200
+  res.body.data.unix_timestamp: isDefined
+}

--- a/test/cases/dashboard/open api/v2-open/16-tools-time-get-current-unix-timestamp.bru
+++ b/test/cases/dashboard/open api/v2-open/16-tools-time-get-current-unix-timestamp.bru
@@ -5,7 +5,7 @@ meta {
 }
 
 get {
-  url: {{scheme}}://{{host}}/api/{{gateway_name}}/prod/api/v2/open/tools/time/get_current_unix_timestamp/
+  url: {{scheme}}://{{host}}/api/bk-apigateway/prod/api/v2/open/tools/time/get_current_unix_timestamp/
   body: none
   auth: none
 }

--- a/test/cases/dashboard/open api/v2-open/17-tools-time-parse-datetime-to-timestamp.bru
+++ b/test/cases/dashboard/open api/v2-open/17-tools-time-parse-datetime-to-timestamp.bru
@@ -5,7 +5,7 @@ meta {
 }
 
 post {
-  url: {{scheme}}://{{host}}/api/{{gateway_name}}/prod/api/v2/open/tools/time/parse_datetime_str_to_timestamp/
+  url: {{scheme}}://{{host}}/api/bk-apigateway/prod/api/v2/open/tools/time/parse_datetime_str_to_timestamp/
   body: json
   auth: none
 }

--- a/test/cases/dashboard/open api/v2-open/17-tools-time-parse-datetime-to-timestamp.bru
+++ b/test/cases/dashboard/open api/v2-open/17-tools-time-parse-datetime-to-timestamp.bru
@@ -1,11 +1,11 @@
 meta {
   name: openapi-v2-tools-time-parse-datetime-to-timestamp
   type: http
-  seq: 19
+  seq: 17
 }
 
 post {
-  url: {{scheme}}://{{host}}/backend/api/v2/open/tools/time/parse_datetime_str_to_timestamp/
+  url: {{scheme}}://{{host}}/api/{{gateway_name}}/prod/api/v2/open/tools/time/parse_datetime_str_to_timestamp/
   body: json
   auth: none
 }

--- a/test/cases/dashboard/open api/v2-open/17-tools-time-parse-datetime-to-timestamp.bru
+++ b/test/cases/dashboard/open api/v2-open/17-tools-time-parse-datetime-to-timestamp.bru
@@ -1,0 +1,28 @@
+meta {
+  name: openapi-v2-tools-time-parse-datetime-to-timestamp
+  type: http
+  seq: 19
+}
+
+post {
+  url: {{scheme}}://{{host}}/backend/api/v2/open/tools/time/parse_datetime_str_to_timestamp/
+  body: json
+  auth: none
+}
+
+headers {
+  Content-Type: application/json
+  X-Bkapi-Authorization: {"bk_app_code": "{{bk_app_code}}", "bk_app_secret": "{{bk_app_secret}}"}
+}
+
+body:json {
+  {
+    "datetime": "2025-01-07 15:30:45",
+    "datetime_format": "%Y-%m-%d %H:%M:%S"
+  }
+}
+
+assert {
+  res.status: eq 200
+  res.body.data.timestamp: isDefined
+}

--- a/test/cases/dashboard/open api/v2-open/18-well-known-oauth-protected-resource.bru
+++ b/test/cases/dashboard/open api/v2-open/18-well-known-oauth-protected-resource.bru
@@ -1,11 +1,11 @@
 meta {
   name: openapi-v2-well-known-oauth-protected-resource
   type: http
-  seq: 21
+  seq: 18
 }
 
 get {
-  url: {{scheme}}://{{host}}/backend/api/v2/open/.well-known/oauth-protected-resource?resource={{scheme}}://{{host}}/backend/api/v2/open/gateways/
+  url: {{scheme}}://{{host}}/api/{{gateway_name}}/prod/api/v2/open/.well-known/oauth-protected-resource?resource={{scheme}}://{{host}}/api/{{gateway_name}}/prod/api/v2/open/gateways/
   body: none
   auth: none
 }

--- a/test/cases/dashboard/open api/v2-open/18-well-known-oauth-protected-resource.bru
+++ b/test/cases/dashboard/open api/v2-open/18-well-known-oauth-protected-resource.bru
@@ -1,0 +1,18 @@
+meta {
+  name: openapi-v2-well-known-oauth-protected-resource
+  type: http
+  seq: 21
+}
+
+get {
+  url: {{scheme}}://{{host}}/backend/api/v2/open/.well-known/oauth-protected-resource?resource={{scheme}}://{{host}}/backend/api/v2/open/gateways/
+  body: none
+  auth: none
+}
+
+assert {
+  res.status: eq 200
+  res.body.resource: isDefined
+  res.body.authorization_servers: isDefined
+  res.body.bearer_methods_supported: isDefined
+}

--- a/test/cases/dashboard/open api/v2-open/18-well-known-oauth-protected-resource.bru
+++ b/test/cases/dashboard/open api/v2-open/18-well-known-oauth-protected-resource.bru
@@ -5,7 +5,7 @@ meta {
 }
 
 get {
-  url: {{scheme}}://{{host}}/api/{{gateway_name}}/prod/api/v2/open/.well-known/oauth-protected-resource?resource={{scheme}}://{{host}}/api/{{gateway_name}}/prod/api/v2/open/gateways/
+  url: {{scheme}}://{{host}}/api/bk-apigateway/prod/api/v2/open/.well-known/oauth-protected-resource?resource={{scheme}}://{{host}}/api/bk-apigateway/prod/api/v2/open/gateways/
   body: none
   auth: none
 }


### PR DESCRIPTION
- 在 ft_e2e_v2_open_api 分支上完成 v2 Open API 的 E2E 测试用例补充，覆盖 Gateway、Resource、MCP Server、Permission、Tools 和 OAuth 发现等 18 个端点。通过 Code Review 发现并修复了数据依赖链缺少空数据保护的缺陷，全部用例通过验证。
- 没有 e2e 测试的接口（3个）：
  - POST /gateways/{gateway_name}/permissions/apply/ ：幂等性问题，bk_apigateway 已有永久权限，重复申请返回 400
  - POST /mcp-servers/permissions/apply/：同上，权限申请幂等性问题
  - GET /tools/log/query_by_request_id/：依赖 bk-log-search 外部服务，开发环境不可用返回 500