### PR TITLE
test(sync): add second httpbin upstream host

### DIFF
--- a/test/sync/httpbin/definition.yaml
+++ b/test/sync/httpbin/definition.yaml
@@ -26,6 +26,8 @@ stages:
           hosts:
             - host: "http://httpbin"
               weight: 100
+            - host: "http://httpbin:80"
+              weight: 100
 
     mcp_servers:
       - name: "httpbin-mcp-server"


### PR DESCRIPTION
Why this change was needed:
The httpbin sync fixture needs to exercise a backend with multiple upstream nodes, including the explicit default HTTP port form used by gateway sync data.

What changed:
Added http://httpbin:80 as a second weighted host beside the existing http://httpbin backend node in the httpbin definition fixture.

Problem solved:
E2E sync coverage can now validate multiple-node backend handling without introducing a separate service dependency.

### Description

<!-- 关联相关issue Please include a summary of the change and which issue is fixed. -->
<!-- 给出必要的上下文以及review需要的必要信息 Please also include relevant motivation and context. -->

Fixes # (issue)

### Checklist

- [ ] 填写 PR 描述及相关 issue (write PR description and related issue)
- [ ] 代码风格检查通过 (code style check passed)
- [ ] PR 中包含单元测试 (include unit test)
- [ ] 单元测试通过 (unit test passed)
- [ ] 本地开发联调环境验证通过 (local development environment verification passed)
