### PR TITLE
feat(export): support exporting resource version docs

### DIFF
--- a/src/dashboard/apigateway/apigateway/apis/web/resource_version/serializers.py
+++ b/src/dashboard/apigateway/apigateway/apis/web/resource_version/serializers.py
@@ -20,7 +20,7 @@ from rest_framework import serializers
 
 from apigateway.apis.web.constants import PLUGIN_MERGE_TYPE
 from apigateway.apps.plugin.constants import PluginBindingScopeEnum
-from apigateway.apps.support.constants import OpenAPIFormatEnum
+from apigateway.apps.support.constants import DocArchiveTypeEnum, OpenAPIFormatEnum
 from apigateway.biz.constants import SEMVER_PATTERN
 from apigateway.biz.resource import ResourceOpenAPISchemaHandler
 from apigateway.biz.validators import ResourceVersionValidator
@@ -257,3 +257,14 @@ class ResourceVersionBatchDeleteInputSLZ(serializers.Serializer):
 
     class Meta:
         ref_name = "apigateway.apis.web.resource_version.serializers.ResourceVersionBatchDeleteInputSLZ"
+
+
+class ResourceVersionDocExportInputSLZ(serializers.Serializer):
+    file_type = serializers.ChoiceField(
+        choices=DocArchiveTypeEnum.get_choices(),
+        default=DocArchiveTypeEnum.TGZ.value,
+        help_text="导出的文件类型，如 tgz/zip",
+    )
+
+    class Meta:
+        ref_name = "apigateway.apis.web.resource_version.serializers.ResourceVersionDocExportInputSLZ"

--- a/src/dashboard/apigateway/apigateway/apis/web/resource_version/urls.py
+++ b/src/dashboard/apigateway/apigateway/apis/web/resource_version/urls.py
@@ -23,6 +23,7 @@ from .views import (
     NextResourceVersionRetrieveApi,
     ResourceVersionBatchDeleteApi,
     ResourceVersionDiffRetrieveApi,
+    ResourceVersionDocExportApi,
     ResourceVersionExportApi,
     ResourceVersionListCreateApi,
     ResourceVersionNeedNewVersionRetrieveApi,
@@ -35,6 +36,11 @@ urlpatterns = [
         "<int:id>/export/",
         ResourceVersionExportApi.as_view(),
         name="gateway.resource_version.export",
+    ),
+    path(
+        "<int:id>/export_docs/",
+        ResourceVersionDocExportApi.as_view(),
+        name="gateway.resource_version.export_docs",
     ),
     path(
         "<int:id>/",

--- a/src/dashboard/apigateway/apigateway/apis/web/resource_version/views.py
+++ b/src/dashboard/apigateway/apigateway/apis/web/resource_version/views.py
@@ -17,6 +17,8 @@
 # to the current version of the project delivered to anyone in the future.
 #
 
+from tempfile import TemporaryDirectory
+
 from django.db import transaction
 from django.utils.decorators import method_decorator
 from django.utils.translation import gettext as _
@@ -34,8 +36,12 @@ from apigateway.biz.audit import Auditor
 from apigateway.biz.backend import BackendHandler
 from apigateway.biz.plugin import PluginBindingHandler
 from apigateway.biz.resource.importer.openapi import OpenAPIExportManager
+from apigateway.biz.resource_doc.archive_factory import ArchiveFileFactory
+from apigateway.biz.resource_doc.exceptions import NoResourceDocError
+from apigateway.biz.resource_doc.exporter.generators import ResourceVersionDocArchiveGenerator
 from apigateway.biz.resource_version import ResourceDifferHandler, ResourceDocVersionHandler, ResourceVersionHandler
 from apigateway.biz.sdk.gateway_sdk import GatewaySDKHandler
+from apigateway.common.error_codes import error_codes
 from apigateway.core.constants import PublishSourceEnum
 from apigateway.core.models import Release, Resource, ResourceVersion
 from apigateway.utils.responses import DownloadableResponse, OKJsonResponse
@@ -48,6 +54,7 @@ from .serializers import (
     ResourceVersionCreateInputSLZ,
     ResourceVersionDiffOutputSLZ,
     ResourceVersionDiffQueryInputSLZ,
+    ResourceVersionDocExportInputSLZ,
     ResourceVersionExportInputSLZ,
     ResourceVersionListInputSLZ,
     ResourceVersionListOutputSLZ,
@@ -400,6 +407,39 @@ class ResourceVersionExportApi(generics.CreateAPIView):
         # 导出的文件名，需满足规范：bk_产品名_功能名_文件名.后缀
         export_filename = f"bk_apigw_resources_{self.request.gateway.name}_{instance.version}.{file_type}"
         return DownloadableResponse(content, filename=export_filename)
+
+
+class ResourceVersionDocExportApi(generics.CreateAPIView):
+    lookup_field = "id"
+
+    def get_queryset(self):
+        return ResourceVersion.objects.filter(gateway=self.request.gateway)
+
+    @swagger_auto_schema(
+        operation_description="导出资源版本对应的文档",
+        request_body=ResourceVersionDocExportInputSLZ,
+        responses={status.HTTP_200_OK: ""},
+        tags=["WebAPI.ResourceVersion"],
+    )
+    def post(self, request, *args, **kwargs):
+        instance = self.get_object()
+        slz = ResourceVersionDocExportInputSLZ(data=request.data)
+        slz.is_valid(raise_exception=True)
+
+        file_type = slz.validated_data["file_type"]
+
+        with TemporaryDirectory() as output_dir:
+            archive_name = f"bk_apigw_docs_{request.gateway.name}_{instance.version}.{file_type}"
+            archivefile = ArchiveFileFactory.from_file_type(file_type)
+
+            try:
+                generator = ResourceVersionDocArchiveGenerator()
+                files = generator.generate(output_dir, instance)
+                archive_path = archivefile.archive(output_dir, archive_name, files)
+            except NoResourceDocError:
+                raise error_codes.INVALID_ARGUMENT.format(_("该资源版本没有对应的资源文档。"))
+
+            return DownloadableResponse(open(archive_path, "rb"), filename=archive_name)
 
 
 class ResourceVersionBatchDeleteApi(generics.DestroyAPIView):

--- a/src/dashboard/apigateway/apigateway/biz/resource_doc/exporter/generators.py
+++ b/src/dashboard/apigateway/apigateway/biz/resource_doc/exporter/generators.py
@@ -16,11 +16,11 @@
 # to the current version of the project delivered to anyone in the future.
 #
 import os
-from typing import List
+from typing import Dict, List
 
-from apigateway.apps.support.models import ResourceDoc
+from apigateway.apps.support.models import ResourceDoc, ResourceDocVersion
 from apigateway.biz.resource_doc.exceptions import NoResourceDocError
-from apigateway.core.models import Resource
+from apigateway.core.models import Resource, ResourceVersion
 from apigateway.utils.file import write_to_file
 
 
@@ -48,6 +48,68 @@ class DocArchiveGenerator:
 
             filename = f"{resource_doc.language}/{resource_name}.md"
             write_to_file(resource_doc.content, os.path.join(output_dir, filename))
+            files.append(filename)
+
+        if not files:
+            raise NoResourceDocError()
+
+        return files
+
+
+class ResourceVersionDocArchiveGenerator:
+    """从 ResourceDocVersion 的快照数据生成文档归档文件"""
+
+    def generate(
+        self,
+        output_dir: str,
+        resource_version: ResourceVersion,
+    ) -> List[str]:
+        """根据资源版本对应的文档版本快照生成文档文件
+
+        :param output_dir: 输出目录
+        :param resource_version: 资源版本实例
+        :return: 生成的文件路径列表（相对于 output_dir）
+        """
+        # 查询对应的文档版本
+        try:
+            doc_version = ResourceDocVersion.objects.get(
+                gateway=resource_version.gateway,
+                resource_version=resource_version,
+            )
+        except ResourceDocVersion.DoesNotExist:
+            raise NoResourceDocError()
+
+        doc_data = doc_version.data
+        if not doc_data:
+            raise NoResourceDocError()
+
+        # 从 resource_version.data 构建 resource_id -> resource_name 映射
+        resource_id_to_name: Dict[int, str] = {resource["id"]: resource["name"] for resource in resource_version.data}
+
+        return self._generate_docs(output_dir, doc_data, resource_id_to_name)
+
+    def _generate_docs(
+        self,
+        output_dir: str,
+        doc_data: list,
+        resource_id_to_name: Dict[int, str],
+    ) -> List[str]:
+        files = []
+        for doc in doc_data:
+            resource_id = doc.get("resource_id")
+            resource_name = resource_id_to_name.get(resource_id)
+            if not resource_name:
+                continue
+
+            language = doc.get("language", "zh")
+            content = doc.get("content", "")
+
+            dirname = os.path.join(output_dir, language)
+            if not os.path.exists(dirname):
+                os.makedirs(dirname)
+
+            filename = f"{language}/{resource_name}.md"
+            write_to_file(content, os.path.join(output_dir, filename))
             files.append(filename)
 
         if not files:

--- a/src/dashboard/apigateway/apigateway/biz/resource_doc/exporter/generators.py
+++ b/src/dashboard/apigateway/apigateway/biz/resource_doc/exporter/generators.py
@@ -15,6 +15,7 @@
 # We undertake not to change the open source license (MIT license) applicable
 # to the current version of the project delivered to anyone in the future.
 #
+import logging
 import os
 from typing import Dict, List
 
@@ -22,6 +23,8 @@ from apigateway.apps.support.models import ResourceDoc, ResourceDocVersion
 from apigateway.biz.resource_doc.exceptions import NoResourceDocError
 from apigateway.core.models import Resource, ResourceVersion
 from apigateway.utils.file import write_to_file
+
+logger = logging.getLogger(__name__)
 
 
 class DocArchiveGenerator:
@@ -99,6 +102,7 @@ class ResourceVersionDocArchiveGenerator:
             resource_id = doc.get("resource_id")
             resource_name = resource_id_to_name.get(resource_id)
             if not resource_name:
+                logger.warning("resource_id %s not found in resource_id_to_name, skip doc generation", resource_id)
                 continue
 
             language = doc.get("language", "zh")

--- a/src/dashboard/apigateway/apigateway/tests/apis/web/resource_version/test_views.py
+++ b/src/dashboard/apigateway/apigateway/tests/apis/web/resource_version/test_views.py
@@ -570,3 +570,109 @@ class TestResourceVersionBatchDeleteApi:
         assert not ResourceVersion.objects.filter(id=rv_id).exists()
         assert not ReleasedResourceDoc.objects.filter(resource_version_id=rv_id).exists()
         assert not ReleasedResource.objects.filter(resource_version_id=rv_id).exists()
+
+
+class TestResourceVersionExportApi:
+    def test_export_resource_yaml(self, request_view, fake_gateway, mocker):
+        """导出资源配置（yaml 格式）"""
+        rv = G(ResourceVersion, gateway=fake_gateway, version="1.0.0", _data=json.dumps([]))
+
+        mock_export = mocker.patch(
+            "apigateway.apis.web.resource_version.views.OpenAPIExportManager.export_resource_version_openapi",
+            return_value="openapi: '2.0'",
+        )
+
+        resp = request_view(
+            method="POST",
+            view_name="gateway.resource_version.export",
+            gateway=fake_gateway,
+            path_params={"gateway_id": fake_gateway.id, "id": rv.id},
+            data={"file_type": "yaml"},
+        )
+        assert resp.status_code == 200
+        assert "bk_apigw_resources_" in resp["Content-Disposition"]
+        assert ".yaml" in resp["Content-Disposition"]
+        mock_export.assert_called_once()
+
+    def test_export_resource_json(self, request_view, fake_gateway, mocker):
+        """导出资源配置（json 格式）"""
+        rv = G(ResourceVersion, gateway=fake_gateway, version="1.0.0", _data=json.dumps([]))
+
+        mocker.patch(
+            "apigateway.apis.web.resource_version.views.OpenAPIExportManager.export_resource_version_openapi",
+            return_value='{"openapi": "2.0"}',
+        )
+
+        resp = request_view(
+            method="POST",
+            view_name="gateway.resource_version.export",
+            gateway=fake_gateway,
+            path_params={"gateway_id": fake_gateway.id, "id": rv.id},
+            data={"file_type": "json"},
+        )
+        assert resp.status_code == 200
+        assert ".json" in resp["Content-Disposition"]
+
+    def test_export_resource_default(self, request_view, fake_gateway, mocker):
+        """不传 file_type 时，默认导出资源配置（yaml）"""
+        rv = G(ResourceVersion, gateway=fake_gateway, version="1.0.0", _data=json.dumps([]))
+
+        mocker.patch(
+            "apigateway.apis.web.resource_version.views.OpenAPIExportManager.export_resource_version_openapi",
+            return_value="openapi: '2.0'",
+        )
+
+        resp = request_view(
+            method="POST",
+            view_name="gateway.resource_version.export",
+            gateway=fake_gateway,
+            path_params={"gateway_id": fake_gateway.id, "id": rv.id},
+            data={},
+        )
+        assert resp.status_code == 200
+        assert ".yaml" in resp["Content-Disposition"]
+
+
+class TestResourceVersionDocExportApi:
+    def test_export_docs_zip(self, request_view, fake_gateway):
+        """导出文档（zip 格式）"""
+        rv = G(
+            ResourceVersion,
+            gateway=fake_gateway,
+            version="1.0.0",
+            _data=json.dumps([{"id": 1, "name": "get_user"}]),
+        )
+        G(
+            ResourceDocVersion,
+            gateway=fake_gateway,
+            resource_version=rv,
+            _data=json.dumps(
+                [
+                    {"resource_id": 1, "language": "zh", "content": "# 获取用户"},
+                ]
+            ),
+        )
+
+        resp = request_view(
+            method="POST",
+            view_name="gateway.resource_version.export_docs",
+            gateway=fake_gateway,
+            path_params={"gateway_id": fake_gateway.id, "id": rv.id},
+            data={"file_type": "zip"},
+        )
+        assert resp.status_code == 200
+        assert "bk_apigw_docs_" in resp["Content-Disposition"]
+        assert ".zip" in resp["Content-Disposition"]
+
+    def test_export_docs_no_doc_version(self, request_view, fake_gateway):
+        """没有文档版本数据时返回错误"""
+        rv = G(ResourceVersion, gateway=fake_gateway, version="1.0.0", _data=json.dumps([]))
+
+        resp = request_view(
+            method="POST",
+            view_name="gateway.resource_version.export_docs",
+            gateway=fake_gateway,
+            path_params={"gateway_id": fake_gateway.id, "id": rv.id},
+            data={"file_type": "zip"},
+        )
+        assert resp.status_code == 400

--- a/src/dashboard/apigateway/apigateway/tests/biz/resource_doc/exporter/test_generators.py
+++ b/src/dashboard/apigateway/apigateway/tests/biz/resource_doc/exporter/test_generators.py
@@ -15,11 +15,15 @@
 # We undertake not to change the open source license (MIT license) applicable
 # to the current version of the project delivered to anyone in the future.
 #
-import pytest
+import json
 
+import pytest
+from django_dynamic_fixture import G
+
+from apigateway.apps.support.models import ResourceDocVersion
 from apigateway.biz.resource_doc.exceptions import NoResourceDocError
-from apigateway.biz.resource_doc.exporter.generators import DocArchiveGenerator
-from apigateway.core.models import Resource
+from apigateway.biz.resource_doc.exporter.generators import DocArchiveGenerator, ResourceVersionDocArchiveGenerator
+from apigateway.core.models import Resource, ResourceVersion
 
 
 class TestDocArchiveGenerator:
@@ -35,3 +39,71 @@ class TestDocArchiveGenerator:
 
         with pytest.raises(NoResourceDocError):
             generator.generate("/tmp", fake_gateway.id, [0])
+
+
+class TestResourceVersionDocArchiveGenerator:
+    def test_generate(self, mocker, fake_gateway):
+        mocker.patch("apigateway.biz.resource_doc.exporter.generators.write_to_file", return_value=None)
+
+        rv = G(
+            ResourceVersion,
+            gateway=fake_gateway,
+            version="1.0.0",
+            _data=json.dumps(
+                [
+                    {"id": 1, "name": "get_user"},
+                    {"id": 2, "name": "create_user"},
+                ]
+            ),
+        )
+        G(
+            ResourceDocVersion,
+            gateway=fake_gateway,
+            resource_version=rv,
+            _data=json.dumps(
+                [
+                    {"resource_id": 1, "language": "zh", "content": "# 获取用户"},
+                    {"resource_id": 2, "language": "zh", "content": "# 创建用户"},
+                    {"resource_id": 1, "language": "en", "content": "# Get User"},
+                ]
+            ),
+        )
+
+        generator = ResourceVersionDocArchiveGenerator()
+        result = generator.generate("/tmp", rv)
+        assert sorted(result) == sorted(["zh/get_user.md", "zh/create_user.md", "en/get_user.md"])
+
+        # 没有对应的文档版本时应抛出异常
+        rv_no_doc = G(
+            ResourceVersion,
+            gateway=fake_gateway,
+            version="2.0.0",
+            _data=json.dumps([{"id": 1, "name": "get_user"}]),
+        )
+        with pytest.raises(NoResourceDocError):
+            generator.generate("/tmp", rv_no_doc)
+
+    def test_generate_skip_unknown_resource_id(self, mocker, fake_gateway):
+        mocker.patch("apigateway.biz.resource_doc.exporter.generators.write_to_file", return_value=None)
+
+        rv = G(
+            ResourceVersion,
+            gateway=fake_gateway,
+            version="1.0.0",
+            _data=json.dumps([{"id": 1, "name": "get_user"}]),
+        )
+        G(
+            ResourceDocVersion,
+            gateway=fake_gateway,
+            resource_version=rv,
+            _data=json.dumps(
+                [
+                    {"resource_id": 1, "language": "zh", "content": "# 获取用户"},
+                    {"resource_id": 999, "language": "zh", "content": "# 未知资源"},
+                ]
+            ),
+        )
+
+        generator = ResourceVersionDocArchiveGenerator()
+        result = generator.generate("/tmp", rv)
+        assert result == ["zh/get_user.md"]


### PR DESCRIPTION
- POST /gateways/{gateway_id}/resource_versions/{id}/export/ 请求体只需传 file_type，值为 zip 或 tgz 时走文档导出路径，值为 yaml 或 json（默认）时走资源配置导出路径。