### PR TITLE
feat: support adaptive MCP Server URL based on least privilege

### DIFF
--- a/src/dashboard/apigateway/apigateway/apis/v2/inner/serializers.py
+++ b/src/dashboard/apigateway/apigateway/apis/v2/inner/serializers.py
@@ -22,6 +22,7 @@ import math
 from django.utils.translation import gettext as _
 from rest_framework import serializers
 
+from apigateway.apis.v2.mcp_server import get_categories_from_context, get_mcp_server_url_from_context
 from apigateway.apps.mcp_server.constants import (
     MCPServerAppPermissionApplyStatusEnum,
     MCPServerProtocolTypeEnum,
@@ -42,7 +43,6 @@ from apigateway.core.constants import GatewayStatusEnum
 from apigateway.service.mcp.mcp_server import (
     build_mcp_server_detail_url,
     build_mcp_server_permission_approval_url,
-    build_mcp_server_url,
 )
 from apigateway.utils import time
 
@@ -357,11 +357,16 @@ class MCPServerBaseSLZ(serializers.Serializer):
         help_text="MCPServer 协议类型",
         choices=MCPServerProtocolTypeEnum.get_choices(),
     )
+    url = serializers.SerializerMethodField(help_text="MCPServer 访问 URL")
+    categories = serializers.SerializerMethodField(help_text="MCPServer 分类列表")
 
     def get_title(self, obj) -> str:
         title = obj.get("title", "") if isinstance(obj, dict) else getattr(obj, "title", "")
         name = obj.get("name", "") if isinstance(obj, dict) else getattr(obj, "name", "")
         return title if title else name
+
+    def get_url(self, obj) -> str:
+        return get_mcp_server_url_from_context(self.context, obj)
 
     def get_doc_link(self, obj):
         obj_id = obj.get("id") if isinstance(obj, dict) else obj.id
@@ -591,7 +596,7 @@ class MCPServerListOutputSLZ(serializers.Serializer):
         return self.context["gateways"][obj.gateway.id]
 
     def get_url(self, obj) -> str:
-        return build_mcp_server_url(obj.name, obj.protocol_type)
+        return get_mcp_server_url_from_context(self.context, obj)
 
     def get_detail_url(self, obj) -> str:
         return build_mcp_server_detail_url(obj.id)

--- a/src/dashboard/apigateway/apigateway/apis/v2/inner/serializers.py
+++ b/src/dashboard/apigateway/apigateway/apis/v2/inner/serializers.py
@@ -361,16 +361,13 @@ class MCPServerBaseSLZ(serializers.Serializer):
     categories = serializers.SerializerMethodField(help_text="MCPServer 分类列表")
 
     def get_title(self, obj) -> str:
-        title = obj.get("title", "") if isinstance(obj, dict) else getattr(obj, "title", "")
-        name = obj.get("name", "") if isinstance(obj, dict) else getattr(obj, "name", "")
-        return title if title else name
+        return obj.title if obj.title else obj.name
 
     def get_url(self, obj) -> str:
         return get_mcp_server_url_from_context(self.context, obj)
 
     def get_doc_link(self, obj):
-        obj_id = obj.get("id") if isinstance(obj, dict) else obj.id
-        return build_mcp_server_detail_url(obj_id)
+        return build_mcp_server_detail_url(obj.id)
 
     class Meta:
         ref_name = "apigateway.apis.v2.inner.serializers.MCPServerBaseSLZ"

--- a/src/dashboard/apigateway/apigateway/apis/v2/inner/serializers.py
+++ b/src/dashboard/apigateway/apigateway/apis/v2/inner/serializers.py
@@ -366,6 +366,9 @@ class MCPServerBaseSLZ(serializers.Serializer):
     def get_url(self, obj) -> str:
         return get_mcp_server_url_from_context(self.context, obj)
 
+    def get_categories(self, obj) -> list:
+        return get_categories_from_context(self.context, obj)
+
     def get_doc_link(self, obj):
         return build_mcp_server_detail_url(obj.id)
 

--- a/src/dashboard/apigateway/apigateway/apis/v2/inner/views.py
+++ b/src/dashboard/apigateway/apigateway/apis/v2/inner/views.py
@@ -482,7 +482,9 @@ class MCPServerPermissionListApi(generics.ListAPIView):
 
         data = slz.validated_data
 
-        queryset = MCPServer.objects.filter(is_public=True, status=MCPServerStatusEnum.ACTIVE.value)
+        queryset = MCPServer.objects.filter(is_public=True, status=MCPServerStatusEnum.ACTIVE.value).select_related(
+            "gateway", "stage"
+        )
 
         keyword = data.get("keyword")
         if keyword:
@@ -506,6 +508,12 @@ class MCPServerPermissionListApi(generics.ListAPIView):
                 mcp_server_permission_status[obj["mcp_server_id"]] = obj["status"]
 
         mcp_server_permissions = []
+        # Build categories map for queryset
+        categories_map = MCPServerHandler.build_categories_map([obj.id for obj in queryset])
+
+        # 计算最低权限级别，用于判断是否展示应用态 URL
+        least_privileges = MCPServerHandler.get_least_privileges(list(queryset))
+
         for obj in queryset:
             permission_status = mcp_server_permission_status.get(
                 obj.id, MCPServerPermissionStatusEnum.NEED_APPLY.value
@@ -522,15 +530,7 @@ class MCPServerPermissionListApi(generics.ListAPIView):
 
             mcp_server_permissions.append(
                 {
-                    "mcp_server": {
-                        "id": obj.id,
-                        "name": obj.name,
-                        "title": obj.title or obj.name,
-                        "description": obj.description,
-                        "tools_count": obj.tools_count,
-                        "tool_names": obj.tool_names,
-                        "protocol_type": obj.protocol_type,
-                    },
+                    "mcp_server": obj,
                     "permission": {
                         "status": permission_status,
                         "action": action,
@@ -542,7 +542,14 @@ class MCPServerPermissionListApi(generics.ListAPIView):
                 }
             )
 
-        slz = serializers.MCPServerPermissionListOutputSLZ(mcp_server_permissions, many=True)
+        slz = serializers.MCPServerPermissionListOutputSLZ(
+            mcp_server_permissions,
+            many=True,
+            context={
+                "categories": categories_map,
+                "least_privileges": least_privileges,
+            },
+        )
         return OKJsonResponse(data=slz.data)
 
 
@@ -599,22 +606,26 @@ class MCPServerAppPermissionListApi(generics.ListAPIView):
         slz = self.get_serializer(data=request.query_params)
         slz.is_valid(raise_exception=True)
 
-        queryset = MCPServerAppPermissionApply.objects.filter(
-            bk_app_code=slz.validated_data["target_app_code"],
-            status__in=[MCPServerAppPermissionApplyStatusEnum.APPROVED.value],
-        ).order_by("-applied_time")
+        queryset = (
+            MCPServerAppPermissionApply.objects.filter(
+                bk_app_code=slz.validated_data["target_app_code"],
+                status__in=[MCPServerAppPermissionApplyStatusEnum.APPROVED.value],
+            )
+            .select_related("mcp_server", "mcp_server__gateway", "mcp_server__stage")
+            .order_by("-applied_time")
+        )
+
+        mcp_servers = [obj.mcp_server for obj in queryset]
+
+        # 计算最低权限级别，用于判断是否展示应用态 URL
+        least_privileges = MCPServerHandler.get_least_privileges(mcp_servers)
+
+        # Build categories map
+        categories_map = MCPServerHandler.build_categories_map([obj.mcp_server_id for obj in queryset])
 
         mcp_server_permissions = [
             {
-                "mcp_server": {
-                    "id": obj.mcp_server_id,
-                    "name": obj.mcp_server.name,
-                    "title": obj.mcp_server.title or obj.mcp_server.name,
-                    "description": obj.mcp_server.description,
-                    "tools_count": obj.mcp_server.tools_count,
-                    "tool_names": obj.mcp_server.tool_names,
-                    "protocol_type": obj.mcp_server.protocol_type,
-                },
+                "mcp_server": obj.mcp_server,
                 "permission": {
                     "status": MCPServerPermissionStatusEnum.OWNED.value,
                     "action": "",
@@ -627,7 +638,14 @@ class MCPServerAppPermissionListApi(generics.ListAPIView):
             for obj in queryset
         ]
 
-        slz = serializers.MCPServerAppPermissionListOutputSLZ(mcp_server_permissions, many=True)
+        slz = serializers.MCPServerAppPermissionListOutputSLZ(
+            mcp_server_permissions,
+            many=True,
+            context={
+                "categories": categories_map,
+                "least_privileges": least_privileges,
+            },
+        )
         return OKJsonResponse(data=slz.data)
 
 
@@ -790,6 +808,12 @@ class MCPServerListApi(generics.ListAPIView):
 
         mcp_server_ids = [mcp_server.id for mcp_server in page]
         context["prompts_count_map"] = MCPServerHandler.get_prompts_count_map(mcp_server_ids)
+
+        # Add categories map
+        context["categories"] = MCPServerHandler.build_categories_map([mcp_server.id for mcp_server in page])
+
+        # 计算最低权限级别，用于判断是否展示应用态 URL
+        context["least_privileges"] = MCPServerHandler.get_least_privileges(page)
 
         output_slz = serializers.MCPServerListOutputSLZ(page, many=True, context=context)
         return self.get_paginated_response(output_slz.data)

--- a/src/dashboard/apigateway/apigateway/apis/v2/inner/views.py
+++ b/src/dashboard/apigateway/apigateway/apis/v2/inner/views.py
@@ -675,20 +675,11 @@ class MCPServerAppPermissionRecordListApi(generics.ListAPIView):
             data.get("query"),
             data.get("applied_time_start"),
             data.get("applied_time_end"),
-        )
+        ).select_related("mcp_server", "mcp_server__gateway", "mcp_server__stage")
 
         mcp_server_permission_records = [
             {
-                "mcp_server": {
-                    "id": obj.mcp_server_id,
-                    "name": obj.mcp_server.name,
-                    "title": obj.mcp_server.title or obj.mcp_server.name,
-                    "description": obj.mcp_server.description,
-                    "tools_count": obj.mcp_server.tools_count,
-                    "tool_names": obj.mcp_server.tool_names,
-                    "protocol_type": obj.mcp_server.protocol_type,
-                    "gateway_id": obj.mcp_server.gateway_id,  # 添加 gateway_id 用于构建审批 URL
-                },
+                "mcp_server": obj.mcp_server,
                 "record": {
                     "id": obj.id,
                     "applied_by": obj.applied_by,
@@ -702,12 +693,28 @@ class MCPServerAppPermissionRecordListApi(generics.ListAPIView):
                     "expire_days": obj.expire_days,
                     "mcp_server_id": obj.mcp_server_id,  # 添加 mcp_server_id 用于构建审批 URL
                     "gateway_id": obj.mcp_server.gateway_id,  # 在 record 中也添加 gateway_id
+                    "tenant_mode": obj.mcp_server.gateway.tenant_mode,
+                    "tenant_id": obj.mcp_server.gateway.tenant_id,
                 },
             }
             for obj in queryset
         ]
 
-        slz = serializers.MCPServerAppPermissionRecordListOutputSLZ(mcp_server_permission_records, many=True)
+        # Build categories map
+        categories_map = MCPServerHandler.build_categories_map([obj.mcp_server_id for obj in queryset])
+
+        # 计算最低权限级别，用于判断是否展示应用态 URL
+        mcp_servers = [obj.mcp_server for obj in queryset]
+        least_privileges = MCPServerHandler.get_least_privileges(mcp_servers)
+
+        slz = serializers.MCPServerAppPermissionRecordListOutputSLZ(
+            mcp_server_permission_records,
+            many=True,
+            context={
+                "categories": categories_map,
+                "least_privileges": least_privileges,
+            },
+        )
 
         return OKJsonResponse(data=slz.data)
 
@@ -735,7 +742,9 @@ class MCPServerAppPermissionRecordRetrieveApi(generics.RetrieveAPIView):
         data = slz.validated_data
 
         try:
-            return MCPServerAppPermissionApply.objects.get(bk_app_code=data["target_app_code"], id=record_id)
+            return MCPServerAppPermissionApply.objects.select_related(
+                "mcp_server", "mcp_server__gateway", "mcp_server__stage"
+            ).get(bk_app_code=data["target_app_code"], id=record_id)
         except MCPServerAppPermissionApply.DoesNotExist:
             raise error_codes.NOT_FOUND
 
@@ -743,16 +752,7 @@ class MCPServerAppPermissionRecordRetrieveApi(generics.RetrieveAPIView):
         instance = self.get_object()
 
         mcp_server_permission_record = {
-            "mcp_server": {
-                "id": instance.mcp_server_id,
-                "name": instance.mcp_server.name,
-                "title": instance.mcp_server.title or instance.mcp_server.name,
-                "description": instance.mcp_server.description,
-                "tools_count": instance.mcp_server.tools_count,
-                "tool_names": instance.mcp_server.tool_names,
-                "protocol_type": instance.mcp_server.protocol_type,
-                "gateway_id": instance.mcp_server.gateway_id,  # 添加 gateway_id 用于构建审批 URL
-            },
+            "mcp_server": instance.mcp_server,
             "record": {
                 "id": instance.id,
                 "applied_by": instance.applied_by,
@@ -766,12 +766,23 @@ class MCPServerAppPermissionRecordRetrieveApi(generics.RetrieveAPIView):
                 "comment": instance.comment,
                 "reason": instance.reason,
                 "expire_days": instance.expire_days,
-                "mcp_server_id": instance.mcp_server_id,  # 添加 mcp_server_id 用于构建审批 URL
-                "gateway_id": instance.mcp_server.gateway_id,  # 在 record 中也添加 gateway_id
+                "mcp_server_id": instance.mcp_server_id,
+                "gateway_id": instance.mcp_server.gateway_id,
             },
         }
 
-        slz = self.get_serializer(mcp_server_permission_record)
+        # Build categories map
+        categories_map = MCPServerHandler.build_categories_map([instance.mcp_server_id])
+
+        # 计算最低权限级别，用于判断是否展示应用态 URL
+        least_privileges = MCPServerHandler.get_least_privileges([instance.mcp_server])
+
+        context = {
+            **self.get_serializer_context(),
+            "categories": categories_map,
+            "least_privileges": least_privileges,
+        }
+        slz = self.get_serializer(mcp_server_permission_record, context=context)
         return OKJsonResponse(data=slz.data)
 
 

--- a/src/dashboard/apigateway/apigateway/apis/v2/mcp_server.py
+++ b/src/dashboard/apigateway/apigateway/apis/v2/mcp_server.py
@@ -35,6 +35,8 @@ from apigateway.core.models import Gateway, Release, Stage
 from apigateway.service.contexts import GatewayAuthContext
 from apigateway.service.mcp.mcp_server import build_mcp_server_url
 
+logger = logging.getLogger(__name__)
+
 
 def get_mcp_server_url_from_context(context: dict, obj: MCPServer) -> str:
     """从 serializer context 中获取 least_privilege 并生成 MCP Server URL
@@ -66,9 +68,6 @@ def get_categories_from_context(context: dict, obj: MCPServer) -> List[Dict[str,
         categories 列表，如 [{"name": "official", "display_name": "官方"}]
     """
     return context.get("categories", {}).get(obj.id, [])
-
-
-logger = logging.getLogger(__name__)
 
 
 def build_mcp_server_list_queryset(

--- a/src/dashboard/apigateway/apigateway/apis/v2/mcp_server.py
+++ b/src/dashboard/apigateway/apigateway/apis/v2/mcp_server.py
@@ -16,7 +16,7 @@
 # to the current version of the project delivered to anyone in the future.
 #
 import logging
-from typing import Any, Dict, List, Optional, Sequence, Tuple, Union
+from typing import Any, Dict, List, Optional, Sequence, Tuple
 
 from django.conf import settings
 from django.db.models import Q, QuerySet
@@ -36,28 +36,37 @@ from apigateway.service.contexts import GatewayAuthContext
 from apigateway.service.mcp.mcp_server import build_mcp_server_url
 
 
-def get_mcp_server_url_from_context(context: dict, obj: Union[dict, MCPServer]) -> str:
+def get_mcp_server_url_from_context(context: dict, obj: MCPServer) -> str:
     """从 serializer context 中获取 least_privilege 并生成 MCP Server URL
 
     统一 inner/open 序列化器中 get_url 方法的公共逻辑，避免重复实现。
-    支持 dict 和 model 实例两种 obj 格式。
 
     Args:
         context: serializer 的 context 字典，应包含 "least_privileges" 键
-        obj: MCPServer 数据，可以是 dict 或 model 实例
+        obj: MCPServer model 实例
 
     Returns:
         MCP Server 访问 URL
     """
-    if isinstance(obj, dict):
-        # dict 格式无法获取 gateway/stage 信息，回退到默认 URL
-        name = obj.get("name", "")
-        protocol_type = obj.get("protocol_type", "")
-        return build_mcp_server_url(name, protocol_type)
-
     least_privileges: Dict[Tuple[int, int], str] = context.get("least_privileges", {})
     least_privilege = least_privileges.get((obj.gateway.id, obj.stage.id), "")
     return MCPServerHandler.get_mcp_server_url(obj, least_privilege)
+
+
+def get_categories_from_context(context: dict, obj: MCPServer) -> List[Dict[str, str]]:
+    """从 serializer context 中获取 obj 对应的 categories 列表
+
+    统一 inner/open 序列化器中的 categories 获取逻辑。
+
+    Args:
+        context: serializer 的 context 字典，应包含 "categories" 键
+        obj: MCPServer model 实例
+
+    Returns:
+        categories 列表，如 [{"name": "official", "display_name": "官方"}]
+    """
+    return context.get("categories", {}).get(obj.id, [])
+
 
 logger = logging.getLogger(__name__)
 

--- a/src/dashboard/apigateway/apigateway/apis/v2/mcp_server.py
+++ b/src/dashboard/apigateway/apigateway/apis/v2/mcp_server.py
@@ -16,7 +16,7 @@
 # to the current version of the project delivered to anyone in the future.
 #
 import logging
-from typing import Any, Dict, Optional, Sequence
+from typing import Any, Dict, List, Optional, Sequence, Tuple, Union
 
 from django.conf import settings
 from django.db.models import Q, QuerySet
@@ -34,6 +34,30 @@ from apigateway.core.constants import GatewayStatusEnum, StageStatusEnum
 from apigateway.core.models import Gateway, Release, Stage
 from apigateway.service.contexts import GatewayAuthContext
 from apigateway.service.mcp.mcp_server import build_mcp_server_url
+
+
+def get_mcp_server_url_from_context(context: dict, obj: Union[dict, MCPServer]) -> str:
+    """从 serializer context 中获取 least_privilege 并生成 MCP Server URL
+
+    统一 inner/open 序列化器中 get_url 方法的公共逻辑，避免重复实现。
+    支持 dict 和 model 实例两种 obj 格式。
+
+    Args:
+        context: serializer 的 context 字典，应包含 "least_privileges" 键
+        obj: MCPServer 数据，可以是 dict 或 model 实例
+
+    Returns:
+        MCP Server 访问 URL
+    """
+    if isinstance(obj, dict):
+        # dict 格式无法获取 gateway/stage 信息，回退到默认 URL
+        name = obj.get("name", "")
+        protocol_type = obj.get("protocol_type", "")
+        return build_mcp_server_url(name, protocol_type)
+
+    least_privileges: Dict[Tuple[int, int], str] = context.get("least_privileges", {})
+    least_privilege = least_privileges.get((obj.gateway.id, obj.stage.id), "")
+    return MCPServerHandler.get_mcp_server_url(obj, least_privilege)
 
 logger = logging.getLogger(__name__)
 

--- a/src/dashboard/apigateway/apigateway/apis/v2/mcp_server.py
+++ b/src/dashboard/apigateway/apigateway/apis/v2/mcp_server.py
@@ -120,7 +120,9 @@ def build_mcp_server_list_context(mcp_servers: Sequence[MCPServer]) -> Dict[str,
         for s in Stage.objects.filter(id__in=stage_ids)
     }
 
-    return {"gateways": gateways, "stages": stages}
+    least_privileges = MCPServerHandler.get_least_privileges(list(mcp_servers))
+
+    return {"gateways": gateways, "stages": stages, "least_privileges": least_privileges}
 
 
 def validate_and_enrich_mcp_server_for_retrieve(
@@ -190,6 +192,8 @@ def validate_and_enrich_mcp_server_for_retrieve(
         {"name": cat.name, "display_name": cat.display_name} for cat in instance.categories.filter(is_active=True)
     ]
 
+    least_privileges = MCPServerHandler.get_least_privileges([instance])
+
     return {
         "labels": labels,
         "tool_name_map": instance.gen_tool_name_map(),
@@ -198,4 +202,5 @@ def validate_and_enrich_mcp_server_for_retrieve(
         "prompts_count_map": prompts_count_map,
         "prompts": prompts,
         "user_custom_doc": user_custom_doc,
+        "least_privileges": least_privileges,
     }

--- a/src/dashboard/apigateway/apigateway/apis/v2/open/serializers.py
+++ b/src/dashboard/apigateway/apigateway/apis/v2/open/serializers.py
@@ -21,6 +21,7 @@ from typing import Any, Dict
 from django.utils.translation import gettext as _
 from rest_framework import serializers
 
+from apigateway.apis.v2.mcp_server import get_categories_from_context, get_mcp_server_url_from_context
 from apigateway.apps.mcp_server.constants import (
     MCPServerAppPermissionApplyStatusEnum,
     MCPServerAppPermissionGrantTypeEnum,
@@ -36,7 +37,6 @@ from apigateway.service.mcp.mcp_server import (
     build_mcp_server_application_url,
     build_mcp_server_detail_url,
     build_mcp_server_permission_approval_url,
-    build_mcp_server_url,
 )
 
 
@@ -234,7 +234,7 @@ class MCPServerBaseOutputSLZ(serializers.Serializer):
         return self.context["gateways"][obj.gateway.id]
 
     def get_url(self, obj) -> str:
-        return build_mcp_server_url(obj.name, obj.protocol_type)
+        return get_mcp_server_url_from_context(self.context, obj)
 
     def get_detail_url(self, obj) -> str:
         return build_mcp_server_detail_url(obj.id)
@@ -541,7 +541,7 @@ class MCPServerRetrieveOutputSLZ(serializers.Serializer):
         return self.context.get("categories", [])
 
     def get_url(self, obj) -> str:
-        return build_mcp_server_url(obj.name, obj.protocol_type)
+        return get_mcp_server_url_from_context(self.context, obj)
 
     def get_user_custom_doc(self, obj) -> str:
         return self.context.get("user_custom_doc", "")

--- a/src/dashboard/apigateway/apigateway/apis/v2/open/serializers.py
+++ b/src/dashboard/apigateway/apigateway/apis/v2/open/serializers.py
@@ -21,7 +21,7 @@ from typing import Any, Dict
 from django.utils.translation import gettext as _
 from rest_framework import serializers
 
-from apigateway.apis.v2.mcp_server import get_categories_from_context, get_mcp_server_url_from_context
+from apigateway.apis.v2.mcp_server import get_mcp_server_url_from_context
 from apigateway.apps.mcp_server.constants import (
     MCPServerAppPermissionApplyStatusEnum,
     MCPServerAppPermissionGrantTypeEnum,

--- a/src/dashboard/apigateway/apigateway/biz/mcp_server/mcp_server.py
+++ b/src/dashboard/apigateway/apigateway/biz/mcp_server/mcp_server.py
@@ -33,6 +33,7 @@ from apigateway.apps.mcp_server.constants import (
     MCPServerAppPermissionApplyStatusEnum,
     MCPServerAppPermissionGrantTypeEnum,
     MCPServerExtendTypeEnum,
+    MCPServerLeastPrivilegeEnum,
     MCPServerStatusEnum,
 )
 from apigateway.apps.mcp_server.models import (
@@ -56,7 +57,7 @@ from apigateway.common.tenant.user_credentials import UserCredentials
 from apigateway.components import bkaidev
 from apigateway.core.constants import GatewayStatusEnum, StageStatusEnum
 from apigateway.core.models import Gateway, Release, Resource
-from apigateway.service.mcp.mcp_server import build_mcp_server_url
+from apigateway.service.mcp.mcp_server import build_mcp_server_application_url, build_mcp_server_url
 from apigateway.utils.time import NeverExpiresTime, now_datetime
 
 logger = logging.getLogger(__name__)
@@ -371,7 +372,31 @@ class MCPServerHandler:
             AppResourcePermission.objects.filter(id__in=to_delete).delete()
 
     @staticmethod
-    def get_app_permission_risks(mcp_servers: list) -> Dict[int, List[str]]:
+    def _get_releases_for_mcp_servers(mcp_servers) -> Dict[Tuple[int, int], Release]:
+        """批量获取 MCP Server 列表对应的 Release 记录
+
+        Args:
+            mcp_servers: MCPServer 实例列表
+
+        Returns:
+            {(gateway_id, stage_id): Release} 映射
+        """
+        gateway_stage_pairs = {(mcp_server.gateway_id, mcp_server.stage_id) for mcp_server in mcp_servers}
+        if not gateway_stage_pairs:
+            return {}
+
+        release_filters = Q()
+        for gateway_id, stage_id in gateway_stage_pairs:
+            release_filters |= Q(gateway_id=gateway_id, stage_id=stage_id)
+
+        releases = Release.objects.filter(release_filters).select_related("resource_version")
+        return {(r.gateway_id, r.stage_id): r for r in releases}
+
+    @staticmethod
+    def get_app_permission_risks(
+        mcp_servers: list,
+        releases: Optional[Dict[Tuple[int, int], Release]] = None,
+    ) -> Dict[int, List[str]]:
         """检测开启了 oauth2_public_client_enabled 的 MCPServer 是否存在应用态权限安全风险。
 
         当 oauth2_public_client_enabled=True 时，public 应用被自动授权；
@@ -379,6 +404,7 @@ class MCPServerHandler:
 
         Args:
             mcp_servers: MCPServer 实例列表（需已 select_related gateway/stage）
+            releases: 可选，预查询的 Release 映射，避免重复查询
 
         Returns:
             {mcp_server_id: [risk_tool_name, ...]} 映射，仅包含存在风险的 MCPServer
@@ -387,22 +413,11 @@ class MCPServerHandler:
         if not risk_mcp_servers:
             return {}
 
-        gateway_stage_pairs = set()
-        mcp_server_gateway_stage: Dict[int, tuple] = {}
-        for mcp_server in risk_mcp_servers:
-            key = (mcp_server.gateway_id, mcp_server.stage_id)
-            gateway_stage_pairs.add(key)
-            mcp_server_gateway_stage[mcp_server.id] = key
+        if releases is None:
+            releases = MCPServerHandler._get_releases_for_mcp_servers(risk_mcp_servers)
 
-        release_filters = Q()
-        for gateway_id, stage_id in gateway_stage_pairs:
-            release_filters |= Q(gateway_id=gateway_id, stage_id=stage_id)
-
-        releases = Release.objects.filter(release_filters).select_related("resource_version")
-
-        release_resource_auth: Dict[tuple, Dict[str, bool]] = {}
-        for release in releases:
-            key = (release.gateway_id, release.stage_id)
+        release_resource_auth: Dict[Tuple[int, int], Dict[str, bool]] = {}
+        for key, release in releases.items():
             resource_auth: Dict[str, bool] = {}
             for resource in release.resource_version.data:
                 auth_config = json.loads(resource.get("contexts", {}).get("resource_auth", {}).get("config", "{}"))
@@ -411,7 +426,7 @@ class MCPServerHandler:
 
         risks: Dict[int, List[str]] = {}
         for mcp_server in risk_mcp_servers:
-            gateway_stage_key = mcp_server_gateway_stage[mcp_server.id]
+            gateway_stage_key = (mcp_server.gateway_id, mcp_server.stage_id)
             resource_auth = release_resource_auth.get(gateway_stage_key, {})
             tool_name_map = mcp_server.gen_tool_name_map()
             risk_tools = [
@@ -423,6 +438,99 @@ class MCPServerHandler:
                 risks[mcp_server.id] = risk_tools
 
         return risks
+
+    @staticmethod
+    def get_least_privileges(
+        mcp_servers,
+        releases: Optional[Dict[Tuple[int, int], Release]] = None,
+    ) -> Dict[Tuple[int, int], str]:
+        """批量计算 MCP Server 的最低权限级别
+
+        遍历每个 MCP Server 的 (gateway_id, stage_id) 对，检查 Release 中对应工具资源
+        是否需要用户认证。如果所有工具都不需要用户认证，则为 APPLICATION；
+        否则为 APPLICATION_AND_USER。
+
+        Args:
+            mcp_servers: MCPServer 实例列表（需已 select_related gateway/stage）
+            releases: 可选，预查询的 Release 映射，避免重复查询
+
+        Returns:
+            {(gateway_id, stage_id): least_privilege} 映射
+        """
+        gateway_stage_tools: Dict[Tuple[int, int], List[str]] = {}
+        for mcp_server in mcp_servers:
+            gateway_stage_tools[(mcp_server.gateway_id, mcp_server.stage_id)] = mcp_server.resource_names
+
+        if not gateway_stage_tools:
+            return {}
+
+        if releases is None:
+            releases = MCPServerHandler._get_releases_for_mcp_servers(mcp_servers)
+
+        least_privileges: Dict[Tuple[int, int], str] = {}
+        for gateway_stage_key, release in releases.items():
+            tool_names = gateway_stage_tools.get(gateway_stage_key, [])
+            least_privilege = MCPServerLeastPrivilegeEnum.APPLICATION.value
+            for resource in release.resource_version.data:
+                if resource["name"] not in tool_names:
+                    continue
+                auth_config = json.loads(resource.get("contexts", {}).get("resource_auth", {}).get("config", "{}"))
+                verified_user_required = not auth_config.get("skip_auth_verification", False) and bool(
+                    auth_config.get("auth_verified_required", False)
+                )
+                if verified_user_required:
+                    least_privilege = MCPServerLeastPrivilegeEnum.APPLICATION_AND_USER.value
+                    break
+            least_privileges[gateway_stage_key] = least_privilege
+
+        return least_privileges
+
+    @staticmethod
+    def get_mcp_server_url(instance: MCPServer, least_privilege: str = "") -> str:
+        """根据 MCP Server 的应用态条件返回合适的访问 URL
+
+        当未开启公共客户端模式且所有工具都是应用态时，返回应用态 URL。
+
+        Args:
+            instance: MCPServer 实例
+            least_privilege: 最低权限级别
+
+        Returns:
+            MCP Server 访问 URL
+        """
+        if (
+            not instance.oauth2_public_client_enabled
+            and least_privilege == MCPServerLeastPrivilegeEnum.APPLICATION.value
+        ):
+            return build_mcp_server_application_url(instance.name, instance.protocol_type)
+        return build_mcp_server_url(instance.name, instance.protocol_type)
+
+    @staticmethod
+    def build_categories_map(mcp_server_ids: List[int]) -> Dict[int, List[Dict[str, str]]]:
+        """批量查询 MCPServer 的分类信息，返回 {mcp_server_id: [{"name": ..., "display_name": ...}]} 映射
+
+        使用单次查询替代 N+1 的 categories.filter() 调用。
+
+        Args:
+            mcp_server_ids: MCPServer ID 列表
+
+        Returns:
+            以 mcp_server_id 为 key 的分类字典映射
+        """
+        if not mcp_server_ids:
+            return {}
+
+        categories_qs = MCPServerCategory.objects.filter(
+            mcp_servers__id__in=mcp_server_ids,
+            is_active=True,
+        ).values("mcp_servers__id", "name", "display_name")
+
+        categories_map: Dict[int, List[Dict[str, str]]] = {}
+        for cat in categories_qs:
+            categories_map.setdefault(cat["mcp_servers__id"], []).append(
+                {"name": cat["name"], "display_name": cat["display_name"]}
+            )
+        return categories_map
 
     @staticmethod
     def disable_servers(gateway_id: int, stage_id: int = 0) -> None:

--- a/src/dashboard/apigateway/apigateway/data/apidocs/zh/v2_inner_list_mcp_server.md
+++ b/src/dashboard/apigateway/apigateway/data/apidocs/zh/v2_inner_list_mcp_server.md
@@ -92,7 +92,7 @@
 | gateway      | object | MCPServer 网关信息        |
 | tools_count  | int    | MCPServer 工具数量        |
 | prompts_count | int    | MCPServer Prompts 数量  |
-| url          | string | MCPServer 访问 URL      |
+| url          | string | MCPServer 访问 URL，根据最低权限级别自适应返回普通 URL 或应用态 URL |
 | detail_url   | string | MCPServer 网关站点详情 URL  |
 | updated_by   | string | 更新人                   |
 | created_by   | string | 创建人                   |

--- a/src/dashboard/apigateway/apigateway/data/apidocs/zh/v2_inner_list_mcp_server_app_permissions.md
+++ b/src/dashboard/apigateway/apigateway/data/apidocs/zh/v2_inner_list_mcp_server_app_permissions.md
@@ -23,10 +23,15 @@ mcp_server 已申请权限列表
         "name": "bk-apigateway-prod-test",
         "title": "测试服务",
         "description": "test",
-        "tools_count": "1",
-        "tool_names": ["tool1"],
+        "tools_count": 1,
+        "tool_names": ["tool1", "tool2"],
         "protocol_type": "sse",
-        "doc_link": ""
+        "url": "https://mcp.example.com/bk-apigateway-prod-test/sse",
+        "doc_link": "",
+        "categories": [
+          {"name": "official", "display_name": "官方"},
+          {"name": "ai", "display_name": "AI"}
+        ]
       },
       "permission": {
         "status": "owned",
@@ -62,7 +67,8 @@ mcp_server 已申请权限列表
 | description     | string | mcp_server 描述     |
 | tools_count     | int    | mcp_server 工具数量   |
 | tool_names      | array  | mcp_server 工具名称列表 |
-| protocol_type   | string | mcp_server 协议类型   |
+| protocol_type   | string | MCPServer 协议类型（sse：SSE 协议，streamable_http：Streamable HTTP 协议） |
+| url             | string | mcp_server 访问 URL，根据最低权限级别自适应返回普通 URL 或应用态 URL |
 | doc_link        | string | mcp_server 文档访问地址 |
 
 

--- a/src/dashboard/apigateway/apigateway/data/apidocs/zh/v2_inner_list_mcp_server_permission_apply_records.md
+++ b/src/dashboard/apigateway/apigateway/data/apidocs/zh/v2_inner_list_mcp_server_permission_apply_records.md
@@ -29,10 +29,15 @@ mcp_server 申请记录列表
         "name": "bk-apigateway-prod-s1",
         "title": "测试服务",
         "description": "test",
-        "tools_count": "1",
-        "tool_names": ["tool1"],
+        "tools_count": 1,
+        "tool_names": ["tool1", "tool2"],
         "protocol_type": "sse",
-        "doc_link": ""
+        "url": "https://mcp.example.com/bk-apigateway-prod-s1/sse",
+        "doc_link": "",
+        "categories": [
+          {"name": "official", "display_name": "官方"},
+          {"name": "ai", "display_name": "AI"}
+        ]
       },
       "record": {
         "id": 1,
@@ -75,7 +80,8 @@ mcp_server 申请记录列表
 | description     | string | mcp_server 描述        |
 | tools_count     | int    | mcp_server 工具数量      |
 | tool_names      | array  | mcp_server 工具名称列表    |
-| protocol_type   | string | mcp_server 协议类型      |
+| protocol_type   | string | MCPServer 协议类型（sse：SSE 协议，streamable_http：Streamable HTTP 协议） |
+| url             | string | mcp_server 访问 URL，根据最低权限级别自适应返回普通 URL 或应用态 URL |
 | doc_link        | string | mcp_server 文档访问地址    |
 
 

--- a/src/dashboard/apigateway/apigateway/data/apidocs/zh/v2_inner_list_mcp_server_permissions.md
+++ b/src/dashboard/apigateway/apigateway/data/apidocs/zh/v2_inner_list_mcp_server_permissions.md
@@ -25,10 +25,15 @@ mcp_server 申请权限列表
         "name": "bk-apigateway-prod-test1",
         "title": "测试服务1",
         "description": "test",
-        "tools_count": "1",
-        "tool_names": ["tool1"],
+        "tools_count": 1,
+        "tool_names": ["tool1", "tool2"],
         "protocol_type": "sse",
-        "doc_link": ""
+        "url": "https://mcp.example.com/bk-apigateway-prod-test1/sse",
+        "doc_link": "",
+        "categories": [
+          {"name": "official", "display_name": "官方"},
+          {"name": "ai", "display_name": "AI"}
+        ]
       },
       "permission": {
         "status": "approved",
@@ -42,10 +47,12 @@ mcp_server 申请权限列表
         "name": "bk-esb-prod-test2",
         "title": "测试服务2",
         "description": "test",
-        "tools_count": "1",
-        "tool_names": ["tool2"],
+        "tools_count": 1,
+        "tool_names": ["tool3"],
         "protocol_type": "sse",
-        "doc_link": ""
+        "url": "https://mcp.example.com/bk-esb-prod-test2/sse",
+        "doc_link": "",
+        "categories": []
       },
       "permission": {
         "status": "need_apply",
@@ -81,7 +88,8 @@ mcp_server 申请权限列表
 | description     | string | mcp_server 描述     |
 | tools_count     | int    | mcp_server 工具数量   |
 | tool_names      | array  | mcp_server 工具名称列表 |
-| protocol_type   | string | mcp_server 协议类型   |
+| protocol_type   | string | MCPServer 协议类型（sse：SSE 协议，streamable_http：Streamable HTTP 协议） |
+| url             | string | mcp_server 访问 URL，根据最低权限级别自适应返回普通 URL 或应用态 URL |
 | doc_link        | string | mcp_server 文档访问地址 |
 
 

--- a/src/dashboard/apigateway/apigateway/data/apidocs/zh/v2_open_list_mcp_server.md
+++ b/src/dashboard/apigateway/apigateway/data/apidocs/zh/v2_open_list_mcp_server.md
@@ -79,7 +79,7 @@
 | protocol_type    | string  | MCP 协议类型（sse：SSE 协议，streamable_http：Streamable HTTP 协议） |
 | oauth2_public_client_enabled   | boolean | 是否开启 OAuth2 公开客户端模式，开启后将会对 bk_app_code=public 的应用进行授权                                         |
 | tools_count      | int     | mcp_server 工具数量                                        |
-| url              | string  | mcp_server 访问地址                                        |
+| url              | string  | mcp_server 访问 URL，根据最低权限级别自适应返回普通 URL 或应用态 URL |
 | detail_url       | string  | mcp_server 网关站点详情地址                                    |
 | updated_by       | string  | 更新人                                                    |
 | created_by       | string  | 创建人                                                    |

--- a/src/dashboard/apigateway/apigateway/data/apidocs/zh/v2_open_list_user_mcp_server.md
+++ b/src/dashboard/apigateway/apigateway/data/apidocs/zh/v2_open_list_user_mcp_server.md
@@ -81,7 +81,7 @@
 | protocol_type       | string  | MCP 协议类型（sse：SSE 协议，streamable_http：Streamable HTTP 协议） |
 | oauth2_public_client_enabled      | boolean | 是否开启 OAuth2 公开客户端模式，开启后将会对 bk_app_code=public 的应用进行授权                                         |
 | tools_count         | int     | mcp_server 工具数量                                        |
-| url                 | string  | mcp_server 访问地址                                        |
+| url                 | string  | mcp_server 访问 URL，根据最低权限级别自适应返回普通 URL 或应用态 URL |
 | detail_url          | string  | mcp_server 网关站点详情地址                                    |
 | updated_by          | string  | 更新人                                                    |
 | created_by          | string  | 创建人                                                    |

--- a/src/dashboard/apigateway/apigateway/data/apidocs/zh/v2_open_retrieve_mcp_server.md
+++ b/src/dashboard/apigateway/apigateway/data/apidocs/zh/v2_open_retrieve_mcp_server.md
@@ -104,7 +104,7 @@
 | status           | int      | mcp_server 状态（0：已停用，1：启用中）                      |
 | protocol_type    | string   | MCP 协议类型（sse：SSE 协议，streamable_http：Streamable HTTP 协议） |
 | oauth2_public_client_enabled   | boolean  | 是否开启 OAuth2 公开客户端模式，开启后将会对 bk_app_code=public 的应用进行授权                                         |
-| url              | string   | mcp_server 访问地址                                          |
+| url              | string   | mcp_server 访问 URL，根据最低权限级别自适应返回普通 URL 或应用态 URL |
 | guideline        | string   | mcp_server 使用指南                                          |
 | tools            | array    | mcp_server 工具列表                                          |
 | prompts          | array    | mcp_server Prompts 列表                                      |


### PR DESCRIPTION
- cherry-pick 只带过来了调用侧改动（serializers/views/公共函数），handler 侧的 4 个方法实现是 AI 从 upstream/master 提取源码后手动写入的，不是 git cherry-pick。