### PR TITLE
feat(mcp_server): add mcp_server_ids filter to v2_inner_list_mcp_server API

### DIFF
--- a/src/dashboard/apigateway/apigateway/apis/v2/inner/serializers.py
+++ b/src/dashboard/apigateway/apigateway/apis/v2/inner/serializers.py
@@ -433,6 +433,8 @@ class MCPServerAppPermissionApplyCreateInputSLZ(serializers.Serializer):
         child=serializers.IntegerField(),
         allow_empty=False,
         required=True,
+        max_length=50,
+        help_text="MCPServer ID 列表，最多 50 个",
     )
     applied_by = serializers.CharField(required=True, help_text="申请人")
     reason = serializers.CharField(required=True, help_text="申请原因")
@@ -598,6 +600,8 @@ class MCPServerListInputSLZ(serializers.Serializer):
             ids = [int(x.strip()) for x in value.split(",")]
         except ValueError:
             raise serializers.ValidationError(_("MCPServer ID 必须为整数，多个以逗号分割"))
+        if len(ids) > 50:
+            raise serializers.ValidationError(_("MCPServer ID 列表最多支持 50 个"))
         return ids
 
 

--- a/src/dashboard/apigateway/apigateway/apis/v2/inner/serializers.py
+++ b/src/dashboard/apigateway/apigateway/apis/v2/inner/serializers.py
@@ -584,9 +584,21 @@ class MCPServerListInputSLZ(serializers.Serializer):
         default="-updated_time",
         help_text="排序字段，支持 id, name, updated_time, created_time，前缀 - 表示降序，默认 -updated_time",
     )
+    mcp_server_ids = serializers.CharField(
+        allow_blank=True, required=False, help_text="MCPServer ID 列表，多个以逗号 , 分割"
+    )
 
     class Meta:
         ref_name = "apigateway.apis.v2.inner.serializers.MCPServerListInputSLZ"
+
+    def validate_mcp_server_ids(self, value):
+        if not value:
+            return []
+        try:
+            ids = [int(x.strip()) for x in value.split(",")]
+        except ValueError:
+            raise serializers.ValidationError(_("MCPServer ID 必须为整数，多个以逗号分割"))
+        return ids
 
 
 class MCPServerListOutputSLZ(serializers.Serializer):

--- a/src/dashboard/apigateway/apigateway/apis/v2/inner/views.py
+++ b/src/dashboard/apigateway/apigateway/apis/v2/inner/views.py
@@ -808,6 +808,7 @@ class MCPServerListApi(generics.ListAPIView):
         queryset = build_mcp_server_list_queryset(
             keyword=slz.validated_data.get("keyword"),
             order_by=slz.validated_data.get("order_by", "-updated_time"),
+            ids=slz.validated_data.get("mcp_server_ids") or None,
         )
 
         page = self.paginate_queryset(queryset)

--- a/src/dashboard/apigateway/apigateway/apis/v2/mcp_server.py
+++ b/src/dashboard/apigateway/apigateway/apis/v2/mcp_server.py
@@ -55,6 +55,7 @@ def build_mcp_server_list_queryset(
     category: Optional[str] = None,
     is_public: Optional[bool] = None,
     order_by: str = "-updated_time",
+    ids: Optional[List[int]] = None,
 ) -> QuerySet:
     """构建 MCPServer 列表的通用 queryset（不含分页）
 
@@ -66,6 +67,7 @@ def build_mcp_server_list_queryset(
         category=category,
         is_public=is_public,
         order_by=order_by,
+        ids=ids,
     )
 
 

--- a/src/dashboard/apigateway/apigateway/apis/v2/open/serializers.py
+++ b/src/dashboard/apigateway/apigateway/apis/v2/open/serializers.py
@@ -334,6 +334,8 @@ class MCPServerAppPermissionApplyCreateInputSLZ(serializers.Serializer):
         child=serializers.IntegerField(),
         allow_empty=False,
         required=True,
+        max_length=50,
+        help_text="MCPServer ID 列表，最多 50 个",
     )
     applied_by = serializers.CharField(required=True, help_text="申请人")
     reason = serializers.CharField(required=True, help_text="申请原因")

--- a/src/dashboard/apigateway/apigateway/biz/mcp_server/mcp_server.py
+++ b/src/dashboard/apigateway/apigateway/biz/mcp_server/mcp_server.py
@@ -606,6 +606,7 @@ class MCPServerHandler:
         categories: Optional[List[str]] = None,
         is_public: Optional[bool] = None,
         order_by: str = "-updated_time",
+        ids: Optional[List[int]] = None,
     ) -> QuerySet:
         """构建 MCPServer 列表的通用 queryset
 
@@ -617,6 +618,7 @@ class MCPServerHandler:
             categories: 多个分类名称列表筛选（支持 AND/OR 逻辑）
             is_public: 是否公开
             order_by: 排序字段
+            ids: MCPServer ID 列表，用于批量筛选
 
         Returns:
             构建好的 queryset
@@ -624,6 +626,9 @@ class MCPServerHandler:
         queryset = MCPServer.objects.filter(status=MCPServerStatusEnum.ACTIVE.value)
         queryset = queryset.filter(gateway__status=GatewayStatusEnum.ACTIVE.value)
         queryset = queryset.filter(stage__status=StageStatusEnum.ACTIVE.value)
+
+        if ids:
+            queryset = queryset.filter(id__in=ids)
 
         if is_public is not None:
             queryset = queryset.filter(is_public=is_public)

--- a/src/dashboard/apigateway/apigateway/data/apidocs/zh/v2_inner_apply_mcp_server_permission.md
+++ b/src/dashboard/apigateway/apigateway/data/apidocs/zh/v2_inner_apply_mcp_server_permission.md
@@ -10,7 +10,7 @@ MCPServer 申请权限/批量申请权限
 | 参数名称                     | 参数类型       | 必选 | 描述                   |
 |--------------------------|------------|----|----------------------|
 | target_app_code          | string     | 是  | 申请权限的应用，应于当前请求的应用一致  |
-| mcp_server_ids           | array[int] | 是  | mcp_server ID 列表     |
+| mcp_server_ids           | array[int] | 是  | mcp_server ID 列表，最多 50 个     |
 | applied_by               | string     | 是  | 申请人                  |
 | reason                   | string     | 是  | 申请理由                 |
 

--- a/src/dashboard/apigateway/apigateway/data/apidocs/zh/v2_inner_list_mcp_server.md
+++ b/src/dashboard/apigateway/apigateway/data/apidocs/zh/v2_inner_list_mcp_server.md
@@ -11,6 +11,7 @@
 |---------|--------|----|-----------------------------------------|
 | keyword | string | 否  | MCPServer 筛选条件，支持模糊匹配 MCPServer 名称或描述 |
 | order_by | string | 否  | 排序字段，支持 id, name, updated_time, created_time，前缀 - 表示降序，默认 -updated_time |
+| mcp_server_ids | string | 否  | MCPServer ID 列表，多个以逗号分割，最多 50 个。例如：1,2,3 |
 
 
 ### 响应示例

--- a/src/dashboard/apigateway/apigateway/data/apidocs/zh/v2_open_mcp_server_app_permissions_apply.md
+++ b/src/dashboard/apigateway/apigateway/data/apidocs/zh/v2_open_mcp_server_app_permissions_apply.md
@@ -9,7 +9,7 @@
 | 参数名称               | 参数类型       | 必选 | 描述               |
 |--------------------|------------|----|------------------|
 | bk_app_code        | string     | 是  | 蓝鲸应用编码           |
-| mcp_server_ids     | array[int] | 是  | mcp_server ID 列表 |
+| mcp_server_ids     | array[int] | 是  | mcp_server ID 列表，最多 50 个 |
 | applied_by         | string     | 是  | 申请人              |
 | reason             | string     | 是  | 申请原因             |
 

--- a/src/dashboard/apigateway/apigateway/data/apigw-definitions/bk-apigateway-resources.yaml
+++ b/src/dashboard/apigateway/apigateway/data/apigw-definitions/bk-apigateway-resources.yaml
@@ -3456,7 +3456,8 @@ paths:
                   type: array
                   items:
                     type: integer
-                  description: mcp_server ID 列表
+                  maxItems: 50
+                  description: mcp_server ID 列表，最多 50 个
                   example: [1, 2, 3]
                 applied_by:
                   type: string
@@ -6381,7 +6382,8 @@ paths:
                   type: array
                   items:
                     type: integer
-                  description: mcp_server ID 列表
+                  maxItems: 50
+                  description: mcp_server ID 列表，最多 50 个
                   example: [1, 2]
                 applied_by:
                   type: string
@@ -6627,6 +6629,24 @@ paths:
       description: 获取全量的 MCPServer 列表（应用态接口）
       tags:
       - v2_inner
+      parameters:
+        - name: keyword
+          in: query
+          schema:
+            type: string
+          description: MCPServer 筛选条件，支持模糊匹配 MCPServer 名称或描述
+        - name: order_by
+          in: query
+          schema:
+            type: string
+          description: 排序字段，支持 id, name, updated_time, created_time，前缀 - 表示降序，默认 -updated_time
+          example: -updated_time
+        - name: mcp_server_ids
+          in: query
+          schema:
+            type: string
+          description: MCPServer ID 列表，多个以逗号分割，最多 50 个
+          example: "1,2,3"
       responses:
         default:
           description: ''

--- a/src/dashboard/apigateway/apigateway/tests/apis/v2/inner/test_views.py
+++ b/src/dashboard/apigateway/apigateway/tests/apis/v2/inner/test_views.py
@@ -967,6 +967,112 @@ class TestMCPServerListApi:
         assert len(result["data"]["results"]) == 1
         assert result["data"]["results"][0]["id"] == mcp_server1.id
 
+    def test_list_with_mcp_server_ids_filter(self, request_view, fake_gateway, mocker):
+        """测试使用 mcp_server_ids 筛选 MCPServer"""
+        fake_gateway.status = GatewayStatusEnum.ACTIVE.value
+        fake_gateway.maintainers = ["admin"]
+        fake_gateway.save()
+
+        stage = G(Stage, gateway=fake_gateway, status=StageStatusEnum.ACTIVE.value)
+
+        mcp_server1 = G(
+            MCPServer,
+            gateway=fake_gateway,
+            stage=stage,
+            name="server-one",
+            is_public=True,
+            status=MCPServerStatusEnum.ACTIVE.value,
+            protocol_type=MCPServerProtocolTypeEnum.SSE.value,
+        )
+        mcp_server2 = G(
+            MCPServer,
+            gateway=fake_gateway,
+            stage=stage,
+            name="server-two",
+            is_public=True,
+            status=MCPServerStatusEnum.ACTIVE.value,
+            protocol_type=MCPServerProtocolTypeEnum.SSE.value,
+        )
+        mcp_server3 = G(
+            MCPServer,
+            gateway=fake_gateway,
+            stage=stage,
+            name="server-three",
+            is_public=True,
+            status=MCPServerStatusEnum.ACTIVE.value,
+            protocol_type=MCPServerProtocolTypeEnum.SSE.value,
+        )
+
+        mocker.patch(
+            "apigateway.biz.mcp_server.mcp_server.GatewayAuthContext.get_gateway_id_to_auth_config",
+            return_value={fake_gateway.id: mock.MagicMock(gateway_type=1)},
+        )
+
+        # 只筛选 server1 和 server3
+        resp = request_view(
+            method="GET",
+            view_name="openapi.v2.inner.mcp_server.list",
+            data={"mcp_server_ids": f"{mcp_server1.id},{mcp_server3.id}"},
+            app=mock.MagicMock(app_code="test"),
+        )
+        result = resp.json()
+
+        assert resp.status_code == 200
+        result_ids = [item["id"] for item in result["data"]["results"]]
+        assert mcp_server1.id in result_ids
+        assert mcp_server3.id in result_ids
+        assert mcp_server2.id not in result_ids
+
+    def test_list_with_mcp_server_ids_empty(self, request_view, fake_gateway, mocker):
+        """测试 mcp_server_ids 为空时返回所有"""
+        fake_gateway.status = GatewayStatusEnum.ACTIVE.value
+        fake_gateway.maintainers = ["admin"]
+        fake_gateway.save()
+
+        stage = G(Stage, gateway=fake_gateway, status=StageStatusEnum.ACTIVE.value)
+
+        mcp_server = G(
+            MCPServer,
+            gateway=fake_gateway,
+            stage=stage,
+            name="server-empty-ids-test",
+            is_public=True,
+            status=MCPServerStatusEnum.ACTIVE.value,
+            protocol_type=MCPServerProtocolTypeEnum.SSE.value,
+        )
+
+        mocker.patch(
+            "apigateway.biz.mcp_server.mcp_server.GatewayAuthContext.get_gateway_id_to_auth_config",
+            return_value={fake_gateway.id: mock.MagicMock(gateway_type=1)},
+        )
+
+        # mcp_server_ids 为空字符串，应返回所有
+        resp = request_view(
+            method="GET",
+            view_name="openapi.v2.inner.mcp_server.list",
+            data={"mcp_server_ids": ""},
+            app=mock.MagicMock(app_code="test"),
+        )
+        result = resp.json()
+
+        assert resp.status_code == 200
+        result_ids = [item["id"] for item in result["data"]["results"]]
+        assert mcp_server.id in result_ids
+
+    def test_list_with_mcp_server_ids_invalid(self, request_view, fake_gateway, mocker):
+        """测试 mcp_server_ids 包含非法值时返回 400"""
+        fake_gateway.status = GatewayStatusEnum.ACTIVE.value
+        fake_gateway.save()
+
+        resp = request_view(
+            method="GET",
+            view_name="openapi.v2.inner.mcp_server.list",
+            data={"mcp_server_ids": "abc,def"},
+            app=mock.MagicMock(app_code="test"),
+        )
+
+        assert resp.status_code == 400
+
     def test_list_returns_oauth2_public_client_enabled_true(self, request_view, fake_gateway, mocker):
         """测试 MCPServer 列表接口返回 oauth2_public_client_enabled=True"""
         fake_gateway.status = GatewayStatusEnum.ACTIVE.value

--- a/src/dashboard/apigateway/apigateway/tests/biz/mcp_server/test_mcp_server.py
+++ b/src/dashboard/apigateway/apigateway/tests/biz/mcp_server/test_mcp_server.py
@@ -1335,6 +1335,77 @@ class TestMCPServerHandler:
         result = MCPServerHandler.build_list_queryset()
         assert server.id not in set(result.values_list("id", flat=True))
 
+    def test_build_list_queryset_with_ids(self, fake_gateway, fake_stage):
+        """按 ID 列表批量筛选"""
+        fake_gateway.status = GatewayStatusEnum.ACTIVE.value
+        fake_gateway.save()
+        fake_stage.status = StageStatusEnum.ACTIVE.value
+        fake_stage.save()
+
+        server_a = G(
+            MCPServer,
+            gateway=fake_gateway,
+            stage=fake_stage,
+            status=MCPServerStatusEnum.ACTIVE.value,
+        )
+        server_b = G(
+            MCPServer,
+            gateway=fake_gateway,
+            stage=fake_stage,
+            status=MCPServerStatusEnum.ACTIVE.value,
+        )
+        server_c = G(
+            MCPServer,
+            gateway=fake_gateway,
+            stage=fake_stage,
+            status=MCPServerStatusEnum.ACTIVE.value,
+        )
+
+        # 只筛选 server_a 和 server_c
+        result = MCPServerHandler.build_list_queryset(ids=[server_a.id, server_c.id])
+        result_ids = set(result.values_list("id", flat=True))
+        assert server_a.id in result_ids
+        assert server_c.id in result_ids
+        assert server_b.id not in result_ids
+
+    def test_build_list_queryset_with_ids_empty_list(self, fake_gateway, fake_stage):
+        """ids 为空列表时不做筛选，返回所有"""
+        fake_gateway.status = GatewayStatusEnum.ACTIVE.value
+        fake_gateway.save()
+        fake_stage.status = StageStatusEnum.ACTIVE.value
+        fake_stage.save()
+
+        server = G(
+            MCPServer,
+            gateway=fake_gateway,
+            stage=fake_stage,
+            status=MCPServerStatusEnum.ACTIVE.value,
+        )
+
+        # ids=[] (falsy) 不应过滤
+        result = MCPServerHandler.build_list_queryset(ids=[])
+        result_ids = set(result.values_list("id", flat=True))
+        assert server.id in result_ids
+
+    def test_build_list_queryset_with_ids_nonexistent(self, fake_gateway, fake_stage):
+        """ids 中包含不存在的 ID 时，只返回存在的"""
+        fake_gateway.status = GatewayStatusEnum.ACTIVE.value
+        fake_gateway.save()
+        fake_stage.status = StageStatusEnum.ACTIVE.value
+        fake_stage.save()
+
+        server = G(
+            MCPServer,
+            gateway=fake_gateway,
+            stage=fake_stage,
+            status=MCPServerStatusEnum.ACTIVE.value,
+        )
+
+        result = MCPServerHandler.build_list_queryset(ids=[server.id, 999999])
+        result_ids = set(result.values_list("id", flat=True))
+        assert server.id in result_ids
+        assert 999999 not in result_ids
+
     # ========== build_list_context 测试 ==========
 
     def test_build_list_context_basic(self, fake_gateway, fake_stage):


### PR DESCRIPTION
- 在 v2_inner_list_mcp_server API 中新增 mcp_server_ids 批量筛选参数，支持按 ID 列表过滤 MCPServer；同步补充 view 层和 biz 层共 6 个测试用例，覆盖正常筛选、空值、非法值、不存在 ID 等边界场景。