### PR TITLE
feat: support adaptive MCP Server URL based on least privilege

### DIFF
--- a/src/dashboard/apigateway/apigateway/apis/v2/inner/serializers.py
+++ b/src/dashboard/apigateway/apigateway/apis/v2/inner/serializers.py
@@ -23,7 +23,7 @@ from typing import Dict, List
 from django.utils.translation import gettext as _
 from rest_framework import serializers
 
-from apigateway.apis.v2.mcp_server import get_categories_from_context
+from apigateway.apis.v2.mcp_server import get_categories_from_context, get_mcp_server_url_from_context
 from apigateway.apps.mcp_server.constants import (
     MCPServerAppPermissionApplyStatusEnum,
     MCPServerProtocolTypeEnum,
@@ -46,7 +46,6 @@ from apigateway.core.constants import GatewayStatusEnum
 from apigateway.service.mcp.mcp_server import (
     build_mcp_server_detail_url,
     build_mcp_server_permission_approval_url,
-    build_mcp_server_url,
 )
 from apigateway.utils import time
 
@@ -370,12 +369,16 @@ class MCPServerBaseSLZ(serializers.Serializer):
         help_text="MCPServer 协议类型",
         choices=MCPServerProtocolTypeEnum.get_choices(),
     )
+    url = serializers.SerializerMethodField(help_text="MCPServer 访问 URL")
     categories = serializers.SerializerMethodField(help_text="MCPServer 分类列表")
 
     def get_title(self, obj) -> str:
         title = obj.get("title", "") if isinstance(obj, dict) else getattr(obj, "title", "")
         name = obj.get("name", "") if isinstance(obj, dict) else getattr(obj, "name", "")
         return title if title else name
+
+    def get_url(self, obj) -> str:
+        return get_mcp_server_url_from_context(self.context, obj)
 
     def get_doc_link(self, obj):
         obj_id = obj.get("id") if isinstance(obj, dict) else obj.id
@@ -641,7 +644,7 @@ class MCPServerListOutputSLZ(serializers.Serializer):
         return self.context["gateways"][obj.gateway.id]
 
     def get_url(self, obj) -> str:
-        return build_mcp_server_url(obj.name, obj.protocol_type)
+        return get_mcp_server_url_from_context(self.context, obj)
 
     def get_detail_url(self, obj) -> str:
         return build_mcp_server_detail_url(obj.id)

--- a/src/dashboard/apigateway/apigateway/apis/v2/inner/serializers.py
+++ b/src/dashboard/apigateway/apigateway/apis/v2/inner/serializers.py
@@ -373,16 +373,13 @@ class MCPServerBaseSLZ(serializers.Serializer):
     categories = serializers.SerializerMethodField(help_text="MCPServer 分类列表")
 
     def get_title(self, obj) -> str:
-        title = obj.get("title", "") if isinstance(obj, dict) else getattr(obj, "title", "")
-        name = obj.get("name", "") if isinstance(obj, dict) else getattr(obj, "name", "")
-        return title if title else name
+        return obj.title if obj.title else obj.name
 
     def get_url(self, obj) -> str:
         return get_mcp_server_url_from_context(self.context, obj)
 
     def get_doc_link(self, obj):
-        obj_id = obj.get("id") if isinstance(obj, dict) else obj.id
-        return build_mcp_server_detail_url(obj_id)
+        return build_mcp_server_detail_url(obj.id)
 
     def get_categories(self, obj) -> List[Dict[str, str]]:
         return get_categories_from_context(self.context, obj)

--- a/src/dashboard/apigateway/apigateway/apis/v2/inner/views.py
+++ b/src/dashboard/apigateway/apigateway/apis/v2/inner/views.py
@@ -485,7 +485,9 @@ class MCPServerPermissionListApi(generics.ListAPIView):
 
         data = slz.validated_data
 
-        queryset = MCPServer.objects.filter(is_public=True, status=MCPServerStatusEnum.ACTIVE.value)
+        queryset = MCPServer.objects.filter(is_public=True, status=MCPServerStatusEnum.ACTIVE.value).select_related(
+            "gateway", "stage"
+        )
 
         keyword = data.get("keyword")
         if keyword:
@@ -512,6 +514,9 @@ class MCPServerPermissionListApi(generics.ListAPIView):
         # Build categories map for queryset
         categories_map = MCPServerHandler.build_categories_map([obj.id for obj in queryset])
 
+        # 计算最低权限级别，用于判断是否展示应用态 URL
+        least_privileges = MCPServerHandler.get_least_privileges(list(queryset))
+
         for obj in queryset:
             permission_status = mcp_server_permission_status.get(
                 obj.id, MCPServerPermissionStatusEnum.NEED_APPLY.value
@@ -528,15 +533,7 @@ class MCPServerPermissionListApi(generics.ListAPIView):
 
             mcp_server_permissions.append(
                 {
-                    "mcp_server": {
-                        "id": obj.id,
-                        "name": obj.name,
-                        "title": obj.title or obj.name,
-                        "description": obj.description,
-                        "tools_count": obj.tools_count,
-                        "tool_names": obj.tool_names,
-                        "protocol_type": obj.protocol_type,
-                    },
+                    "mcp_server": obj,
                     "permission": {
                         "status": permission_status,
                         "action": action,
@@ -549,7 +546,12 @@ class MCPServerPermissionListApi(generics.ListAPIView):
             )
 
         slz = serializers.MCPServerPermissionListOutputSLZ(
-            mcp_server_permissions, many=True, context={"categories": categories_map}
+            mcp_server_permissions,
+            many=True,
+            context={
+                "categories": categories_map,
+                "least_privileges": least_privileges,
+            },
         )
         return OKJsonResponse(data=slz.data)
 
@@ -607,22 +609,26 @@ class MCPServerAppPermissionListApi(generics.ListAPIView):
         slz = self.get_serializer(data=request.query_params)
         slz.is_valid(raise_exception=True)
 
-        queryset = MCPServerAppPermissionApply.objects.filter(
-            bk_app_code=slz.validated_data["target_app_code"],
-            status__in=[MCPServerAppPermissionApplyStatusEnum.APPROVED.value],
-        ).order_by("-applied_time")
+        queryset = (
+            MCPServerAppPermissionApply.objects.filter(
+                bk_app_code=slz.validated_data["target_app_code"],
+                status__in=[MCPServerAppPermissionApplyStatusEnum.APPROVED.value],
+            )
+            .select_related("mcp_server", "mcp_server__gateway", "mcp_server__stage")
+            .order_by("-applied_time")
+        )
+
+        mcp_servers = [obj.mcp_server for obj in queryset]
+
+        # 计算最低权限级别，用于判断是否展示应用态 URL
+        least_privileges = MCPServerHandler.get_least_privileges(mcp_servers)
+
+        # Build categories map
+        categories_map = MCPServerHandler.build_categories_map([obj.mcp_server_id for obj in queryset])
 
         mcp_server_permissions = [
             {
-                "mcp_server": {
-                    "id": obj.mcp_server_id,
-                    "name": obj.mcp_server.name,
-                    "title": obj.mcp_server.title or obj.mcp_server.name,
-                    "description": obj.mcp_server.description,
-                    "tools_count": obj.mcp_server.tools_count,
-                    "tool_names": obj.mcp_server.tool_names,
-                    "protocol_type": obj.mcp_server.protocol_type,
-                },
+                "mcp_server": obj.mcp_server,
                 "permission": {
                     "status": MCPServerPermissionStatusEnum.OWNED.value,
                     "action": "",
@@ -635,11 +641,13 @@ class MCPServerAppPermissionListApi(generics.ListAPIView):
             for obj in queryset
         ]
 
-        # Build categories map
-        categories_map = MCPServerHandler.build_categories_map([obj.mcp_server_id for obj in queryset])
-
         slz = serializers.MCPServerAppPermissionListOutputSLZ(
-            mcp_server_permissions, many=True, context={"categories": categories_map}
+            mcp_server_permissions,
+            many=True,
+            context={
+                "categories": categories_map,
+                "least_privileges": least_privileges,
+            },
         )
         return OKJsonResponse(data=slz.data)
 
@@ -818,6 +826,9 @@ class MCPServerListApi(generics.ListAPIView):
 
         # Add categories map
         context["categories"] = MCPServerHandler.build_categories_map([mcp_server.id for mcp_server in page])
+
+        # 计算最低权限级别，用于判断是否展示应用态 URL
+        context["least_privileges"] = MCPServerHandler.get_least_privileges(page)
 
         output_slz = serializers.MCPServerListOutputSLZ(page, many=True, context=context)
         return self.get_paginated_response(output_slz.data)

--- a/src/dashboard/apigateway/apigateway/apis/v2/inner/views.py
+++ b/src/dashboard/apigateway/apigateway/apis/v2/inner/views.py
@@ -678,20 +678,11 @@ class MCPServerAppPermissionRecordListApi(generics.ListAPIView):
             data.get("query"),
             data.get("applied_time_start"),
             data.get("applied_time_end"),
-        )
+        ).select_related("mcp_server", "mcp_server__gateway", "mcp_server__stage")
 
         mcp_server_permission_records = [
             {
-                "mcp_server": {
-                    "id": obj.mcp_server_id,
-                    "name": obj.mcp_server.name,
-                    "title": obj.mcp_server.title or obj.mcp_server.name,
-                    "description": obj.mcp_server.description,
-                    "tools_count": obj.mcp_server.tools_count,
-                    "tool_names": obj.mcp_server.tool_names,
-                    "protocol_type": obj.mcp_server.protocol_type,
-                    "gateway_id": obj.mcp_server.gateway_id,  # 添加 gateway_id 用于构建审批 URL
-                },
+                "mcp_server": obj.mcp_server,
                 "record": {
                     "id": obj.id,
                     "bk_app_code": obj.bk_app_code,
@@ -704,8 +695,8 @@ class MCPServerAppPermissionRecordListApi(generics.ListAPIView):
                     "comment": obj.comment,
                     "reason": obj.reason,
                     "expire_days": obj.expire_days,
-                    "mcp_server_id": obj.mcp_server_id,  # 添加 mcp_server_id 用于构建审批 URL
-                    "gateway_id": obj.mcp_server.gateway_id,  # 在 record 中也添加 gateway_id
+                    "mcp_server_id": obj.mcp_server_id,
+                    "gateway_id": obj.mcp_server.gateway_id,
                     "tenant_mode": obj.mcp_server.gateway.tenant_mode,
                     "tenant_id": obj.mcp_server.gateway.tenant_id,
                 },
@@ -716,8 +707,17 @@ class MCPServerAppPermissionRecordListApi(generics.ListAPIView):
         # Build categories map
         categories_map = MCPServerHandler.build_categories_map([obj.mcp_server_id for obj in queryset])
 
+        # 计算最低权限级别，用于判断是否展示应用态 URL
+        mcp_servers = [obj.mcp_server for obj in queryset]
+        least_privileges = MCPServerHandler.get_least_privileges(mcp_servers)
+
         slz = serializers.MCPServerAppPermissionRecordListOutputSLZ(
-            mcp_server_permission_records, many=True, context={"categories": categories_map}
+            mcp_server_permission_records,
+            many=True,
+            context={
+                "categories": categories_map,
+                "least_privileges": least_privileges,
+            },
         )
 
         return OKJsonResponse(data=slz.data)
@@ -746,7 +746,9 @@ class MCPServerAppPermissionRecordRetrieveApi(generics.RetrieveAPIView):
         data = slz.validated_data
 
         try:
-            return MCPServerAppPermissionApply.objects.get(bk_app_code=data["target_app_code"], id=record_id)
+            return MCPServerAppPermissionApply.objects.select_related(
+                "mcp_server", "mcp_server__gateway", "mcp_server__stage"
+            ).get(bk_app_code=data["target_app_code"], id=record_id)
         except MCPServerAppPermissionApply.DoesNotExist:
             raise error_codes.NOT_FOUND
 
@@ -754,16 +756,7 @@ class MCPServerAppPermissionRecordRetrieveApi(generics.RetrieveAPIView):
         instance = self.get_object()
 
         mcp_server_permission_record = {
-            "mcp_server": {
-                "id": instance.mcp_server_id,
-                "name": instance.mcp_server.name,
-                "title": instance.mcp_server.title or instance.mcp_server.name,
-                "description": instance.mcp_server.description,
-                "tools_count": instance.mcp_server.tools_count,
-                "tool_names": instance.mcp_server.tool_names,
-                "protocol_type": instance.mcp_server.protocol_type,
-                "gateway_id": instance.mcp_server.gateway_id,  # 添加 gateway_id 用于构建审批 URL
-            },
+            "mcp_server": instance.mcp_server,
             "record": {
                 "id": instance.id,
                 "applied_by": instance.applied_by,
@@ -777,15 +770,22 @@ class MCPServerAppPermissionRecordRetrieveApi(generics.RetrieveAPIView):
                 "comment": instance.comment,
                 "reason": instance.reason,
                 "expire_days": instance.expire_days,
-                "mcp_server_id": instance.mcp_server_id,  # 添加 mcp_server_id 用于构建审批 URL
-                "gateway_id": instance.mcp_server.gateway_id,  # 在 record 中也添加 gateway_id
+                "mcp_server_id": instance.mcp_server_id,
+                "gateway_id": instance.mcp_server.gateway_id,
             },
         }
 
         # Build categories map
         categories_map = MCPServerHandler.build_categories_map([instance.mcp_server_id])
 
-        context = {**self.get_serializer_context(), "categories": categories_map}
+        # 计算最低权限级别，用于判断是否展示应用态 URL
+        least_privileges = MCPServerHandler.get_least_privileges([instance.mcp_server])
+
+        context = {
+            **self.get_serializer_context(),
+            "categories": categories_map,
+            "least_privileges": least_privileges,
+        }
         slz = self.get_serializer(mcp_server_permission_record, context=context)
         return OKJsonResponse(data=slz.data)
 

--- a/src/dashboard/apigateway/apigateway/apis/v2/mcp_server.py
+++ b/src/dashboard/apigateway/apigateway/apis/v2/mcp_server.py
@@ -26,53 +26,44 @@ v2 MCP Server 公共函数模块
     - validate_and_enrich_mcp_server_for_retrieve -> MCPServerHandler.build_retrieve_context
 """
 
-from typing import Any, Dict, List, Optional, Sequence, Tuple, Union
+from typing import Any, Dict, List, Optional, Sequence, Tuple
 
 from django.db.models import QuerySet
 
 from apigateway.apps.mcp_server.models import MCPServer
 from apigateway.biz.mcp_server import MCPServerHandler
-from apigateway.service.mcp.mcp_server import build_mcp_server_url
 
 
-def get_mcp_server_url_from_context(context: dict, obj: Union[dict, MCPServer]) -> str:
+def get_mcp_server_url_from_context(context: dict, obj: MCPServer) -> str:
     """从 serializer context 中获取 least_privilege 并生成 MCP Server URL
 
     统一 inner/open 序列化器中 get_url 方法的公共逻辑，避免重复实现。
-    支持 dict 和 model 实例两种 obj 格式。
 
     Args:
         context: serializer 的 context 字典，应包含 "least_privileges" 键
-        obj: MCPServer 数据，可以是 dict 或 model 实例
+        obj: MCPServer model 实例
 
     Returns:
         MCP Server 访问 URL
     """
-    if isinstance(obj, dict):
-        # dict 格式无法获取 gateway/stage 信息，回退到默认 URL
-        name = obj.get("name", "")
-        protocol_type = obj.get("protocol_type", "")
-        return build_mcp_server_url(name, protocol_type)
-
     least_privileges: Dict[Tuple[int, int], str] = context.get("least_privileges", {})
     least_privilege = least_privileges.get((obj.gateway.id, obj.stage.id), "")
     return MCPServerHandler.get_mcp_server_url(obj, least_privilege)
 
 
-def get_categories_from_context(context: dict, obj: Union[dict, MCPServer]) -> List[Dict[str, str]]:
+def get_categories_from_context(context: dict, obj: MCPServer) -> List[Dict[str, str]]:
     """从 serializer context 中获取 obj 对应的 categories 列表
 
-    支持 dict 和 model 实例两种 obj 格式，统一 inner/open 序列化器中的 categories 获取逻辑。
+    统一 inner/open 序列化器中的 categories 获取逻辑。
 
     Args:
         context: serializer 的 context 字典，应包含 "categories" 键
-        obj: MCPServer 数据，可以是 dict（含 "id" 键）或 model 实例（含 id 属性）
+        obj: MCPServer model 实例
 
     Returns:
         categories 列表，如 [{"name": "official", "display_name": "官方"}]
     """
-    obj_id = obj.get("id") if isinstance(obj, dict) else obj.id
-    return context.get("categories", {}).get(obj_id, [])
+    return context.get("categories", {}).get(obj.id, [])
 
 
 def build_mcp_server_list_queryset(

--- a/src/dashboard/apigateway/apigateway/apis/v2/mcp_server.py
+++ b/src/dashboard/apigateway/apigateway/apis/v2/mcp_server.py
@@ -26,12 +26,37 @@ v2 MCP Server 公共函数模块
     - validate_and_enrich_mcp_server_for_retrieve -> MCPServerHandler.build_retrieve_context
 """
 
-from typing import Any, Dict, List, Optional, Sequence, Union
+from typing import Any, Dict, List, Optional, Sequence, Tuple, Union
 
 from django.db.models import QuerySet
 
 from apigateway.apps.mcp_server.models import MCPServer
 from apigateway.biz.mcp_server import MCPServerHandler
+from apigateway.service.mcp.mcp_server import build_mcp_server_url
+
+
+def get_mcp_server_url_from_context(context: dict, obj: Union[dict, MCPServer]) -> str:
+    """从 serializer context 中获取 least_privilege 并生成 MCP Server URL
+
+    统一 inner/open 序列化器中 get_url 方法的公共逻辑，避免重复实现。
+    支持 dict 和 model 实例两种 obj 格式。
+
+    Args:
+        context: serializer 的 context 字典，应包含 "least_privileges" 键
+        obj: MCPServer 数据，可以是 dict 或 model 实例
+
+    Returns:
+        MCP Server 访问 URL
+    """
+    if isinstance(obj, dict):
+        # dict 格式无法获取 gateway/stage 信息，回退到默认 URL
+        name = obj.get("name", "")
+        protocol_type = obj.get("protocol_type", "")
+        return build_mcp_server_url(name, protocol_type)
+
+    least_privileges: Dict[Tuple[int, int], str] = context.get("least_privileges", {})
+    least_privilege = least_privileges.get((obj.gateway.id, obj.stage.id), "")
+    return MCPServerHandler.get_mcp_server_url(obj, least_privilege)
 
 
 def get_categories_from_context(context: dict, obj: Union[dict, MCPServer]) -> List[Dict[str, str]]:

--- a/src/dashboard/apigateway/apigateway/apis/v2/open/serializers.py
+++ b/src/dashboard/apigateway/apigateway/apis/v2/open/serializers.py
@@ -21,7 +21,7 @@ from typing import Any, Dict, List, Optional
 from django.utils.translation import gettext as _
 from rest_framework import serializers
 
-from apigateway.apis.v2.mcp_server import get_categories_from_context
+from apigateway.apis.v2.mcp_server import get_categories_from_context, get_mcp_server_url_from_context
 from apigateway.apps.mcp_server.constants import (
     MCPServerAppPermissionApplyStatusEnum,
     MCPServerAppPermissionGrantTypeEnum,
@@ -43,7 +43,6 @@ from apigateway.service.mcp.mcp_server import (
     build_mcp_server_application_url,
     build_mcp_server_detail_url,
     build_mcp_server_permission_approval_url,
-    build_mcp_server_url,
 )
 
 
@@ -293,7 +292,7 @@ class MCPServerBaseOutputSLZ(serializers.Serializer):
         return self.context["gateways"][obj.gateway.id]
 
     def get_url(self, obj) -> str:
-        return build_mcp_server_url(obj.name, obj.protocol_type)
+        return get_mcp_server_url_from_context(self.context, obj)
 
     def get_detail_url(self, obj) -> str:
         return build_mcp_server_detail_url(obj.id)
@@ -608,7 +607,7 @@ class MCPServerRetrieveOutputSLZ(serializers.Serializer):
         return self.context.get("categories", [])
 
     def get_url(self, obj) -> str:
-        return build_mcp_server_url(obj.name, obj.protocol_type)
+        return get_mcp_server_url_from_context(self.context, obj)
 
     def get_user_custom_doc(self, obj) -> str:
         return self.context.get("user_custom_doc", "")

--- a/src/dashboard/apigateway/apigateway/data/apidocs/zh/v2_inner_list_mcp_server.md
+++ b/src/dashboard/apigateway/apigateway/data/apidocs/zh/v2_inner_list_mcp_server.md
@@ -97,7 +97,7 @@
 | gateway      | object | MCPServer 网关信息        |
 | tools_count  | int    | MCPServer 工具数量        |
 | prompts_count | int    | MCPServer Prompts 数量  |
-| url          | string | MCPServer 访问 URL      |
+| url          | string | MCPServer 访问 URL，根据最低权限级别自适应返回普通 URL 或应用态 URL |
 | detail_url   | string | MCPServer 网关站点详情 URL  |
 | updated_by   | string | 更新人                   |
 | created_by   | string | 创建人                   |

--- a/src/dashboard/apigateway/apigateway/data/apidocs/zh/v2_inner_list_mcp_server_app_permissions.md
+++ b/src/dashboard/apigateway/apigateway/data/apidocs/zh/v2_inner_list_mcp_server_app_permissions.md
@@ -24,6 +24,9 @@ mcp_server 已申请权限列表
         "title": "测试服务",
         "description": "test",
         "tools_count": "1",
+        "tool_names": ["tool1", "tool2"],
+        "protocol_type": "sse",
+        "url": "https://mcp.example.com/bk-apigateway-prod-test/sse",
         "doc_link": "",
         "categories": [
           {"name": "official", "display_name": "官方"},
@@ -63,6 +66,9 @@ mcp_server 已申请权限列表
 | title           | string | mcp_server 中文名/显示名称 |
 | description     | string | mcp_server 描述     |
 | tools_count     | int    | mcp_server 工具数量   |
+| tool_names      | array  | mcp_server 工具名称列表 |
+| protocol_type   | string | MCPServer 协议类型（sse：SSE 协议，streamable_http：Streamable HTTP 协议） |
+| url             | string | mcp_server 访问 URL，根据最低权限级别自适应返回普通 URL 或应用态 URL |
 | doc_link        | string | mcp_server 文档访问地址 |
 | categories      | array  | mcp_server 分类列表，每项包含 name（英文标识）和 display_name（显示名称） |
 

--- a/src/dashboard/apigateway/apigateway/data/apidocs/zh/v2_inner_list_mcp_server_permission_apply_records.md
+++ b/src/dashboard/apigateway/apigateway/data/apidocs/zh/v2_inner_list_mcp_server_permission_apply_records.md
@@ -30,6 +30,9 @@ mcp_server 申请记录列表
         "title": "测试服务",
         "description": "test",
         "tools_count": "1",
+        "tool_names": ["tool1", "tool2"],
+        "protocol_type": "sse",
+        "url": "https://mcp.example.com/bk-apigateway-prod-s1/sse",
         "doc_link": "",
         "categories": [
           {"name": "official", "display_name": "官方"},
@@ -76,6 +79,9 @@ mcp_server 申请记录列表
 | title           | string | mcp_server 中文名/显示名称  |
 | description     | string | mcp_server 描述        |
 | tools_count     | int    | mcp_server 工具数量      |
+| tool_names      | array  | mcp_server 工具名称列表    |
+| protocol_type   | string | MCPServer 协议类型（sse：SSE 协议，streamable_http：Streamable HTTP 协议） |
+| url             | string | mcp_server 访问 URL，根据最低权限级别自适应返回普通 URL 或应用态 URL |
 | doc_link        | string | mcp_server 文档访问地址    |
 | categories      | array  | mcp_server 分类列表，每项包含 name（英文标识）和 display_name（显示名称） |
 

--- a/src/dashboard/apigateway/apigateway/data/apidocs/zh/v2_inner_list_mcp_server_permissions.md
+++ b/src/dashboard/apigateway/apigateway/data/apidocs/zh/v2_inner_list_mcp_server_permissions.md
@@ -26,6 +26,9 @@ mcp_server 申请权限列表
         "title": "测试服务1",
         "description": "test",
         "tools_count": "1",
+        "tool_names": ["tool1", "tool2"],
+        "protocol_type": "sse",
+        "url": "https://mcp.example.com/bk-apigateway-prod-test1/sse",
         "doc_link": "",
         "categories": [
           {"name": "official", "display_name": "官方"},
@@ -45,6 +48,9 @@ mcp_server 申请权限列表
         "title": "测试服务2",
         "description": "test",
         "tools_count": "1",
+        "tool_names": ["tool3"],
+        "protocol_type": "sse",
+        "url": "https://mcp.example.com/bk-esb-prod-test2/sse",
         "doc_link": "",
         "categories": []
       },
@@ -81,6 +87,9 @@ mcp_server 申请权限列表
 | title           | string | mcp_server 中文名/显示名称 |
 | description     | string | mcp_server 描述     |
 | tools_count     | int    | mcp_server 工具数量   |
+| tool_names      | array  | mcp_server 工具名称列表 |
+| protocol_type   | string | MCPServer 协议类型（sse：SSE 协议，streamable_http：Streamable HTTP 协议） |
+| url             | string | mcp_server 访问 URL，根据最低权限级别自适应返回普通 URL 或应用态 URL |
 | doc_link        | string | mcp_server 文档访问地址 |
 | categories      | array  | mcp_server 分类列表，每项包含 name（英文标识）和 display_name（显示名称） |
 

--- a/src/dashboard/apigateway/apigateway/data/apidocs/zh/v2_open_list_mcp_server.md
+++ b/src/dashboard/apigateway/apigateway/data/apidocs/zh/v2_open_list_mcp_server.md
@@ -84,7 +84,7 @@
 | oauth2_public_client_enabled   | boolean | 是否开启 OAuth2 公开客户端模式，开启后将会对 bk_app_code=public 的应用进行授权                                         |
 | categories      | array  | mcp_server 分类列表，每项包含 name（英文标识）和 display_name（显示名称） |
 | tools_count      | int     | mcp_server 工具数量                                        |
-| url              | string  | mcp_server 访问地址                                        |
+| url              | string  | mcp_server 访问 URL，根据最低权限级别自适应返回普通 URL 或应用态 URL |
 | detail_url       | string  | mcp_server 网关站点详情地址                                    |
 | updated_by       | string  | 更新人                                                    |
 | created_by       | string  | 创建人                                                    |

--- a/src/dashboard/apigateway/apigateway/data/apidocs/zh/v2_open_list_user_mcp_server.md
+++ b/src/dashboard/apigateway/apigateway/data/apidocs/zh/v2_open_list_user_mcp_server.md
@@ -86,7 +86,7 @@
 | oauth2_public_client_enabled      | boolean | 是否开启 OAuth2 公开客户端模式，开启后将会对 bk_app_code=public 的应用进行授权                                         |
 | categories          | array  | mcp_server 分类列表，每项包含 name（英文标识）和 display_name（显示名称） |
 | tools_count         | int     | mcp_server 工具数量                                        |
-| url                 | string  | mcp_server 访问地址                                        |
+| url                 | string  | mcp_server 访问 URL，根据最低权限级别自适应返回普通 URL 或应用态 URL |
 | detail_url          | string  | mcp_server 网关站点详情地址                                    |
 | updated_by          | string  | 更新人                                                    |
 | created_by          | string  | 创建人                                                    |

--- a/src/dashboard/apigateway/apigateway/data/apidocs/zh/v2_open_retrieve_mcp_server.md
+++ b/src/dashboard/apigateway/apigateway/data/apidocs/zh/v2_open_retrieve_mcp_server.md
@@ -104,7 +104,7 @@
 | status           | int      | mcp_server 状态（0：已停用，1：启用中）                      |
 | protocol_type    | string   | MCP 协议类型（sse：SSE 协议，streamable_http：Streamable HTTP 协议） |
 | oauth2_public_client_enabled   | boolean  | 是否开启 OAuth2 公开客户端模式，开启后将会对 bk_app_code=public 的应用进行授权                                         |
-| url              | string   | mcp_server 访问地址                                          |
+| url              | string   | mcp_server 访问 URL，根据最低权限级别自适应返回普通 URL 或应用态 URL |
 | guideline        | string   | mcp_server 使用指南                                          |
 | tools            | array    | mcp_server 工具列表                                          |
 | prompts          | array    | mcp_server Prompts 列表                                      |


### PR DESCRIPTION
- 抽取 MCPServerBaseSLZ 中重复的 get_url 逻辑到公共函数 get_mcp_server_url_from_context，支持 dict 和 model 实例两种输入；为 MCPServerPermissionListApi 补上缺失的 select_related("gateway", "stage") 避免 N+1 查询；移除各 Serializer 中不再直接使用的 MCPServerHandler import，修复 import 排序使其符合项目规范。