### PR TITLE
fix: inject tenant_mode and tenant_id in v2 GatewaySyncApi

### DIFF
--- a/src/dashboard/apigateway/apigateway/apis/v2/sync/views.py
+++ b/src/dashboard/apigateway/apigateway/apis/v2/sync/views.py
@@ -115,6 +115,11 @@ class GatewaySyncApi(generics.CreateAPIView):
         slz = self.get_serializer(gateway, data=request.data)
         slz.is_valid(raise_exception=True)
 
+        # assign the tenant_mode and tenant_id based on the calling app
+        tenant_mode, tenant_id = get_app_tenant_info(request.app.app_code)
+        slz.validated_data["tenant_mode"] = tenant_mode
+        slz.validated_data["tenant_id"] = tenant_id
+
         # save gateway
         username = request.user.username or settings.GATEWAY_DEFAULT_CREATOR
 


### PR DESCRIPTION
- 修复：v2 sync API (GatewaySyncApi) 创建网关时没有设置 tenant_mode，导致 GatewayData.tenant_mode 为 None，写入数据库时触发 IntegrityError: Column 'tenant_mode' cannot be null。