### PR TITLE
feat(workbench): add personal workbench module for permission management

### DIFF
--- a/src/dashboard/apigateway/apigateway/apis/web/personal_workbench/__init__.py
+++ b/src/dashboard/apigateway/apigateway/apis/web/personal_workbench/__init__.py
@@ -1,0 +1,17 @@
+#
+# TencentBlueKing is pleased to support the open source community by making
+# 蓝鲸智云 - API 网关(BlueKing - APIGateway) available.
+# Copyright (C) 2025 Tencent. All rights reserved.
+# Licensed under the MIT License (the "License"); you may not use this file except
+# in compliance with the License. You may obtain a copy of the License at
+#
+#     http://opensource.org/licenses/MIT
+#
+# Unless required by applicable law or agreed to in writing, software distributed under
+# the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+# either express or implied. See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# We undertake not to change the open source license (MIT license) applicable
+# to the current version of the project delivered to anyone in the future.
+#

--- a/src/dashboard/apigateway/apigateway/apis/web/personal_workbench/filters.py
+++ b/src/dashboard/apigateway/apigateway/apis/web/personal_workbench/filters.py
@@ -1,0 +1,71 @@
+#
+# TencentBlueKing is pleased to support the open source community by making
+# 蓝鲸智云 - API 网关(BlueKing - APIGateway) available.
+# Copyright (C) 2025 Tencent. All rights reserved.
+# Licensed under the MIT License (the "License"); you may not use this file except
+# in compliance with the License. You may obtain a copy of the License at
+#
+#     http://opensource.org/licenses/MIT
+#
+# Unless required by applicable law or agreed to in writing, software distributed under
+# the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+# either express or implied. See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# We undertake not to change the open source license (MIT license) applicable
+# to the current version of the project delivered to anyone in the future.
+#
+
+from django.db.models import Q
+from django_filters import rest_framework as filters
+
+from apigateway.apps.mcp_server.models import MCPServerAppPermissionApply
+from apigateway.apps.permission.constants import GrantDimensionEnum
+from apigateway.apps.permission.models import AppPermissionApply, AppPermissionRecord
+
+
+class WorkbenchGatewayPermissionApplyFilter(filters.FilterSet):
+    """个人工作台 - API 网关权限申请筛选器"""
+
+    bk_app_code = filters.CharFilter(lookup_expr="icontains")
+    applied_by = filters.CharFilter(lookup_expr="icontains")
+    grant_dimension = filters.ChoiceFilter(choices=GrantDimensionEnum.get_choices())
+    keyword = filters.CharFilter(method="keyword_filter")
+
+    class Meta:
+        model = AppPermissionApply
+        fields = ["bk_app_code", "applied_by", "grant_dimension", "keyword"]
+
+    def keyword_filter(self, queryset, name, value):
+        return queryset.filter(Q(bk_app_code__icontains=value) | Q(gateway__name__icontains=value))
+
+
+class WorkbenchGatewayPermissionRecordFilter(filters.FilterSet):
+    """个人工作台 - API 网关已办记录筛选器"""
+
+    bk_app_code = filters.CharFilter(lookup_expr="icontains")
+    applied_by = filters.CharFilter(lookup_expr="icontains")
+    grant_dimension = filters.ChoiceFilter(choices=GrantDimensionEnum.get_choices())
+    keyword = filters.CharFilter(method="keyword_filter")
+
+    class Meta:
+        model = AppPermissionRecord
+        fields = ["bk_app_code", "applied_by", "grant_dimension", "keyword"]
+
+    def keyword_filter(self, queryset, name, value):
+        return queryset.filter(Q(bk_app_code__icontains=value) | Q(gateway__name__icontains=value))
+
+
+class WorkbenchMCPPermissionApplyFilter(filters.FilterSet):
+    """个人工作台 - MCP Server 权限申请筛选器"""
+
+    bk_app_code = filters.CharFilter(lookup_expr="icontains")
+    applied_by = filters.CharFilter(lookup_expr="icontains")
+    keyword = filters.CharFilter(method="keyword_filter")
+
+    class Meta:
+        model = MCPServerAppPermissionApply
+        fields = ["bk_app_code", "applied_by", "keyword"]
+
+    def keyword_filter(self, queryset, name, value):
+        return queryset.filter(Q(bk_app_code__icontains=value) | Q(mcp_server__name__icontains=value))

--- a/src/dashboard/apigateway/apigateway/apis/web/personal_workbench/filters.py
+++ b/src/dashboard/apigateway/apigateway/apis/web/personal_workbench/filters.py
@@ -70,4 +70,8 @@ class WorkbenchMCPPermissionApplyFilter(filters.FilterSet):
         fields = ["bk_app_code", "applied_by", "status", "keyword"]
 
     def keyword_filter(self, queryset, name, value):
-        return queryset.filter(Q(bk_app_code__icontains=value) | Q(mcp_server__name__icontains=value))
+        return queryset.filter(
+            Q(bk_app_code__icontains=value)
+            | Q(mcp_server__name__icontains=value)
+            | Q(mcp_server__title__icontains=value)
+        )

--- a/src/dashboard/apigateway/apigateway/apis/web/personal_workbench/filters.py
+++ b/src/dashboard/apigateway/apigateway/apis/web/personal_workbench/filters.py
@@ -19,6 +19,7 @@
 from django.db.models import Q
 from django_filters import rest_framework as filters
 
+from apigateway.apps.mcp_server.constants import MCPServerAppPermissionApplyStatusEnum
 from apigateway.apps.mcp_server.models import MCPServerAppPermissionApply
 from apigateway.apps.permission.constants import GrantDimensionEnum
 from apigateway.apps.permission.models import AppPermissionApply, AppPermissionRecord
@@ -61,11 +62,12 @@ class WorkbenchMCPPermissionApplyFilter(filters.FilterSet):
 
     bk_app_code = filters.CharFilter(lookup_expr="icontains")
     applied_by = filters.CharFilter(lookup_expr="icontains")
+    status = filters.ChoiceFilter(choices=MCPServerAppPermissionApplyStatusEnum.get_choices())
     keyword = filters.CharFilter(method="keyword_filter")
 
     class Meta:
         model = MCPServerAppPermissionApply
-        fields = ["bk_app_code", "applied_by", "keyword"]
+        fields = ["bk_app_code", "applied_by", "status", "keyword"]
 
     def keyword_filter(self, queryset, name, value):
         return queryset.filter(Q(bk_app_code__icontains=value) | Q(mcp_server__name__icontains=value))

--- a/src/dashboard/apigateway/apigateway/apis/web/personal_workbench/serializers.py
+++ b/src/dashboard/apigateway/apigateway/apis/web/personal_workbench/serializers.py
@@ -161,8 +161,6 @@ class WorkbenchMCPServerBaseSLZ(serializers.Serializer):
         ref_name = "apigateway.apis.web.personal_workbench.serializers.WorkbenchMCPServerBaseSLZ"
 
     def get_title(self, obj) -> str:
-        if isinstance(obj, dict):
-            return obj.get("title") or obj.get("name", "")
         return obj.title if obj.title else obj.name
 
 

--- a/src/dashboard/apigateway/apigateway/apis/web/personal_workbench/serializers.py
+++ b/src/dashboard/apigateway/apigateway/apis/web/personal_workbench/serializers.py
@@ -1,0 +1,233 @@
+#
+# TencentBlueKing is pleased to support the open source community by making
+# 蓝鲸智云 - API 网关(BlueKing - APIGateway) available.
+# Copyright (C) 2025 Tencent. All rights reserved.
+# Licensed under the MIT License (the "License"); you may not use this file except
+# in compliance with the License. You may obtain a copy of the License at
+#
+#     http://opensource.org/licenses/MIT
+#
+# Unless required by applicable law or agreed to in writing, software distributed under
+# the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+# either express or implied. See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# We undertake not to change the open source license (MIT license) applicable
+# to the current version of the project delivered to anyone in the future.
+#
+
+from rest_framework import serializers
+
+from apigateway.apps.mcp_server.constants import MCPServerAppPermissionApplyStatusEnum
+from apigateway.apps.mcp_server.models import MCPServerAppPermissionApply
+from apigateway.apps.permission.constants import (
+    GrantDimensionEnum,
+    PermissionApplyExpireDaysEnum,
+)
+from apigateway.apps.permission.models import AppPermissionApply, AppPermissionRecord
+from apigateway.service.bk_itsm import ItsmPermissionApplyHelper
+
+# ========== 查询输入序列化器 ==========
+
+
+class WorkbenchGatewayPermissionQueryInputSLZ(serializers.Serializer):
+    """个人工作台 - API 网关权限查询输入"""
+
+    bk_app_code = serializers.CharField(required=False, allow_blank=True, help_text="蓝鲸应用 ID")
+    applied_by = serializers.CharField(required=False, allow_blank=True, help_text="申请人")
+    grant_dimension = serializers.ChoiceField(
+        choices=GrantDimensionEnum.get_choices(), required=False, help_text="授权维度"
+    )
+    keyword = serializers.CharField(
+        required=False, allow_blank=True, help_text="搜索关键字（模糊匹配网关名称或应用ID）"
+    )
+
+    class Meta:
+        ref_name = "apigateway.apis.web.personal_workbench.serializers.WorkbenchGatewayPermissionQueryInputSLZ"
+
+
+class WorkbenchMCPPermissionQueryInputSLZ(serializers.Serializer):
+    """个人工作台 - MCP Server 权限查询输入"""
+
+    bk_app_code = serializers.CharField(required=False, allow_blank=True, help_text="蓝鲸应用 ID")
+    applied_by = serializers.CharField(required=False, allow_blank=True, help_text="申请人")
+    keyword = serializers.CharField(
+        required=False, allow_blank=True, help_text="搜索关键字（模糊匹配 MCP Server 名称或应用ID）"
+    )
+
+    class Meta:
+        ref_name = "apigateway.apis.web.personal_workbench.serializers.WorkbenchMCPPermissionQueryInputSLZ"
+
+
+# ========== API 网关 输出序列化器 ==========
+
+
+class WorkbenchGatewayPermissionApplyOutputSLZ(serializers.ModelSerializer):
+    """个人工作台 - API 网关代办/我的申请 输出序列化器"""
+
+    gateway_name = serializers.SerializerMethodField(help_text="网关名称")
+    expire_days_display = serializers.SerializerMethodField(help_text="权限期限显示")
+    grant_dimension_display = serializers.SerializerMethodField(help_text="授权维度显示")
+    itsm_ticket_url = serializers.SerializerMethodField(help_text="ITSM 单据中心链接")
+
+    class Meta:
+        ref_name = "apigateway.apis.web.personal_workbench.serializers.WorkbenchGatewayPermissionApplyOutputSLZ"
+        model = AppPermissionApply
+        fields = [
+            "id",
+            "bk_app_code",
+            "gateway_name",
+            "grant_dimension",
+            "grant_dimension_display",
+            "expire_days",
+            "expire_days_display",
+            "reason",
+            "applied_by",
+            "created_time",
+            "status",
+            "itsm_ticket_id",
+            "itsm_ticket_url",
+        ]
+        read_only_fields = fields
+
+    def get_gateway_name(self, obj) -> str:
+        return obj.gateway.name if obj.gateway else ""
+
+    def get_expire_days_display(self, obj) -> str:
+        return PermissionApplyExpireDaysEnum.get_choice_label(obj.expire_days)
+
+    def get_grant_dimension_display(self, obj) -> str:
+        return GrantDimensionEnum.get_choice_label(obj.grant_dimension)
+
+    def get_itsm_ticket_url(self, obj) -> str:
+        return ItsmPermissionApplyHelper.build_ticket_url(obj.itsm_ticket_id)
+
+
+class WorkbenchGatewayPermissionRecordOutputSLZ(serializers.ModelSerializer):
+    """个人工作台 - API 网关已办 输出序列化器"""
+
+    gateway_name = serializers.SerializerMethodField(help_text="网关名称")
+    expire_days_display = serializers.SerializerMethodField(help_text="权限期限显示")
+    grant_dimension_display = serializers.SerializerMethodField(help_text="授权维度显示")
+    itsm_ticket_url = serializers.SerializerMethodField(help_text="ITSM 单据中心链接")
+
+    class Meta:
+        ref_name = "apigateway.apis.web.personal_workbench.serializers.WorkbenchGatewayPermissionRecordOutputSLZ"
+        model = AppPermissionRecord
+        fields = [
+            "id",
+            "bk_app_code",
+            "gateway_name",
+            "grant_dimension",
+            "grant_dimension_display",
+            "expire_days",
+            "expire_days_display",
+            "reason",
+            "applied_by",
+            "applied_time",
+            "handled_by",
+            "handled_time",
+            "status",
+            "comment",
+            "itsm_ticket_id",
+            "itsm_ticket_url",
+        ]
+        read_only_fields = fields
+
+    def get_gateway_name(self, obj) -> str:
+        return obj.gateway.name if obj.gateway else ""
+
+    def get_expire_days_display(self, obj) -> str:
+        return PermissionApplyExpireDaysEnum.get_choice_label(obj.expire_days)
+
+    def get_grant_dimension_display(self, obj) -> str:
+        return GrantDimensionEnum.get_choice_label(obj.grant_dimension)
+
+    def get_itsm_ticket_url(self, obj) -> str:
+        return ItsmPermissionApplyHelper.build_ticket_url(obj.itsm_ticket_id)
+
+
+# ========== MCP Server 输出序列化器 ==========
+
+
+class WorkbenchMCPServerBaseSLZ(serializers.Serializer):
+    """MCP Server 简要信息"""
+
+    id = serializers.IntegerField(read_only=True, help_text="MCPServer ID")
+    name = serializers.CharField(read_only=True, help_text="MCPServer 名称")
+    title = serializers.SerializerMethodField(help_text="MCPServer 显示名称")
+
+    class Meta:
+        ref_name = "apigateway.apis.web.personal_workbench.serializers.WorkbenchMCPServerBaseSLZ"
+
+    def get_title(self, obj) -> str:
+        if isinstance(obj, dict):
+            return obj.get("title") or obj.get("name", "")
+        return obj.title if obj.title else obj.name
+
+
+class WorkbenchMCPPermissionApplyOutputSLZ(serializers.ModelSerializer):
+    """个人工作台 - MCP Server 代办/我的申请 输出序列化器"""
+
+    mcp_server = WorkbenchMCPServerBaseSLZ(help_text="MCP Server 信息")
+    itsm_ticket_url = serializers.SerializerMethodField(help_text="ITSM 单据中心链接")
+    status_display = serializers.SerializerMethodField(help_text="审批状态显示")
+
+    class Meta:
+        ref_name = "apigateway.apis.web.personal_workbench.serializers.WorkbenchMCPPermissionApplyOutputSLZ"
+        model = MCPServerAppPermissionApply
+        fields = [
+            "id",
+            "bk_app_code",
+            "mcp_server",
+            "applied_by",
+            "applied_time",
+            "reason",
+            "expire_days",
+            "status",
+            "status_display",
+            "itsm_ticket_id",
+            "itsm_ticket_url",
+        ]
+        read_only_fields = fields
+
+    def get_itsm_ticket_url(self, obj) -> str:
+        return ItsmPermissionApplyHelper.build_ticket_url(obj.itsm_ticket_id)
+
+    def get_status_display(self, obj) -> str:
+        return MCPServerAppPermissionApplyStatusEnum.get_choice_label(obj.status)
+
+
+class WorkbenchMCPPermissionHandledOutputSLZ(serializers.ModelSerializer):
+    """个人工作台 - MCP Server 已办 输出序列化器"""
+
+    mcp_server = WorkbenchMCPServerBaseSLZ(help_text="MCP Server 信息")
+    itsm_ticket_url = serializers.SerializerMethodField(help_text="ITSM 单据中心链接")
+    status_display = serializers.SerializerMethodField(help_text="审批状态显示")
+
+    class Meta:
+        ref_name = "apigateway.apis.web.personal_workbench.serializers.WorkbenchMCPPermissionHandledOutputSLZ"
+        model = MCPServerAppPermissionApply
+        fields = [
+            "id",
+            "bk_app_code",
+            "mcp_server",
+            "applied_by",
+            "applied_time",
+            "reason",
+            "expire_days",
+            "handled_by",
+            "handled_time",
+            "status",
+            "status_display",
+            "comment",
+            "itsm_ticket_id",
+            "itsm_ticket_url",
+        ]
+        read_only_fields = fields
+
+    def get_itsm_ticket_url(self, obj) -> str:
+        return ItsmPermissionApplyHelper.build_ticket_url(obj.itsm_ticket_id)
+
+    def get_status_display(self, obj) -> str:
+        return MCPServerAppPermissionApplyStatusEnum.get_choice_label(obj.status)

--- a/src/dashboard/apigateway/apigateway/apis/web/personal_workbench/serializers.py
+++ b/src/dashboard/apigateway/apigateway/apis/web/personal_workbench/serializers.py
@@ -29,10 +29,12 @@ from apigateway.biz.permission.permission import ResourcePermissionHandler
 from apigateway.service.bk_itsm import ItsmPermissionApplyHelper
 
 # ========== 查询输入序列化器 ==========
+# NOTE: 以下 Input SLZ 仅用于 swagger 文档生成，实际查询过滤由 filters.py 中的 FilterSet 生效。
+# 修改查询参数时需同步修改对应的 FilterSet 以保持一致性。
 
 
 class WorkbenchGatewayPermissionQueryInputSLZ(serializers.Serializer):
-    """个人工作台 - API 网关权限查询输入"""
+    """个人工作台 - API 网关权限查询输入（仅用于文档生成，实际过滤由 FilterSet 处理）"""
 
     bk_app_code = serializers.CharField(required=False, allow_blank=True, help_text="蓝鲸应用 ID")
     applied_by = serializers.CharField(required=False, allow_blank=True, help_text="申请人")
@@ -48,7 +50,7 @@ class WorkbenchGatewayPermissionQueryInputSLZ(serializers.Serializer):
 
 
 class WorkbenchMCPPermissionQueryInputSLZ(serializers.Serializer):
-    """个人工作台 - MCP Server 权限查询输入"""
+    """个人工作台 - MCP Server 权限查询输入（仅用于文档生成，实际过滤由 FilterSet 处理）"""
 
     bk_app_code = serializers.CharField(required=False, allow_blank=True, help_text="蓝鲸应用 ID")
     applied_by = serializers.CharField(required=False, allow_blank=True, help_text="申请人")
@@ -93,7 +95,7 @@ class WorkbenchGatewayPermissionApplyOutputSLZ(serializers.ModelSerializer):
         read_only_fields = fields
 
     def get_gateway_name(self, obj) -> str:
-        return obj.gateway.name if obj.gateway else ""
+        return obj.gateway.name
 
     def get_expire_days_display(self, obj) -> str:
         return PermissionApplyExpireDaysEnum.get_choice_label(obj.expire_days)
@@ -102,12 +104,11 @@ class WorkbenchGatewayPermissionApplyOutputSLZ(serializers.ModelSerializer):
         return GrantDimensionEnum.get_choice_label(obj.grant_dimension)
 
     def get_applied_by(self, obj) -> str:
-        gateway = obj.gateway
         return ResourcePermissionHandler.convert_applied_by_to_display_name(
             obj.bk_app_code,
             obj.applied_by,
-            gateway.tenant_mode if gateway else "",
-            gateway.tenant_id if gateway else "",
+            obj.gateway.tenant_mode,
+            obj.gateway.tenant_id,
         )
 
     def get_itsm_ticket_url(self, obj) -> str:
@@ -147,7 +148,7 @@ class WorkbenchGatewayPermissionRecordOutputSLZ(serializers.ModelSerializer):
         read_only_fields = fields
 
     def get_gateway_name(self, obj) -> str:
-        return obj.gateway.name if obj.gateway else ""
+        return obj.gateway.name
 
     def get_expire_days_display(self, obj) -> str:
         return PermissionApplyExpireDaysEnum.get_choice_label(obj.expire_days)
@@ -156,12 +157,11 @@ class WorkbenchGatewayPermissionRecordOutputSLZ(serializers.ModelSerializer):
         return GrantDimensionEnum.get_choice_label(obj.grant_dimension)
 
     def get_applied_by(self, obj) -> str:
-        gateway = obj.gateway
         return ResourcePermissionHandler.convert_applied_by_to_display_name(
             obj.bk_app_code,
             obj.applied_by,
-            gateway.tenant_mode if gateway else "",
-            gateway.tenant_id if gateway else "",
+            obj.gateway.tenant_mode,
+            obj.gateway.tenant_id,
         )
 
     def get_itsm_ticket_url(self, obj) -> str:
@@ -212,12 +212,12 @@ class WorkbenchMCPPermissionApplyOutputSLZ(serializers.ModelSerializer):
         read_only_fields = fields
 
     def get_applied_by(self, obj) -> str:
-        gateway = obj.mcp_server.gateway if obj.mcp_server else None
+        gateway = obj.mcp_server.gateway
         return ResourcePermissionHandler.convert_applied_by_to_display_name(
             obj.bk_app_code,
             obj.applied_by,
-            gateway.tenant_mode if gateway else "",
-            gateway.tenant_id if gateway else "",
+            gateway.tenant_mode,
+            gateway.tenant_id,
         )
 
     def get_itsm_ticket_url(self, obj) -> str:
@@ -257,12 +257,12 @@ class WorkbenchMCPPermissionHandledOutputSLZ(serializers.ModelSerializer):
         read_only_fields = fields
 
     def get_applied_by(self, obj) -> str:
-        gateway = obj.mcp_server.gateway if obj.mcp_server else None
+        gateway = obj.mcp_server.gateway
         return ResourcePermissionHandler.convert_applied_by_to_display_name(
             obj.bk_app_code,
             obj.applied_by,
-            gateway.tenant_mode if gateway else "",
-            gateway.tenant_id if gateway else "",
+            gateway.tenant_mode,
+            gateway.tenant_id,
         )
 
     def get_itsm_ticket_url(self, obj) -> str:

--- a/src/dashboard/apigateway/apigateway/apis/web/personal_workbench/serializers.py
+++ b/src/dashboard/apigateway/apigateway/apis/web/personal_workbench/serializers.py
@@ -25,6 +25,7 @@ from apigateway.apps.permission.constants import (
     PermissionApplyExpireDaysEnum,
 )
 from apigateway.apps.permission.models import AppPermissionApply, AppPermissionRecord
+from apigateway.biz.permission.permission import ResourcePermissionHandler
 from apigateway.service.bk_itsm import ItsmPermissionApplyHelper
 
 # ========== 查询输入序列化器 ==========
@@ -68,6 +69,7 @@ class WorkbenchGatewayPermissionApplyOutputSLZ(serializers.ModelSerializer):
     gateway_name = serializers.SerializerMethodField(help_text="网关名称")
     expire_days_display = serializers.SerializerMethodField(help_text="权限期限显示")
     grant_dimension_display = serializers.SerializerMethodField(help_text="授权维度显示")
+    applied_by = serializers.SerializerMethodField(help_text="申请人")
     itsm_ticket_url = serializers.SerializerMethodField(help_text="ITSM 单据中心链接")
 
     class Meta:
@@ -99,6 +101,15 @@ class WorkbenchGatewayPermissionApplyOutputSLZ(serializers.ModelSerializer):
     def get_grant_dimension_display(self, obj) -> str:
         return GrantDimensionEnum.get_choice_label(obj.grant_dimension)
 
+    def get_applied_by(self, obj) -> str:
+        gateway = obj.gateway
+        return ResourcePermissionHandler.convert_applied_by_to_display_name(
+            obj.bk_app_code,
+            obj.applied_by,
+            gateway.tenant_mode if gateway else "",
+            gateway.tenant_id if gateway else "",
+        )
+
     def get_itsm_ticket_url(self, obj) -> str:
         return ItsmPermissionApplyHelper.build_ticket_url(obj.itsm_ticket_id)
 
@@ -109,6 +120,7 @@ class WorkbenchGatewayPermissionRecordOutputSLZ(serializers.ModelSerializer):
     gateway_name = serializers.SerializerMethodField(help_text="网关名称")
     expire_days_display = serializers.SerializerMethodField(help_text="权限期限显示")
     grant_dimension_display = serializers.SerializerMethodField(help_text="授权维度显示")
+    applied_by = serializers.SerializerMethodField(help_text="申请人")
     itsm_ticket_url = serializers.SerializerMethodField(help_text="ITSM 单据中心链接")
 
     class Meta:
@@ -143,6 +155,15 @@ class WorkbenchGatewayPermissionRecordOutputSLZ(serializers.ModelSerializer):
     def get_grant_dimension_display(self, obj) -> str:
         return GrantDimensionEnum.get_choice_label(obj.grant_dimension)
 
+    def get_applied_by(self, obj) -> str:
+        gateway = obj.gateway
+        return ResourcePermissionHandler.convert_applied_by_to_display_name(
+            obj.bk_app_code,
+            obj.applied_by,
+            gateway.tenant_mode if gateway else "",
+            gateway.tenant_id if gateway else "",
+        )
+
     def get_itsm_ticket_url(self, obj) -> str:
         return ItsmPermissionApplyHelper.build_ticket_url(obj.itsm_ticket_id)
 
@@ -168,6 +189,7 @@ class WorkbenchMCPPermissionApplyOutputSLZ(serializers.ModelSerializer):
     """个人工作台 - MCP Server 代办/我的申请 输出序列化器"""
 
     mcp_server = WorkbenchMCPServerBaseSLZ(help_text="MCP Server 信息")
+    applied_by = serializers.SerializerMethodField(help_text="申请人")
     itsm_ticket_url = serializers.SerializerMethodField(help_text="ITSM 单据中心链接")
     status_display = serializers.SerializerMethodField(help_text="审批状态显示")
 
@@ -189,6 +211,15 @@ class WorkbenchMCPPermissionApplyOutputSLZ(serializers.ModelSerializer):
         ]
         read_only_fields = fields
 
+    def get_applied_by(self, obj) -> str:
+        gateway = obj.mcp_server.gateway if obj.mcp_server else None
+        return ResourcePermissionHandler.convert_applied_by_to_display_name(
+            obj.bk_app_code,
+            obj.applied_by,
+            gateway.tenant_mode if gateway else "",
+            gateway.tenant_id if gateway else "",
+        )
+
     def get_itsm_ticket_url(self, obj) -> str:
         return ItsmPermissionApplyHelper.build_ticket_url(obj.itsm_ticket_id)
 
@@ -200,6 +231,7 @@ class WorkbenchMCPPermissionHandledOutputSLZ(serializers.ModelSerializer):
     """个人工作台 - MCP Server 已办 输出序列化器"""
 
     mcp_server = WorkbenchMCPServerBaseSLZ(help_text="MCP Server 信息")
+    applied_by = serializers.SerializerMethodField(help_text="申请人")
     itsm_ticket_url = serializers.SerializerMethodField(help_text="ITSM 单据中心链接")
     status_display = serializers.SerializerMethodField(help_text="审批状态显示")
 
@@ -223,6 +255,15 @@ class WorkbenchMCPPermissionHandledOutputSLZ(serializers.ModelSerializer):
             "itsm_ticket_url",
         ]
         read_only_fields = fields
+
+    def get_applied_by(self, obj) -> str:
+        gateway = obj.mcp_server.gateway if obj.mcp_server else None
+        return ResourcePermissionHandler.convert_applied_by_to_display_name(
+            obj.bk_app_code,
+            obj.applied_by,
+            gateway.tenant_mode if gateway else "",
+            gateway.tenant_id if gateway else "",
+        )
 
     def get_itsm_ticket_url(self, obj) -> str:
         return ItsmPermissionApplyHelper.build_ticket_url(obj.itsm_ticket_id)

--- a/src/dashboard/apigateway/apigateway/apis/web/personal_workbench/urls.py
+++ b/src/dashboard/apigateway/apigateway/apis/web/personal_workbench/urls.py
@@ -16,7 +16,7 @@
 # We undertake not to change the open source license (MIT license) applicable
 # to the current version of the project delivered to anyone in the future.
 #
-from django.urls import path
+from django.urls import include, path
 
 from .views import (
     WorkbenchHandledGatewayPermissionListApi,
@@ -27,38 +27,19 @@ from .views import (
     WorkbenchPendingMCPPermissionListApi,
 )
 
+gateway_permission_patterns = [
+    path("pending/", WorkbenchPendingGatewayPermissionListApi.as_view(), name="workbench.permissions.gateway.pending"),
+    path("applied/", WorkbenchMyApplyGatewayPermissionListApi.as_view(), name="workbench.permissions.gateway.applied"),
+    path("handled/", WorkbenchHandledGatewayPermissionListApi.as_view(), name="workbench.permissions.gateway.handled"),
+]
+
+mcp_permission_patterns = [
+    path("pending/", WorkbenchPendingMCPPermissionListApi.as_view(), name="workbench.permissions.mcp.pending"),
+    path("applied/", WorkbenchMyApplyMCPPermissionListApi.as_view(), name="workbench.permissions.mcp.applied"),
+    path("handled/", WorkbenchHandledMCPPermissionListApi.as_view(), name="workbench.permissions.mcp.handled"),
+]
+
 urlpatterns = [
-    # 我的代办
-    path(
-        "pending/gateway-permissions/",
-        WorkbenchPendingGatewayPermissionListApi.as_view(),
-        name="personal_workbench.pending.gateway_permissions",
-    ),
-    path(
-        "pending/mcp-permissions/",
-        WorkbenchPendingMCPPermissionListApi.as_view(),
-        name="personal_workbench.pending.mcp_permissions",
-    ),
-    # 我的申请
-    path(
-        "my-apply/gateway-permissions/",
-        WorkbenchMyApplyGatewayPermissionListApi.as_view(),
-        name="personal_workbench.my_apply.gateway_permissions",
-    ),
-    path(
-        "my-apply/mcp-permissions/",
-        WorkbenchMyApplyMCPPermissionListApi.as_view(),
-        name="personal_workbench.my_apply.mcp_permissions",
-    ),
-    # 我的已办
-    path(
-        "handled/gateway-permissions/",
-        WorkbenchHandledGatewayPermissionListApi.as_view(),
-        name="personal_workbench.handled.gateway_permissions",
-    ),
-    path(
-        "handled/mcp-permissions/",
-        WorkbenchHandledMCPPermissionListApi.as_view(),
-        name="personal_workbench.handled.mcp_permissions",
-    ),
+    path("permissions/gateway/", include(gateway_permission_patterns)),
+    path("permissions/mcp/", include(mcp_permission_patterns)),
 ]

--- a/src/dashboard/apigateway/apigateway/apis/web/personal_workbench/urls.py
+++ b/src/dashboard/apigateway/apigateway/apis/web/personal_workbench/urls.py
@@ -1,0 +1,64 @@
+# -*- coding: utf-8 -*-
+#
+# TencentBlueKing is pleased to support the open source community by making
+# 蓝鲸智云 - API 网关(BlueKing - APIGateway) available.
+# Copyright (C) 2025 Tencent. All rights reserved.
+# Licensed under the MIT License (the "License"); you may not use this file except
+# in compliance with the License. You may obtain a copy of the License at
+#
+#     http://opensource.org/licenses/MIT
+#
+# Unless required by applicable law or agreed to in writing, software distributed under
+# the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+# either express or implied. See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# We undertake not to change the open source license (MIT license) applicable
+# to the current version of the project delivered to anyone in the future.
+#
+from django.urls import path
+
+from .views import (
+    WorkbenchHandledGatewayPermissionListApi,
+    WorkbenchHandledMCPPermissionListApi,
+    WorkbenchMyApplyGatewayPermissionListApi,
+    WorkbenchMyApplyMCPPermissionListApi,
+    WorkbenchPendingGatewayPermissionListApi,
+    WorkbenchPendingMCPPermissionListApi,
+)
+
+urlpatterns = [
+    # 我的代办
+    path(
+        "pending/gateway-permissions/",
+        WorkbenchPendingGatewayPermissionListApi.as_view(),
+        name="personal_workbench.pending.gateway_permissions",
+    ),
+    path(
+        "pending/mcp-permissions/",
+        WorkbenchPendingMCPPermissionListApi.as_view(),
+        name="personal_workbench.pending.mcp_permissions",
+    ),
+    # 我的申请
+    path(
+        "my-apply/gateway-permissions/",
+        WorkbenchMyApplyGatewayPermissionListApi.as_view(),
+        name="personal_workbench.my_apply.gateway_permissions",
+    ),
+    path(
+        "my-apply/mcp-permissions/",
+        WorkbenchMyApplyMCPPermissionListApi.as_view(),
+        name="personal_workbench.my_apply.mcp_permissions",
+    ),
+    # 我的已办
+    path(
+        "handled/gateway-permissions/",
+        WorkbenchHandledGatewayPermissionListApi.as_view(),
+        name="personal_workbench.handled.gateway_permissions",
+    ),
+    path(
+        "handled/mcp-permissions/",
+        WorkbenchHandledMCPPermissionListApi.as_view(),
+        name="personal_workbench.handled.mcp_permissions",
+    ),
+]

--- a/src/dashboard/apigateway/apigateway/apis/web/personal_workbench/views.py
+++ b/src/dashboard/apigateway/apigateway/apis/web/personal_workbench/views.py
@@ -43,24 +43,8 @@ from .serializers import (
 )
 
 
-def _get_user_maintainer_gateway_ids(username: str, tenant_id: str = "") -> list[int]:
-    """获取当前用户作为 maintainer 的所有网关 ID
-
-    复用 GatewayHandler.list_gateways_by_user，该方法内部已处理：
-    1. _maintainers__contains 粗筛 + has_permission 精确过滤（避免子串误匹配）
-    2. tenant_id 维度的数据隔离（多租户场景）
-    """
-    if not username:
-        return []
-    gateways = GatewayHandler.list_gateways_by_user(username, tenant_id)
-    return [gw.id for gw in gateways]
-
-
-class BaseWorkbenchListApi(generics.ListAPIView):
-    """个人工作台列表接口基类
-
-    子类只需声明 filterset_class / serializer_class / get_queryset()，
-    分页+序列化逻辑由 DRF ListAPIView 默认 list() 处理。
+class WorkbenchPermissionMixin:
+    """个人工作台权限接口 Mixin
 
     个人工作台接口无需网关级别权限校验（URL 不含 gateway_id），
     仅需登录认证，因此显式声明 permission_classes = [IsAuthenticated]。
@@ -81,7 +65,7 @@ class BaseWorkbenchListApi(generics.ListAPIView):
         tags=["WebAPI.PersonalWorkbench"],
     ),
 )
-class WorkbenchPendingGatewayPermissionListApi(BaseWorkbenchListApi):
+class WorkbenchPendingGatewayPermissionListApi(WorkbenchPermissionMixin, generics.ListAPIView):
     """我的代办 - API 网关
 
     展示当前用户作为网关管理员（maintainer）待审批的权限申请单
@@ -93,7 +77,8 @@ class WorkbenchPendingGatewayPermissionListApi(BaseWorkbenchListApi):
     def get_queryset(self):
         username = self.request.user.username
         tenant_id = get_user_tenant_id(self.request)
-        gateway_ids = _get_user_maintainer_gateway_ids(username, tenant_id)
+        gateways = GatewayHandler.list_gateways_by_user(username, tenant_id)
+        gateway_ids = [gw.id for gw in gateways]
         return (
             AppPermissionApply.objects.filter(
                 gateway_id__in=gateway_ids,
@@ -113,7 +98,7 @@ class WorkbenchPendingGatewayPermissionListApi(BaseWorkbenchListApi):
         tags=["WebAPI.PersonalWorkbench"],
     ),
 )
-class WorkbenchPendingMCPPermissionListApi(BaseWorkbenchListApi):
+class WorkbenchPendingMCPPermissionListApi(WorkbenchPermissionMixin, generics.ListAPIView):
     """我的代办 - MCP Server
 
     展示当前用户作为 MCP Server 所属网关管理员待审批的申请单
@@ -125,7 +110,8 @@ class WorkbenchPendingMCPPermissionListApi(BaseWorkbenchListApi):
     def get_queryset(self):
         username = self.request.user.username
         tenant_id = get_user_tenant_id(self.request)
-        gateway_ids = _get_user_maintainer_gateway_ids(username, tenant_id)
+        gateways = GatewayHandler.list_gateways_by_user(username, tenant_id)
+        gateway_ids = [gw.id for gw in gateways]
         return (
             MCPServerAppPermissionApply.objects.filter(
                 mcp_server__gateway_id__in=gateway_ids,
@@ -149,7 +135,7 @@ class WorkbenchPendingMCPPermissionListApi(BaseWorkbenchListApi):
         tags=["WebAPI.PersonalWorkbench"],
     ),
 )
-class WorkbenchMyApplyGatewayPermissionListApi(BaseWorkbenchListApi):
+class WorkbenchMyApplyGatewayPermissionListApi(WorkbenchPermissionMixin, generics.ListAPIView):
     """我的申请 - API 网关
 
     展示当前用户自己提交的权限申请
@@ -172,7 +158,7 @@ class WorkbenchMyApplyGatewayPermissionListApi(BaseWorkbenchListApi):
         tags=["WebAPI.PersonalWorkbench"],
     ),
 )
-class WorkbenchMyApplyMCPPermissionListApi(BaseWorkbenchListApi):
+class WorkbenchMyApplyMCPPermissionListApi(WorkbenchPermissionMixin, generics.ListAPIView):
     """我的申请 - MCP Server
 
     展示当前用户自己提交的 MCP Server 权限申请
@@ -205,7 +191,7 @@ class WorkbenchMyApplyMCPPermissionListApi(BaseWorkbenchListApi):
         tags=["WebAPI.PersonalWorkbench"],
     ),
 )
-class WorkbenchHandledGatewayPermissionListApi(BaseWorkbenchListApi):
+class WorkbenchHandledGatewayPermissionListApi(WorkbenchPermissionMixin, generics.ListAPIView):
     """我的已办 - API 网关
 
     展示当前用户已处理过的权限申请记录
@@ -233,7 +219,7 @@ class WorkbenchHandledGatewayPermissionListApi(BaseWorkbenchListApi):
         tags=["WebAPI.PersonalWorkbench"],
     ),
 )
-class WorkbenchHandledMCPPermissionListApi(BaseWorkbenchListApi):
+class WorkbenchHandledMCPPermissionListApi(WorkbenchPermissionMixin, generics.ListAPIView):
     """我的已办 - MCP Server
 
     展示当前用户已处理的 MCP Server 权限申请

--- a/src/dashboard/apigateway/apigateway/apis/web/personal_workbench/views.py
+++ b/src/dashboard/apigateway/apigateway/apis/web/personal_workbench/views.py
@@ -1,0 +1,254 @@
+#
+# TencentBlueKing is pleased to support the open source community by making
+# 蓝鲸智云 - API 网关(BlueKing - APIGateway) available.
+# Copyright (C) 2025 Tencent. All rights reserved.
+# Licensed under the MIT License (the "License"); you may not use this file except
+# in compliance with the License. You may obtain a copy of the License at
+#
+#     http://opensource.org/licenses/MIT
+#
+# Unless required by applicable law or agreed to in writing, software distributed under
+# the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+# either express or implied. See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# We undertake not to change the open source license (MIT license) applicable
+# to the current version of the project delivered to anyone in the future.
+#
+
+from typing import List
+
+from django.utils.decorators import method_decorator
+from drf_yasg.utils import swagger_auto_schema
+from rest_framework import generics, status
+
+from apigateway.apps.mcp_server.constants import MCPServerAppPermissionApplyStatusEnum
+from apigateway.apps.mcp_server.models import MCPServerAppPermissionApply
+from apigateway.apps.permission.constants import ApplyStatusEnum
+from apigateway.apps.permission.models import AppPermissionApply, AppPermissionRecord
+from apigateway.core.models import Gateway
+
+from .filters import (
+    WorkbenchGatewayPermissionApplyFilter,
+    WorkbenchGatewayPermissionRecordFilter,
+    WorkbenchMCPPermissionApplyFilter,
+)
+from .serializers import (
+    WorkbenchGatewayPermissionApplyOutputSLZ,
+    WorkbenchGatewayPermissionQueryInputSLZ,
+    WorkbenchGatewayPermissionRecordOutputSLZ,
+    WorkbenchMCPPermissionApplyOutputSLZ,
+    WorkbenchMCPPermissionHandledOutputSLZ,
+    WorkbenchMCPPermissionQueryInputSLZ,
+)
+
+
+def _get_user_maintainer_gateway_ids(username: str) -> List[int]:
+    """获取当前用户作为 maintainer 的所有网关 ID
+
+    _maintainers 是以 `;` 拼接的字符串，contains 查询可能匹配到子串（如 admin 匹配 superadmin），
+    因此先用 contains 粗筛，再通过 has_permission 做精确过滤，与 GatewayHandler.list_gateways_by_user 逻辑保持一致。
+    """
+    gateways = Gateway.objects.filter(_maintainers__contains=username)
+    return [gw.id for gw in gateways if gw.has_permission(username)]
+
+
+class BaseWorkbenchListApi(generics.ListAPIView):
+    """个人工作台列表接口基类
+
+    子类只需声明 filterset_class / serializer_class / get_queryset()，
+    list 的分页+序列化逻辑统一在此处理，减少重复代码。
+    """
+
+    def list(self, request, *args, **kwargs):
+        queryset = self.filter_queryset(self.get_queryset())
+        page = self.paginate_queryset(queryset)
+        serializer = self.get_serializer(page, many=True)
+        return self.get_paginated_response(serializer.data)
+
+
+# ========== 我的代办 ==========
+
+
+@method_decorator(
+    name="get",
+    decorator=swagger_auto_schema(
+        operation_description="个人工作台 - 我的代办 - API 网关权限申请列表",
+        query_serializer=WorkbenchGatewayPermissionQueryInputSLZ,
+        responses={status.HTTP_200_OK: WorkbenchGatewayPermissionApplyOutputSLZ(many=True)},
+        tags=["WebAPI.PersonalWorkbench"],
+    ),
+)
+class WorkbenchPendingGatewayPermissionListApi(BaseWorkbenchListApi):
+    """我的代办 - API 网关
+
+    展示当前用户作为网关管理员（maintainer）待审批的权限申请单
+    """
+
+    serializer_class = WorkbenchGatewayPermissionApplyOutputSLZ
+    filterset_class = WorkbenchGatewayPermissionApplyFilter
+
+    def get_queryset(self):
+        username = self.request.user.username
+        gateway_ids = _get_user_maintainer_gateway_ids(username)
+        return (
+            AppPermissionApply.objects.filter(
+                gateway_id__in=gateway_ids,
+                status=ApplyStatusEnum.PENDING.value,
+            )
+            .select_related("gateway")
+            .order_by("-id")
+        )
+
+
+@method_decorator(
+    name="get",
+    decorator=swagger_auto_schema(
+        operation_description="个人工作台 - 我的代办 - MCP Server 权限申请列表",
+        query_serializer=WorkbenchMCPPermissionQueryInputSLZ,
+        responses={status.HTTP_200_OK: WorkbenchMCPPermissionApplyOutputSLZ(many=True)},
+        tags=["WebAPI.PersonalWorkbench"],
+    ),
+)
+class WorkbenchPendingMCPPermissionListApi(BaseWorkbenchListApi):
+    """我的代办 - MCP Server
+
+    展示当前用户作为 MCP Server 所属网关管理员待审批的申请单
+    """
+
+    serializer_class = WorkbenchMCPPermissionApplyOutputSLZ
+    filterset_class = WorkbenchMCPPermissionApplyFilter
+
+    def get_queryset(self):
+        username = self.request.user.username
+        gateway_ids = _get_user_maintainer_gateway_ids(username)
+        return (
+            MCPServerAppPermissionApply.objects.filter(
+                mcp_server__gateway_id__in=gateway_ids,
+                status=MCPServerAppPermissionApplyStatusEnum.PENDING.value,
+                is_deleted=False,
+            )
+            .select_related("mcp_server", "mcp_server__gateway")
+            .order_by("-id")
+        )
+
+
+# ========== 我的申请 ==========
+
+
+@method_decorator(
+    name="get",
+    decorator=swagger_auto_schema(
+        operation_description="个人工作台 - 我的申请 - API 网关权限申请列表",
+        query_serializer=WorkbenchGatewayPermissionQueryInputSLZ,
+        responses={status.HTTP_200_OK: WorkbenchGatewayPermissionApplyOutputSLZ(many=True)},
+        tags=["WebAPI.PersonalWorkbench"],
+    ),
+)
+class WorkbenchMyApplyGatewayPermissionListApi(BaseWorkbenchListApi):
+    """我的申请 - API 网关
+
+    展示当前用户自己提交的权限申请
+    """
+
+    serializer_class = WorkbenchGatewayPermissionApplyOutputSLZ
+    filterset_class = WorkbenchGatewayPermissionApplyFilter
+
+    def get_queryset(self):
+        username = self.request.user.username
+        return AppPermissionApply.objects.filter(applied_by=username).select_related("gateway").order_by("-id")
+
+
+@method_decorator(
+    name="get",
+    decorator=swagger_auto_schema(
+        operation_description="个人工作台 - 我的申请 - MCP Server 权限申请列表",
+        query_serializer=WorkbenchMCPPermissionQueryInputSLZ,
+        responses={status.HTTP_200_OK: WorkbenchMCPPermissionApplyOutputSLZ(many=True)},
+        tags=["WebAPI.PersonalWorkbench"],
+    ),
+)
+class WorkbenchMyApplyMCPPermissionListApi(BaseWorkbenchListApi):
+    """我的申请 - MCP Server
+
+    展示当前用户自己提交的 MCP Server 权限申请
+    """
+
+    serializer_class = WorkbenchMCPPermissionApplyOutputSLZ
+    filterset_class = WorkbenchMCPPermissionApplyFilter
+
+    def get_queryset(self):
+        username = self.request.user.username
+        return (
+            MCPServerAppPermissionApply.objects.filter(
+                applied_by=username,
+                is_deleted=False,
+            )
+            .select_related("mcp_server", "mcp_server__gateway")
+            .order_by("-id")
+        )
+
+
+# ========== 我的已办 ==========
+
+
+@method_decorator(
+    name="get",
+    decorator=swagger_auto_schema(
+        operation_description="个人工作台 - 我的已办 - API 网关权限申请列表",
+        query_serializer=WorkbenchGatewayPermissionQueryInputSLZ,
+        responses={status.HTTP_200_OK: WorkbenchGatewayPermissionRecordOutputSLZ(many=True)},
+        tags=["WebAPI.PersonalWorkbench"],
+    ),
+)
+class WorkbenchHandledGatewayPermissionListApi(BaseWorkbenchListApi):
+    """我的已办 - API 网关
+
+    展示当前用户已处理过的权限申请记录
+    """
+
+    serializer_class = WorkbenchGatewayPermissionRecordOutputSLZ
+    filterset_class = WorkbenchGatewayPermissionRecordFilter
+
+    def get_queryset(self):
+        username = self.request.user.username
+        return (
+            AppPermissionRecord.objects.filter(handled_by=username)
+            .exclude(status=ApplyStatusEnum.PENDING.value)
+            .select_related("gateway")
+            .order_by("-handled_time")
+        )
+
+
+@method_decorator(
+    name="get",
+    decorator=swagger_auto_schema(
+        operation_description="个人工作台 - 我的已办 - MCP Server 权限申请列表",
+        query_serializer=WorkbenchMCPPermissionQueryInputSLZ,
+        responses={status.HTTP_200_OK: WorkbenchMCPPermissionHandledOutputSLZ(many=True)},
+        tags=["WebAPI.PersonalWorkbench"],
+    ),
+)
+class WorkbenchHandledMCPPermissionListApi(BaseWorkbenchListApi):
+    """我的已办 - MCP Server
+
+    展示当前用户已处理的 MCP Server 权限申请
+    """
+
+    serializer_class = WorkbenchMCPPermissionHandledOutputSLZ
+    filterset_class = WorkbenchMCPPermissionApplyFilter
+
+    def get_queryset(self):
+        username = self.request.user.username
+        return (
+            MCPServerAppPermissionApply.objects.filter(
+                handled_by=username,
+                status__in=[
+                    MCPServerAppPermissionApplyStatusEnum.APPROVED.value,
+                    MCPServerAppPermissionApplyStatusEnum.REJECTED.value,
+                ],
+                is_deleted=False,
+            )
+            .select_related("mcp_server", "mcp_server__gateway")
+            .order_by("-handled_time")
+        )

--- a/src/dashboard/apigateway/apigateway/apis/web/personal_workbench/views.py
+++ b/src/dashboard/apigateway/apigateway/apis/web/personal_workbench/views.py
@@ -16,17 +16,17 @@
 # to the current version of the project delivered to anyone in the future.
 #
 
-from typing import List
-
 from django.utils.decorators import method_decorator
 from drf_yasg.utils import swagger_auto_schema
 from rest_framework import generics, status
+from rest_framework.permissions import IsAuthenticated
 
 from apigateway.apps.mcp_server.constants import MCPServerAppPermissionApplyStatusEnum
 from apigateway.apps.mcp_server.models import MCPServerAppPermissionApply
 from apigateway.apps.permission.constants import ApplyStatusEnum
 from apigateway.apps.permission.models import AppPermissionApply, AppPermissionRecord
-from apigateway.core.models import Gateway
+from apigateway.biz.gateway.gateway import GatewayHandler
+from apigateway.common.tenant.request import get_user_tenant_id
 
 from .filters import (
     WorkbenchGatewayPermissionApplyFilter,
@@ -43,28 +43,30 @@ from .serializers import (
 )
 
 
-def _get_user_maintainer_gateway_ids(username: str) -> List[int]:
+def _get_user_maintainer_gateway_ids(username: str, tenant_id: str = "") -> list[int]:
     """获取当前用户作为 maintainer 的所有网关 ID
 
-    _maintainers 是以 `;` 拼接的字符串，contains 查询可能匹配到子串（如 admin 匹配 superadmin），
-    因此先用 contains 粗筛，再通过 has_permission 做精确过滤，与 GatewayHandler.list_gateways_by_user 逻辑保持一致。
+    复用 GatewayHandler.list_gateways_by_user，该方法内部已处理：
+    1. _maintainers__contains 粗筛 + has_permission 精确过滤（避免子串误匹配）
+    2. tenant_id 维度的数据隔离（多租户场景）
     """
-    gateways = Gateway.objects.filter(_maintainers__contains=username)
-    return [gw.id for gw in gateways if gw.has_permission(username)]
+    if not username:
+        return []
+    gateways = GatewayHandler.list_gateways_by_user(username, tenant_id)
+    return [gw.id for gw in gateways]
 
 
 class BaseWorkbenchListApi(generics.ListAPIView):
     """个人工作台列表接口基类
 
     子类只需声明 filterset_class / serializer_class / get_queryset()，
-    list 的分页+序列化逻辑统一在此处理，减少重复代码。
+    分页+序列化逻辑由 DRF ListAPIView 默认 list() 处理。
+
+    个人工作台接口无需网关级别权限校验（URL 不含 gateway_id），
+    仅需登录认证，因此显式声明 permission_classes = [IsAuthenticated]。
     """
 
-    def list(self, request, *args, **kwargs):
-        queryset = self.filter_queryset(self.get_queryset())
-        page = self.paginate_queryset(queryset)
-        serializer = self.get_serializer(page, many=True)
-        return self.get_paginated_response(serializer.data)
+    permission_classes = [IsAuthenticated]
 
 
 # ========== 我的代办 ==========
@@ -90,7 +92,8 @@ class WorkbenchPendingGatewayPermissionListApi(BaseWorkbenchListApi):
 
     def get_queryset(self):
         username = self.request.user.username
-        gateway_ids = _get_user_maintainer_gateway_ids(username)
+        tenant_id = get_user_tenant_id(self.request)
+        gateway_ids = _get_user_maintainer_gateway_ids(username, tenant_id)
         return (
             AppPermissionApply.objects.filter(
                 gateway_id__in=gateway_ids,
@@ -121,7 +124,8 @@ class WorkbenchPendingMCPPermissionListApi(BaseWorkbenchListApi):
 
     def get_queryset(self):
         username = self.request.user.username
-        gateway_ids = _get_user_maintainer_gateway_ids(username)
+        tenant_id = get_user_tenant_id(self.request)
+        gateway_ids = _get_user_maintainer_gateway_ids(username, tenant_id)
         return (
             MCPServerAppPermissionApply.objects.filter(
                 mcp_server__gateway_id__in=gateway_ids,
@@ -243,12 +247,9 @@ class WorkbenchHandledMCPPermissionListApi(BaseWorkbenchListApi):
         return (
             MCPServerAppPermissionApply.objects.filter(
                 handled_by=username,
-                status__in=[
-                    MCPServerAppPermissionApplyStatusEnum.APPROVED.value,
-                    MCPServerAppPermissionApplyStatusEnum.REJECTED.value,
-                ],
                 is_deleted=False,
             )
+            .exclude(status=MCPServerAppPermissionApplyStatusEnum.PENDING.value)
             .select_related("mcp_server", "mcp_server__gateway")
             .order_by("-handled_time")
         )

--- a/src/dashboard/apigateway/apigateway/tests/apis/web/personal_workbench/__init__.py
+++ b/src/dashboard/apigateway/apigateway/tests/apis/web/personal_workbench/__init__.py
@@ -1,0 +1,17 @@
+#
+# TencentBlueKing is pleased to support the open source community by making
+# 蓝鲸智云 - API 网关(BlueKing - APIGateway) available.
+# Copyright (C) 2025 Tencent. All rights reserved.
+# Licensed under the MIT License (the "License"); you may not use this file except
+# in compliance with the License. You may obtain a copy of the License at
+#
+#     http://opensource.org/licenses/MIT
+#
+# Unless required by applicable law or agreed to in writing, software distributed under
+# the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+# either express or implied. See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# We undertake not to change the open source license (MIT license) applicable
+# to the current version of the project delivered to anyone in the future.
+#

--- a/src/dashboard/apigateway/apigateway/tests/apis/web/personal_workbench/test_serializers.py
+++ b/src/dashboard/apigateway/apigateway/tests/apis/web/personal_workbench/test_serializers.py
@@ -1,0 +1,210 @@
+# -*- coding: utf-8 -*-
+#
+# TencentBlueKing is pleased to support the open source community by making
+# 蓝鲸智云 - API 网关(BlueKing - APIGateway) available.
+# Copyright (C) 2025 Tencent. All rights reserved.
+# Licensed under the MIT License (the "License"); you may not use this file except
+# in compliance with the License. You may obtain a copy of the License at
+#
+#     http://opensource.org/licenses/MIT
+#
+# Unless required by applicable law or agreed to in writing, software distributed under
+# the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+# either express or implied. See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# We undertake not to change the open source license (MIT license) applicable
+# to the current version of the project delivered to anyone in the future.
+#
+
+from unittest.mock import patch
+
+import pytest
+from ddf import G
+
+from apigateway.apis.web.personal_workbench.serializers import (
+    WorkbenchGatewayPermissionApplyOutputSLZ,
+    WorkbenchGatewayPermissionRecordOutputSLZ,
+    WorkbenchMCPPermissionApplyOutputSLZ,
+    WorkbenchMCPPermissionHandledOutputSLZ,
+)
+from apigateway.apps.mcp_server.constants import MCPServerAppPermissionApplyStatusEnum, MCPServerStatusEnum
+from apigateway.apps.mcp_server.models import MCPServer, MCPServerAppPermissionApply
+from apigateway.apps.permission.constants import ApplyStatusEnum, GrantDimensionEnum
+from apigateway.apps.permission.models import AppPermissionApply, AppPermissionRecord
+from apigateway.core.constants import GatewayStatusEnum, StageStatusEnum
+from apigateway.utils.time import now_datetime
+
+pytestmark = pytest.mark.django_db
+
+
+class TestWorkbenchGatewayPermissionApplyOutputSLZ:
+    def test_serialization(self, fake_gateway):
+        """测试 API 网关申请单序列化器输出格式正确"""
+        apply_record = G(
+            AppPermissionApply,
+            gateway=fake_gateway,
+            bk_app_code="test_app",
+            applied_by="test_user",
+            status=ApplyStatusEnum.PENDING.value,
+            grant_dimension=GrantDimensionEnum.RESOURCE.value,
+            expire_days=180,
+            reason="need access to resources",
+            itsm_ticket_id="12345",
+        )
+
+        slz = WorkbenchGatewayPermissionApplyOutputSLZ(apply_record)
+        data = slz.data
+
+        assert data["id"] == apply_record.id
+        assert data["bk_app_code"] == "test_app"
+        assert data["applied_by"] == "test_user"
+        assert data["gateway_name"] == fake_gateway.name
+        assert data["status"] == ApplyStatusEnum.PENDING.value
+        assert data["grant_dimension"] == GrantDimensionEnum.RESOURCE.value
+        assert "grant_dimension_display" in data
+        assert "expire_days_display" in data
+        assert data["reason"] == "need access to resources"
+        assert data["itsm_ticket_id"] == "12345"
+
+    @patch(
+        "apigateway.service.bk_itsm.ItsmPermissionApplyHelper.build_ticket_url", return_value="https://itsm/ticket/123"
+    )
+    def test_itsm_ticket_url(self, mock_build_url, fake_gateway):
+        """测试 ITSM 单据 URL 生成"""
+        apply_record = G(
+            AppPermissionApply,
+            gateway=fake_gateway,
+            bk_app_code="test_app",
+            applied_by="test_user",
+            status=ApplyStatusEnum.PENDING.value,
+            itsm_ticket_id="123",
+        )
+
+        slz = WorkbenchGatewayPermissionApplyOutputSLZ(apply_record)
+        data = slz.data
+
+        assert data["itsm_ticket_url"] == "https://itsm/ticket/123"
+
+
+class TestWorkbenchGatewayPermissionRecordOutputSLZ:
+    def test_serialization(self, fake_gateway):
+        """测试 API 网关已办记录序列化器输出格式正确"""
+        record = G(
+            AppPermissionRecord,
+            gateway=fake_gateway,
+            bk_app_code="test_app",
+            applied_by="applicant",
+            applied_time=now_datetime(),
+            handled_by="handler",
+            handled_time=now_datetime(),
+            status=ApplyStatusEnum.APPROVED.value,
+            grant_dimension=GrantDimensionEnum.API.value,
+            expire_days=180,
+            reason="need gateway access",
+            comment="approved",
+            itsm_ticket_id="67890",
+        )
+
+        slz = WorkbenchGatewayPermissionRecordOutputSLZ(record)
+        data = slz.data
+
+        assert data["id"] == record.id
+        assert data["bk_app_code"] == "test_app"
+        assert data["applied_by"] == "applicant"
+        assert data["handled_by"] == "handler"
+        assert data["gateway_name"] == fake_gateway.name
+        assert data["status"] == ApplyStatusEnum.APPROVED.value
+        assert data["comment"] == "approved"
+        assert "grant_dimension_display" in data
+        assert "expire_days_display" in data
+
+
+class TestWorkbenchMCPPermissionApplyOutputSLZ:
+    def test_serialization(self, fake_gateway, fake_stage):
+        """测试 MCP Server 申请单序列化器输出格式正确"""
+        fake_gateway.status = GatewayStatusEnum.ACTIVE.value
+        fake_gateway.save()
+        fake_stage.status = StageStatusEnum.ACTIVE.value
+        fake_stage.save()
+
+        mcp_server = G(
+            MCPServer,
+            name="test-mcp",
+            title="Test MCP Server",
+            gateway=fake_gateway,
+            stage=fake_stage,
+            status=MCPServerStatusEnum.ACTIVE.value,
+            _resource_names="r1;r2",
+        )
+
+        apply_record = G(
+            MCPServerAppPermissionApply,
+            mcp_server=mcp_server,
+            bk_app_code="test_app",
+            applied_by="test_user",
+            applied_time=now_datetime(),
+            status=MCPServerAppPermissionApplyStatusEnum.PENDING.value,
+            reason="need mcp access",
+            itsm_ticket_id="99999",
+            is_deleted=False,
+        )
+
+        slz = WorkbenchMCPPermissionApplyOutputSLZ(apply_record)
+        data = slz.data
+
+        assert data["id"] == apply_record.id
+        assert data["bk_app_code"] == "test_app"
+        assert data["applied_by"] == "test_user"
+        assert data["mcp_server"]["id"] == mcp_server.id
+        assert data["mcp_server"]["name"] == "test-mcp"
+        assert data["mcp_server"]["title"] == "Test MCP Server"
+        assert data["status"] == MCPServerAppPermissionApplyStatusEnum.PENDING.value
+        assert "status_display" in data
+        assert data["reason"] == "need mcp access"
+
+
+class TestWorkbenchMCPPermissionHandledOutputSLZ:
+    def test_serialization(self, fake_gateway, fake_stage):
+        """测试 MCP Server 已办记录序列化器输出格式正确"""
+        fake_gateway.status = GatewayStatusEnum.ACTIVE.value
+        fake_gateway.save()
+        fake_stage.status = StageStatusEnum.ACTIVE.value
+        fake_stage.save()
+
+        mcp_server = G(
+            MCPServer,
+            name="test-mcp-handled",
+            title="Handled MCP",
+            gateway=fake_gateway,
+            stage=fake_stage,
+            status=MCPServerStatusEnum.ACTIVE.value,
+            _resource_names="r1",
+        )
+
+        apply_record = G(
+            MCPServerAppPermissionApply,
+            mcp_server=mcp_server,
+            bk_app_code="test_app",
+            applied_by="applicant",
+            applied_time=now_datetime(),
+            handled_by="handler",
+            handled_time=now_datetime(),
+            status=MCPServerAppPermissionApplyStatusEnum.APPROVED.value,
+            comment="looks good",
+            itsm_ticket_id="88888",
+            is_deleted=False,
+        )
+
+        slz = WorkbenchMCPPermissionHandledOutputSLZ(apply_record)
+        data = slz.data
+
+        assert data["id"] == apply_record.id
+        assert data["bk_app_code"] == "test_app"
+        assert data["applied_by"] == "applicant"
+        assert data["handled_by"] == "handler"
+        assert data["mcp_server"]["id"] == mcp_server.id
+        assert data["status"] == MCPServerAppPermissionApplyStatusEnum.APPROVED.value
+        assert data["comment"] == "looks good"
+        assert "status_display" in data
+        assert "handled_time" in data

--- a/src/dashboard/apigateway/apigateway/tests/apis/web/personal_workbench/test_views.py
+++ b/src/dashboard/apigateway/apigateway/tests/apis/web/personal_workbench/test_views.py
@@ -1,0 +1,612 @@
+# -*- coding: utf-8 -*-
+#
+# TencentBlueKing is pleased to support the open source community by making
+# 蓝鲸智云 - API 网关(BlueKing - APIGateway) available.
+# Copyright (C) 2025 Tencent. All rights reserved.
+# Licensed under the MIT License (the "License"); you may not use this file except
+# in compliance with the License. You may obtain a copy of the License at
+#
+#     http://opensource.org/licenses/MIT
+#
+# Unless required by applicable law or agreed to in writing, software distributed under
+# the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+# either express or implied. See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# We undertake not to change the open source license (MIT license) applicable
+# to the current version of the project delivered to anyone in the future.
+#
+
+import pytest
+from ddf import G
+
+from apigateway.apps.mcp_server.constants import MCPServerAppPermissionApplyStatusEnum, MCPServerStatusEnum
+from apigateway.apps.mcp_server.models import MCPServer, MCPServerAppPermissionApply
+from apigateway.apps.permission.constants import ApplyStatusEnum, GrantDimensionEnum
+from apigateway.apps.permission.models import AppPermissionApply, AppPermissionRecord
+from apigateway.core.constants import GatewayStatusEnum, StageStatusEnum
+from apigateway.core.models import Gateway
+from apigateway.utils.time import now_datetime
+
+pytestmark = pytest.mark.django_db
+
+
+FAKE_USERNAME = "admin"
+
+
+@pytest.fixture
+def fake_other_gateway(faker):
+    """创建一个当前用户不是 maintainer 的网关"""
+    return G(
+        Gateway,
+        name=faker.pystr(),
+        _maintainers="other_user",
+        status=GatewayStatusEnum.ACTIVE.value,
+        is_public=True,
+        tenant_mode="single",
+        tenant_id="default",
+    )
+
+
+@pytest.fixture
+def fake_substring_gateway(faker):
+    """创建一个 maintainer 包含当前用户名子串的网关（superadmin 包含 admin），用于验证精确匹配"""
+    return G(
+        Gateway,
+        name=faker.pystr(),
+        _maintainers="superadmin",
+        status=GatewayStatusEnum.ACTIVE.value,
+        is_public=True,
+        tenant_mode="single",
+        tenant_id="default",
+    )
+
+
+@pytest.fixture
+def fake_mcp_server(fake_gateway, fake_stage, faker):
+    """创建一个 MCP Server"""
+    fake_gateway.status = GatewayStatusEnum.ACTIVE.value
+    fake_gateway.save()
+    fake_stage.status = StageStatusEnum.ACTIVE.value
+    fake_stage.save()
+
+    return G(
+        MCPServer,
+        name=faker.pystr()[:20],
+        gateway=fake_gateway,
+        stage=fake_stage,
+        status=MCPServerStatusEnum.ACTIVE.value,
+        description=faker.pystr(),
+        is_public=True,
+        _resource_names="resource1;resource2",
+    )
+
+
+# ==================== 我的代办 - API 网关 ====================
+
+
+class TestWorkbenchPendingGatewayPermissionListApi:
+    def test_list(self, request_view, fake_gateway):
+        """测试我的代办 - API 网关：当前用户是 maintainer 的网关下有待审批的申请单"""
+        G(
+            AppPermissionApply,
+            gateway=fake_gateway,
+            bk_app_code="app1",
+            applied_by="applicant1",
+            status=ApplyStatusEnum.PENDING.value,
+            grant_dimension=GrantDimensionEnum.RESOURCE.value,
+            reason="need access",
+        )
+
+        resp = request_view(
+            method="GET",
+            view_name="personal_workbench.pending.gateway_permissions",
+        )
+        result = resp.json()
+
+        assert resp.status_code == 200
+        assert result["data"]["count"] == 1
+        assert result["data"]["results"][0]["bk_app_code"] == "app1"
+        assert result["data"]["results"][0]["gateway_name"] == fake_gateway.name
+
+    def test_list_excludes_non_maintainer_gateway(self, request_view, fake_gateway, fake_other_gateway):
+        """测试我的代办 - 不返回非 maintainer 网关的申请"""
+        G(
+            AppPermissionApply,
+            gateway=fake_other_gateway,
+            bk_app_code="app2",
+            applied_by="applicant2",
+            status=ApplyStatusEnum.PENDING.value,
+        )
+
+        resp = request_view(
+            method="GET",
+            view_name="personal_workbench.pending.gateway_permissions",
+        )
+        result = resp.json()
+
+        assert resp.status_code == 200
+        assert result["data"]["count"] == 0
+
+    def test_list_excludes_substring_maintainer_gateway(self, request_view, fake_substring_gateway):
+        """测试我的代办 - 用户名 admin 不应匹配 maintainer 为 superadmin 的网关（子串精确过滤）"""
+        G(
+            AppPermissionApply,
+            gateway=fake_substring_gateway,
+            bk_app_code="app_substring",
+            applied_by="applicant_sub",
+            status=ApplyStatusEnum.PENDING.value,
+        )
+
+        resp = request_view(
+            method="GET",
+            view_name="personal_workbench.pending.gateway_permissions",
+        )
+        result = resp.json()
+
+        assert resp.status_code == 200
+        assert result["data"]["count"] == 0
+
+    def test_list_excludes_non_pending(self, request_view, fake_gateway):
+        """测试我的代办 - 不返回已审批或已驳回的申请"""
+        G(
+            AppPermissionApply,
+            gateway=fake_gateway,
+            bk_app_code="app3",
+            applied_by="applicant3",
+            status=ApplyStatusEnum.APPROVED.value,
+        )
+
+        resp = request_view(
+            method="GET",
+            view_name="personal_workbench.pending.gateway_permissions",
+        )
+        result = resp.json()
+
+        assert resp.status_code == 200
+        assert result["data"]["count"] == 0
+
+    def test_list_filter_by_bk_app_code(self, request_view, fake_gateway):
+        """测试我的代办 - 按 bk_app_code 筛选"""
+        G(
+            AppPermissionApply,
+            gateway=fake_gateway,
+            bk_app_code="target_app",
+            applied_by="applicant",
+            status=ApplyStatusEnum.PENDING.value,
+        )
+        G(
+            AppPermissionApply,
+            gateway=fake_gateway,
+            bk_app_code="other_app",
+            applied_by="applicant",
+            status=ApplyStatusEnum.PENDING.value,
+        )
+
+        resp = request_view(
+            method="GET",
+            view_name="personal_workbench.pending.gateway_permissions",
+            data={"bk_app_code": "target"},
+        )
+        result = resp.json()
+
+        assert resp.status_code == 200
+        assert result["data"]["count"] == 1
+        assert result["data"]["results"][0]["bk_app_code"] == "target_app"
+
+    def test_list_empty(self, request_view):
+        """测试我的代办 - 空数据"""
+        resp = request_view(
+            method="GET",
+            view_name="personal_workbench.pending.gateway_permissions",
+        )
+        result = resp.json()
+
+        assert resp.status_code == 200
+        assert result["data"]["count"] == 0
+        assert result["data"]["results"] == []
+
+
+# ==================== 我的代办 - MCP Server ====================
+
+
+class TestWorkbenchPendingMCPPermissionListApi:
+    def test_list(self, request_view, fake_gateway, fake_mcp_server):
+        """测试我的代办 - MCP Server：当前用户是 maintainer 的网关下有待审批的 MCP 申请"""
+        G(
+            MCPServerAppPermissionApply,
+            mcp_server=fake_mcp_server,
+            bk_app_code="app1",
+            applied_by="applicant1",
+            applied_time=now_datetime(),
+            status=MCPServerAppPermissionApplyStatusEnum.PENDING.value,
+            is_deleted=False,
+        )
+
+        resp = request_view(
+            method="GET",
+            view_name="personal_workbench.pending.mcp_permissions",
+        )
+        result = resp.json()
+
+        assert resp.status_code == 200
+        assert result["data"]["count"] == 1
+        assert result["data"]["results"][0]["bk_app_code"] == "app1"
+        assert result["data"]["results"][0]["mcp_server"]["id"] == fake_mcp_server.id
+
+    def test_list_excludes_substring_maintainer_gateway(self, request_view, fake_substring_gateway, fake_stage, faker):
+        """测试我的代办 - MCP Server：用户名 admin 不应匹配 maintainer 为 superadmin 的网关"""
+        fake_stage.status = StageStatusEnum.ACTIVE.value
+        fake_stage.save()
+
+        mcp_server_sub = G(
+            MCPServer,
+            name=faker.pystr()[:20],
+            gateway=fake_substring_gateway,
+            stage=fake_stage,
+            status=MCPServerStatusEnum.ACTIVE.value,
+            description=faker.pystr(),
+            is_public=True,
+            _resource_names="resource1",
+        )
+        G(
+            MCPServerAppPermissionApply,
+            mcp_server=mcp_server_sub,
+            bk_app_code="app_substring",
+            applied_by="applicant_sub",
+            applied_time=now_datetime(),
+            status=MCPServerAppPermissionApplyStatusEnum.PENDING.value,
+            is_deleted=False,
+        )
+
+        resp = request_view(
+            method="GET",
+            view_name="personal_workbench.pending.mcp_permissions",
+        )
+        result = resp.json()
+
+        assert resp.status_code == 200
+        assert result["data"]["count"] == 0
+
+    def test_list_excludes_deleted(self, request_view, fake_gateway, fake_mcp_server):
+        """测试我的代办 - 不返回已删除的 MCP 申请"""
+        G(
+            MCPServerAppPermissionApply,
+            mcp_server=fake_mcp_server,
+            bk_app_code="app2",
+            applied_by="applicant2",
+            applied_time=now_datetime(),
+            status=MCPServerAppPermissionApplyStatusEnum.PENDING.value,
+            is_deleted=True,
+        )
+
+        resp = request_view(
+            method="GET",
+            view_name="personal_workbench.pending.mcp_permissions",
+        )
+        result = resp.json()
+
+        assert resp.status_code == 200
+        assert result["data"]["count"] == 0
+
+    def test_list_empty(self, request_view):
+        """测试我的代办 - MCP Server 空数据"""
+        resp = request_view(
+            method="GET",
+            view_name="personal_workbench.pending.mcp_permissions",
+        )
+        result = resp.json()
+
+        assert resp.status_code == 200
+        assert result["data"]["count"] == 0
+        assert result["data"]["results"] == []
+
+
+# ==================== 我的申请 - API 网关 ====================
+
+
+class TestWorkbenchMyApplyGatewayPermissionListApi:
+    def test_list(self, request_view, fake_gateway):
+        """测试我的申请 - API 网关：返回当前用户提交的申请"""
+        G(
+            AppPermissionApply,
+            gateway=fake_gateway,
+            bk_app_code="app1",
+            applied_by=FAKE_USERNAME,
+            status=ApplyStatusEnum.PENDING.value,
+            grant_dimension=GrantDimensionEnum.RESOURCE.value,
+        )
+
+        resp = request_view(
+            method="GET",
+            view_name="personal_workbench.my_apply.gateway_permissions",
+        )
+        result = resp.json()
+
+        assert resp.status_code == 200
+        assert result["data"]["count"] == 1
+        assert result["data"]["results"][0]["applied_by"] == FAKE_USERNAME
+
+    def test_list_excludes_other_user_apply(self, request_view, fake_gateway):
+        """测试我的申请 - 不返回其他用户提交的申请"""
+        G(
+            AppPermissionApply,
+            gateway=fake_gateway,
+            bk_app_code="app2",
+            applied_by="other_user",
+            status=ApplyStatusEnum.PENDING.value,
+        )
+
+        resp = request_view(
+            method="GET",
+            view_name="personal_workbench.my_apply.gateway_permissions",
+        )
+        result = resp.json()
+
+        assert resp.status_code == 200
+        assert result["data"]["count"] == 0
+
+    def test_list_includes_all_status(self, request_view, fake_gateway):
+        """测试我的申请 - 包含各种状态的申请"""
+        for status_val in [ApplyStatusEnum.PENDING.value, ApplyStatusEnum.APPROVED.value]:
+            G(
+                AppPermissionApply,
+                gateway=fake_gateway,
+                bk_app_code="app",
+                applied_by=FAKE_USERNAME,
+                status=status_val,
+            )
+
+        resp = request_view(
+            method="GET",
+            view_name="personal_workbench.my_apply.gateway_permissions",
+        )
+        result = resp.json()
+
+        assert resp.status_code == 200
+        assert result["data"]["count"] == 2
+
+
+# ==================== 我的申请 - MCP Server ====================
+
+
+class TestWorkbenchMyApplyMCPPermissionListApi:
+    def test_list(self, request_view, fake_gateway, fake_mcp_server):
+        """测试我的申请 - MCP Server：返回当前用户提交的 MCP 权限申请"""
+        G(
+            MCPServerAppPermissionApply,
+            mcp_server=fake_mcp_server,
+            bk_app_code="app1",
+            applied_by=FAKE_USERNAME,
+            applied_time=now_datetime(),
+            status=MCPServerAppPermissionApplyStatusEnum.PENDING.value,
+            is_deleted=False,
+        )
+
+        resp = request_view(
+            method="GET",
+            view_name="personal_workbench.my_apply.mcp_permissions",
+        )
+        result = resp.json()
+
+        assert resp.status_code == 200
+        assert result["data"]["count"] == 1
+        assert result["data"]["results"][0]["applied_by"] == FAKE_USERNAME
+
+    def test_list_excludes_other_user_apply(self, request_view, fake_gateway, fake_mcp_server):
+        """测试我的申请 - MCP Server 不返回其他用户的申请"""
+        G(
+            MCPServerAppPermissionApply,
+            mcp_server=fake_mcp_server,
+            bk_app_code="app2",
+            applied_by="other_user",
+            applied_time=now_datetime(),
+            status=MCPServerAppPermissionApplyStatusEnum.PENDING.value,
+            is_deleted=False,
+        )
+
+        resp = request_view(
+            method="GET",
+            view_name="personal_workbench.my_apply.mcp_permissions",
+        )
+        result = resp.json()
+
+        assert resp.status_code == 200
+        assert result["data"]["count"] == 0
+
+
+# ==================== 我的已办 - API 网关 ====================
+
+
+class TestWorkbenchHandledGatewayPermissionListApi:
+    def test_list(self, request_view, fake_gateway):
+        """测试我的已办 - API 网关：返回当前用户处理过的记录"""
+        G(
+            AppPermissionRecord,
+            gateway=fake_gateway,
+            bk_app_code="app1",
+            applied_by="applicant1",
+            applied_time=now_datetime(),
+            handled_by=FAKE_USERNAME,
+            handled_time=now_datetime(),
+            status=ApplyStatusEnum.APPROVED.value,
+            grant_dimension=GrantDimensionEnum.RESOURCE.value,
+        )
+
+        resp = request_view(
+            method="GET",
+            view_name="personal_workbench.handled.gateway_permissions",
+        )
+        result = resp.json()
+
+        assert resp.status_code == 200
+        assert result["data"]["count"] == 1
+        assert result["data"]["results"][0]["handled_by"] == FAKE_USERNAME
+        assert result["data"]["results"][0]["gateway_name"] == fake_gateway.name
+
+    def test_list_excludes_pending(self, request_view, fake_gateway):
+        """测试我的已办 - 不返回 pending 状态的记录"""
+        G(
+            AppPermissionRecord,
+            gateway=fake_gateway,
+            bk_app_code="app2",
+            applied_by="applicant2",
+            applied_time=now_datetime(),
+            handled_by=FAKE_USERNAME,
+            handled_time=now_datetime(),
+            status=ApplyStatusEnum.PENDING.value,
+        )
+
+        resp = request_view(
+            method="GET",
+            view_name="personal_workbench.handled.gateway_permissions",
+        )
+        result = resp.json()
+
+        assert resp.status_code == 200
+        assert result["data"]["count"] == 0
+
+    def test_list_excludes_other_handler(self, request_view, fake_gateway):
+        """测试我的已办 - 不返回其他人处理的记录"""
+        G(
+            AppPermissionRecord,
+            gateway=fake_gateway,
+            bk_app_code="app3",
+            applied_by="applicant3",
+            applied_time=now_datetime(),
+            handled_by="other_handler",
+            handled_time=now_datetime(),
+            status=ApplyStatusEnum.APPROVED.value,
+        )
+
+        resp = request_view(
+            method="GET",
+            view_name="personal_workbench.handled.gateway_permissions",
+        )
+        result = resp.json()
+
+        assert resp.status_code == 200
+        assert result["data"]["count"] == 0
+
+    def test_list_empty(self, request_view):
+        """测试我的已办 - 空数据"""
+        resp = request_view(
+            method="GET",
+            view_name="personal_workbench.handled.gateway_permissions",
+        )
+        result = resp.json()
+
+        assert resp.status_code == 200
+        assert result["data"]["count"] == 0
+        assert result["data"]["results"] == []
+
+
+# ==================== 我的已办 - MCP Server ====================
+
+
+class TestWorkbenchHandledMCPPermissionListApi:
+    def test_list(self, request_view, fake_gateway, fake_mcp_server):
+        """测试我的已办 - MCP Server：返回当前用户处理过的 MCP 审批"""
+        G(
+            MCPServerAppPermissionApply,
+            mcp_server=fake_mcp_server,
+            bk_app_code="app1",
+            applied_by="applicant1",
+            applied_time=now_datetime(),
+            handled_by=FAKE_USERNAME,
+            handled_time=now_datetime(),
+            status=MCPServerAppPermissionApplyStatusEnum.APPROVED.value,
+            is_deleted=False,
+        )
+
+        resp = request_view(
+            method="GET",
+            view_name="personal_workbench.handled.mcp_permissions",
+        )
+        result = resp.json()
+
+        assert resp.status_code == 200
+        assert result["data"]["count"] == 1
+        assert result["data"]["results"][0]["handled_by"] == FAKE_USERNAME
+        assert result["data"]["results"][0]["mcp_server"]["id"] == fake_mcp_server.id
+
+    def test_list_includes_rejected(self, request_view, fake_gateway, fake_mcp_server):
+        """测试我的已办 - 包含已驳回的记录"""
+        G(
+            MCPServerAppPermissionApply,
+            mcp_server=fake_mcp_server,
+            bk_app_code="app2",
+            applied_by="applicant2",
+            applied_time=now_datetime(),
+            handled_by=FAKE_USERNAME,
+            handled_time=now_datetime(),
+            status=MCPServerAppPermissionApplyStatusEnum.REJECTED.value,
+            is_deleted=False,
+        )
+
+        resp = request_view(
+            method="GET",
+            view_name="personal_workbench.handled.mcp_permissions",
+        )
+        result = resp.json()
+
+        assert resp.status_code == 200
+        assert result["data"]["count"] == 1
+
+    def test_list_excludes_pending(self, request_view, fake_gateway, fake_mcp_server):
+        """测试我的已办 - 不返回 pending 状态的记录"""
+        G(
+            MCPServerAppPermissionApply,
+            mcp_server=fake_mcp_server,
+            bk_app_code="app3",
+            applied_by="applicant3",
+            applied_time=now_datetime(),
+            handled_by=FAKE_USERNAME,
+            handled_time=now_datetime(),
+            status=MCPServerAppPermissionApplyStatusEnum.PENDING.value,
+            is_deleted=False,
+        )
+
+        resp = request_view(
+            method="GET",
+            view_name="personal_workbench.handled.mcp_permissions",
+        )
+        result = resp.json()
+
+        assert resp.status_code == 200
+        assert result["data"]["count"] == 0
+
+    def test_list_excludes_deleted(self, request_view, fake_gateway, fake_mcp_server):
+        """测试我的已办 - 不返回已删除的记录"""
+        G(
+            MCPServerAppPermissionApply,
+            mcp_server=fake_mcp_server,
+            bk_app_code="app4",
+            applied_by="applicant4",
+            applied_time=now_datetime(),
+            handled_by=FAKE_USERNAME,
+            handled_time=now_datetime(),
+            status=MCPServerAppPermissionApplyStatusEnum.APPROVED.value,
+            is_deleted=True,
+        )
+
+        resp = request_view(
+            method="GET",
+            view_name="personal_workbench.handled.mcp_permissions",
+        )
+        result = resp.json()
+
+        assert resp.status_code == 200
+        assert result["data"]["count"] == 0
+
+    def test_list_empty(self, request_view):
+        """测试我的已办 - MCP Server 空数据"""
+        resp = request_view(
+            method="GET",
+            view_name="personal_workbench.handled.mcp_permissions",
+        )
+        result = resp.json()
+
+        assert resp.status_code == 200
+        assert result["data"]["count"] == 0
+        assert result["data"]["results"] == []

--- a/src/dashboard/apigateway/apigateway/tests/apis/web/personal_workbench/test_views.py
+++ b/src/dashboard/apigateway/apigateway/tests/apis/web/personal_workbench/test_views.py
@@ -100,7 +100,7 @@ class TestWorkbenchPendingGatewayPermissionListApi:
 
         resp = request_view(
             method="GET",
-            view_name="personal_workbench.pending.gateway_permissions",
+            view_name="workbench.permissions.gateway.pending",
         )
         result = resp.json()
 
@@ -121,7 +121,7 @@ class TestWorkbenchPendingGatewayPermissionListApi:
 
         resp = request_view(
             method="GET",
-            view_name="personal_workbench.pending.gateway_permissions",
+            view_name="workbench.permissions.gateway.pending",
         )
         result = resp.json()
 
@@ -140,7 +140,7 @@ class TestWorkbenchPendingGatewayPermissionListApi:
 
         resp = request_view(
             method="GET",
-            view_name="personal_workbench.pending.gateway_permissions",
+            view_name="workbench.permissions.gateway.pending",
         )
         result = resp.json()
 
@@ -159,7 +159,7 @@ class TestWorkbenchPendingGatewayPermissionListApi:
 
         resp = request_view(
             method="GET",
-            view_name="personal_workbench.pending.gateway_permissions",
+            view_name="workbench.permissions.gateway.pending",
         )
         result = resp.json()
 
@@ -185,7 +185,7 @@ class TestWorkbenchPendingGatewayPermissionListApi:
 
         resp = request_view(
             method="GET",
-            view_name="personal_workbench.pending.gateway_permissions",
+            view_name="workbench.permissions.gateway.pending",
             data={"bk_app_code": "target"},
         )
         result = resp.json()
@@ -198,7 +198,7 @@ class TestWorkbenchPendingGatewayPermissionListApi:
         """测试我的代办 - 空数据"""
         resp = request_view(
             method="GET",
-            view_name="personal_workbench.pending.gateway_permissions",
+            view_name="workbench.permissions.gateway.pending",
         )
         result = resp.json()
 
@@ -225,7 +225,7 @@ class TestWorkbenchPendingMCPPermissionListApi:
 
         resp = request_view(
             method="GET",
-            view_name="personal_workbench.pending.mcp_permissions",
+            view_name="workbench.permissions.mcp.pending",
         )
         result = resp.json()
 
@@ -261,7 +261,7 @@ class TestWorkbenchPendingMCPPermissionListApi:
 
         resp = request_view(
             method="GET",
-            view_name="personal_workbench.pending.mcp_permissions",
+            view_name="workbench.permissions.mcp.pending",
         )
         result = resp.json()
 
@@ -282,7 +282,7 @@ class TestWorkbenchPendingMCPPermissionListApi:
 
         resp = request_view(
             method="GET",
-            view_name="personal_workbench.pending.mcp_permissions",
+            view_name="workbench.permissions.mcp.pending",
         )
         result = resp.json()
 
@@ -293,7 +293,7 @@ class TestWorkbenchPendingMCPPermissionListApi:
         """测试我的代办 - MCP Server 空数据"""
         resp = request_view(
             method="GET",
-            view_name="personal_workbench.pending.mcp_permissions",
+            view_name="workbench.permissions.mcp.pending",
         )
         result = resp.json()
 
@@ -319,7 +319,7 @@ class TestWorkbenchMyApplyGatewayPermissionListApi:
 
         resp = request_view(
             method="GET",
-            view_name="personal_workbench.my_apply.gateway_permissions",
+            view_name="workbench.permissions.gateway.applied",
         )
         result = resp.json()
 
@@ -339,7 +339,7 @@ class TestWorkbenchMyApplyGatewayPermissionListApi:
 
         resp = request_view(
             method="GET",
-            view_name="personal_workbench.my_apply.gateway_permissions",
+            view_name="workbench.permissions.gateway.applied",
         )
         result = resp.json()
 
@@ -359,7 +359,7 @@ class TestWorkbenchMyApplyGatewayPermissionListApi:
 
         resp = request_view(
             method="GET",
-            view_name="personal_workbench.my_apply.gateway_permissions",
+            view_name="workbench.permissions.gateway.applied",
         )
         result = resp.json()
 
@@ -385,7 +385,7 @@ class TestWorkbenchMyApplyMCPPermissionListApi:
 
         resp = request_view(
             method="GET",
-            view_name="personal_workbench.my_apply.mcp_permissions",
+            view_name="workbench.permissions.mcp.applied",
         )
         result = resp.json()
 
@@ -407,7 +407,7 @@ class TestWorkbenchMyApplyMCPPermissionListApi:
 
         resp = request_view(
             method="GET",
-            view_name="personal_workbench.my_apply.mcp_permissions",
+            view_name="workbench.permissions.mcp.applied",
         )
         result = resp.json()
 
@@ -435,7 +435,7 @@ class TestWorkbenchHandledGatewayPermissionListApi:
 
         resp = request_view(
             method="GET",
-            view_name="personal_workbench.handled.gateway_permissions",
+            view_name="workbench.permissions.gateway.handled",
         )
         result = resp.json()
 
@@ -459,7 +459,7 @@ class TestWorkbenchHandledGatewayPermissionListApi:
 
         resp = request_view(
             method="GET",
-            view_name="personal_workbench.handled.gateway_permissions",
+            view_name="workbench.permissions.gateway.handled",
         )
         result = resp.json()
 
@@ -481,7 +481,7 @@ class TestWorkbenchHandledGatewayPermissionListApi:
 
         resp = request_view(
             method="GET",
-            view_name="personal_workbench.handled.gateway_permissions",
+            view_name="workbench.permissions.gateway.handled",
         )
         result = resp.json()
 
@@ -492,7 +492,7 @@ class TestWorkbenchHandledGatewayPermissionListApi:
         """测试我的已办 - 空数据"""
         resp = request_view(
             method="GET",
-            view_name="personal_workbench.handled.gateway_permissions",
+            view_name="workbench.permissions.gateway.handled",
         )
         result = resp.json()
 
@@ -521,7 +521,7 @@ class TestWorkbenchHandledMCPPermissionListApi:
 
         resp = request_view(
             method="GET",
-            view_name="personal_workbench.handled.mcp_permissions",
+            view_name="workbench.permissions.mcp.handled",
         )
         result = resp.json()
 
@@ -546,7 +546,7 @@ class TestWorkbenchHandledMCPPermissionListApi:
 
         resp = request_view(
             method="GET",
-            view_name="personal_workbench.handled.mcp_permissions",
+            view_name="workbench.permissions.mcp.handled",
         )
         result = resp.json()
 
@@ -569,7 +569,7 @@ class TestWorkbenchHandledMCPPermissionListApi:
 
         resp = request_view(
             method="GET",
-            view_name="personal_workbench.handled.mcp_permissions",
+            view_name="workbench.permissions.mcp.handled",
         )
         result = resp.json()
 
@@ -592,7 +592,7 @@ class TestWorkbenchHandledMCPPermissionListApi:
 
         resp = request_view(
             method="GET",
-            view_name="personal_workbench.handled.mcp_permissions",
+            view_name="workbench.permissions.mcp.handled",
         )
         result = resp.json()
 
@@ -603,7 +603,7 @@ class TestWorkbenchHandledMCPPermissionListApi:
         """测试我的已办 - MCP Server 空数据"""
         resp = request_view(
             method="GET",
-            view_name="personal_workbench.handled.mcp_permissions",
+            view_name="workbench.permissions.mcp.handled",
         )
         result = resp.json()
 

--- a/src/dashboard/apigateway/apigateway/urls.py
+++ b/src/dashboard/apigateway/apigateway/urls.py
@@ -91,8 +91,8 @@ urlpatterns = [
     ),
     # mcp server marketplace
     path("backend/mcp-marketplace/", include("apigateway.apis.web.mcp_marketplace.urls")),
-    # personal workbench
-    path("backend/personal-workbench/", include("apigateway.apis.web.personal_workbench.urls")),
+    # personal workbench: /me/workbench/
+    path("backend/me/workbench/", include("apigateway.apis.web.personal_workbench.urls")),
     # todo 不应该放在顶层，后续要想办法挪到下层
     # FIXME: not used? commented out in 2026-03-23, remove in the future
     # path(

--- a/src/dashboard/apigateway/apigateway/urls.py
+++ b/src/dashboard/apigateway/apigateway/urls.py
@@ -91,6 +91,8 @@ urlpatterns = [
     ),
     # mcp server marketplace
     path("backend/mcp-marketplace/", include("apigateway.apis.web.mcp_marketplace.urls")),
+    # personal workbench
+    path("backend/personal-workbench/", include("apigateway.apis.web.personal_workbench.urls")),
     # todo 不应该放在顶层，后续要想办法挪到下层
     # FIXME: not used? commented out in 2026-03-23, remove in the future
     # path(


### PR DESCRIPTION
## What changed

Add a new **Personal Workbench** module that provides a centralized view for gateway maintainers and applicants to manage their permission-related tasks.

### New Endpoints (6 total)

| Category | Endpoint | Description |
|----------|----------|-------------|
| 我的代办 | `GET /backend/me/workbench/permissions/gateway/pending/` | Pending gateway permission applications (for maintainers) |
| 我的代办 | `GET /backend/me/workbench/permissions/mcp/pending/` | Pending MCP Server permission applications |
| 我的申请 | `GET /backend/me/workbench/permissions/gateway/applied/` | My submitted gateway permission applications |
| 我的申请 | `GET /backend/me/workbench/permissions/mcp/applied/` | My submitted MCP Server permission applications |
| 我的已办 | `GET /backend/me/workbench/permissions/gateway/handled/` | Handled gateway permission records |
| 我的已办 | `GET /backend/me/workbench/permissions/mcp/handled/` | Handled MCP Server permission records |

### Key Design Decisions

- **RESTful URL structure**: `/me/workbench/permissions/{gateway,mcp}/{pending,applied,handled}/` with nested `include()` for clean separation
- **Mixin composition**: `WorkbenchPermissionMixin` provides shared `get_queryset()` logic for maintainer gateway filtering, composed with `generics.ListAPIView` via multiple inheritance
- **Precise maintainer matching**: Uses `GatewayHandler.list_gateways_by_user()` for exact permission matching
- **Standard patterns**: Uses `serializer_class` + `get_serializer()` consistent with DRF conventions
- **Input SLZ for docs only**: Query input serializers are for swagger documentation generation; actual filtering is handled by django-filter FilterSets

### Files Changed

- `apis/web/personal_workbench/` — views, serializers, filters, urls
- `tests/apis/web/personal_workbench/` — 29 test cases including authorization boundary and substring regression tests
- `urls.py` — route registration

### Test Coverage

- 29 tests all passing
- Includes authorization boundary tests (non-maintainer exclusion)
- Includes substring maintainer mismatch regression tests
- Covers all 6 endpoints with filter and edge case scenarios
