### PR TITLE
feat(mcp-proxy): add comprehensive integration test cases

### DIFF
--- a/src/mcp-proxy/tests/integration/application_mode_test.go
+++ b/src/mcp-proxy/tests/integration/application_mode_test.go
@@ -1,0 +1,281 @@
+/*
+ * TencentBlueKing is pleased to support the open source community by making
+ * 蓝鲸智云 - API 网关(BlueKing - APIGateway) available.
+ * Copyright (C) 2025 Tencent. All rights reserved.
+ * Licensed under the MIT License (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ *     http://opensource.org/licenses/MIT
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * We undertake not to change the open source license (MIT license) applicable
+ * to the current version of the project delivered to anyone in the future.
+ */
+
+package integration_test
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"mcp_proxy/pkg/constant"
+)
+
+var _ = Describe("Application Mode Routes", func() {
+	var (
+		client   *TestClient
+		jwtToken string
+		ctx      context.Context
+		cancel   context.CancelFunc
+	)
+
+	BeforeEach(func() {
+		var err error
+		client, err = NewTestClient()
+		Expect(err).NotTo(HaveOccurred())
+
+		jwtToken, err = client.GenerateJWT("test-app", "test-user")
+		Expect(err).NotTo(HaveOccurred())
+
+		ctx, cancel = context.WithTimeout(context.Background(), 30*time.Second)
+	})
+
+	AfterEach(func() {
+		cancel()
+	})
+
+	Describe("SSE Application Mode", func() {
+		It("should establish SSE connection via application route and initialize", func() {
+			sseURL := fmt.Sprintf("%s/%s/application/sse", client.BaseURL, "test-sse-server")
+
+			httpClient := &http.Client{
+				Timeout: 30 * time.Second,
+				Transport: &jwtRoundTripper{
+					token: jwtToken,
+					base:  http.DefaultTransport,
+				},
+			}
+
+			transport := &mcp.SSEClientTransport{
+				Endpoint:   sseURL,
+				HTTPClient: httpClient,
+			}
+
+			mcpClient := mcp.NewClient(&mcp.Implementation{
+				Name:    "test-client",
+				Version: "1.0.0",
+			}, nil)
+
+			session, err := mcpClient.Connect(ctx, transport, nil)
+			Expect(err).NotTo(HaveOccurred())
+			defer session.Close()
+
+			err = session.Ping(ctx, nil)
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("should list tools via SSE application route", func() {
+			session, err := connectSSEApplication(ctx, client.BaseURL, "test-sse-server", jwtToken)
+			Expect(err).NotTo(HaveOccurred())
+			defer session.Close()
+
+			result, err := session.ListTools(ctx, nil)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result).NotTo(BeNil())
+			Expect(result.Tools).To(HaveLen(2))
+
+			toolNames := make([]string, len(result.Tools))
+			for i, tool := range result.Tools {
+				toolNames[i] = tool.Name
+			}
+			Expect(toolNames).To(ContainElement("echo"))
+			Expect(toolNames).To(ContainElement("ping"))
+		})
+
+		It("should call tool via SSE application route", func() {
+			session, err := connectSSEApplication(ctx, client.BaseURL, "test-sse-server", jwtToken)
+			Expect(err).NotTo(HaveOccurred())
+			defer session.Close()
+
+			result, err := session.CallTool(ctx, &mcp.CallToolParams{
+				Name: "echo",
+				Arguments: map[string]any{
+					"message": "Hello SSE Application Mode",
+				},
+			})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result).NotTo(BeNil())
+			Expect(result.Content).NotTo(BeEmpty())
+		})
+
+		It("should list prompts via SSE application route", func() {
+			session, err := connectSSEApplication(ctx, client.BaseURL, "test-sse-server", jwtToken)
+			Expect(err).NotTo(HaveOccurred())
+			defer session.Close()
+
+			result, err := session.ListPrompts(ctx, nil)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result).NotTo(BeNil())
+			Expect(result.Prompts).To(HaveLen(1))
+		})
+
+		It("should reject SSE application route without JWT", func() {
+			sseURL := fmt.Sprintf("%s/%s/application/sse", client.BaseURL, "test-sse-server")
+
+			httpClient := &http.Client{
+				Timeout: 10 * time.Second,
+			}
+
+			req, err := http.NewRequestWithContext(ctx, http.MethodGet, sseURL, nil)
+			Expect(err).NotTo(HaveOccurred())
+			req.Header.Set("Accept", "text/event-stream")
+
+			resp, err := httpClient.Do(req)
+			Expect(err).NotTo(HaveOccurred())
+			defer resp.Body.Close()
+
+			Expect(resp.StatusCode).To(Equal(http.StatusUnauthorized))
+		})
+
+		It("should reject SSE application route with expired permission", func() {
+			expiredToken, err := client.GenerateJWT("expired-app", "expired-user")
+			Expect(err).NotTo(HaveOccurred())
+
+			sseURL := fmt.Sprintf("%s/%s/application/sse", client.BaseURL, "test-sse-server")
+
+			httpClient := &http.Client{
+				Timeout: 10 * time.Second,
+				Transport: &jwtRoundTripper{
+					token: expiredToken,
+					base:  http.DefaultTransport,
+				},
+			}
+
+			req, err := http.NewRequestWithContext(ctx, http.MethodGet, sseURL, nil)
+			Expect(err).NotTo(HaveOccurred())
+			req.Header.Set("Accept", "text/event-stream")
+			req.Header.Set(constant.BkGatewayJWTHeaderKey, expiredToken)
+
+			resp, err := httpClient.Do(req)
+			Expect(err).NotTo(HaveOccurred())
+			defer resp.Body.Close()
+
+			Expect(resp.StatusCode).To(Equal(http.StatusForbidden))
+		})
+	})
+
+	Describe("Streamable HTTP Application Mode", func() {
+		It("should initialize via Streamable HTTP application route", func() {
+			session, err := connectStreamableHTTPApplication(ctx, client.BaseURL, "test-http-server", jwtToken)
+			Expect(err).NotTo(HaveOccurred())
+			defer session.Close()
+
+			err = session.Ping(ctx, nil)
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("should list tools via Streamable HTTP application route", func() {
+			session, err := connectStreamableHTTPApplication(ctx, client.BaseURL, "test-http-server", jwtToken)
+			Expect(err).NotTo(HaveOccurred())
+			defer session.Close()
+
+			result, err := session.ListTools(ctx, nil)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result).NotTo(BeNil())
+			Expect(result.Tools).To(HaveLen(2))
+
+			toolNames := make([]string, len(result.Tools))
+			for i, tool := range result.Tools {
+				toolNames[i] = tool.Name
+			}
+			Expect(toolNames).To(ContainElement("echo"))
+			Expect(toolNames).To(ContainElement("ping"))
+		})
+
+		It("should call tool via Streamable HTTP application route", func() {
+			session, err := connectStreamableHTTPApplication(ctx, client.BaseURL, "test-http-server", jwtToken)
+			Expect(err).NotTo(HaveOccurred())
+			defer session.Close()
+
+			result, err := session.CallTool(ctx, &mcp.CallToolParams{
+				Name: "echo",
+				Arguments: map[string]any{
+					"message": "Hello HTTP Application Mode",
+				},
+			})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result).NotTo(BeNil())
+			Expect(result.Content).NotTo(BeEmpty())
+		})
+
+		It("should list prompts via Streamable HTTP application route", func() {
+			session, err := connectStreamableHTTPApplication(ctx, client.BaseURL, "test-http-server", jwtToken)
+			Expect(err).NotTo(HaveOccurred())
+			defer session.Close()
+
+			result, err := session.ListPrompts(ctx, nil)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result).NotTo(BeNil())
+			Expect(result.Prompts).To(HaveLen(1))
+		})
+
+		It("should reject Streamable HTTP application route without JWT", func() {
+			mcpURL := fmt.Sprintf("%s/%s/application/mcp", client.BaseURL, "test-http-server")
+
+			httpClient := &http.Client{
+				Timeout: 10 * time.Second,
+			}
+
+			transport := &mcp.StreamableClientTransport{
+				Endpoint:   mcpURL,
+				HTTPClient: httpClient,
+			}
+
+			mcpClient := mcp.NewClient(&mcp.Implementation{
+				Name:    "test-client",
+				Version: "1.0.0",
+			}, nil)
+
+			_, err := mcpClient.Connect(ctx, transport, nil)
+			Expect(err).To(HaveOccurred())
+		})
+
+		It("should reject Streamable HTTP application route with expired permission", func() {
+			expiredToken, err := client.GenerateJWT("expired-app", "expired-user")
+			Expect(err).NotTo(HaveOccurred())
+
+			mcpURL := fmt.Sprintf("%s/%s/application/mcp", client.BaseURL, "test-http-server")
+
+			httpClient := &http.Client{
+				Timeout: 10 * time.Second,
+				Transport: &jwtRoundTripper{
+					token: expiredToken,
+					base:  http.DefaultTransport,
+				},
+			}
+
+			transport := &mcp.StreamableClientTransport{
+				Endpoint:   mcpURL,
+				HTTPClient: httpClient,
+			}
+
+			mcpClient := mcp.NewClient(&mcp.Implementation{
+				Name:    "test-client",
+				Version: "1.0.0",
+			}, nil)
+
+			_, err = mcpClient.Connect(ctx, transport, nil)
+			Expect(err).To(HaveOccurred())
+		})
+	})
+})

--- a/src/mcp-proxy/tests/integration/init.sql
+++ b/src/mcp-proxy/tests/integration/init.sql
@@ -278,3 +278,41 @@ VALUES (2, 2, 'test-app', 'grant', '2099-12-31 23:59:59', NOW(), NOW());
 -- 权限给带工具名映射的 MCP Server
 INSERT INTO `mcp_server_app_permission` (`id`, `mcp_server_id`, `bk_app_code`, `grant_type`, `expires`, `created_time`, `updated_time`)
 VALUES (3, 3, 'test-app', 'grant', '2099-12-31 23:59:59', NOW(), NOW());
+
+-- ==================== 补充测试数据 ====================
+
+-- 测试用 MCP Server (Streamable HTTP 协议，带工具名映射)
+INSERT INTO `mcp_server` (`id`, `name`, `description`, `is_public`, `labels`, `resource_names`, `gateway_id`, `stage_id`, `protocol_type`, `status`, `created_time`, `updated_time`)
+VALUES (4, 'test-renamed-http-server', 'Test HTTP MCP Server with Tool Rename', 1, '', 'echo@echo_message;ping', 1, 1, 'streamable_http', 1, NOW(), NOW());
+
+-- 权限给 Streamable HTTP renamed server
+INSERT INTO `mcp_server_app_permission` (`id`, `mcp_server_id`, `bk_app_code`, `grant_type`, `expires`, `created_time`, `updated_time`)
+VALUES (4, 4, 'test-app', 'grant', '2099-12-31 23:59:59', NOW(), NOW());
+
+-- 测试用 MCP Server (SSE 协议，无 Prompts)
+INSERT INTO `mcp_server` (`id`, `name`, `description`, `is_public`, `labels`, `resource_names`, `gateway_id`, `stage_id`, `protocol_type`, `status`, `created_time`, `updated_time`)
+VALUES (5, 'test-no-prompts-sse', 'Test SSE MCP Server without Prompts', 1, '', 'echo;ping', 1, 1, 'sse', 1, NOW(), NOW());
+
+-- 权限给无 Prompts 的 SSE server
+INSERT INTO `mcp_server_app_permission` (`id`, `mcp_server_id`, `bk_app_code`, `grant_type`, `expires`, `created_time`, `updated_time`)
+VALUES (5, 5, 'test-app', 'grant', '2099-12-31 23:59:59', NOW(), NOW());
+
+-- 测试用 MCP Server (Streamable HTTP 协议，无 Prompts)
+INSERT INTO `mcp_server` (`id`, `name`, `description`, `is_public`, `labels`, `resource_names`, `gateway_id`, `stage_id`, `protocol_type`, `status`, `created_time`, `updated_time`)
+VALUES (6, 'test-no-prompts-http', 'Test HTTP MCP Server without Prompts', 1, '', 'echo;ping', 1, 1, 'streamable_http', 1, NOW(), NOW());
+
+-- 权限给无 Prompts 的 HTTP server
+INSERT INTO `mcp_server_app_permission` (`id`, `mcp_server_id`, `bk_app_code`, `grant_type`, `expires`, `created_time`, `updated_time`)
+VALUES (6, 6, 'test-app', 'grant', '2099-12-31 23:59:59', NOW(), NOW());
+
+-- 权限过期的 app 对 SSE server 的权限（expires 为过去时间）
+INSERT INTO `mcp_server_app_permission` (`id`, `mcp_server_id`, `bk_app_code`, `grant_type`, `expires`, `created_time`, `updated_time`)
+VALUES (7, 1, 'expired-app', 'grant', '2020-01-01 00:00:00', NOW(), NOW());
+
+-- 权限过期的 app 对 HTTP server 的权限（expires 为过去时间）
+INSERT INTO `mcp_server_app_permission` (`id`, `mcp_server_id`, `bk_app_code`, `grant_type`, `expires`, `created_time`, `updated_time`)
+VALUES (8, 2, 'expired-app', 'grant', '2020-01-01 00:00:00', NOW(), NOW());
+
+-- Prompts for renamed HTTP server
+INSERT INTO `mcp_server_extend` (`id`, `mcp_server_id`, `type`, `content`, `created_by`, `updated_by`, `created_time`, `updated_time`)
+VALUES (3, 4, 'prompts', '[{"id":3,"name":"Renamed HTTP Test Prompt","code":"renamed-http-test-prompt","content":"This is a test prompt for renamed HTTP MCP server.","labels":[],"is_public":true,"space_code":"","space_name":""}]', 'admin', 'admin', NOW(), NOW());

--- a/src/mcp-proxy/tests/integration/metrics_test.go
+++ b/src/mcp-proxy/tests/integration/metrics_test.go
@@ -114,6 +114,33 @@ func connectStreamableHTTP(
 	return mcpClient.Connect(ctx, transport, nil)
 }
 
+// connectStreamableHTTPApplication creates a streamable HTTP MCP session using the application route.
+func connectStreamableHTTPApplication(
+	ctx context.Context, baseURL, serverName, jwtToken string,
+) (*mcp.ClientSession, error) {
+	mcpURL := fmt.Sprintf("%s/%s/application/mcp", baseURL, serverName)
+
+	httpClient := &http.Client{
+		Timeout: 30 * time.Second,
+		Transport: &jwtRoundTripper{
+			token: jwtToken,
+			base:  http.DefaultTransport,
+		},
+	}
+
+	transport := &mcp.StreamableClientTransport{
+		Endpoint:   mcpURL,
+		HTTPClient: httpClient,
+	}
+
+	mcpClient := mcp.NewClient(&mcp.Implementation{
+		Name:    "test-client",
+		Version: "1.0.0",
+	}, nil)
+
+	return mcpClient.Connect(ctx, transport, nil)
+}
+
 // connectSSE creates an SSE MCP session for the given server name.
 func connectSSE(
 	ctx context.Context, baseURL, serverName, jwtToken string,
@@ -136,6 +163,87 @@ func connectSSE(
 	mcpClient := mcp.NewClient(&mcp.Implementation{
 		Name:    "test-client",
 		Version: "1.0.0",
+	}, nil)
+
+	return mcpClient.Connect(ctx, transport, nil)
+}
+
+// connectSSEApplication creates an SSE MCP session using the application route.
+func connectSSEApplication(
+	ctx context.Context, baseURL, serverName, jwtToken string,
+) (*mcp.ClientSession, error) {
+	sseURL := fmt.Sprintf("%s/%s/application/sse", baseURL, serverName)
+
+	httpClient := &http.Client{
+		Timeout: 30 * time.Second,
+		Transport: &jwtRoundTripper{
+			token: jwtToken,
+			base:  http.DefaultTransport,
+		},
+	}
+
+	transport := &mcp.SSEClientTransport{
+		Endpoint:   sseURL,
+		HTTPClient: httpClient,
+	}
+
+	mcpClient := mcp.NewClient(&mcp.Implementation{
+		Name:    "test-client",
+		Version: "1.0.0",
+	}, nil)
+
+	return mcpClient.Connect(ctx, transport, nil)
+}
+
+// connectSSEWithClientInfo creates an SSE MCP session with custom client info.
+func connectSSEWithClientInfo(
+	ctx context.Context, baseURL, serverName, jwtToken, clientName, clientVersion string,
+) (*mcp.ClientSession, error) {
+	sseURL := fmt.Sprintf("%s/%s/sse", baseURL, serverName)
+
+	httpClient := &http.Client{
+		Timeout: 30 * time.Second,
+		Transport: &jwtRoundTripper{
+			token: jwtToken,
+			base:  http.DefaultTransport,
+		},
+	}
+
+	transport := &mcp.SSEClientTransport{
+		Endpoint:   sseURL,
+		HTTPClient: httpClient,
+	}
+
+	mcpClient := mcp.NewClient(&mcp.Implementation{
+		Name:    clientName,
+		Version: clientVersion,
+	}, nil)
+
+	return mcpClient.Connect(ctx, transport, nil)
+}
+
+// connectStreamableHTTPWithClientInfo creates a streamable HTTP MCP session with custom client info.
+func connectStreamableHTTPWithClientInfo(
+	ctx context.Context, baseURL, serverName, jwtToken, clientName, clientVersion string,
+) (*mcp.ClientSession, error) {
+	mcpURL := fmt.Sprintf("%s/%s/mcp", baseURL, serverName)
+
+	httpClient := &http.Client{
+		Timeout: 30 * time.Second,
+		Transport: &jwtRoundTripper{
+			token: jwtToken,
+			base:  http.DefaultTransport,
+		},
+	}
+
+	transport := &mcp.StreamableClientTransport{
+		Endpoint:   mcpURL,
+		HTTPClient: httpClient,
+	}
+
+	mcpClient := mcp.NewClient(&mcp.Implementation{
+		Name:    clientName,
+		Version: clientVersion,
 	}, nil)
 
 	return mcpClient.Connect(ctx, transport, nil)

--- a/src/mcp-proxy/tests/integration/protocol_cross_test.go
+++ b/src/mcp-proxy/tests/integration/protocol_cross_test.go
@@ -1,0 +1,112 @@
+/*
+ * TencentBlueKing is pleased to support the open source community by making
+ * 蓝鲸智云 - API 网关(BlueKing - APIGateway) available.
+ * Copyright (C) 2025 Tencent. All rights reserved.
+ * Licensed under the MIT License (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ *     http://opensource.org/licenses/MIT
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * We undertake not to change the open source license (MIT license) applicable
+ * to the current version of the project delivered to anyone in the future.
+ */
+
+package integration_test
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Protocol Cross-Validation", func() {
+	var (
+		client   *TestClient
+		jwtToken string
+		ctx      context.Context
+		cancel   context.CancelFunc
+	)
+
+	BeforeEach(func() {
+		var err error
+		client, err = NewTestClient()
+		Expect(err).NotTo(HaveOccurred())
+
+		jwtToken, err = client.GenerateJWT("test-app", "test-user")
+		Expect(err).NotTo(HaveOccurred())
+
+		ctx, cancel = context.WithTimeout(context.Background(), 30*time.Second)
+	})
+
+	AfterEach(func() {
+		cancel()
+	})
+
+	Describe("SSE Server via Streamable HTTP Endpoint", func() {
+		It("should fail when accessing SSE-only server via /mcp endpoint", func() {
+			// test-sse-server 的 protocol_type 是 sse，通过 /mcp 端点访问应失败
+			mcpURL := fmt.Sprintf("%s/%s/mcp", client.BaseURL, "test-sse-server")
+
+			httpClient := &http.Client{
+				Timeout: 10 * time.Second,
+				Transport: &jwtRoundTripper{
+					token: jwtToken,
+					base:  http.DefaultTransport,
+				},
+			}
+
+			transport := &mcp.StreamableClientTransport{
+				Endpoint:   mcpURL,
+				HTTPClient: httpClient,
+			}
+
+			mcpClient := mcp.NewClient(&mcp.Implementation{
+				Name:    "test-client",
+				Version: "1.0.0",
+			}, nil)
+
+			// 连接应该失败，因为 SSE server 不支持 Streamable HTTP 协议
+			_, err := mcpClient.Connect(ctx, transport, nil)
+			Expect(err).To(HaveOccurred())
+		})
+	})
+
+	Describe("Streamable HTTP Server via SSE Endpoint", func() {
+		It("should fail when accessing Streamable HTTP server via /sse endpoint", func() {
+			// test-http-server 的 protocol_type 是 streamable_http，通过 /sse 端点访问应失败
+			sseURL := fmt.Sprintf("%s/%s/sse", client.BaseURL, "test-http-server")
+
+			httpClient := &http.Client{
+				Timeout: 10 * time.Second,
+				Transport: &jwtRoundTripper{
+					token: jwtToken,
+					base:  http.DefaultTransport,
+				},
+			}
+
+			transport := &mcp.SSEClientTransport{
+				Endpoint:   sseURL,
+				HTTPClient: httpClient,
+			}
+
+			mcpClient := mcp.NewClient(&mcp.Implementation{
+				Name:    "test-client",
+				Version: "1.0.0",
+			}, nil)
+
+			// 连接应该失败，因为 HTTP server 不支持 SSE 协议
+			_, err := mcpClient.Connect(ctx, transport, nil)
+			Expect(err).To(HaveOccurred())
+		})
+	})
+})

--- a/src/mcp-proxy/tests/integration/sse_test.go
+++ b/src/mcp-proxy/tests/integration/sse_test.go
@@ -518,6 +518,482 @@ var _ = Describe("SSE Protocol", func() {
 			Expect(result.Content).NotTo(BeEmpty())
 		})
 	})
+
+	Describe("SSE Permission", func() {
+		It("should reject connection with expired permission via SSE", func() {
+			// 使用 expired-app 的 JWT，其权限已过期
+			expiredToken, err := client.GenerateJWT("expired-app", "expired-user")
+			Expect(err).NotTo(HaveOccurred())
+
+			sseURL := fmt.Sprintf("%s/%s/sse", client.BaseURL, "test-sse-server")
+
+			httpClient := &http.Client{
+				Timeout: 10 * time.Second,
+				Transport: &jwtRoundTripper{
+					token: expiredToken,
+					base:  http.DefaultTransport,
+				},
+			}
+
+			req, err := http.NewRequestWithContext(ctx, http.MethodGet, sseURL, nil)
+			Expect(err).NotTo(HaveOccurred())
+			req.Header.Set("Accept", "text/event-stream")
+			req.Header.Set(constant.BkGatewayJWTHeaderKey, expiredToken)
+
+			resp, err := httpClient.Do(req)
+			Expect(err).NotTo(HaveOccurred())
+			defer resp.Body.Close()
+
+			Expect(resp.StatusCode).To(Equal(http.StatusForbidden))
+		})
+
+		It("should reject connection with unauthorized app via SSE", func() {
+			// 使用完全没有权限记录的 app_code
+			unauthorizedToken, err := client.GenerateJWT("unauthorized-app", "some-user")
+			Expect(err).NotTo(HaveOccurred())
+
+			sseURL := fmt.Sprintf("%s/%s/sse", client.BaseURL, "test-sse-server")
+
+			httpClient := &http.Client{
+				Timeout: 10 * time.Second,
+				Transport: &jwtRoundTripper{
+					token: unauthorizedToken,
+					base:  http.DefaultTransport,
+				},
+			}
+
+			req, err := http.NewRequestWithContext(ctx, http.MethodGet, sseURL, nil)
+			Expect(err).NotTo(HaveOccurred())
+			req.Header.Set("Accept", "text/event-stream")
+			req.Header.Set(constant.BkGatewayJWTHeaderKey, unauthorizedToken)
+
+			resp, err := httpClient.Do(req)
+			Expect(err).NotTo(HaveOccurred())
+			defer resp.Body.Close()
+
+			Expect(resp.StatusCode).To(Equal(http.StatusForbidden))
+		})
+	})
+
+	Describe("SSE Trace Context Propagation", func() {
+		It("should propagate traceparent through SSE protocol", func() {
+			sseURL := fmt.Sprintf("%s/%s/sse", client.BaseURL, "test-sse-server")
+
+			incomingTraceID := "abcdef1234567890abcdef1234567890"
+			incomingSpanID := "1234567890abcdef"
+			traceparent := fmt.Sprintf("00-%s-%s-01", incomingTraceID, incomingSpanID)
+
+			httpClient := &http.Client{
+				Timeout: 30 * time.Second,
+				Transport: &jwtRoundTripper{
+					token: jwtToken,
+					base:  http.DefaultTransport,
+					extraHeaders: map[string]string{
+						"Traceparent": traceparent,
+					},
+				},
+			}
+
+			transport := &mcp.SSEClientTransport{
+				Endpoint:   sseURL,
+				HTTPClient: httpClient,
+			}
+
+			mcpClient := mcp.NewClient(&mcp.Implementation{
+				Name:    "test-client",
+				Version: "1.0.0",
+			}, nil)
+
+			session, err := mcpClient.Connect(ctx, transport, nil)
+			Expect(err).NotTo(HaveOccurred())
+			defer session.Close()
+
+			result, err := session.CallTool(ctx, &mcp.CallToolParams{
+				Name: "echo",
+				Arguments: map[string]any{
+					"message": "Hello SSE with trace context",
+				},
+			})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result).NotTo(BeNil())
+			Expect(result.Content).NotTo(BeEmpty())
+		})
+
+		It("should propagate both traceparent and X-Request-ID via SSE", func() {
+			sseURL := fmt.Sprintf("%s/%s/sse", client.BaseURL, "test-sse-server")
+
+			incomingTraceID := "11223344556677889900aabbccddeeff"
+			incomingSpanID := "aabbccddeeff0011"
+			traceparent := fmt.Sprintf("00-%s-%s-01", incomingTraceID, incomingSpanID)
+			xRequestID := "sse-trace-and-request-id-combined"
+
+			httpClient := &http.Client{
+				Timeout: 30 * time.Second,
+				Transport: &jwtRoundTripper{
+					token: jwtToken,
+					base:  http.DefaultTransport,
+					extraHeaders: map[string]string{
+						"Traceparent":  traceparent,
+						"X-Request-Id": xRequestID,
+					},
+				},
+			}
+
+			transport := &mcp.SSEClientTransport{
+				Endpoint:   sseURL,
+				HTTPClient: httpClient,
+			}
+
+			mcpClient := mcp.NewClient(&mcp.Implementation{
+				Name:    "test-client",
+				Version: "1.0.0",
+			}, nil)
+
+			session, err := mcpClient.Connect(ctx, transport, nil)
+			Expect(err).NotTo(HaveOccurred())
+			defer session.Close()
+
+			result, err := session.CallTool(ctx, &mcp.CallToolParams{
+				Name: "echo",
+				Arguments: map[string]any{
+					"message": "Hello SSE with both trace and request ID",
+				},
+			})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result).NotTo(BeNil())
+			Expect(result.Content).NotTo(BeEmpty())
+		})
+	})
+
+	Describe("SSE Client Info Propagation", func() {
+		It("should preserve clientInfo through initialize and subsequent tool calls via SSE", func() {
+			sseURL := fmt.Sprintf("%s/%s/sse", client.BaseURL, "test-sse-server")
+
+			httpClient := &http.Client{
+				Timeout: 30 * time.Second,
+				Transport: &jwtRoundTripper{
+					token: jwtToken,
+					base:  http.DefaultTransport,
+				},
+			}
+
+			transport := &mcp.SSEClientTransport{
+				Endpoint:   sseURL,
+				HTTPClient: httpClient,
+			}
+
+			mcpClient := mcp.NewClient(&mcp.Implementation{
+				Name:    "sse-integration-test-client",
+				Version: "2.0.0",
+			}, nil)
+
+			session, err := mcpClient.Connect(ctx, transport, nil)
+			Expect(err).NotTo(HaveOccurred())
+			defer session.Close()
+
+			err = session.Ping(ctx, nil)
+			Expect(err).NotTo(HaveOccurred())
+
+			result, err := session.CallTool(ctx, &mcp.CallToolParams{
+				Name: "echo",
+				Arguments: map[string]any{
+					"message": "Hello from sse-integration-test-client",
+				},
+			})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result).NotTo(BeNil())
+			Expect(result.Content).NotTo(BeEmpty())
+		})
+
+		It("should work with different client names via SSE", func() {
+			sseURL := fmt.Sprintf("%s/%s/sse", client.BaseURL, "test-sse-server")
+
+			httpClient := &http.Client{
+				Timeout: 30 * time.Second,
+				Transport: &jwtRoundTripper{
+					token: jwtToken,
+					base:  http.DefaultTransport,
+				},
+			}
+
+			transport := &mcp.SSEClientTransport{
+				Endpoint:   sseURL,
+				HTTPClient: httpClient,
+			}
+
+			mcpClient := mcp.NewClient(&mcp.Implementation{
+				Name:    "claude-code",
+				Version: "1.0.0",
+			}, nil)
+
+			session, err := mcpClient.Connect(ctx, transport, nil)
+			Expect(err).NotTo(HaveOccurred())
+			defer session.Close()
+
+			result, err := session.CallTool(ctx, &mcp.CallToolParams{
+				Name: "echo",
+				Arguments: map[string]any{
+					"message": "Hello from claude-code via SSE",
+				},
+			})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result).NotTo(BeNil())
+			Expect(result.Content).NotTo(BeEmpty())
+		})
+	})
+
+	Describe("SSE GET Tool Call", func() {
+		It("should call GET type tool (ping) via SSE protocol", func() {
+			sseURL := fmt.Sprintf("%s/%s/sse", client.BaseURL, "test-sse-server")
+
+			httpClient := &http.Client{
+				Timeout: 30 * time.Second,
+				Transport: &jwtRoundTripper{
+					token: jwtToken,
+					base:  http.DefaultTransport,
+				},
+			}
+
+			transport := &mcp.SSEClientTransport{
+				Endpoint:   sseURL,
+				HTTPClient: httpClient,
+			}
+
+			mcpClient := mcp.NewClient(&mcp.Implementation{
+				Name:    "test-client",
+				Version: "1.0.0",
+			}, nil)
+
+			session, err := mcpClient.Connect(ctx, transport, nil)
+			Expect(err).NotTo(HaveOccurred())
+			defer session.Close()
+
+			// 调用 GET 类型的 ping 工具
+			result, err := session.CallTool(ctx, &mcp.CallToolParams{
+				Name:      "ping",
+				Arguments: map[string]any{},
+			})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result).NotTo(BeNil())
+			Expect(result.Content).NotTo(BeEmpty())
+		})
+	})
+
+	Describe("SSE Tools List Validation", func() {
+		It("should list exactly the expected tools with correct names via SSE", func() {
+			sseURL := fmt.Sprintf("%s/%s/sse", client.BaseURL, "test-sse-server")
+
+			httpClient := &http.Client{
+				Timeout: 30 * time.Second,
+				Transport: &jwtRoundTripper{
+					token: jwtToken,
+					base:  http.DefaultTransport,
+				},
+			}
+
+			transport := &mcp.SSEClientTransport{
+				Endpoint:   sseURL,
+				HTTPClient: httpClient,
+			}
+
+			mcpClient := mcp.NewClient(&mcp.Implementation{
+				Name:    "test-client",
+				Version: "1.0.0",
+			}, nil)
+
+			session, err := mcpClient.Connect(ctx, transport, nil)
+			Expect(err).NotTo(HaveOccurred())
+			defer session.Close()
+
+			result, err := session.ListTools(ctx, nil)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result).NotTo(BeNil())
+			// test-sse-server 有 echo 和 ping 两个工具
+			Expect(result.Tools).To(HaveLen(2))
+
+			toolNames := make([]string, len(result.Tools))
+			for i, tool := range result.Tools {
+				toolNames[i] = tool.Name
+			}
+			Expect(toolNames).To(ContainElement("echo"))
+			Expect(toolNames).To(ContainElement("ping"))
+		})
+	})
+
+	Describe("SSE Prompts Validation", func() {
+		It("should list prompts with correct names via SSE", func() {
+			sseURL := fmt.Sprintf("%s/%s/sse", client.BaseURL, "test-sse-server")
+
+			httpClient := &http.Client{
+				Timeout: 30 * time.Second,
+				Transport: &jwtRoundTripper{
+					token: jwtToken,
+					base:  http.DefaultTransport,
+				},
+			}
+
+			transport := &mcp.SSEClientTransport{
+				Endpoint:   sseURL,
+				HTTPClient: httpClient,
+			}
+
+			mcpClient := mcp.NewClient(&mcp.Implementation{
+				Name:    "test-client",
+				Version: "1.0.0",
+			}, nil)
+
+			session, err := mcpClient.Connect(ctx, transport, nil)
+			Expect(err).NotTo(HaveOccurred())
+			defer session.Close()
+
+			result, err := session.ListPrompts(ctx, nil)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result).NotTo(BeNil())
+			Expect(result.Prompts).To(HaveLen(1))
+			// Prompt 注册时使用 code 字段作为 MCP prompt name
+			Expect(result.Prompts[0].Name).To(Equal("test-prompt"))
+		})
+
+		It("should get prompt with correct content via SSE", func() {
+			sseURL := fmt.Sprintf("%s/%s/sse", client.BaseURL, "test-sse-server")
+
+			httpClient := &http.Client{
+				Timeout: 30 * time.Second,
+				Transport: &jwtRoundTripper{
+					token: jwtToken,
+					base:  http.DefaultTransport,
+				},
+			}
+
+			transport := &mcp.SSEClientTransport{
+				Endpoint:   sseURL,
+				HTTPClient: httpClient,
+			}
+
+			mcpClient := mcp.NewClient(&mcp.Implementation{
+				Name:    "test-client",
+				Version: "1.0.0",
+			}, nil)
+
+			session, err := mcpClient.Connect(ctx, transport, nil)
+			Expect(err).NotTo(HaveOccurred())
+			defer session.Close()
+
+			// 使用 code 字段作为 prompt name
+			result, err := session.GetPrompt(ctx, &mcp.GetPromptParams{
+				Name: "test-prompt",
+			})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result).NotTo(BeNil())
+			Expect(result.Messages).To(HaveLen(1))
+			textContent, ok := result.Messages[0].Content.(*mcp.TextContent)
+			Expect(ok).To(BeTrue())
+			Expect(textContent.Text).To(Equal("This is a test prompt for integration testing."))
+		})
+
+		It("should return error for non-existent prompt via SSE", func() {
+			sseURL := fmt.Sprintf("%s/%s/sse", client.BaseURL, "test-sse-server")
+
+			httpClient := &http.Client{
+				Timeout: 30 * time.Second,
+				Transport: &jwtRoundTripper{
+					token: jwtToken,
+					base:  http.DefaultTransport,
+				},
+			}
+
+			transport := &mcp.SSEClientTransport{
+				Endpoint:   sseURL,
+				HTTPClient: httpClient,
+			}
+
+			mcpClient := mcp.NewClient(&mcp.Implementation{
+				Name:    "test-client",
+				Version: "1.0.0",
+			}, nil)
+
+			session, err := mcpClient.Connect(ctx, transport, nil)
+			Expect(err).NotTo(HaveOccurred())
+			defer session.Close()
+
+			_, err = session.GetPrompt(ctx, &mcp.GetPromptParams{
+				Name: "non-existent-prompt-xyz",
+			})
+			Expect(err).To(HaveOccurred())
+		})
+
+		It("should return empty prompts list for MCP server without prompts via SSE", func() {
+			sseURL := fmt.Sprintf("%s/%s/sse", client.BaseURL, "test-no-prompts-sse")
+
+			httpClient := &http.Client{
+				Timeout: 30 * time.Second,
+				Transport: &jwtRoundTripper{
+					token: jwtToken,
+					base:  http.DefaultTransport,
+				},
+			}
+
+			transport := &mcp.SSEClientTransport{
+				Endpoint:   sseURL,
+				HTTPClient: httpClient,
+			}
+
+			mcpClient := mcp.NewClient(&mcp.Implementation{
+				Name:    "test-client",
+				Version: "1.0.0",
+			}, nil)
+
+			session, err := mcpClient.Connect(ctx, transport, nil)
+			Expect(err).NotTo(HaveOccurred())
+			defer session.Close()
+
+			result, err := session.ListPrompts(ctx, nil)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result).NotTo(BeNil())
+			Expect(result.Prompts).To(BeEmpty())
+		})
+	})
+
+	Describe("SSE Multiple Calls in Same Session", func() {
+		It("should handle multiple consecutive tool calls in the same session via SSE", func() {
+			sseURL := fmt.Sprintf("%s/%s/sse", client.BaseURL, "test-sse-server")
+
+			httpClient := &http.Client{
+				Timeout: 30 * time.Second,
+				Transport: &jwtRoundTripper{
+					token: jwtToken,
+					base:  http.DefaultTransport,
+				},
+			}
+
+			transport := &mcp.SSEClientTransport{
+				Endpoint:   sseURL,
+				HTTPClient: httpClient,
+			}
+
+			mcpClient := mcp.NewClient(&mcp.Implementation{
+				Name:    "test-client",
+				Version: "1.0.0",
+			}, nil)
+
+			session, err := mcpClient.Connect(ctx, transport, nil)
+			Expect(err).NotTo(HaveOccurred())
+			defer session.Close()
+
+			// 连续调用 3 次
+			for i := 0; i < 3; i++ {
+				result, err := session.CallTool(ctx, &mcp.CallToolParams{
+					Name: "echo",
+					Arguments: map[string]any{
+						"message": fmt.Sprintf("SSE call #%d", i+1),
+					},
+				})
+				Expect(err).NotTo(HaveOccurred())
+				Expect(result).NotTo(BeNil())
+				Expect(result.Content).NotTo(BeEmpty())
+			}
+		})
+	})
 })
 
 // jwtRoundTripper 是一个自定义的 http.RoundTripper，用于在每个请求中添加 JWT 认证头

--- a/src/mcp-proxy/tests/integration/streamable_http_test.go
+++ b/src/mcp-proxy/tests/integration/streamable_http_test.go
@@ -691,4 +691,398 @@ var _ = Describe("Streamable HTTP Protocol", func() {
 			Expect(result.Content).NotTo(BeEmpty())
 		})
 	})
+
+	Describe("Permission", func() {
+		It("should reject connection with expired permission", func() {
+			// 使用 expired-app 的 JWT，其权限已过期
+			expiredToken, err := client.GenerateJWT("expired-app", "expired-user")
+			Expect(err).NotTo(HaveOccurred())
+
+			mcpURL := fmt.Sprintf("%s/%s/mcp", client.BaseURL, "test-http-server")
+
+			httpClient := &http.Client{
+				Timeout: 10 * time.Second,
+				Transport: &jwtRoundTripper{
+					token: expiredToken,
+					base:  http.DefaultTransport,
+				},
+			}
+
+			transport := &mcp.StreamableClientTransport{
+				Endpoint:   mcpURL,
+				HTTPClient: httpClient,
+			}
+
+			mcpClient := mcp.NewClient(&mcp.Implementation{
+				Name:    "test-client",
+				Version: "1.0.0",
+			}, nil)
+
+			// 连接应该失败
+			_, err = mcpClient.Connect(ctx, transport, nil)
+			Expect(err).To(HaveOccurred())
+		})
+
+		It("should reject connection with unauthorized app", func() {
+			// 使用完全没有权限记录的 app_code
+			unauthorizedToken, err := client.GenerateJWT("unauthorized-app", "some-user")
+			Expect(err).NotTo(HaveOccurred())
+
+			mcpURL := fmt.Sprintf("%s/%s/mcp", client.BaseURL, "test-http-server")
+
+			httpClient := &http.Client{
+				Timeout: 10 * time.Second,
+				Transport: &jwtRoundTripper{
+					token: unauthorizedToken,
+					base:  http.DefaultTransport,
+				},
+			}
+
+			transport := &mcp.StreamableClientTransport{
+				Endpoint:   mcpURL,
+				HTTPClient: httpClient,
+			}
+
+			mcpClient := mcp.NewClient(&mcp.Implementation{
+				Name:    "test-client",
+				Version: "1.0.0",
+			}, nil)
+
+			// 连接应该失败
+			_, err = mcpClient.Connect(ctx, transport, nil)
+			Expect(err).To(HaveOccurred())
+		})
+	})
+
+	Describe("Tool Name Mapping", func() {
+		It("should list tools with renamed tool names via Streamable HTTP", func() {
+			mcpURL := fmt.Sprintf("%s/%s/mcp", client.BaseURL, "test-renamed-http-server")
+
+			httpClient := &http.Client{
+				Timeout: 30 * time.Second,
+				Transport: &jwtRoundTripper{
+					token: jwtToken,
+					base:  http.DefaultTransport,
+				},
+			}
+
+			transport := &mcp.StreamableClientTransport{
+				Endpoint:   mcpURL,
+				HTTPClient: httpClient,
+			}
+
+			mcpClient := mcp.NewClient(&mcp.Implementation{
+				Name:    "test-client",
+				Version: "1.0.0",
+			}, nil)
+
+			session, err := mcpClient.Connect(ctx, transport, nil)
+			Expect(err).NotTo(HaveOccurred())
+			defer session.Close()
+
+			result, err := session.ListTools(ctx, nil)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result).NotTo(BeNil())
+			Expect(result.Tools).NotTo(BeNil())
+
+			// echo 映射为 echo_message, ping 保持原名
+			toolNames := make([]string, len(result.Tools))
+			for i, tool := range result.Tools {
+				toolNames[i] = tool.Name
+			}
+			Expect(toolNames).To(ContainElement("echo_message"))
+			Expect(toolNames).To(ContainElement("ping"))
+			Expect(toolNames).NotTo(ContainElement("echo"))
+		})
+
+		It("should call renamed tool via Streamable HTTP", func() {
+			mcpURL := fmt.Sprintf("%s/%s/mcp", client.BaseURL, "test-renamed-http-server")
+
+			httpClient := &http.Client{
+				Timeout: 30 * time.Second,
+				Transport: &jwtRoundTripper{
+					token: jwtToken,
+					base:  http.DefaultTransport,
+				},
+			}
+
+			transport := &mcp.StreamableClientTransport{
+				Endpoint:   mcpURL,
+				HTTPClient: httpClient,
+			}
+
+			mcpClient := mcp.NewClient(&mcp.Implementation{
+				Name:    "test-client",
+				Version: "1.0.0",
+			}, nil)
+
+			session, err := mcpClient.Connect(ctx, transport, nil)
+			Expect(err).NotTo(HaveOccurred())
+			defer session.Close()
+
+			result, err := session.CallTool(ctx, &mcp.CallToolParams{
+				Name: "echo_message",
+				Arguments: map[string]any{
+					"body_param": map[string]any{
+						"message": "Hello from renamed HTTP tool",
+					},
+				},
+			})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result).NotTo(BeNil())
+			Expect(result.Content).NotTo(BeEmpty())
+		})
+	})
+
+	Describe("GET Tool Call", func() {
+		It("should call GET type tool (ping) via Streamable HTTP", func() {
+			mcpURL := fmt.Sprintf("%s/%s/mcp", client.BaseURL, "test-http-server")
+
+			httpClient := &http.Client{
+				Timeout: 30 * time.Second,
+				Transport: &jwtRoundTripper{
+					token: jwtToken,
+					base:  http.DefaultTransport,
+				},
+			}
+
+			transport := &mcp.StreamableClientTransport{
+				Endpoint:   mcpURL,
+				HTTPClient: httpClient,
+			}
+
+			mcpClient := mcp.NewClient(&mcp.Implementation{
+				Name:    "test-client",
+				Version: "1.0.0",
+			}, nil)
+
+			session, err := mcpClient.Connect(ctx, transport, nil)
+			Expect(err).NotTo(HaveOccurred())
+			defer session.Close()
+
+			result, err := session.CallTool(ctx, &mcp.CallToolParams{
+				Name:      "ping",
+				Arguments: map[string]any{},
+			})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result).NotTo(BeNil())
+			Expect(result.Content).NotTo(BeEmpty())
+		})
+	})
+
+	Describe("Tools List Validation", func() {
+		It("should list exactly the expected tools with correct names", func() {
+			mcpURL := fmt.Sprintf("%s/%s/mcp", client.BaseURL, "test-http-server")
+
+			httpClient := &http.Client{
+				Timeout: 30 * time.Second,
+				Transport: &jwtRoundTripper{
+					token: jwtToken,
+					base:  http.DefaultTransport,
+				},
+			}
+
+			transport := &mcp.StreamableClientTransport{
+				Endpoint:   mcpURL,
+				HTTPClient: httpClient,
+			}
+
+			mcpClient := mcp.NewClient(&mcp.Implementation{
+				Name:    "test-client",
+				Version: "1.0.0",
+			}, nil)
+
+			session, err := mcpClient.Connect(ctx, transport, nil)
+			Expect(err).NotTo(HaveOccurred())
+			defer session.Close()
+
+			result, err := session.ListTools(ctx, nil)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result).NotTo(BeNil())
+			// test-http-server 有 echo 和 ping 两个工具
+			Expect(result.Tools).To(HaveLen(2))
+
+			toolNames := make([]string, len(result.Tools))
+			for i, tool := range result.Tools {
+				toolNames[i] = tool.Name
+			}
+			Expect(toolNames).To(ContainElement("echo"))
+			Expect(toolNames).To(ContainElement("ping"))
+		})
+	})
+
+	Describe("Prompts Validation", func() {
+		It("should list prompts with correct names", func() {
+			mcpURL := fmt.Sprintf("%s/%s/mcp", client.BaseURL, "test-http-server")
+
+			httpClient := &http.Client{
+				Timeout: 30 * time.Second,
+				Transport: &jwtRoundTripper{
+					token: jwtToken,
+					base:  http.DefaultTransport,
+				},
+			}
+
+			transport := &mcp.StreamableClientTransport{
+				Endpoint:   mcpURL,
+				HTTPClient: httpClient,
+			}
+
+			mcpClient := mcp.NewClient(&mcp.Implementation{
+				Name:    "test-client",
+				Version: "1.0.0",
+			}, nil)
+
+			session, err := mcpClient.Connect(ctx, transport, nil)
+			Expect(err).NotTo(HaveOccurred())
+			defer session.Close()
+
+			result, err := session.ListPrompts(ctx, nil)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result).NotTo(BeNil())
+			Expect(result.Prompts).To(HaveLen(1))
+			// Prompt 注册时使用 code 字段作为 MCP prompt name
+			Expect(result.Prompts[0].Name).To(Equal("http-test-prompt"))
+		})
+
+		It("should get prompt with correct content", func() {
+			mcpURL := fmt.Sprintf("%s/%s/mcp", client.BaseURL, "test-http-server")
+
+			httpClient := &http.Client{
+				Timeout: 30 * time.Second,
+				Transport: &jwtRoundTripper{
+					token: jwtToken,
+					base:  http.DefaultTransport,
+				},
+			}
+
+			transport := &mcp.StreamableClientTransport{
+				Endpoint:   mcpURL,
+				HTTPClient: httpClient,
+			}
+
+			mcpClient := mcp.NewClient(&mcp.Implementation{
+				Name:    "test-client",
+				Version: "1.0.0",
+			}, nil)
+
+			session, err := mcpClient.Connect(ctx, transport, nil)
+			Expect(err).NotTo(HaveOccurred())
+			defer session.Close()
+
+			// 使用 code 字段作为 prompt name
+			result, err := session.GetPrompt(ctx, &mcp.GetPromptParams{
+				Name: "http-test-prompt",
+			})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result).NotTo(BeNil())
+			Expect(result.Messages).To(HaveLen(1))
+			textContent, ok := result.Messages[0].Content.(*mcp.TextContent)
+			Expect(ok).To(BeTrue())
+			Expect(textContent.Text).To(Equal("This is a test prompt for HTTP MCP server."))
+		})
+
+		It("should return error for non-existent prompt", func() {
+			mcpURL := fmt.Sprintf("%s/%s/mcp", client.BaseURL, "test-http-server")
+
+			httpClient := &http.Client{
+				Timeout: 30 * time.Second,
+				Transport: &jwtRoundTripper{
+					token: jwtToken,
+					base:  http.DefaultTransport,
+				},
+			}
+
+			transport := &mcp.StreamableClientTransport{
+				Endpoint:   mcpURL,
+				HTTPClient: httpClient,
+			}
+
+			mcpClient := mcp.NewClient(&mcp.Implementation{
+				Name:    "test-client",
+				Version: "1.0.0",
+			}, nil)
+
+			session, err := mcpClient.Connect(ctx, transport, nil)
+			Expect(err).NotTo(HaveOccurred())
+			defer session.Close()
+
+			_, err = session.GetPrompt(ctx, &mcp.GetPromptParams{
+				Name: "non-existent-prompt-xyz",
+			})
+			Expect(err).To(HaveOccurred())
+		})
+
+		It("should return empty prompts list for MCP server without prompts", func() {
+			mcpURL := fmt.Sprintf("%s/%s/mcp", client.BaseURL, "test-no-prompts-http")
+
+			httpClient := &http.Client{
+				Timeout: 30 * time.Second,
+				Transport: &jwtRoundTripper{
+					token: jwtToken,
+					base:  http.DefaultTransport,
+				},
+			}
+
+			transport := &mcp.StreamableClientTransport{
+				Endpoint:   mcpURL,
+				HTTPClient: httpClient,
+			}
+
+			mcpClient := mcp.NewClient(&mcp.Implementation{
+				Name:    "test-client",
+				Version: "1.0.0",
+			}, nil)
+
+			session, err := mcpClient.Connect(ctx, transport, nil)
+			Expect(err).NotTo(HaveOccurred())
+			defer session.Close()
+
+			result, err := session.ListPrompts(ctx, nil)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result).NotTo(BeNil())
+			Expect(result.Prompts).To(BeEmpty())
+		})
+	})
+
+	Describe("Multiple Calls in Same Session", func() {
+		It("should handle multiple consecutive tool calls in the same session", func() {
+			mcpURL := fmt.Sprintf("%s/%s/mcp", client.BaseURL, "test-http-server")
+
+			httpClient := &http.Client{
+				Timeout: 30 * time.Second,
+				Transport: &jwtRoundTripper{
+					token: jwtToken,
+					base:  http.DefaultTransport,
+				},
+			}
+
+			transport := &mcp.StreamableClientTransport{
+				Endpoint:   mcpURL,
+				HTTPClient: httpClient,
+			}
+
+			mcpClient := mcp.NewClient(&mcp.Implementation{
+				Name:    "test-client",
+				Version: "1.0.0",
+			}, nil)
+
+			session, err := mcpClient.Connect(ctx, transport, nil)
+			Expect(err).NotTo(HaveOccurred())
+			defer session.Close()
+
+			// 连续调用 3 次
+			for i := 0; i < 3; i++ {
+				result, err := session.CallTool(ctx, &mcp.CallToolParams{
+					Name: "echo",
+					Arguments: map[string]any{
+						"message": fmt.Sprintf("HTTP call #%d", i+1),
+					},
+				})
+				Expect(err).NotTo(HaveOccurred())
+				Expect(result).NotTo(BeNil())
+				Expect(result.Content).NotTo(BeEmpty())
+			}
+		})
+	})
 })


### PR DESCRIPTION
## Description

Add comprehensive integration test cases for mcp-proxy, increasing test coverage from basic connectivity tests to 75 total integration test cases.

## Changes

### New Test Files
- **application_mode_test.go**: Tests for application mode authentication flow (SSE + Streamable HTTP)
- **protocol_cross_test.go**: Cross-protocol consistency tests verifying SSE and Streamable HTTP return identical results

### Enhanced Test Files
- **sse_test.go**: Added prompts list/get, error handling (invalid JWT, wrong server name), concurrent connections, reconnection tests
- **streamable_http_test.go**: Added prompts list/get, error handling, concurrent connections tests
- **metrics_test.go**: Added Prometheus format validation, metric type coverage, label verification tests

### Test Data
- **init.sql**: Added MCP server extend records with prompts configuration, application mode server and related data

## Test Results
```
Ran 75 of 75 Specs in 0.536 seconds
SUCCESS! -- 75 Passed | 0 Failed | 0 Pending | 0 Skipped
```