### PR TITLE
fix(mcp-server-log): fix chain status detection and total latency correction

### DIFF
--- a/src/dashboard/apigateway/apigateway/biz/mcp_server_log/chain_helpers.py
+++ b/src/dashboard/apigateway/apigateway/biz/mcp_server_log/chain_helpers.py
@@ -62,6 +62,35 @@ def _find_first_mcp_span(span_list: List[Dict]) -> Optional[Dict]:
     return None
 
 
+def _check_has_error(span_list: List[Dict]) -> bool:
+    """递归检查 span 列表中是否存在错误
+
+    判断依据：
+    1. detail 中有 error 字段（MCP 层错误）
+    2. HTTP 状态码 >= 400（HTTP 层错误）
+    """
+    for span in span_list:
+        # 检查 detail.error
+        if span.get("detail", {}).get("error"):
+            return True
+        # 检查 HTTP 状态码（status 字段在 HTTP 层 span 中是 HTTP 状态码）
+        http_status = span.get("status")
+        if http_status is not None and _is_http_error_status(http_status):
+            return True
+        # 递归检查子 span
+        if _check_has_error(span.get("children", [])):
+            return True
+    return False
+
+
+def _is_http_error_status(status) -> bool:
+    """判断 HTTP 状态码是否为错误（>= 400）"""
+    try:
+        return int(status) >= 400
+    except (ValueError, TypeError):
+        return False
+
+
 def _collect_latencies(span_list: List[Dict], total_latency_ms: float, latency_distribution: list) -> None:
     """递归收集各服务的耗时信息"""
     for span in span_list:
@@ -97,12 +126,15 @@ def build_chain_summary(chain_data: dict) -> dict:
     _collect_services(spans, services)
     span_count = _count_spans(spans)
 
-    # 计算状态：如果有任何 error 则为 failed
+    # 计算状态：递归检查所有 span（含子 span）是否存在错误，同时检查上游网关状态
     status = "success"
-    for span in spans:
-        if span.get("detail", {}).get("error"):
+    if _check_has_error(spans):
+        status = "failed"
+    else:
+        # 检查上游网关日志的状态
+        upstream_log = chain_data.get("upstream_gateway_log")
+        if upstream_log and (_is_http_error_status(upstream_log.get("status")) or upstream_log.get("error")):
             status = "failed"
-            break
 
     # 从 HTTP 入口 span 提取公共信息，从第一个 MCP 子 span 提取 MCP 特有信息
     first_span = spans[0] if spans else {}

--- a/src/dashboard/apigateway/apigateway/biz/mcp_server_log/chain_search.py
+++ b/src/dashboard/apigateway/apigateway/biz/mcp_server_log/chain_search.py
@@ -16,7 +16,7 @@
 # to the current version of the project delivered to anyone in the future.
 #
 import logging
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Optional
 
 from django.conf import settings
 
@@ -147,6 +147,10 @@ class MCPServerLogChainSearchClient:
             downstream_gateway_log is not None,
         )
 
+        # 9. 修正总耗时：SSE / Streamable HTTP 场景下 mcp-proxy 的 HTTP span latency 极短，
+        # 应取上游网关 request_duration 和 span 最大结束时间的最大值
+        total_latency_ms = _correct_total_latency(total_latency_ms, upstream_gateway_log)
+
         return {
             "request_id": self._request_id,
             "x_request_id": x_request_id,
@@ -223,6 +227,9 @@ class MCPServerLogChainSearchClient:
             upstream_request_id,
             downstream_gateway_log is not None,
         )
+
+        # 9. 修正总耗时
+        total_latency_ms = _correct_total_latency(total_latency_ms, upstream_gateway_log)
 
         return {
             "request_id": request_id,
@@ -332,3 +339,20 @@ def _extract_timestamp(http_logs: List[Dict], all_logs: List[Dict]):
     if all_logs and all_logs[0].get("timestamp"):
         return all_logs[0]["timestamp"]
     return None
+
+
+def _correct_total_latency(span_latency_ms: float, upstream_gateway_log: Optional[Dict]) -> float:
+    """修正总耗时
+
+    SSE / Streamable HTTP 场景下，mcp-proxy 的 HTTP span latency 极短（仅连接建立耗时），
+    而上游网关 (bk-apigateway) 记录的 request_duration 包含了整个请求的完整耗时。
+    取两者的最大值作为总耗时。
+    """
+    if not upstream_gateway_log:
+        return span_latency_ms
+
+    gateway_duration = upstream_gateway_log.get("request_duration")
+    if gateway_duration is not None:
+        return max(span_latency_ms, float(gateway_duration))
+
+    return span_latency_ms


### PR DESCRIPTION
## Problem Description

There are two issues with MCP Server call chain logs:

1. **Inaccurate status detection**: When the HTTP span status is 404, the overall chain status still shows success. The root cause is that the status check only examines detail.error, without checking HTTP status codes or upstream gateway log status.

2. **Inaccurate total latency in SSE / Streamable HTTP scenarios**: In these long-connection scenarios, the mcp-proxy HTTP span latency is very short (only connection setup time), resulting in inaccurate total latency display.

## Fix Details

### chain_helpers.py
- Add `_check_has_error()`: Recursively check all spans (including child spans) for errors (detail.error or HTTP status code >= 400)
- Add `_is_http_error_status()`: Determine whether an HTTP status code indicates an error
- Add upstream gateway log status checking in `build_chain_summary()`

### chain_search.py
- Add `_correct_total_latency()`: Use `max(span_latency, upstream_gateway_request_duration)` as total latency
- Call the correction logic in both `search_chain()` and `search_chain_by_x_request_id()`