### PR TITLE
fix(sdk): avoid gateway description in python sdk metadata

### DIFF
--- a/src/dashboard/apigateway/apigateway/apps/support/api_sdk/generators/swagger.py
+++ b/src/dashboard/apigateway/apigateway/apps/support/api_sdk/generators/swagger.py
@@ -57,7 +57,7 @@ class SwaggerTemplateGenerator(Generator):
         exporter = ResourceSwaggerExporter(
             api_version=self.context.version,
             title=self.context.resource_version.gateway.name,
-            description=self.context.resource_version.gateway.description,
+            description=f"an sdk for {self.context.resource_version.gateway.name} on bk-apigateway",
             include_bk_apigateway_resource=False,
         )
 

--- a/src/dashboard/apigateway/apigateway/tests/apps/support/api_sdk/generators/test_swagger.py
+++ b/src/dashboard/apigateway/apigateway/tests/apps/support/api_sdk/generators/test_swagger.py
@@ -15,6 +15,8 @@
 # We undertake not to change the open source license (MIT license) applicable
 # to the current version of the project delivered to anyone in the future.
 #
+import ast
+
 import pytest
 
 from apigateway.apps.support.api_sdk.generators.swagger import PythonTemplateGenerator
@@ -28,3 +30,25 @@ def python_generator(sdk_context):
 def test_python_generator(public_api_resources, output_dir, tmpdir, python_generator: PythonTemplateGenerator):
     python_generator.generate(output_dir, public_api_resources)
     assert tmpdir.join("setup.py").exists()
+
+
+def test_python_generator_uses_safe_setup_py_description(
+    public_api_resources,
+    output_dir,
+    tmpdir,
+    python_generator: PythonTemplateGenerator,
+):
+    gateway = python_generator.context.resource_version.gateway
+    gateway.name = "demo-gateway"
+    gateway.description = "gateway description '''\nINJECTED = 'should stay data'\n#"
+
+    python_generator.generate(output_dir, public_api_resources)
+
+    setup_source = tmpdir.join("setup.py").read()
+    tree = ast.parse(setup_source)
+    setup_call = next(
+        node for node in ast.walk(tree) if isinstance(node, ast.Call) and getattr(node.func, "id", "") == "setup"
+    )
+    description_arg = next(keyword for keyword in setup_call.keywords if keyword.arg == "description")
+    assert isinstance(description_arg.value, ast.Constant)
+    assert description_arg.value.value == "an sdk for demo-gateway on bk-apigateway"


### PR DESCRIPTION
## Summary
- Stop using `gateway.description` as Python SDK generated setup.py metadata.
- Use a fixed SDK description derived from the gateway name instead.
- Add a regression test that parses generated setup.py after a malicious gateway description.

## Verification
- `pytest ... test_swagger.py -q` -> `2 passed`
- `ruff format --check ... swagger.py test_swagger.py` -> `2 files already formatted`
- `ruff check ... swagger.py test_swagger.py` -> `All checks passed!`