### PR TITLE
fix(dashboard): redact health check errors and hide debug docs

### DIFF
--- a/src/dashboard/apigateway/apigateway/healthz/views.py
+++ b/src/dashboard/apigateway/apigateway/healthz/views.py
@@ -16,6 +16,7 @@
 # to the current version of the project delivered to anyone in the future.
 #
 import json
+import logging
 
 import redis
 import requests
@@ -26,6 +27,8 @@ from requests.exceptions import HTTPError, RequestException
 
 from apigateway.utils.redis_utils import get_redis_pool
 from apigateway.utils.responses import FailJsonResponse, OKJsonResponse
+
+logger = logging.getLogger(__name__)
 
 
 class CheckError(Exception):
@@ -53,11 +56,9 @@ class HealthzView(View):
             try:
                 checker()
             except CheckError as err:
-                return FailJsonResponse(status=500, code="UNKNOWN", messge=f"Error: {err}")
+                return FailJsonResponse(status=500, code="UNKNOWN", message=str(err))
             except CheckWarning as err:
-                return OKJsonResponse(
-                    data={"message": f"Warning: some checks fail and do not affect core functions. {err}"}
-                )
+                return OKJsonResponse(data={"message": f"Warning: {err}"})
 
         return OKJsonResponse()
 
@@ -73,7 +74,7 @@ class HealthzView(View):
         ]
         empty_keys = [key for key in not_allow_empty_keys if not getattr(settings, key, None)]
         if empty_keys:
-            raise CheckError(f"These django settings should not be empty: {', '.join(empty_keys)}")
+            raise CheckError("check settings failed")
 
     def _check_database(self):
         from apigateway.core.models import Gateway
@@ -81,7 +82,8 @@ class HealthzView(View):
         try:
             Gateway.objects.exists()
         except Exception as err:
-            raise CheckError(f"Query from database failed, error: {err}")
+            logger.exception("healthz database check failed")
+            raise CheckError("check database failed")
 
     def _check_redis(self):
         config = getattr(settings, "CHANNEL_REDIS_CONFIG", None)
@@ -94,7 +96,8 @@ class HealthzView(View):
             client.expire(key, 60)
             client.get(key)
         except Exception as err:
-            raise CheckError(f"Redis check failed [{config['host']}:{config['port']}], error: {err}")
+            logger.exception("healthz redis check failed")
+            raise CheckError("check redis failed")
 
     def _check_external_dependency_url(self):
         url_keys = [
@@ -106,13 +109,11 @@ class HealthzView(View):
             try:
                 resp = requests.get(url, timeout=3, verify=False)
             except RequestException as err:
-                raise CheckError(f"Request api error, url: {url}, error: {err}")
+                logger.exception("healthz external dependency url check failed")
+                raise CheckError("check external dependency url failed")
 
             if resp.status_code >= 500:
-                raise CheckError(
-                    f"Request api status_code >= 500, url: {url}, "
-                    f"status_code: {resp.status_code}, response content: {resp.text}"
-                )
+                raise CheckError("check external dependency url failed")
 
     def _check_bk_paasv3(self):
         url = settings.BK_PAAS3_API_URL.rstrip("/") + "/prod/system/uni_applications/query/by_id/"
@@ -136,21 +137,17 @@ class HealthzView(View):
                 verify=False,
             )
         except RequestException as err:
-            raise CheckWarning(f"Request paas3.0 api to get application error, url: {url}, error: {err}")
+            logger.exception("healthz bk_paasv3 check failed")
+            raise CheckWarning("check bk_paasv3 failed")
 
         try:
             result = resp.json()
         except (TypeError, json.JSONDecodeError):
-            raise CheckWarning(
-                "The response to paas3.0 api is not a valid json, "
-                "please check django settings: BK_APP_CODE, BK_APP_SECRET, "
-                f"url: {url}, response content: {resp.text}, "
-            )
+            logger.exception("healthz bk_paasv3 check failed")
+            raise CheckWarning("check bk_paasv3 failed")
 
         try:
             resp.raise_for_status()
-        except HTTPError:
-            raise CheckWarning(
-                f"Request paas3.0 api to get application fail, request url: {url}, response: {resp.text}, "
-                "please check django settings: BK_APP_CODE, BK_APP_SECRET"
-            )
+        except HTTPError as err:
+            logger.exception("healthz bk_paasv3 check failed")
+            raise CheckWarning("check bk_paasv3 failed")

--- a/src/dashboard/apigateway/apigateway/tests/drf_yasg/test_urls.py
+++ b/src/dashboard/apigateway/apigateway/tests/drf_yasg/test_urls.py
@@ -15,13 +15,11 @@
 # We undertake not to change the open source license (MIT license) applicable
 # to the current version of the project delivered to anyone in the future.
 #
+import pytest
+from django.urls import NoReverseMatch, reverse
+
+
 class TestUrls:
-    def test_urls(self, request_view):
-        resp = request_view(
-            method="GET",
-            view_name="schema-swagger-ui",
-            data={
-                "format": "openapi",
-            },
-        )
-        assert resp.status_code == 200
+    def test_urls_disabled_when_debug_is_false(self):
+        with pytest.raises(NoReverseMatch):
+            reverse("schema-swagger-ui")

--- a/src/dashboard/apigateway/apigateway/urls.py
+++ b/src/dashboard/apigateway/apigateway/urls.py
@@ -31,6 +31,7 @@ Including another URLconf
     2. Add a URL to urlpatterns:  path('blog/', include('blog.urls'))
 """
 
+from django.conf import settings
 from django.contrib import admin
 from django.urls import include, path, re_path
 from django.views.i18n import set_language
@@ -90,16 +91,17 @@ urlpatterns = [
 ]
 
 
-# backend/docs/
-urlpatterns += [
-    # drf-yasg automatically generated documents
-    re_path(
-        r"^backend/docs/auto/swagger(?P<format>\.json|\.yaml)$",
-        schema_view.without_ui(cache_timeout=0),
-        name="schema-json",
-    ),
-    re_path(
-        r"^backend/docs/auto/swagger/$", schema_view.with_ui("swagger", cache_timeout=0), name="schema-swagger-ui"
-    ),
-    re_path(r"^backend/docs/auto/redoc/$", schema_view.with_ui("redoc", cache_timeout=0), name="schema-redoc"),
-]
+if settings.DEBUG:
+    # backend/docs/
+    urlpatterns += [
+        # drf-yasg automatically generated documents
+        re_path(
+            r"^backend/docs/auto/swagger(?P<format>\.json|\.yaml)$",
+            schema_view.without_ui(cache_timeout=0),
+            name="schema-json",
+        ),
+        re_path(
+            r"^backend/docs/auto/swagger/$", schema_view.with_ui("swagger", cache_timeout=0), name="schema-swagger-ui"
+        ),
+        re_path(r"^backend/docs/auto/redoc/$", schema_view.with_ui("redoc", cache_timeout=0), name="schema-redoc"),
+    ]


### PR DESCRIPTION
Why this change was needed:
Health check responses and auto-generated docs routes were exposing more than they should in the default runtime. The health endpoint now returns generic failure messages while keeping details in logs, and the drf-yasg routes are limited to debug mode.

What changed:
- replaced detailed healthz response bodies with redacted error and warning messages
- logged backend check failures for database, redis, external dependency, and paasv3 checks
- gated drf-yasg swagger and redoc routes behind settings.DEBUG
- updated the tracked URL test to match the new non-debug behavior

Problem solved:
Operational failures no longer leak backend details through /healthz, and auto-generated API docs are no longer exposed outside debug mode by default.

### Description

<!-- 关联相关issue Please include a summary of the change and which issue is fixed. -->
<!-- 给出必要的上下文以及review需要的必要信息 Please also include relevant motivation and context. -->

Fixes # (issue)

### Checklist

- [ ] 填写 PR 描述及相关 issue (write PR description and related issue)
- [ ] 代码风格检查通过 (code style check passed)
- [ ] PR 中包含单元测试 (include unit test)
- [ ] 单元测试通过 (unit test passed)
- [ ] 本地开发联调环境验证通过 (local development environment verification passed)
