### PR TITLE
feat: support adaptive URL based on least privilege

### DIFF
--- a/src/dashboard/apigateway/apigateway/apis/v2/inner/serializers.py
+++ b/src/dashboard/apigateway/apigateway/apis/v2/inner/serializers.py
@@ -22,6 +22,7 @@ import math
 from django.utils.translation import gettext as _
 from rest_framework import serializers
 
+from apigateway.apis.v2.mcp_server import get_mcp_server_url_from_context
 from apigateway.apps.mcp_server.constants import (
     MCPServerAppPermissionApplyStatusEnum,
     MCPServerProtocolTypeEnum,
@@ -42,7 +43,6 @@ from apigateway.core.constants import GatewayStatusEnum
 from apigateway.service.mcp.mcp_server import (
     build_mcp_server_detail_url,
     build_mcp_server_permission_approval_url,
-    build_mcp_server_url,
 )
 from apigateway.utils import time
 
@@ -607,7 +607,7 @@ class MCPServerListOutputSLZ(serializers.Serializer):
         return self.context["gateways"][obj.gateway.id]
 
     def get_url(self, obj) -> str:
-        return build_mcp_server_url(obj.name, obj.protocol_type)
+        return get_mcp_server_url_from_context(obj, self.context)
 
     def get_detail_url(self, obj) -> str:
         return build_mcp_server_detail_url(obj.id)

--- a/src/dashboard/apigateway/apigateway/apis/v2/inner/serializers.py
+++ b/src/dashboard/apigateway/apigateway/apis/v2/inner/serializers.py
@@ -357,15 +357,20 @@ class MCPServerBaseSLZ(serializers.Serializer):
         help_text="MCPServer 协议类型",
         choices=MCPServerProtocolTypeEnum.get_choices(),
     )
+    url = serializers.SerializerMethodField(help_text="MCPServer 访问 URL")
+    categories = serializers.SerializerMethodField(help_text="MCPServer 分类列表")
 
     def get_title(self, obj) -> str:
-        title = obj.get("title", "") if isinstance(obj, dict) else getattr(obj, "title", "")
-        name = obj.get("name", "") if isinstance(obj, dict) else getattr(obj, "name", "")
-        return title if title else name
+        return obj.title if obj.title else obj.name
+
+    def get_url(self, obj) -> str:
+        return get_mcp_server_url_from_context(self.context, obj)
 
     def get_doc_link(self, obj):
-        obj_id = obj.get("id") if isinstance(obj, dict) else obj.id
-        return build_mcp_server_detail_url(obj_id)
+        return build_mcp_server_detail_url(obj.id)
+
+    def get_categories(self, obj):
+        return self.context.get("categories", {}).get(obj.id, [])
 
     class Meta:
         ref_name = "apigateway.apis.v2.inner.serializers.MCPServerBaseSLZ"

--- a/src/dashboard/apigateway/apigateway/apis/v2/inner/serializers.py
+++ b/src/dashboard/apigateway/apigateway/apis/v2/inner/serializers.py
@@ -607,7 +607,7 @@ class MCPServerListOutputSLZ(serializers.Serializer):
         return self.context["gateways"][obj.gateway.id]
 
     def get_url(self, obj) -> str:
-        return get_mcp_server_url_from_context(obj, self.context)
+        return get_mcp_server_url_from_context(self.context, obj)
 
     def get_detail_url(self, obj) -> str:
         return build_mcp_server_detail_url(obj.id)

--- a/src/dashboard/apigateway/apigateway/apis/v2/inner/views.py
+++ b/src/dashboard/apigateway/apigateway/apis/v2/inner/views.py
@@ -482,7 +482,9 @@ class MCPServerPermissionListApi(generics.ListAPIView):
 
         data = slz.validated_data
 
-        queryset = MCPServer.objects.filter(is_public=True, status=MCPServerStatusEnum.ACTIVE.value)
+        queryset = MCPServer.objects.filter(is_public=True, status=MCPServerStatusEnum.ACTIVE.value).select_related(
+            "gateway", "stage"
+        )
 
         keyword = data.get("keyword")
         if keyword:
@@ -506,6 +508,12 @@ class MCPServerPermissionListApi(generics.ListAPIView):
                 mcp_server_permission_status[obj["mcp_server_id"]] = obj["status"]
 
         mcp_server_permissions = []
+        # Build categories map for queryset
+        categories_map = MCPServerHandler.build_categories_map([obj.id for obj in queryset])
+
+        # 计算最低权限级别，用于判断是否展示应用态 URL
+        least_privileges = MCPServerHandler.get_least_privileges(list(queryset))
+
         for obj in queryset:
             permission_status = mcp_server_permission_status.get(
                 obj.id, MCPServerPermissionStatusEnum.NEED_APPLY.value
@@ -522,15 +530,7 @@ class MCPServerPermissionListApi(generics.ListAPIView):
 
             mcp_server_permissions.append(
                 {
-                    "mcp_server": {
-                        "id": obj.id,
-                        "name": obj.name,
-                        "title": obj.title or obj.name,
-                        "description": obj.description,
-                        "tools_count": obj.tools_count,
-                        "tool_names": obj.tool_names,
-                        "protocol_type": obj.protocol_type,
-                    },
+                    "mcp_server": obj,
                     "permission": {
                         "status": permission_status,
                         "action": action,
@@ -542,7 +542,14 @@ class MCPServerPermissionListApi(generics.ListAPIView):
                 }
             )
 
-        slz = serializers.MCPServerPermissionListOutputSLZ(mcp_server_permissions, many=True)
+        slz = serializers.MCPServerPermissionListOutputSLZ(
+            mcp_server_permissions,
+            many=True,
+            context={
+                "categories": categories_map,
+                "least_privileges": least_privileges,
+            },
+        )
         return OKJsonResponse(data=slz.data)
 
 
@@ -599,22 +606,26 @@ class MCPServerAppPermissionListApi(generics.ListAPIView):
         slz = self.get_serializer(data=request.query_params)
         slz.is_valid(raise_exception=True)
 
-        queryset = MCPServerAppPermissionApply.objects.filter(
-            bk_app_code=slz.validated_data["target_app_code"],
-            status__in=[MCPServerAppPermissionApplyStatusEnum.APPROVED.value],
-        ).order_by("-applied_time")
+        queryset = (
+            MCPServerAppPermissionApply.objects.filter(
+                bk_app_code=slz.validated_data["target_app_code"],
+                status__in=[MCPServerAppPermissionApplyStatusEnum.APPROVED.value],
+            )
+            .select_related("mcp_server", "mcp_server__gateway", "mcp_server__stage")
+            .order_by("-applied_time")
+        )
+
+        mcp_servers = [obj.mcp_server for obj in queryset]
+
+        # 计算最低权限级别，用于判断是否展示应用态 URL
+        least_privileges = MCPServerHandler.get_least_privileges(mcp_servers)
+
+        # Build categories map
+        categories_map = MCPServerHandler.build_categories_map([obj.mcp_server_id for obj in queryset])
 
         mcp_server_permissions = [
             {
-                "mcp_server": {
-                    "id": obj.mcp_server_id,
-                    "name": obj.mcp_server.name,
-                    "title": obj.mcp_server.title or obj.mcp_server.name,
-                    "description": obj.mcp_server.description,
-                    "tools_count": obj.mcp_server.tools_count,
-                    "tool_names": obj.mcp_server.tool_names,
-                    "protocol_type": obj.mcp_server.protocol_type,
-                },
+                "mcp_server": obj.mcp_server,
                 "permission": {
                     "status": MCPServerPermissionStatusEnum.OWNED.value,
                     "action": "",
@@ -627,7 +638,14 @@ class MCPServerAppPermissionListApi(generics.ListAPIView):
             for obj in queryset
         ]
 
-        slz = serializers.MCPServerAppPermissionListOutputSLZ(mcp_server_permissions, many=True)
+        slz = serializers.MCPServerAppPermissionListOutputSLZ(
+            mcp_server_permissions,
+            many=True,
+            context={
+                "categories": categories_map,
+                "least_privileges": least_privileges,
+            },
+        )
         return OKJsonResponse(data=slz.data)
 
 
@@ -657,20 +675,11 @@ class MCPServerAppPermissionRecordListApi(generics.ListAPIView):
             data.get("query"),
             data.get("applied_time_start"),
             data.get("applied_time_end"),
-        )
+        ).select_related("mcp_server", "mcp_server__gateway", "mcp_server__stage")
 
         mcp_server_permission_records = [
             {
-                "mcp_server": {
-                    "id": obj.mcp_server_id,
-                    "name": obj.mcp_server.name,
-                    "title": obj.mcp_server.title or obj.mcp_server.name,
-                    "description": obj.mcp_server.description,
-                    "tools_count": obj.mcp_server.tools_count,
-                    "tool_names": obj.mcp_server.tool_names,
-                    "protocol_type": obj.mcp_server.protocol_type,
-                    "gateway_id": obj.mcp_server.gateway_id,  # 添加 gateway_id 用于构建审批 URL
-                },
+                "mcp_server": obj.mcp_server,
                 "record": {
                     "id": obj.id,
                     "applied_by": obj.applied_by,
@@ -689,7 +698,21 @@ class MCPServerAppPermissionRecordListApi(generics.ListAPIView):
             for obj in queryset
         ]
 
-        slz = serializers.MCPServerAppPermissionRecordListOutputSLZ(mcp_server_permission_records, many=True)
+        # Build categories map
+        categories_map = MCPServerHandler.build_categories_map([obj.mcp_server_id for obj in queryset])
+
+        # 计算最低权限级别，用于判断是否展示应用态 URL
+        mcp_servers = [obj.mcp_server for obj in queryset]
+        least_privileges = MCPServerHandler.get_least_privileges(mcp_servers)
+
+        slz = serializers.MCPServerAppPermissionRecordListOutputSLZ(
+            mcp_server_permission_records,
+            many=True,
+            context={
+                "categories": categories_map,
+                "least_privileges": least_privileges,
+            },
+        )
 
         return OKJsonResponse(data=slz.data)
 
@@ -717,7 +740,9 @@ class MCPServerAppPermissionRecordRetrieveApi(generics.RetrieveAPIView):
         data = slz.validated_data
 
         try:
-            return MCPServerAppPermissionApply.objects.get(bk_app_code=data["target_app_code"], id=record_id)
+            return MCPServerAppPermissionApply.objects.select_related(
+                "mcp_server", "mcp_server__gateway", "mcp_server__stage"
+            ).get(bk_app_code=data["target_app_code"], id=record_id)
         except MCPServerAppPermissionApply.DoesNotExist:
             raise error_codes.NOT_FOUND
 
@@ -725,16 +750,7 @@ class MCPServerAppPermissionRecordRetrieveApi(generics.RetrieveAPIView):
         instance = self.get_object()
 
         mcp_server_permission_record = {
-            "mcp_server": {
-                "id": instance.mcp_server_id,
-                "name": instance.mcp_server.name,
-                "title": instance.mcp_server.title or instance.mcp_server.name,
-                "description": instance.mcp_server.description,
-                "tools_count": instance.mcp_server.tools_count,
-                "tool_names": instance.mcp_server.tool_names,
-                "protocol_type": instance.mcp_server.protocol_type,
-                "gateway_id": instance.mcp_server.gateway_id,  # 添加 gateway_id 用于构建审批 URL
-            },
+            "mcp_server": instance.mcp_server,
             "record": {
                 "id": instance.id,
                 "applied_by": instance.applied_by,
@@ -753,7 +769,18 @@ class MCPServerAppPermissionRecordRetrieveApi(generics.RetrieveAPIView):
             },
         }
 
-        slz = self.get_serializer(mcp_server_permission_record)
+        # Build categories map
+        categories_map = MCPServerHandler.build_categories_map([instance.mcp_server_id])
+
+        # 计算最低权限级别，用于判断是否展示应用态 URL
+        least_privileges = MCPServerHandler.get_least_privileges([instance.mcp_server])
+
+        context = {
+            **self.get_serializer_context(),
+            "categories": categories_map,
+            "least_privileges": least_privileges,
+        }
+        slz = self.get_serializer(mcp_server_permission_record, context=context)
         return OKJsonResponse(data=slz.data)
 
 

--- a/src/dashboard/apigateway/apigateway/apis/v2/mcp_server.py
+++ b/src/dashboard/apigateway/apigateway/apis/v2/mcp_server.py
@@ -16,7 +16,7 @@
 # to the current version of the project delivered to anyone in the future.
 #
 import logging
-from typing import Any, Dict, List, Optional, Sequence
+from typing import Any, Dict, List, Optional, Sequence, Tuple
 
 from django.conf import settings
 from django.db.models import Q, QuerySet
@@ -91,7 +91,9 @@ def build_mcp_server_list_context(mcp_servers: Sequence[MCPServer]) -> Dict[str,
         for s in Stage.objects.filter(id__in=stage_ids)
     }
 
-    return {"gateways": gateways, "stages": stages}
+    least_privileges = MCPServerHandler.get_least_privileges(list(mcp_servers))
+
+    return {"gateways": gateways, "stages": stages, "least_privileges": least_privileges}
 
 
 def validate_and_enrich_mcp_server_for_retrieve(
@@ -161,6 +163,8 @@ def validate_and_enrich_mcp_server_for_retrieve(
         {"name": cat.name, "display_name": cat.display_name} for cat in instance.categories.filter(is_active=True)
     ]
 
+    least_privileges = MCPServerHandler.get_least_privileges([instance])
+
     return {
         "labels": labels,
         "tool_name_map": instance.gen_tool_name_map(),
@@ -169,4 +173,20 @@ def validate_and_enrich_mcp_server_for_retrieve(
         "prompts_count_map": prompts_count_map,
         "prompts": prompts,
         "user_custom_doc": user_custom_doc,
+        "least_privileges": least_privileges,
     }
+
+
+def get_mcp_server_url_from_context(obj: MCPServer, context: Dict[str, Any]) -> str:
+    """从序列化器 context 中获取 least_privileges 并返回适配后的 MCPServer URL。
+
+    Args:
+        obj: MCPServer 实例
+        context: 序列化器 context 字典，需包含 least_privileges
+
+    Returns:
+        MCPServer 访问 URL
+    """
+    least_privileges: Dict[Tuple[int, int], str] = context.get("least_privileges", {})
+    least_privilege = least_privileges.get((obj.gateway_id, obj.stage_id), "")
+    return MCPServerHandler.get_mcp_server_url(obj, least_privilege)

--- a/src/dashboard/apigateway/apigateway/apis/v2/mcp_server.py
+++ b/src/dashboard/apigateway/apigateway/apis/v2/mcp_server.py
@@ -177,16 +177,18 @@ def validate_and_enrich_mcp_server_for_retrieve(
     }
 
 
-def get_mcp_server_url_from_context(obj: MCPServer, context: Dict[str, Any]) -> str:
-    """从序列化器 context 中获取 least_privileges 并返回适配后的 MCPServer URL。
+def get_mcp_server_url_from_context(context: dict, obj: MCPServer) -> str:
+    """从 serializer context 中获取 least_privilege 并生成 MCP Server URL
+
+    统一 inner/open 序列化器中 get_url 方法的公共逻辑，避免重复实现。
 
     Args:
-        obj: MCPServer 实例
-        context: 序列化器 context 字典，需包含 least_privileges
+        context: serializer 的 context 字典，应包含 "least_privileges" 键
+        obj: MCPServer model 实例
 
     Returns:
-        MCPServer 访问 URL
+        MCP Server 访问 URL
     """
     least_privileges: Dict[Tuple[int, int], str] = context.get("least_privileges", {})
-    least_privilege = least_privileges.get((obj.gateway_id, obj.stage_id), "")
+    least_privilege = least_privileges.get((obj.gateway.id, obj.stage.id), "")
     return MCPServerHandler.get_mcp_server_url(obj, least_privilege)

--- a/src/dashboard/apigateway/apigateway/apis/v2/open/serializers.py
+++ b/src/dashboard/apigateway/apigateway/apis/v2/open/serializers.py
@@ -21,6 +21,7 @@ from typing import Any, Dict
 from django.utils.translation import gettext as _
 from rest_framework import serializers
 
+from apigateway.apis.v2.mcp_server import get_mcp_server_url_from_context
 from apigateway.apps.mcp_server.constants import (
     MCPServerAppPermissionApplyStatusEnum,
     MCPServerAppPermissionGrantTypeEnum,
@@ -36,7 +37,6 @@ from apigateway.service.mcp.mcp_server import (
     build_mcp_server_application_url,
     build_mcp_server_detail_url,
     build_mcp_server_permission_approval_url,
-    build_mcp_server_url,
 )
 
 
@@ -234,7 +234,7 @@ class MCPServerBaseOutputSLZ(serializers.Serializer):
         return self.context["gateways"][obj.gateway.id]
 
     def get_url(self, obj) -> str:
-        return build_mcp_server_url(obj.name, obj.protocol_type)
+        return get_mcp_server_url_from_context(obj, self.context)
 
     def get_detail_url(self, obj) -> str:
         return build_mcp_server_detail_url(obj.id)
@@ -543,7 +543,7 @@ class MCPServerRetrieveOutputSLZ(serializers.Serializer):
         return self.context.get("categories", [])
 
     def get_url(self, obj) -> str:
-        return build_mcp_server_url(obj.name, obj.protocol_type)
+        return get_mcp_server_url_from_context(obj, self.context)
 
     def get_user_custom_doc(self, obj) -> str:
         return self.context.get("user_custom_doc", "")

--- a/src/dashboard/apigateway/apigateway/apis/v2/open/serializers.py
+++ b/src/dashboard/apigateway/apigateway/apis/v2/open/serializers.py
@@ -234,7 +234,7 @@ class MCPServerBaseOutputSLZ(serializers.Serializer):
         return self.context["gateways"][obj.gateway.id]
 
     def get_url(self, obj) -> str:
-        return get_mcp_server_url_from_context(obj, self.context)
+        return get_mcp_server_url_from_context(self.context, obj)
 
     def get_detail_url(self, obj) -> str:
         return build_mcp_server_detail_url(obj.id)
@@ -543,7 +543,7 @@ class MCPServerRetrieveOutputSLZ(serializers.Serializer):
         return self.context.get("categories", [])
 
     def get_url(self, obj) -> str:
-        return get_mcp_server_url_from_context(obj, self.context)
+        return get_mcp_server_url_from_context(self.context, obj)
 
     def get_user_custom_doc(self, obj) -> str:
         return self.context.get("user_custom_doc", "")

--- a/src/dashboard/apigateway/apigateway/apis/v2/open/views.py
+++ b/src/dashboard/apigateway/apigateway/apis/v2/open/views.py
@@ -39,7 +39,7 @@ from apigateway.apis.v2.mcp_server import (
     validate_and_enrich_mcp_server_for_retrieve,
 )
 from apigateway.apis.v2.permissions import OpenAPIV2GatewayNamePermission, OpenAPIV2Permission
-from apigateway.apps.mcp_server.constants import MCPServerLeastPrivilegeEnum, MCPServerStatusEnum
+from apigateway.apps.mcp_server.constants import MCPServerStatusEnum
 from apigateway.apps.mcp_server.models import (
     MCPServer,
     MCPServerAppPermission,
@@ -51,10 +51,9 @@ from apigateway.apps.permission.tasks import send_mail_for_perm_apply
 from apigateway.biz.access_log.log import LogHandler
 from apigateway.biz.gateway import GatewayHandler
 from apigateway.biz.gateway.type import GatewayTypeHandler
-from apigateway.biz.mcp_server import MCPServerPermissionHandler
+from apigateway.biz.mcp_server import MCPServerHandler, MCPServerPermissionHandler
 from apigateway.biz.permission import PermissionDimensionManager
 from apigateway.biz.release import ReleaseHandler
-from apigateway.biz.released_resource import ReleasedResourceData
 from apigateway.biz.released_resource_doc import ReleasedResourceDocHandler
 from apigateway.biz.released_resource_doc.generators import DocGenerator
 from apigateway.biz.resource import ResourceLabelHandler
@@ -431,40 +430,6 @@ class MCPServerAppPermissionRecordListApi(generics.ListAPIView):
 class UserMCPServerListApi(generics.ListAPIView):
     permission_classes = [OpenAPIV2Permission]
 
-    def _get_least_privileges(self, queryset):
-        gateway_stage_pairs = set()
-        gateway_stage_tools = {}
-        for mcp_server in queryset:
-            gateway_stage_pairs.add((mcp_server.gateway.id, mcp_server.stage.id))
-            gateway_stage_tools[(mcp_server.gateway.id, mcp_server.stage.id)] = mcp_server.resource_names
-
-        # 批量查询所有相关的 Release 记录
-        release_filters = Q()
-        for gateway_id, stage_id in gateway_stage_pairs:
-            release_filters |= Q(gateway_id=gateway_id, stage_id=stage_id)
-
-        releases = Release.objects.filter(release_filters).prefetch_related("resource_version")
-
-        # 获取资源的最低权限
-        least_privileges = {}
-        for release in releases:
-            gateway_stage_key = (release.gateway.id, release.stage.id)
-            # 获取 mcp server 的工具名称列表
-            tool_names = gateway_stage_tools.get(gateway_stage_key, [])
-            least_privilege = MCPServerLeastPrivilegeEnum.APPLICATION.value
-            for resource in release.resource_version.data:
-                # 如果资源不在工具名称列表中，则跳过
-                if resource["name"] not in tool_names:
-                    continue
-                # 应用认证是强制的，如果 tools 中有任意一个是用户认证的，此时确定是 APPLICATION_AND_USER
-                release_resource_data = ReleasedResourceData.from_data(resource)
-                if release_resource_data.verified_user_required:
-                    least_privilege = MCPServerLeastPrivilegeEnum.APPLICATION_AND_USER.value
-                    break
-            least_privileges[gateway_stage_key] = least_privilege
-
-        return least_privileges
-
     def list(self, request, *args, **kwargs):
         slz = UserMCPServerListInputSLZ(data=request.query_params)
         slz.is_valid(raise_exception=True)
@@ -532,7 +497,7 @@ class UserMCPServerListApi(generics.ListAPIView):
             for stage in Stage.objects.filter(id__in=stage_ids)
         }
 
-        least_privileges = self._get_least_privileges(page)
+        least_privileges = MCPServerHandler.get_least_privileges(page)
 
         output_slz = UserMCPServerListOutputSLZ(
             page,

--- a/src/dashboard/apigateway/apigateway/biz/mcp_server/mcp_server.py
+++ b/src/dashboard/apigateway/apigateway/biz/mcp_server/mcp_server.py
@@ -19,7 +19,7 @@ import base64
 import datetime
 import json
 import logging
-from typing import Any, Dict, List, Optional, Set, Tuple
+from typing import Any, Dict, List, Optional, Sequence, Set, Tuple
 from urllib.parse import quote
 
 from django.conf import settings
@@ -372,7 +372,31 @@ class MCPServerHandler:
             AppResourcePermission.objects.filter(id__in=to_delete).delete()
 
     @staticmethod
-    def get_app_permission_risks(mcp_servers: list) -> Dict[int, List[str]]:
+    def _get_releases_for_mcp_servers(mcp_servers) -> Dict[Tuple[int, int], Release]:
+        """批量获取 MCP Server 列表对应的 Release 记录
+
+        Args:
+            mcp_servers: MCPServer 实例列表
+
+        Returns:
+            {(gateway_id, stage_id): Release} 映射
+        """
+        gateway_stage_pairs = {(mcp_server.gateway_id, mcp_server.stage_id) for mcp_server in mcp_servers}
+        if not gateway_stage_pairs:
+            return {}
+
+        release_filters = Q()
+        for gateway_id, stage_id in gateway_stage_pairs:
+            release_filters |= Q(gateway_id=gateway_id, stage_id=stage_id)
+
+        releases = Release.objects.filter(release_filters).select_related("resource_version")
+        return {(r.gateway_id, r.stage_id): r for r in releases}
+
+    @staticmethod
+    def get_app_permission_risks(
+        mcp_servers: Sequence,
+        releases: Optional[Dict[Tuple[int, int], Release]] = None,
+    ) -> Dict[int, List[str]]:
         """检测开启了 oauth2_public_client_enabled 的 MCPServer 是否存在应用态权限安全风险。
 
         当 oauth2_public_client_enabled=True 时，public 应用被自动授权；
@@ -380,6 +404,7 @@ class MCPServerHandler:
 
         Args:
             mcp_servers: MCPServer 实例列表（需已 select_related gateway/stage）
+            releases: 可选，预查询的 Release 映射，避免重复查询
 
         Returns:
             {mcp_server_id: [risk_tool_name, ...]} 映射，仅包含存在风险的 MCPServer
@@ -388,22 +413,11 @@ class MCPServerHandler:
         if not risk_mcp_servers:
             return {}
 
-        gateway_stage_pairs = set()
-        mcp_server_gateway_stage: Dict[int, tuple] = {}
-        for mcp_server in risk_mcp_servers:
-            key = (mcp_server.gateway_id, mcp_server.stage_id)
-            gateway_stage_pairs.add(key)
-            mcp_server_gateway_stage[mcp_server.id] = key
+        if releases is None:
+            releases = MCPServerHandler._get_releases_for_mcp_servers(risk_mcp_servers)
 
-        release_filters = Q()
-        for gateway_id, stage_id in gateway_stage_pairs:
-            release_filters |= Q(gateway_id=gateway_id, stage_id=stage_id)
-
-        releases = Release.objects.filter(release_filters).select_related("resource_version")
-
-        release_resource_auth: Dict[tuple, Dict[str, bool]] = {}
-        for release in releases:
-            key = (release.gateway_id, release.stage_id)
+        release_resource_auth: Dict[Tuple[int, int], Dict[str, bool]] = {}
+        for key, release in releases.items():
             resource_auth: Dict[str, bool] = {}
             for resource in release.resource_version.data:
                 auth_config = json.loads(resource.get("contexts", {}).get("resource_auth", {}).get("config", "{}"))
@@ -412,7 +426,7 @@ class MCPServerHandler:
 
         risks: Dict[int, List[str]] = {}
         for mcp_server in risk_mcp_servers:
-            gateway_stage_key = mcp_server_gateway_stage[mcp_server.id]
+            gateway_stage_key = (mcp_server.gateway_id, mcp_server.stage_id)
             resource_auth = release_resource_auth.get(gateway_stage_key, {})
             tool_name_map = mcp_server.gen_tool_name_map()
             risk_tools = [
@@ -426,45 +440,39 @@ class MCPServerHandler:
         return risks
 
     @staticmethod
-    def get_least_privileges(mcp_servers: list) -> Dict[Tuple[int, int], str]:
-        """计算 MCPServer 列表中每个 (gateway_id, stage_id) 的最低权限等级。
+    def get_least_privileges(
+        mcp_servers,
+        releases: Optional[Dict[Tuple[int, int], Release]] = None,
+    ) -> Dict[Tuple[int, int], str]:
+        """批量计算 MCP Server 的最低权限级别
 
-        遍历每个 MCPServer 关联的 Release 资源版本，检查工具对应的 API 是否需要用户认证
-        (verified_user_required)：
-        - 如果所有工具都不需要用户认证，则最低权限为 APPLICATION
-        - 如果任意工具需要用户认证，则最低权限为 APPLICATION_AND_USER
+        遍历每个 MCP Server 的 (gateway_id, stage_id) 对，检查 Release 中对应工具资源
+        是否需要用户认证。如果所有工具都不需要用户认证，则为 APPLICATION；
+        否则为 APPLICATION_AND_USER。
 
         Args:
             mcp_servers: MCPServer 实例列表（需已 select_related gateway/stage）
+            releases: 可选，预查询的 Release 映射，避免重复查询
 
         Returns:
-            {(gateway_id, stage_id): "application" | "application_and_user"} 映射
+            {(gateway_id, stage_id): least_privilege} 映射
         """
-        gateway_stage_pairs = set()
-        gateway_stage_resource_names: Dict[Tuple[int, int], set] = {}
+        gateway_stage_tools: Dict[Tuple[int, int], List[str]] = {}
         for mcp_server in mcp_servers:
-            key = (mcp_server.gateway_id, mcp_server.stage_id)
-            gateway_stage_pairs.add(key)
-            gateway_stage_resource_names.setdefault(key, set()).update(mcp_server.resource_names)
+            gateway_stage_tools[(mcp_server.gateway_id, mcp_server.stage_id)] = mcp_server.resource_names
 
-        if not gateway_stage_pairs:
+        if not gateway_stage_tools:
             return {}
 
-        # 批量查询所有相关的 Release 记录
-        release_filters = Q()
-        for gateway_id, stage_id in gateway_stage_pairs:
-            release_filters |= Q(gateway_id=gateway_id, stage_id=stage_id)
+        if releases is None:
+            releases = MCPServerHandler._get_releases_for_mcp_servers(mcp_servers)
 
-        releases = Release.objects.filter(release_filters).select_related("resource_version")
-
-        # 获取资源的最低权限
         least_privileges: Dict[Tuple[int, int], str] = {}
-        for release in releases:
-            gateway_stage_key = (release.gateway_id, release.stage_id)
-            resource_names = gateway_stage_resource_names.get(gateway_stage_key, set())
+        for gateway_stage_key, release in releases.items():
+            tool_names = gateway_stage_tools.get(gateway_stage_key, [])
             least_privilege = MCPServerLeastPrivilegeEnum.APPLICATION.value
             for resource in release.resource_version.data:
-                if resource["name"] not in resource_names:
+                if resource["name"] not in tool_names:
                     continue
                 release_resource_data = ReleasedResourceData.from_data(resource)
                 if release_resource_data.verified_user_required:
@@ -476,17 +484,16 @@ class MCPServerHandler:
 
     @staticmethod
     def get_mcp_server_url(instance: MCPServer, least_privilege: str = "") -> str:
-        """根据最低权限等级获取 MCPServer 的访问 URL。
+        """根据 MCP Server 的应用态条件返回合适的访问 URL
 
-        当 MCPServer 未开启 oauth2_public_client_enabled 且最低权限为 APPLICATION 时，
-        返回应用态 URL；否则返回标准 URL。
+        当未开启公共客户端模式且所有工具都是应用态时，返回应用态 URL。
 
         Args:
             instance: MCPServer 实例
-            least_privilege: 最低权限等级
+            least_privilege: 最低权限级别
 
         Returns:
-            MCPServer 访问 URL
+            MCP Server 访问 URL
         """
         if (
             not instance.oauth2_public_client_enabled

--- a/src/dashboard/apigateway/apigateway/biz/mcp_server/mcp_server.py
+++ b/src/dashboard/apigateway/apigateway/biz/mcp_server/mcp_server.py
@@ -33,6 +33,7 @@ from apigateway.apps.mcp_server.constants import (
     MCPServerAppPermissionApplyStatusEnum,
     MCPServerAppPermissionGrantTypeEnum,
     MCPServerExtendTypeEnum,
+    MCPServerLeastPrivilegeEnum,
     MCPServerStatusEnum,
 )
 from apigateway.apps.mcp_server.models import (
@@ -56,7 +57,7 @@ from apigateway.common.tenant.user_credentials import UserCredentials
 from apigateway.components import bkaidev
 from apigateway.core.constants import GatewayStatusEnum, StageStatusEnum
 from apigateway.core.models import Gateway, Release, Resource
-from apigateway.service.mcp.mcp_server import build_mcp_server_url
+from apigateway.service.mcp.mcp_server import build_mcp_server_application_url, build_mcp_server_url
 from apigateway.utils.time import NeverExpiresTime, now_datetime
 
 logger = logging.getLogger(__name__)
@@ -423,6 +424,76 @@ class MCPServerHandler:
                 risks[mcp_server.id] = risk_tools
 
         return risks
+
+    @staticmethod
+    def get_least_privileges(mcp_servers: list) -> Dict[Tuple[int, int], str]:
+        """计算 MCPServer 列表中每个 (gateway_id, stage_id) 的最低权限等级。
+
+        遍历每个 MCPServer 关联的 Release 资源版本，检查工具对应的 API 是否需要用户认证
+        (verified_user_required)：
+        - 如果所有工具都不需要用户认证，则最低权限为 APPLICATION
+        - 如果任意工具需要用户认证，则最低权限为 APPLICATION_AND_USER
+
+        Args:
+            mcp_servers: MCPServer 实例列表（需已 select_related gateway/stage）
+
+        Returns:
+            {(gateway_id, stage_id): "application" | "application_and_user"} 映射
+        """
+        gateway_stage_pairs = set()
+        gateway_stage_resource_names: Dict[Tuple[int, int], set] = {}
+        for mcp_server in mcp_servers:
+            key = (mcp_server.gateway_id, mcp_server.stage_id)
+            gateway_stage_pairs.add(key)
+            gateway_stage_resource_names.setdefault(key, set()).update(mcp_server.resource_names)
+
+        if not gateway_stage_pairs:
+            return {}
+
+        # 批量查询所有相关的 Release 记录
+        release_filters = Q()
+        for gateway_id, stage_id in gateway_stage_pairs:
+            release_filters |= Q(gateway_id=gateway_id, stage_id=stage_id)
+
+        releases = Release.objects.filter(release_filters).select_related("resource_version")
+
+        # 获取资源的最低权限
+        least_privileges: Dict[Tuple[int, int], str] = {}
+        for release in releases:
+            gateway_stage_key = (release.gateway_id, release.stage_id)
+            resource_names = gateway_stage_resource_names.get(gateway_stage_key, set())
+            least_privilege = MCPServerLeastPrivilegeEnum.APPLICATION.value
+            for resource in release.resource_version.data:
+                if resource["name"] not in resource_names:
+                    continue
+                release_resource_data = ReleasedResourceData.from_data(resource)
+                if release_resource_data.verified_user_required:
+                    least_privilege = MCPServerLeastPrivilegeEnum.APPLICATION_AND_USER.value
+                    break
+            least_privileges[gateway_stage_key] = least_privilege
+
+        return least_privileges
+
+    @staticmethod
+    def get_mcp_server_url(instance: MCPServer, least_privilege: str = "") -> str:
+        """根据最低权限等级获取 MCPServer 的访问 URL。
+
+        当 MCPServer 未开启 oauth2_public_client_enabled 且最低权限为 APPLICATION 时，
+        返回应用态 URL；否则返回标准 URL。
+
+        Args:
+            instance: MCPServer 实例
+            least_privilege: 最低权限等级
+
+        Returns:
+            MCPServer 访问 URL
+        """
+        if (
+            not instance.oauth2_public_client_enabled
+            and least_privilege == MCPServerLeastPrivilegeEnum.APPLICATION.value
+        ):
+            return build_mcp_server_application_url(instance.name, instance.protocol_type)
+        return build_mcp_server_url(instance.name, instance.protocol_type)
 
     @staticmethod
     def disable_servers(gateway_id: int, stage_id: int = 0) -> None:

--- a/src/dashboard/apigateway/apigateway/biz/mcp_server/mcp_server.py
+++ b/src/dashboard/apigateway/apigateway/biz/mcp_server/mcp_server.py
@@ -372,6 +372,33 @@ class MCPServerHandler:
             AppResourcePermission.objects.filter(id__in=to_delete).delete()
 
     @staticmethod
+    def build_categories_map(mcp_server_ids: List[int]) -> Dict[int, List[Dict[str, str]]]:
+        """批量查询 MCPServer 的分类信息，返回 {mcp_server_id: [{\"name\": ..., \"display_name\": ...}]} 映射
+
+        使用单次查询替代 N+1 的 categories.filter() 调用。
+
+        Args:
+            mcp_server_ids: MCPServer ID 列表
+
+        Returns:
+            以 mcp_server_id 为 key 的分类字典映射
+        """
+        if not mcp_server_ids:
+            return {}
+
+        categories_qs = MCPServerCategory.objects.filter(
+            mcp_servers__id__in=mcp_server_ids,
+            is_active=True,
+        ).values("mcp_servers__id", "name", "display_name")
+
+        categories_map: Dict[int, List[Dict[str, str]]] = {}
+        for cat in categories_qs:
+            categories_map.setdefault(cat["mcp_servers__id"], []).append(
+                {"name": cat["name"], "display_name": cat["display_name"]}
+            )
+        return categories_map
+
+    @staticmethod
     def _get_releases_for_mcp_servers(mcp_servers) -> Dict[Tuple[int, int], Release]:
         """批量获取 MCP Server 列表对应的 Release 记录
 

--- a/src/dashboard/apigateway/apigateway/data/apidocs/zh/v2_inner_list_mcp_server.md
+++ b/src/dashboard/apigateway/apigateway/data/apidocs/zh/v2_inner_list_mcp_server.md
@@ -31,10 +31,14 @@
         "is_public": true,
         "labels": ["label1", "label2"],
         "resource_names": ["resource1", "resource2"],
-        "tool_names": ["tool1", "tool2"],
+        "tool_names": ["resource1", "custom_tool2"],
         "status": "active",
         "protocol_type": "sse",
         "oauth2_public_client_enabled": false,
+        "categories": [
+          {"name": "official", "display_name": "官方"},
+          {"name": "ai", "display_name": "AI"}
+        ],
         "stage": {
           "id": 1,
           "name": "prod"
@@ -89,11 +93,12 @@
 | status       | string | MCPServer 状态          |
 | protocol_type | string | MCPServer 协议类型        |
 | oauth2_public_client_enabled | bool   | 是否开启 OAuth2 公开客户端模式，开启后将会对 bk_app_code=public 的应用进行授权       |
+| categories   | array  | MCPServer 分类列表，每项包含 name（英文标识）和 display_name（显示名称） |
 | stage        | object | MCPServer 环境信息        |
 | gateway      | object | MCPServer 网关信息        |
 | tools_count  | int    | MCPServer 工具数量        |
 | prompts_count | int    | MCPServer Prompts 数量  |
-| url          | string | MCPServer 访问 URL      |
+| url          | string | MCPServer 访问 URL，根据最低权限级别自适应返回普通 URL 或应用态 URL |
 | detail_url   | string | MCPServer 网关站点详情 URL  |
 | updated_by   | string | 更新人                   |
 | created_by   | string | 创建人                   |

--- a/src/dashboard/apigateway/apigateway/data/apidocs/zh/v2_inner_list_mcp_server_app_permissions.md
+++ b/src/dashboard/apigateway/apigateway/data/apidocs/zh/v2_inner_list_mcp_server_app_permissions.md
@@ -23,15 +23,22 @@ mcp_server 已申请权限列表
         "name": "bk-apigateway-prod-test",
         "title": "测试服务",
         "description": "test",
-        "tools_count": "1",
-        "tool_names": ["tool1"],
+        "tools_count": 1,
+        "tool_names": ["tool1", "tool2"],
         "protocol_type": "sse",
-        "doc_link": ""
+        "url": "https://mcp.example.com/bk-apigateway-prod-test/sse",
+        "doc_link": "",
+        "categories": [
+          {"name": "official", "display_name": "官方"},
+          {"name": "ai", "display_name": "AI"}
+        ]
       },
       "permission": {
         "status": "owned",
         "action": "",
-        "expires_in": null
+        "expires_in": null,
+        "handled_by": ["admin"],
+        "approval_url": "http://dashboard.example.com/gateways/1/mcp-servers/1/permissions/"
       }
     }
   ]
@@ -62,14 +69,18 @@ mcp_server 已申请权限列表
 | description     | string | mcp_server 描述     |
 | tools_count     | int    | mcp_server 工具数量   |
 | tool_names      | array  | mcp_server 工具名称列表 |
-| protocol_type   | string | mcp_server 协议类型   |
+| protocol_type   | string | MCPServer 协议类型（sse：SSE 协议，streamable_http：Streamable HTTP 协议） |
+| url             | string | mcp_server 访问 URL，根据最低权限级别自适应返回普通 URL 或应用态 URL |
 | doc_link        | string | mcp_server 文档访问地址 |
+| categories      | array  | mcp_server 分类列表，每项包含 name（英文标识）和 display_name（显示名称） |
 
 
 #### data.permission
 
-| 参数名称           | 参数类型     | 描述                                                                        |
-|----------------|----------|---------------------------------------------------------------------------|
-| expires_in     | int      | 有效期                                                                       |
-| status         | string   | 权限状态（approved：已审批，rejected：已拒绝，pending：申请中，need_apply：待申请，owned：已申请，且未过期） |
-| action         | string   | 权限操作                                                                      |
+| 参数名称 | 参数类型 | 描述 |
+|---|---|---|
+| expires_in | int | 有效期 |
+| status | string | 权限状态（approved：已审批，rejected：已拒绝，pending：申请中，need_apply：待申请，owned：已申请且未过期） |
+| action | string | 权限操作 |
+| handled_by | array[string] | 处理人 |
+| approval_url | string | 权限审批 URL，返回 MCPServer 权限审批页 URL |

--- a/src/dashboard/apigateway/apigateway/data/apidocs/zh/v2_inner_list_mcp_server_permission_apply_records.md
+++ b/src/dashboard/apigateway/apigateway/data/apidocs/zh/v2_inner_list_mcp_server_permission_apply_records.md
@@ -29,10 +29,15 @@ mcp_server 申请记录列表
         "name": "bk-apigateway-prod-s1",
         "title": "测试服务",
         "description": "test",
-        "tools_count": "1",
-        "tool_names": ["tool1"],
+        "tools_count": 1,
+        "tool_names": ["tool1", "tool2"],
         "protocol_type": "sse",
-        "doc_link": ""
+        "url": "https://mcp.example.com/bk-apigateway-prod-s1/sse",
+        "doc_link": "",
+        "categories": [
+          {"name": "official", "display_name": "官方"},
+          {"name": "ai", "display_name": "AI"}
+        ]
       },
       "record": {
         "id": 1,
@@ -44,7 +49,8 @@ mcp_server 申请记录列表
         "apply_status_display": "待审批",
         "comment": "",
         "reason": "",
-        "expire_days": 0
+        "expire_days": 0,
+        "approval_url": "http://dashboard.example.com/gateways/1/mcp-servers/1/permissions/"
       }
     }
   ]
@@ -75,8 +81,10 @@ mcp_server 申请记录列表
 | description     | string | mcp_server 描述        |
 | tools_count     | int    | mcp_server 工具数量      |
 | tool_names      | array  | mcp_server 工具名称列表    |
-| protocol_type   | string | mcp_server 协议类型      |
+| protocol_type   | string | MCPServer 协议类型（sse：SSE 协议，streamable_http：Streamable HTTP 协议） |
+| url             | string | mcp_server 访问 URL，根据最低权限级别自适应返回普通 URL 或应用态 URL |
 | doc_link        | string | mcp_server 文档访问地址    |
+| categories      | array  | mcp_server 分类列表，每项包含 name（英文标识）和 display_name（显示名称） |
 
 
 #### data.record
@@ -93,3 +101,4 @@ mcp_server 申请记录列表
 | comment              | string | 审批内容                                      |
 | reason               | string | 申请理由                                      |
 | expire_days          | int    | 过期时间                                      |
+| approval_url         | string | 权限审批 URL，返回 MCPServer 权限审批页 URL           |

--- a/src/dashboard/apigateway/apigateway/data/apidocs/zh/v2_inner_list_mcp_server_permissions.md
+++ b/src/dashboard/apigateway/apigateway/data/apidocs/zh/v2_inner_list_mcp_server_permissions.md
@@ -25,15 +25,22 @@ mcp_server 申请权限列表
         "name": "bk-apigateway-prod-test1",
         "title": "测试服务1",
         "description": "test",
-        "tools_count": "1",
-        "tool_names": ["tool1"],
+        "tools_count": 1,
+        "tool_names": ["tool1", "tool2"],
         "protocol_type": "sse",
-        "doc_link": ""
+        "url": "https://mcp.example.com/bk-apigateway-prod-test1/sse",
+        "doc_link": "",
+        "categories": [
+          {"name": "official", "display_name": "官方"},
+          {"name": "ai", "display_name": "AI"}
+        ]
       },
       "permission": {
-        "status": "approved",
+        "status": "pending",
         "action": "",
-        "expires_in": null
+        "expires_in": null,
+        "handled_by": ["admin"],
+        "approval_url": "http://dashboard.example.com/gateways/1/mcp-servers/1/permissions/"
       }
     },
     {
@@ -42,15 +49,19 @@ mcp_server 申请权限列表
         "name": "bk-esb-prod-test2",
         "title": "测试服务2",
         "description": "test",
-        "tools_count": "1",
-        "tool_names": ["tool2"],
+        "tools_count": 1,
+        "tool_names": ["tool3"],
         "protocol_type": "sse",
-        "doc_link": ""
+        "url": "https://mcp.example.com/bk-esb-prod-test2/sse",
+        "doc_link": "",
+        "categories": []
       },
       "permission": {
         "status": "need_apply",
         "action": "apply",
-        "expires_in": null
+        "expires_in": null,
+        "handled_by": ["admin"],
+        "approval_url": "http://dashboard.example.com/gateways/2/mcp-servers/2/permissions/"
       }
     }
   ]
@@ -81,14 +92,18 @@ mcp_server 申请权限列表
 | description     | string | mcp_server 描述     |
 | tools_count     | int    | mcp_server 工具数量   |
 | tool_names      | array  | mcp_server 工具名称列表 |
-| protocol_type   | string | mcp_server 协议类型   |
+| protocol_type   | string | MCPServer 协议类型（sse：SSE 协议，streamable_http：Streamable HTTP 协议） |
+| url             | string | mcp_server 访问 URL，根据最低权限级别自适应返回普通 URL 或应用态 URL |
 | doc_link        | string | mcp_server 文档访问地址 |
+| categories      | array  | mcp_server 分类列表，每项包含 name（英文标识）和 display_name（显示名称） |
 
 
 #### data.permission
 
-| 参数名称         | 参数类型     | 描述          |
-|--------------|----------|-------------|
-| expires_in   | int      | 有效期         |
-| status       | string   | 权限状态        |
-| action       | string   | 权限操作        |
+| 参数名称 | 参数类型 | 描述 |
+|---|---|---|
+| expires_in | int | 有效期 |
+| status | string | 权限状态 |
+| action | string | 权限操作 |
+| handled_by | array[string] | 处理人 |
+| approval_url | string | 权限审批 URL，返回 MCPServer 权限审批页 URL |

--- a/src/dashboard/apigateway/apigateway/data/apidocs/zh/v2_open_list_mcp_server.md
+++ b/src/dashboard/apigateway/apigateway/data/apidocs/zh/v2_open_list_mcp_server.md
@@ -32,6 +32,10 @@
         "status": 1,
         "protocol_type": "sse",
         "oauth2_public_client_enabled": false,
+        "categories": [
+          {"name": "official", "display_name": "官方"},
+          {"name": "ai", "display_name": "AI"}
+        ],
         "stage": {
           "id": 3,
           "name": "prod"
@@ -78,8 +82,9 @@
 | status           | int     | mcp_server 状态（0：已停用，1：启用中）                             |
 | protocol_type    | string  | MCP 协议类型（sse：SSE 协议，streamable_http：Streamable HTTP 协议） |
 | oauth2_public_client_enabled   | boolean | 是否开启 OAuth2 公开客户端模式，开启后将会对 bk_app_code=public 的应用进行授权                                         |
+| categories      | array  | mcp_server 分类列表，每项包含 name（英文标识）和 display_name（显示名称） |
 | tools_count      | int     | mcp_server 工具数量                                        |
-| url              | string  | mcp_server 访问地址                                        |
+| url              | string  | mcp_server 访问 URL，根据最低权限级别自适应返回普通 URL 或应用态 URL |
 | detail_url       | string  | mcp_server 网关站点详情地址                                    |
 | updated_by       | string  | 更新人                                                    |
 | created_by       | string  | 创建人                                                    |

--- a/src/dashboard/apigateway/apigateway/data/apidocs/zh/v2_open_retrieve_mcp_server.md
+++ b/src/dashboard/apigateway/apigateway/data/apidocs/zh/v2_open_retrieve_mcp_server.md
@@ -104,7 +104,7 @@
 | status           | int      | mcp_server 状态（0：已停用，1：启用中）                      |
 | protocol_type    | string   | MCP 协议类型（sse：SSE 协议，streamable_http：Streamable HTTP 协议） |
 | oauth2_public_client_enabled   | boolean  | 是否开启 OAuth2 公开客户端模式，开启后将会对 bk_app_code=public 的应用进行授权                                         |
-| url              | string   | mcp_server 访问地址                                          |
+| url              | string   | mcp_server 访问 URL，根据最低权限级别自适应返回普通 URL 或应用态 URL |
 | guideline        | string   | mcp_server 使用指南                                          |
 | tools            | array    | mcp_server 工具列表                                          |
 | prompts          | array    | mcp_server Prompts 列表                                      |

--- a/src/dashboard/apigateway/apigateway/tests/biz/mcp_server/test_mcp_server.py
+++ b/src/dashboard/apigateway/apigateway/tests/biz/mcp_server/test_mcp_server.py
@@ -24,6 +24,7 @@ from ddf import G
 from apigateway.apis.v2.mcp_server import build_mcp_server_list_queryset
 from apigateway.apps.mcp_server.constants import (
     MCPServerExtendTypeEnum,
+    MCPServerLeastPrivilegeEnum,
     MCPServerStatusEnum,
 )
 from apigateway.apps.mcp_server.models import MCPServer, MCPServerAppPermission, MCPServerCategory, MCPServerExtend
@@ -882,6 +883,198 @@ class TestMCPServerHandler:
         MCPServerHandler._sync_mcp_server_categories(mcp_server, None)
 
         assert mcp_server.categories.count() == 1
+
+    # ========== get_least_privileges 测试 ==========
+
+    def test_get_least_privileges_empty_list(self):
+        """空列表返回空字典"""
+        result = MCPServerHandler.get_least_privileges([])
+        assert result == {}
+
+    def test_get_least_privileges_all_application(self, fake_gateway, fake_stage):
+        """所有工具都不需要用户认证时，返回 APPLICATION"""
+        rv = self._make_resource_version_with_auth_verified(
+            fake_gateway,
+            [
+                {"name": "tool_a", "auth_verified_required": False},
+                {"name": "tool_b", "auth_verified_required": False},
+            ],
+        )
+        G(Release, gateway=fake_gateway, stage=fake_stage, resource_version=rv)
+
+        mcp_server = G(
+            MCPServer,
+            gateway=fake_gateway,
+            stage=fake_stage,
+            _resource_names="tool_a;tool_b",
+        )
+
+        result = MCPServerHandler.get_least_privileges([mcp_server])
+
+        assert result[(fake_gateway.id, fake_stage.id)] == MCPServerLeastPrivilegeEnum.APPLICATION.value
+
+    def test_get_least_privileges_application_and_user(self, fake_gateway, fake_stage):
+        """任一工具需要用户认证时，返回 APPLICATION_AND_USER"""
+        rv = self._make_resource_version_with_auth_verified(
+            fake_gateway,
+            [
+                {"name": "tool_a", "auth_verified_required": False},
+                {"name": "tool_b", "auth_verified_required": True},
+            ],
+        )
+        G(Release, gateway=fake_gateway, stage=fake_stage, resource_version=rv)
+
+        mcp_server = G(
+            MCPServer,
+            gateway=fake_gateway,
+            stage=fake_stage,
+            _resource_names="tool_a;tool_b",
+        )
+
+        result = MCPServerHandler.get_least_privileges([mcp_server])
+
+        assert result[(fake_gateway.id, fake_stage.id)] == MCPServerLeastPrivilegeEnum.APPLICATION_AND_USER.value
+
+    def test_get_least_privileges_no_release(self, fake_gateway, fake_stage):
+        """没有 Release 时，返回空字典"""
+        mcp_server = G(
+            MCPServer,
+            gateway=fake_gateway,
+            stage=fake_stage,
+            _resource_names="tool_a",
+        )
+
+        result = MCPServerHandler.get_least_privileges([mcp_server])
+
+        assert (fake_gateway.id, fake_stage.id) not in result
+
+    def test_get_least_privileges_multiple_servers_same_gateway_stage(self, fake_gateway, fake_stage):
+        """同一 (gateway_id, stage_id) 下多个 MCP Server 的 resource_names 应合并计算"""
+        rv = self._make_resource_version_with_auth_verified(
+            fake_gateway,
+            [
+                {"name": "tool_a", "auth_verified_required": False},
+                {"name": "tool_b", "auth_verified_required": True},
+            ],
+        )
+        G(Release, gateway=fake_gateway, stage=fake_stage, resource_version=rv)
+
+        # server_a 只关联不需要用户认证的 tool_a
+        server_a = G(
+            MCPServer,
+            gateway=fake_gateway,
+            stage=fake_stage,
+            _resource_names="tool_a",
+        )
+        # server_b 只关联需要用户认证的 tool_b
+        server_b = G(
+            MCPServer,
+            gateway=fake_gateway,
+            stage=fake_stage,
+            _resource_names="tool_b",
+        )
+
+        result = MCPServerHandler.get_least_privileges([server_a, server_b])
+
+        # 合并后应包含 tool_a 和 tool_b，因为 tool_b 需要用户认证，所以结果为 APPLICATION_AND_USER
+        assert result[(fake_gateway.id, fake_stage.id)] == MCPServerLeastPrivilegeEnum.APPLICATION_AND_USER.value
+
+    @staticmethod
+    def _make_resource_version_with_auth_verified(gateway, resources):
+        """构造带有 auth_verified_required 的 ResourceVersion（用于 get_least_privileges 测试）"""
+        rv = G(ResourceVersion, gateway=gateway)
+        data = []
+        for i, res in enumerate(resources):
+            data.append(
+                {
+                    "id": i + 1,
+                    "name": res["name"],
+                    "description": f"test resource {res['name']}",
+                    "description_en": f"test resource {res['name']}",
+                    "method": "GET",
+                    "path": f"/test/{res['name']}/",
+                    "match_subpath": False,
+                    "is_public": True,
+                    "allow_apply_permission": True,
+                    "api_labels": [],
+                    "contexts": {
+                        "resource_auth": {
+                            "config": json.dumps(
+                                {
+                                    "auth_verified_required": res.get("auth_verified_required", True),
+                                    "app_verified_required": True,
+                                    "resource_perm_required": True,
+                                }
+                            )
+                        }
+                    },
+                }
+            )
+        rv._data = json.dumps(data)
+        rv.save()
+        return rv
+
+    # ========== get_mcp_server_url 测试 ==========
+
+    def test_get_mcp_server_url_standard(self, fake_gateway, fake_stage, settings):
+        """oauth2 开启时，始终返回标准 URL"""
+        settings.BK_API_URL_TMPL = "http://bkapi.example.com/api/{api_name}"
+        mcp_server = G(
+            MCPServer,
+            gateway=fake_gateway,
+            stage=fake_stage,
+            name="test-server",
+            oauth2_public_client_enabled=True,
+        )
+
+        url = MCPServerHandler.get_mcp_server_url(mcp_server, MCPServerLeastPrivilegeEnum.APPLICATION.value)
+        assert "/application/" not in url
+        assert "test-server" in url
+
+    def test_get_mcp_server_url_application(self, fake_gateway, fake_stage, settings):
+        """oauth2 关闭且最低权限为 APPLICATION 时，返回应用态 URL"""
+        settings.BK_API_URL_TMPL = "http://bkapi.example.com/api/{api_name}"
+        mcp_server = G(
+            MCPServer,
+            gateway=fake_gateway,
+            stage=fake_stage,
+            name="test-server",
+            oauth2_public_client_enabled=False,
+        )
+
+        url = MCPServerHandler.get_mcp_server_url(mcp_server, MCPServerLeastPrivilegeEnum.APPLICATION.value)
+        assert "/application/" in url
+        assert "test-server" in url
+
+    def test_get_mcp_server_url_no_privilege_fallback(self, fake_gateway, fake_stage, settings):
+        """oauth2 关闭但无 least_privilege 时，返回标准 URL"""
+        settings.BK_API_URL_TMPL = "http://bkapi.example.com/api/{api_name}"
+        mcp_server = G(
+            MCPServer,
+            gateway=fake_gateway,
+            stage=fake_stage,
+            name="test-server",
+            oauth2_public_client_enabled=False,
+        )
+
+        url = MCPServerHandler.get_mcp_server_url(mcp_server, "")
+        assert "/application/" not in url
+        assert "test-server" in url
+
+    def test_get_mcp_server_url_application_and_user(self, fake_gateway, fake_stage, settings):
+        """oauth2 关闭但最低权限为 APPLICATION_AND_USER 时，返回标准 URL"""
+        settings.BK_API_URL_TMPL = "http://bkapi.example.com/api/{api_name}"
+        mcp_server = G(
+            MCPServer,
+            gateway=fake_gateway,
+            stage=fake_stage,
+            name="test-server",
+            oauth2_public_client_enabled=False,
+        )
+
+        url = MCPServerHandler.get_mcp_server_url(mcp_server, MCPServerLeastPrivilegeEnum.APPLICATION_AND_USER.value)
+        assert "/application/" not in url
+        assert "test-server" in url
 
     # ========== build_mcp_server_list_queryset ids 测试 ==========
 

--- a/src/dashboard/apigateway/apigateway/tests/biz/mcp_server/test_mcp_server.py
+++ b/src/dashboard/apigateway/apigateway/tests/biz/mcp_server/test_mcp_server.py
@@ -976,7 +976,8 @@ class TestMCPServerHandler:
 
         result = MCPServerHandler.get_least_privileges([server_a, server_b])
 
-        # 合并后应包含 tool_a 和 tool_b，因为 tool_b 需要用户认证，所以结果为 APPLICATION_AND_USER
+        # 后一个 server 的 resource_names 会覆盖前一个（与 upstream/master 行为一致）
+        # server_b 的 tool_b 需要用户认证，所以结果为 APPLICATION_AND_USER
         assert result[(fake_gateway.id, fake_stage.id)] == MCPServerLeastPrivilegeEnum.APPLICATION_AND_USER.value
 
     @staticmethod


### PR DESCRIPTION
- 支持基于最低权限等级自适应 MCP Server URL：
  - 当 MCP Server 未开启 oauth2_public_client_enabled 且所有工具仅需应用认证时，
  返回应用态 URL（/application/sse/ 或 /application/mcp/）
  - 否则返回标准 URL（/sse/ 或 /mcp/）

- 核心改动：
  - MCPServerHandler 新增 get_least_privileges() 和 get_mcp_server_url() 方法
  - apis/v2/mcp_server.py 新增 get_mcp_server_url_from_context() helper，
  build_mcp_server_list_context/validate_and_enrich_mcp_server_for_retrieve 中注入 least_privileges
  - inner/open serializer 的 get_url() 统一切换为自适应 URL