### PR TITLE
fix(dashboard): redact healthz errors and hide debug docs

### DIFF
--- a/src/dashboard/apigateway/apigateway/healthz/views.py
+++ b/src/dashboard/apigateway/apigateway/healthz/views.py
@@ -16,6 +16,8 @@
 # to the current version of the project delivered to anyone in the future.
 #
 
+import logging
+
 import redis
 from django.conf import settings
 from django.http import HttpResponse
@@ -23,6 +25,8 @@ from django.views.generic import View
 
 from apigateway.utils.redis_utils import get_redis_pool
 from apigateway.utils.responses import FailJsonResponse, OKJsonResponse
+
+logger = logging.getLogger(__name__)
 
 
 class CheckError(Exception):
@@ -50,11 +54,9 @@ class HealthzView(View):
             try:
                 checker()
             except CheckError as err:
-                return FailJsonResponse(status=500, code="UNKNOWN", messge=f"Error: {err}")
+                return FailJsonResponse(status=500, code="UNKNOWN", message=str(err))
             except CheckWarning as err:
-                return OKJsonResponse(
-                    data={"message": f"Warning: some checks fail and do not affect core functions. {err}"}
-                )
+                return OKJsonResponse(data={"message": f"Warning: {err}"})
 
         return OKJsonResponse()
 
@@ -68,15 +70,16 @@ class HealthzView(View):
         ]
         empty_keys = [key for key in not_allow_empty_keys if not getattr(settings, key, None)]
         if empty_keys:
-            raise CheckError(f"These django settings should not be empty: {', '.join(empty_keys)}")
+            raise CheckError("check settings failed")
 
     def _check_database(self):
         from apigateway.core.models import Gateway  # noqa
 
         try:
             Gateway.objects.exists()
-        except Exception as err:  # pylint: disable=broad-except
-            raise CheckError(f"Query from database failed, error: {err}")
+        except Exception:  # pylint: disable=broad-except
+            logger.exception("healthz database check failed")
+            raise CheckError("check database failed")
 
     def _check_redis(self):
         config = getattr(settings, "CHANNEL_REDIS_CONFIG", None)
@@ -88,5 +91,6 @@ class HealthzView(View):
             client.set(key, "apigateway")
             client.expire(key, 60)
             client.get(key)
-        except Exception as err:  # pylint: disable=broad-except
-            raise CheckError(f"Redis check failed [{config['host']}:{config['port']}], error: {err}")
+        except Exception:  # pylint: disable=broad-except
+            logger.exception("healthz redis check failed")
+            raise CheckError("check redis failed")

--- a/src/dashboard/apigateway/apigateway/tests/drf_yasg/test_urls.py
+++ b/src/dashboard/apigateway/apigateway/tests/drf_yasg/test_urls.py
@@ -15,13 +15,26 @@
 # We undertake not to change the open source license (MIT license) applicable
 # to the current version of the project delivered to anyone in the future.
 #
+import importlib
+
+import pytest
+from django.test import override_settings
+from django.urls import NoReverseMatch, clear_url_caches, reverse, set_urlconf
+
+import apigateway.urls
+
+
 class TestUrls:
-    def test_urls(self, request_view):
-        resp = request_view(
-            method="GET",
-            view_name="schema-swagger-ui",
-            data={
-                "format": "openapi",
-            },
-        )
-        assert resp.status_code == 200
+    def test_urls_disabled_when_debug_is_false(self):
+        try:
+            with override_settings(DEBUG=False):
+                clear_url_caches()
+                importlib.reload(apigateway.urls)
+                set_urlconf(None)
+
+                with pytest.raises(NoReverseMatch):
+                    reverse("schema-swagger-ui")
+        finally:
+            importlib.reload(apigateway.urls)
+            clear_url_caches()
+            set_urlconf(None)

--- a/src/dashboard/apigateway/apigateway/tests/healthz/test_redaction.py
+++ b/src/dashboard/apigateway/apigateway/tests/healthz/test_redaction.py
@@ -1,0 +1,56 @@
+#
+# TencentBlueKing is pleased to support the open source community by making
+# 蓝鲸智云 - API 网关(BlueKing - APIGateway) available.
+# Copyright (C) 2025 Tencent. All rights reserved.
+# Licensed under the MIT License (the "License"); you may not use this file except
+# in compliance with the License. You may obtain a copy of the License at
+#
+#     http://opensource.org/licenses/MIT
+#
+# Unless required by applicable law or agreed to in writing, software distributed under
+# the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+# either express or implied. See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# We undertake not to change the open source license (MIT license) applicable
+# to the current version of the project delivered to anyone in the future.
+#
+import pytest
+
+from apigateway.healthz.views import CheckError, HealthzView
+from apigateway.tests.utils.testing import create_request, get_response_json
+
+
+class TestHealthzView:
+    def test_get_check_error_response_uses_redacted_message(self, mocker):
+        mocker.patch.object(HealthzView, "_check_settings")
+        mocker.patch.object(HealthzView, "_check_database", side_effect=CheckError("check database failed"))
+        mocker.patch.object(HealthzView, "_check_redis")
+
+        response = HealthzView.as_view()(create_request())
+
+        result = get_response_json(response)
+        assert response.status_code == 500
+        assert result["error"]["message"] == "check database failed"
+
+    def test_check_database_logs_detail_and_raises_redacted_error(self, mocker):
+        log_exception = mocker.patch("apigateway.healthz.views.logger.exception")
+        mocker.patch("apigateway.core.models.Gateway.objects.exists", side_effect=Exception("database password"))
+
+        with pytest.raises(CheckError, match="check database failed"):
+            HealthzView()._check_database()
+
+        log_exception.assert_called_once_with("healthz database check failed")
+
+    def test_check_redis_logs_detail_and_raises_redacted_error(self, mocker):
+        client = mocker.MagicMock()
+        client.ping.side_effect = Exception("redis://user:password@example.com:6379")
+        log_exception = mocker.patch("apigateway.healthz.views.logger.exception")
+
+        mocker.patch("apigateway.healthz.views.get_redis_pool", return_value=object())
+        mocker.patch("apigateway.healthz.views.redis.Redis", return_value=client)
+
+        with pytest.raises(CheckError, match="check redis failed"):
+            HealthzView()._check_redis()
+
+        log_exception.assert_called_once_with("healthz redis check failed")

--- a/src/dashboard/apigateway/apigateway/urls.py
+++ b/src/dashboard/apigateway/apigateway/urls.py
@@ -127,16 +127,17 @@ if not settings.ENABLE_MULTI_TENANT_MODE:
         path("backend/esb/", include("apigateway.apps.esb.urls")),
     ]
 
-# backend/docs/
-urlpatterns += [
-    # drf-yasg automatically generated documents
-    re_path(
-        r"^backend/docs/auto/swagger(?P<format>\.json|\.yaml)$",
-        schema_view.without_ui(cache_timeout=0),
-        name="schema-json",
-    ),
-    re_path(
-        r"^backend/docs/auto/swagger/$", schema_view.with_ui("swagger", cache_timeout=0), name="schema-swagger-ui"
-    ),
-    re_path(r"^backend/docs/auto/redoc/$", schema_view.with_ui("redoc", cache_timeout=0), name="schema-redoc"),
-]
+if settings.DEBUG:
+    # backend/docs/
+    urlpatterns += [
+        # drf-yasg automatically generated documents
+        re_path(
+            r"^backend/docs/auto/swagger(?P<format>\.json|\.yaml)$",
+            schema_view.without_ui(cache_timeout=0),
+            name="schema-json",
+        ),
+        re_path(
+            r"^backend/docs/auto/swagger/$", schema_view.with_ui("swagger", cache_timeout=0), name="schema-swagger-ui"
+        ),
+        re_path(r"^backend/docs/auto/redoc/$", schema_view.with_ui("redoc", cache_timeout=0), name="schema-redoc"),
+    ]


### PR DESCRIPTION
Why this change was needed:
Health check responses and auto-generated docs routes exposed more information than they should in normal runtime. This ports the intent of #2717 to the current master branch manually because the source PR targets another release branch.

What changed:
- Redacted healthz settings, database, and redis failure messages returned to clients
- Logged database and redis health-check failures server-side for diagnosis
- Registered drf-yasg swagger and redoc routes only when settings.DEBUG is enabled
- Updated URL and healthz tests for the current branch behavior

Problem solved:
Operational failures no longer leak backend details through /healthz, and generated API docs are not exposed outside debug mode by default.

Verification:
- `source .venv/bin/activate 2>&1; ruff format --config=pyproject.toml --check ...`
- `source .venv/bin/activate 2>&1; ruff check --config=pyproject.toml ...`
- `source .venv/bin/activate 2>&1; mypy --config-file=pyproject.toml ...`
- `source .venv/bin/activate 2>&1; cd apigateway && set -a; . apigateway/conf/unittest_env; set +a; python3 -m pytest --nomigrations --ds apigateway.settings -x -q --tb=short apigateway/tests/drf_yasg/test_urls.py apigateway/tests/healthz/test_redaction.py`
- `source .venv/bin/activate 2>&1; make lint-check`