### PR TITLE
fix(trace): report BkAIDev trace for tools/call and enrich session_id/client_id

### DIFF
--- a/src/mcp-proxy/config.yaml.tpl
+++ b/src/mcp-proxy/config.yaml.tpl
@@ -59,12 +59,13 @@ logger:
 ## config for metric/prometheus
 metric:
   ## Metric name prefix, should be aligned with the dashboard's PROMETHEUS_METRIC_NAME_PREFIX.
-  ## Can also be overridden by the PROMETHEUS_METRIC_NAME_PREFIX environment variable.
+  ## The PROMETHEUS_METRIC_NAME_PREFIX environment variable takes priority when set.
   namePrefix: "bk_apigateway_"
 
 ## config for mcp server
 mcpServer:
   interval: 60
+  ## The BK_API_URL_TMPL environment variable takes priority when set.
   bkApiUrlTmpl: ""
   # messageUrlFormat / messageApplicationUrlFormat：蓝鲸网关资源路径模板；第一个 % 之前的段用于推导 SSE 对外前缀（网关剥前缀时与官方 SDK 的 endpoint 一致）
   # messageUrlFormat: "/api/bk-apigateway/prod/api/v2/mcp-servers/%s/sse/message"
@@ -107,7 +108,14 @@ tracing:
     dbAPI: true
     mcpAPI: true
 
+## config for bk ai dev trace (independent from tracing)
+bkAIDevTrace:
+  enable: false  # 环境变量 BKAI_DEV_TRACE_ENABLE 优先，设置后将覆盖此配置值
+  endpoint: ""  # 例如: "127.0.0.1:4318"；环境变量 BKAI_DEV_TRACE_ENDPOINT 优先
+  serviceName: "apigateway-mcp-proxy"  # 环境变量 BKAI_DEV_TRACE_SERVICE_NAME 优先
+  token: ""  # 环境变量 BKAI_DEV_TRACE_TOKEN 优先
+
 ## config for pprof
 pprof:
-  username: "bk-apigateway"  # 可通过环境变量 PPROF_USERNAME 覆盖
-  password: "xxxxx"  # 可通过环境变量 PPROF_PASSWORD 覆盖，生产环境请使用强密码
+  username: "bk-apigateway"  # 环境变量 PPROF_USERNAME 优先
+  password: "xxxxx"  # 环境变量 PPROF_PASSWORD 优先，生产环境请使用强密码

--- a/src/mcp-proxy/pkg/config/config.go
+++ b/src/mcp-proxy/pkg/config/config.go
@@ -23,6 +23,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"strconv"
 	"strings"
 	"time"
 
@@ -332,29 +333,43 @@ func Load(v *viper.Viper) (*Config, error) {
 		return nil, err
 	}
 
-	// parse the list to map
-	// 1. database
+	if err := initAndValidateDatabases(cfg); err != nil {
+		return nil, err
+	}
+
+	applyMcpServerDefaults(cfg)
+	applyBkAIDevTraceDefaults(v, cfg)
+	applyMetricDefaults(cfg)
+	applyPProfDefaults(cfg)
+
+	G = cfg
+	return cfg, nil
+}
+
+func initAndValidateDatabases(cfg *Config) error {
 	cfg.DatabaseMap = make(map[string]Database)
 	for _, db := range cfg.Databases {
 		cfg.DatabaseMap[db.ID] = db
 	}
 
 	if len(cfg.DatabaseMap) == 0 {
-		return nil, errors.New("database cannot be empty")
+		return errors.New("database cannot be empty")
 	}
 
-	// 验证所有数据库配置
 	for _, db := range cfg.Databases {
 		if err := db.ValidateDatabase(); err != nil {
-			return nil, err
+			return err
 		}
 	}
+	return nil
+}
 
+func applyMcpServerDefaults(cfg *Config) {
 	if cfg.McpServer.Interval == 0 {
 		cfg.McpServer.Interval = 60 * time.Second
 	}
-	if cfg.McpServer.BkApiUrlTmpl == "" {
-		cfg.McpServer.BkApiUrlTmpl = os.Getenv("BK_API_URL_TMPL")
+	if env := os.Getenv("BK_API_URL_TMPL"); env != "" {
+		cfg.McpServer.BkApiUrlTmpl = env
 	}
 	if cfg.McpServer.MessageUrlFormat == "" {
 		cfg.McpServer.MessageUrlFormat = "/api/bk-apigateway/prod/api/v2/mcp-servers/%s/sse/message"
@@ -366,11 +381,11 @@ func Load(v *viper.Viper) (*Config, error) {
 	if cfg.McpServer.InnerJwtExpireTime == 0 {
 		cfg.McpServer.InnerJwtExpireTime = time.Minute * 5
 	}
-	if cfg.McpServer.EncryptKey == "" {
-		cfg.McpServer.EncryptKey = os.Getenv("ENCRYPT_KEY")
+	if env := os.Getenv("ENCRYPT_KEY"); env != "" {
+		cfg.McpServer.EncryptKey = env
 	}
-	if cfg.McpServer.CryptoNonce == "" {
-		cfg.McpServer.CryptoNonce = os.Getenv("BK_APIGW_CRYPTO_NONCE")
+	if env := os.Getenv("BK_APIGW_CRYPTO_NONCE"); env != "" {
+		cfg.McpServer.CryptoNonce = env
 	}
 	// Transport defaults for upstream tool calls
 	if cfg.McpServer.Transport.MaxIdleConns == 0 {
@@ -405,28 +420,47 @@ func Load(v *viper.Viper) (*Config, error) {
 	if cfg.McpServer.LogTruncate.APILogErrorResponseSize == 0 {
 		cfg.McpServer.LogTruncate.APILogErrorResponseSize = defaultAPILogErrorRespSize
 	}
-	if cfg.Metric.NamePrefix == "" {
-		cfg.Metric.NamePrefix = os.Getenv("PROMETHEUS_METRIC_NAME_PREFIX")
-		if cfg.Metric.NamePrefix == "" {
-			cfg.Metric.NamePrefix = "bk_apigateway_"
+}
+
+func applyBkAIDevTraceDefaults(_ *viper.Viper, cfg *Config) {
+	if env := os.Getenv("BKAI_DEV_TRACE_ENABLE"); env != "" {
+		if enabled, err := strconv.ParseBool(env); err == nil {
+			cfg.BkAIDevTrace.Enable = enabled
 		}
 	}
+	if env := os.Getenv("BKAI_DEV_TRACE_ENDPOINT"); env != "" {
+		cfg.BkAIDevTrace.Endpoint = env
+	}
+	if env := os.Getenv("BKAI_DEV_TRACE_SERVICE_NAME"); env != "" {
+		cfg.BkAIDevTrace.ServiceName = env
+	}
+	if env := os.Getenv("BKAI_DEV_TRACE_TOKEN"); env != "" {
+		cfg.BkAIDevTrace.Token = env
+	}
+}
 
+func applyMetricDefaults(cfg *Config) {
+	if env := os.Getenv("PROMETHEUS_METRIC_NAME_PREFIX"); env != "" {
+		cfg.Metric.NamePrefix = env
+	}
+	if cfg.Metric.NamePrefix == "" {
+		cfg.Metric.NamePrefix = "bk_apigateway_"
+	}
+}
+
+func applyPProfDefaults(cfg *Config) {
+	if env := os.Getenv("PPROF_USERNAME"); env != "" {
+		cfg.PProf.Username = env
+	}
 	if cfg.PProf.Username == "" {
-		cfg.PProf.Username = os.Getenv("PPROF_USERNAME")
-		if cfg.PProf.Username == "" {
-			cfg.PProf.Username = "bk-mcp" // 默认用户名
-		}
+		cfg.PProf.Username = "bk-mcp" // 默认用户名
+	}
+	if env := os.Getenv("PPROF_PASSWORD"); env != "" {
+		cfg.PProf.Password = env
 	}
 	if cfg.PProf.Password == "" {
-		cfg.PProf.Password = os.Getenv("PPROF_PASSWORD")
-		if cfg.PProf.Password == "" {
-			cfg.PProf.Password = "DebugModel@bk" // 默认密码，生产环境应该修改
-		}
+		cfg.PProf.Password = "DebugModel@bk" // 默认密码，生产环境应该修改
 	}
-
-	G = cfg
-	return cfg, nil
 }
 
 // GinAPIEnabled get gin api trace switch

--- a/src/mcp-proxy/pkg/config/config_test.go
+++ b/src/mcp-proxy/pkg/config/config_test.go
@@ -561,6 +561,66 @@ var _ = Describe("Config", func() {
 	})
 
 	Describe("Load defaults", func() {
+		It("should load bkAIDevTrace config from env when values are empty", func() {
+			v := viper.New()
+			v.Set("databases", []map[string]interface{}{
+				{
+					"id": "default", "host": "localhost", "port": 3306,
+					"user": "root", "password": "password", "name": "testdb",
+				},
+			})
+
+			Expect(os.Setenv("BKAI_DEV_TRACE_ENABLE", "true")).To(Succeed())
+			Expect(os.Setenv("BKAI_DEV_TRACE_ENDPOINT", "127.0.0.1:4318")).To(Succeed())
+			Expect(os.Setenv("BKAI_DEV_TRACE_SERVICE_NAME", "env-trace-service")).To(Succeed())
+			Expect(os.Setenv("BKAI_DEV_TRACE_TOKEN", "env-trace-token")).To(Succeed())
+			DeferCleanup(func() {
+				_ = os.Unsetenv("BKAI_DEV_TRACE_ENABLE")
+				_ = os.Unsetenv("BKAI_DEV_TRACE_ENDPOINT")
+				_ = os.Unsetenv("BKAI_DEV_TRACE_SERVICE_NAME")
+				_ = os.Unsetenv("BKAI_DEV_TRACE_TOKEN")
+			})
+
+			cfg, err := config.Load(v)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(cfg.BkAIDevTrace.Enable).To(BeTrue())
+			Expect(cfg.BkAIDevTrace.Endpoint).To(Equal("127.0.0.1:4318"))
+			Expect(cfg.BkAIDevTrace.ServiceName).To(Equal("env-trace-service"))
+			Expect(cfg.BkAIDevTrace.Token).To(Equal("env-trace-token"))
+		})
+
+		It("should override config file values with env vars for bkAIDevTrace", func() {
+			v := viper.New()
+			v.Set("databases", []map[string]interface{}{
+				{
+					"id": "default", "host": "localhost", "port": 3306,
+					"user": "root", "password": "password", "name": "testdb",
+				},
+			})
+			v.Set("bkAIDevTrace.enable", false)
+			v.Set("bkAIDevTrace.endpoint", "from-config:4318")
+			v.Set("bkAIDevTrace.serviceName", "from-config-service")
+			v.Set("bkAIDevTrace.token", "from-config-token")
+
+			Expect(os.Setenv("BKAI_DEV_TRACE_ENABLE", "true")).To(Succeed())
+			Expect(os.Setenv("BKAI_DEV_TRACE_ENDPOINT", "from-env:4318")).To(Succeed())
+			Expect(os.Setenv("BKAI_DEV_TRACE_SERVICE_NAME", "from-env-service")).To(Succeed())
+			Expect(os.Setenv("BKAI_DEV_TRACE_TOKEN", "from-env-token")).To(Succeed())
+			DeferCleanup(func() {
+				_ = os.Unsetenv("BKAI_DEV_TRACE_ENABLE")
+				_ = os.Unsetenv("BKAI_DEV_TRACE_ENDPOINT")
+				_ = os.Unsetenv("BKAI_DEV_TRACE_SERVICE_NAME")
+				_ = os.Unsetenv("BKAI_DEV_TRACE_TOKEN")
+			})
+
+			cfg, err := config.Load(v)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(cfg.BkAIDevTrace.Enable).To(BeTrue())
+			Expect(cfg.BkAIDevTrace.Endpoint).To(Equal("from-env:4318"))
+			Expect(cfg.BkAIDevTrace.ServiceName).To(Equal("from-env-service"))
+			Expect(cfg.BkAIDevTrace.Token).To(Equal("from-env-token"))
+		})
+
 		It("should set Transport defaults", func() {
 			v := viper.New()
 			v.Set("databases", []map[string]interface{}{

--- a/src/mcp-proxy/pkg/infra/proxy/proxy.go
+++ b/src/mcp-proxy/pkg/infra/proxy/proxy.go
@@ -49,6 +49,7 @@ import (
 	"mcp_proxy/pkg/cacheimpls"
 	"mcp_proxy/pkg/config"
 	"mcp_proxy/pkg/constant"
+	"mcp_proxy/pkg/infra/bkaidevtrace"
 	"mcp_proxy/pkg/infra/logging"
 	"mcp_proxy/pkg/infra/trace"
 	"mcp_proxy/pkg/metric"
@@ -642,6 +643,64 @@ func setupToolCallSpan(
 	return ctx, span
 }
 
+// setupBkAIDevToolCallSpan starts a dedicated BKAIDev span for tools/call.
+// tools/call is handled inside tool handler and may bypass MCP receiving middleware,
+// so we must report this span here.
+func setupBkAIDevToolCallSpan(
+	ctx context.Context,
+	req *mcp.CallToolRequest,
+	serverName,
+	toolName string,
+) (context.Context, oteltrace.Span) {
+	if !bkaidevtrace.Enabled() {
+		return ctx, nil
+	}
+
+	ctx, span := bkaidevtrace.StartSpan(ctx, fmt.Sprintf("mcp_gw.%s.tools/call", serverName))
+	if span == nil {
+		return ctx, nil
+	}
+
+	appCode := util.GetAppCodeFromContext(ctx)
+	username := util.GetUsernameFromContext(ctx)
+	clientIP := util.GetClientIPFromContext(ctx)
+	clientID := util.GetClientIDFromContext(ctx)
+	gatewayName := util.GetGatewayNameFromContext(ctx)
+	requestID := util.GetRequestIDFromContext(ctx)
+	xRequestID := util.GetXRequestIDFromContext(ctx)
+	traceID := bkaidevtrace.GetTraceIDFromContext(ctx)
+
+	span.SetAttributes(
+		attribute.String("app_code", appCode),
+		attribute.String("bk_username", username),
+		attribute.String("client_ip", clientIP),
+		attribute.String("client_id", clientID),
+		attribute.String("gateway_name", gatewayName),
+		attribute.String("mcp_server_name", serverName),
+		attribute.String("request_id", requestID),
+		attribute.String("x_request_id", xRequestID),
+		attribute.String("trace_id", traceID),
+		attribute.String("tool_name", toolName),
+	)
+	if req != nil {
+		if ss, ok := req.GetSession().(*mcp.ServerSession); ok && ss != nil {
+			span.SetAttributes(attribute.String("session_id", ss.ID()))
+		}
+	}
+
+	if itsmFlex := util.GetBkApiItsmFlexData(ctx); itsmFlex != nil {
+		span.SetAttributes(
+			attribute.String("caller_executor", itsmFlex.CallerExecutor),
+			attribute.String("agent_code", itsmFlex.AgentCode),
+			attribute.String("service_catalogue", itsmFlex.ServiceCatalogue),
+			attribute.String("caller_bk_biz_env", itsmFlex.CallerBizEnv),
+			attribute.String("caller_bk_biz_id", itsmFlex.CallerBizID),
+		)
+	}
+
+	return ctx, span
+}
+
 // prepareToolCallAuditLog prepares audit logger with request context information.
 func prepareToolCallAuditLog(
 	ctx context.Context,
@@ -752,6 +811,24 @@ func genToolHandler(toolApiConfig *ToolConfig, serverName string, rawResponseEna
 	// 生成handler
 	handler := func(ctx context.Context, req *mcp.CallToolRequest) (result *mcp.CallToolResult, err error) {
 		start := time.Now()
+
+		// tools/call may bypass MCP receiving middleware, so create BKAIDev span here.
+		ctx, bkAIDevSpan := setupBkAIDevToolCallSpan(ctx, req, serverName, toolApiConfig.Name)
+		if bkAIDevSpan != nil {
+			defer func() {
+				hasError := err != nil || (result != nil && result.IsError)
+				status := "success"
+				if hasError {
+					status = "failed"
+					bkAIDevSpan.SetStatus(codes.Error, "tools/call failed")
+				}
+				bkAIDevSpan.SetAttributes(
+					attribute.String("status", status),
+					attribute.Float64("latency_ms", time.Since(start).Seconds()*1000),
+				)
+				bkAIDevSpan.End()
+			}()
+		}
 
 		// Start a trace span for the actual upstream tool invocation
 		ctx, span := setupToolCallSpan(

--- a/src/mcp-proxy/pkg/infra/proxy/proxy.go
+++ b/src/mcp-proxy/pkg/infra/proxy/proxy.go
@@ -670,6 +670,16 @@ func setupBkAIDevToolCallSpan(
 	xRequestID := util.GetXRequestIDFromContext(ctx)
 	traceID := bkaidevtrace.GetTraceIDFromContext(ctx)
 
+	// Enrich client_id with ClientInfo from session, consistent with LoggingMiddleware
+	if req != nil {
+		if ss, ok := req.GetSession().(*mcp.ServerSession); ok && ss != nil {
+			if initParams := ss.InitializeParams(); initParams != nil && initParams.ClientInfo != nil {
+				clientID = initParams.ClientInfo.Name
+			}
+			span.SetAttributes(attribute.String("session_id", ss.ID()))
+		}
+	}
+
 	span.SetAttributes(
 		attribute.String("app_code", appCode),
 		attribute.String("bk_username", username),
@@ -682,11 +692,6 @@ func setupBkAIDevToolCallSpan(
 		attribute.String("trace_id", traceID),
 		attribute.String("tool_name", toolName),
 	)
-	if req != nil {
-		if ss, ok := req.GetSession().(*mcp.ServerSession); ok && ss != nil {
-			span.SetAttributes(attribute.String("session_id", ss.ID()))
-		}
-	}
 
 	if itsmFlex := util.GetBkApiItsmFlexData(ctx); itsmFlex != nil {
 		span.SetAttributes(

--- a/src/mcp-proxy/pkg/infra/proxy/proxy_test.go
+++ b/src/mcp-proxy/pkg/infra/proxy/proxy_test.go
@@ -41,7 +41,9 @@ import (
 
 	"mcp_proxy/pkg/config"
 	"mcp_proxy/pkg/constant"
+	"mcp_proxy/pkg/infra/bkaidevtrace"
 	"mcp_proxy/pkg/infra/trace"
+	"mcp_proxy/pkg/util"
 )
 
 var _ = Describe("MCPProxy", func() {
@@ -658,6 +660,57 @@ var _ = Describe("MCPProxy", func() {
 			// Second call should be a no-op
 			InitSharedTransport(config.Transport{MaxIdleConns: 200})
 			Expect(sharedTransport.MaxIdleConns).To(Equal(50))
+		})
+	})
+
+	Describe("setupBkAIDevToolCallSpan", func() {
+		It("should create tools/call span with expected attributes", func() {
+			bkaidevtrace.ResetForTest()
+			exporter := tracetest.NewInMemoryExporter()
+			tp := sdktrace.NewTracerProvider(sdktrace.WithSyncer(exporter))
+			defer func() {
+				_ = tp.Shutdown(context.Background())
+				bkaidevtrace.ResetForTest()
+			}()
+			bkaidevtrace.SetTestProvider(tp, propagation.NewCompositeTextMapPropagator(
+				propagation.TraceContext{},
+				propagation.Baggage{},
+			))
+
+			ctx := context.Background()
+			ctx = context.WithValue(ctx, constant.BkAppCode, "test-app")
+			ctx = context.WithValue(ctx, constant.BkUsername, "tester")
+			ctx = context.WithValue(ctx, constant.ClientIP, "127.0.0.1")
+			ctx = context.WithValue(ctx, constant.ClientID, "client-a")
+			ctx = context.WithValue(ctx, constant.GatewayName, "gw-a")
+			ctx = context.WithValue(ctx, constant.RequestID, "req-1")
+			ctx = context.WithValue(ctx, constant.XRequestID, "x-req-1")
+			ctx = context.WithValue(ctx, constant.BkApiItsmFlexData, &util.ItsmFlexData{
+				CallerExecutor:   "judge-caller",
+				AgentCode:        "ai-test-appcode",
+				ServiceCatalogue: "test1/test2/test3",
+				CallerBizEnv:     "public",
+				CallerBizID:      "6000086",
+			})
+
+			_, span := setupBkAIDevToolCallSpan(ctx, nil, "test-server", "test-tool")
+			Expect(span).NotTo(BeNil())
+			span.End()
+
+			spans := exporter.GetSpans()
+			Expect(spans).To(HaveLen(1))
+			Expect(spans[0].Name).To(Equal("mcp_gw.test-server.tools/call"))
+
+			attrMap := make(map[string]interface{})
+			for _, attr := range spans[0].Attributes {
+				attrMap[string(attr.Key)] = attr.Value.AsInterface()
+			}
+			Expect(attrMap["mcp_server_name"]).To(Equal("test-server"))
+			Expect(attrMap["tool_name"]).To(Equal("test-tool"))
+			Expect(attrMap["app_code"]).To(Equal("test-app"))
+			Expect(attrMap["service_catalogue"]).To(Equal("test1/test2/test3"))
+			Expect(attrMap["caller_bk_biz_env"]).To(Equal("public"))
+			Expect(attrMap["caller_bk_biz_id"]).To(Equal("6000086"))
 		})
 	})
 

--- a/src/mcp-proxy/pkg/mcp/middleware.go
+++ b/src/mcp-proxy/pkg/mcp/middleware.go
@@ -584,6 +584,15 @@ func BkAIDevTraceMiddleware(serverName string) mcp.Middleware {
 			username := util.GetUsernameFromContext(ctx)
 			clientIP := util.GetClientIPFromContext(ctx)
 			clientID := util.GetClientIDFromContext(ctx)
+			// Enrich client_id with ClientInfo from session, consistent with LoggingMiddleware
+			if req != nil {
+				if ss, ok := req.GetSession().(*mcp.ServerSession); ok && ss != nil {
+					if initParams := ss.InitializeParams(); initParams != nil && initParams.ClientInfo != nil {
+						clientID = initParams.ClientInfo.Name
+					}
+					span.SetAttributes(attribute.String("session_id", ss.ID()))
+				}
+			}
 			gatewayName := util.GetGatewayNameFromContext(ctx)
 			requestID := util.GetRequestIDFromContext(ctx)
 			xRequestID := util.GetXRequestIDFromContext(ctx)
@@ -600,11 +609,6 @@ func BkAIDevTraceMiddleware(serverName string) mcp.Middleware {
 				attribute.String("x_request_id", xRequestID),
 				attribute.String("trace_id", traceID),
 			)
-			if req != nil {
-				if ss, ok := req.GetSession().(*mcp.ServerSession); ok && ss != nil {
-					span.SetAttributes(attribute.String("session_id", ss.ID()))
-				}
-			}
 
 			// ItsmFlex fields
 			if itsmFlex := util.GetBkApiItsmFlexData(ctx); itsmFlex != nil {

--- a/src/mcp-proxy/pkg/mcp/middleware.go
+++ b/src/mcp-proxy/pkg/mcp/middleware.go
@@ -600,12 +600,20 @@ func BkAIDevTraceMiddleware(serverName string) mcp.Middleware {
 				attribute.String("x_request_id", xRequestID),
 				attribute.String("trace_id", traceID),
 			)
+			if req != nil {
+				if ss, ok := req.GetSession().(*mcp.ServerSession); ok && ss != nil {
+					span.SetAttributes(attribute.String("session_id", ss.ID()))
+				}
+			}
 
 			// ItsmFlex fields
 			if itsmFlex := util.GetBkApiItsmFlexData(ctx); itsmFlex != nil {
 				span.SetAttributes(
 					attribute.String("caller_executor", itsmFlex.CallerExecutor),
 					attribute.String("agent_code", itsmFlex.AgentCode),
+					attribute.String("service_catalogue", itsmFlex.ServiceCatalogue),
+					attribute.String("caller_bk_biz_env", itsmFlex.CallerBizEnv),
+					attribute.String("caller_bk_biz_id", itsmFlex.CallerBizID),
 				)
 			}
 

--- a/src/mcp-proxy/pkg/mcp/middleware_test.go
+++ b/src/mcp-proxy/pkg/mcp/middleware_test.go
@@ -546,10 +546,50 @@ var _ = Describe("Middleware", func() {
 			Expect(attrs["tool_name"]).To(Equal("test-tool"))
 		})
 
-		It("should include caller_executor and agent_code when ItsmFlex is present", func() {
+		It("should include session_id when request has server session", func() {
+			server := sdkmcp.NewServer(&sdkmcp.Implementation{Name: "test-server", Version: "1.0.0"}, nil)
+			serverTransport, clientTransport := sdkmcp.NewInMemoryTransports()
+
+			testCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+			defer cancel()
+
+			serverSession, err := server.Connect(testCtx, serverTransport, nil)
+			Expect(err).NotTo(HaveOccurred())
+			defer serverSession.Close()
+
+			client := sdkmcp.NewClient(&sdkmcp.Implementation{Name: "client", Version: "1.0.0"}, nil)
+			clientSession, err := client.Connect(testCtx, clientTransport, nil)
+			Expect(err).NotTo(HaveOccurred())
+			defer clientSession.Close()
+
+			req := &sdkmcp.ServerRequest[*sdkmcp.InitializeParams]{
+				Session: serverSession,
+				Params:  &sdkmcp.InitializeParams{},
+			}
+
+			middleware := mcppkg.BkAIDevTraceMiddleware(serverName)
+			handler := middleware(func(ctx context.Context, method string, req sdkmcp.Request) (sdkmcp.Result, error) {
+				return successResult, nil
+			})
+			_, err = handler(ctx, "initialize", req)
+			Expect(err).NotTo(HaveOccurred())
+
+			spans := exporter.GetSpans()
+			Expect(len(spans)).To(Equal(1))
+			attrs := make(map[string]any)
+			for _, attr := range spans[0].Attributes {
+				attrs[string(attr.Key)] = attr.Value.AsInterface()
+			}
+			Expect(attrs["session_id"]).To(Equal(serverSession.ID()))
+		})
+
+		It("should include ItsmFlex attributes when ItsmFlex is present", func() {
 			testCtx := context.WithValue(ctx, constant.BkApiItsmFlexData, &util.ItsmFlexData{
-				CallerExecutor: "judge-caller",
-				AgentCode:      "ai-test-appcode",
+				CallerExecutor:   "judge-caller",
+				AgentCode:        "ai-test-appcode",
+				ServiceCatalogue: "test1/test2/test3",
+				CallerBizEnv:     "public",
+				CallerBizID:      "6000086",
 			})
 
 			middleware := mcppkg.BkAIDevTraceMiddleware(serverName)
@@ -567,6 +607,9 @@ var _ = Describe("Middleware", func() {
 			}
 			Expect(attrs["caller_executor"]).To(Equal("judge-caller"))
 			Expect(attrs["agent_code"]).To(Equal("ai-test-appcode"))
+			Expect(attrs["service_catalogue"]).To(Equal("test1/test2/test3"))
+			Expect(attrs["caller_bk_biz_env"]).To(Equal("public"))
+			Expect(attrs["caller_bk_biz_id"]).To(Equal("6000086"))
 		})
 
 		It("should record latency_ms as float with sub-millisecond precision", func() {

--- a/src/mcp-proxy/pkg/middleware/mcp_header_test.go
+++ b/src/mcp-proxy/pkg/middleware/mcp_header_test.go
@@ -93,7 +93,7 @@ var _ = Describe("MCPHeader", func() {
 			c, _ := gin.CreateTestContext(w)
 			c.Request = httptest.NewRequest(http.MethodGet, "/test", nil)
 
-			itsmFlexJSON := `{"agent.info.code":"ai-test-appcode","agent.info.name":"AgentName","agent.session.caller_executor":"judge-caller","agent.session.executor":"judge-executor"}`
+			itsmFlexJSON := `{"agent.info.code":"ai-test-appcode","agent.info.name":"AgentName","agent.info.service_catalogue":"test1/test2/test3","agent.session.caller_bk_biz_env":"public","agent.session.caller_bk_biz_id":"6000086","agent.session.caller_executor":"judge-caller","agent.session.executor":"judge-executor"}`
 			c.Request.Header.Set(constant.BkApiItsmFlexKey, itsmFlexJSON)
 
 			mw := middleware.MCPServerHeaderMiddleware()
@@ -103,6 +103,9 @@ var _ = Describe("MCPHeader", func() {
 			Expect(data).NotTo(BeNil())
 			Expect(data.AgentCode).To(Equal("ai-test-appcode"))
 			Expect(data.AgentName).To(Equal("AgentName"))
+			Expect(data.ServiceCatalogue).To(Equal("test1/test2/test3"))
+			Expect(data.CallerBizEnv).To(Equal("public"))
+			Expect(data.CallerBizID).To(Equal("6000086"))
 			Expect(data.CallerExecutor).To(Equal("judge-caller"))
 			Expect(data.Executor).To(Equal("judge-executor"))
 		})

--- a/src/mcp-proxy/pkg/util/context.go
+++ b/src/mcp-proxy/pkg/util/context.go
@@ -296,10 +296,13 @@ func GetBkApiAllowedHeaders(ctx context.Context) map[string]string {
 
 // ItsmFlexData holds fields extracted from X-Bkapi-ItsmFlex header.
 type ItsmFlexData struct {
-	AgentCode      string `json:"agent.info.code"`
-	AgentName      string `json:"agent.info.name"`
-	CallerExecutor string `json:"agent.session.caller_executor"`
-	Executor       string `json:"agent.session.executor"`
+	AgentCode        string `json:"agent.info.code"`
+	AgentName        string `json:"agent.info.name"`
+	ServiceCatalogue string `json:"agent.info.service_catalogue"`
+	CallerBizEnv     string `json:"agent.session.caller_bk_biz_env"`
+	CallerBizID      string `json:"agent.session.caller_bk_biz_id"`
+	CallerExecutor   string `json:"agent.session.caller_executor"`
+	Executor         string `json:"agent.session.executor"`
 }
 
 // SetBkApiItsmFlexData stores the parsed ItsmFlex data into context.


### PR DESCRIPTION
## Problem
1. tools/call is handled inside genToolHandler and may bypass MCP receiving middleware, causing missing BkAIDev trace spans.
2. session_id was not attached to BkAIDev spans for any MCP method.
3. client_id in BkAIDev trace was inconsistent with LoggingMiddleware — it only used the context value (often app_code) instead of the real MCP client name from InitializeParams.ClientInfo.

## Solution
1. Add setupBkAIDevToolCallSpan in proxy.go to create mcp_gw.<server>.tools/call span with status/latency, covering the tools/call path that bypasses middleware.
2. Attach session_id from req.GetSession() to BkAIDev spans for all MCP methods (initialize, tools/list, tools/call, etc.).
3. Enrich client_id with InitializeParams.ClientInfo.Name from the MCP session in both BkAIDevTraceMiddleware and setupBkAIDevToolCallSpan, falling back to the context value. This ensures trace and log client_id values are identical.
4. Include itsm flex fields (service_catalogue, caller_bk_biz_env, caller_bk_biz_id) in BkAIDevTraceMiddleware.

## Changes
- pkg/infra/proxy/proxy.go: add setupBkAIDevToolCallSpan, enrich client_id from session
- pkg/infra/proxy/proxy_test.go: add unit tests for setupBkAIDevToolCallSpan
- pkg/mcp/middleware.go: add session_id, enrich client_id, add itsm flex fields
- pkg/mcp/middleware_test.go: add session_id injection test
- pkg/util/context.go: extend ItsmFlexData struct
- pkg/middleware/mcp_header_test.go: update itsm flex test data

## Testing
- go test ./pkg/mcp/... ./pkg/infra/proxy/... ./pkg/middleware/... ./pkg/util/...