### PR TITLE
fix(sdk): avoid gateway description in python sdk metadata

### DIFF
--- a/src/dashboard/apigateway/apigateway/biz/sdk/generators/openapi.py
+++ b/src/dashboard/apigateway/apigateway/biz/sdk/generators/openapi.py
@@ -57,7 +57,7 @@ class OpenAPITemplateGenerator(Generator):
         exporter = OpenAPIExportManager(
             api_version=self.context.version,
             title=self.context.resource_version.gateway.name,
-            description=self.context.resource_version.gateway.description,
+            description=f"an sdk for {self.context.resource_version.gateway.name} on bk-apigateway",
             include_bk_apigateway_resource=False,
         )
 

--- a/src/dashboard/apigateway/apigateway/tests/biz/sdk/generators/test_swagger.py
+++ b/src/dashboard/apigateway/apigateway/tests/biz/sdk/generators/test_swagger.py
@@ -15,6 +15,8 @@
 # We undertake not to change the open source license (MIT license) applicable
 # to the current version of the project delivered to anyone in the future.
 #
+import ast
+
 import pytest
 
 from apigateway.biz.sdk.generators.openapi import PythonTemplateGenerator
@@ -28,3 +30,25 @@ def python_generator(sdk_context):
 def test_python_generator(public_api_resources, output_dir, tmpdir, python_generator: PythonTemplateGenerator):
     python_generator.generate(output_dir, public_api_resources)
     assert tmpdir.join("setup.py").exists()
+
+
+def test_python_generator_uses_safe_setup_py_description(
+    public_api_resources,
+    output_dir,
+    tmpdir,
+    python_generator: PythonTemplateGenerator,
+):
+    gateway = python_generator.context.resource_version.gateway
+    gateway.name = "demo-gateway"
+    gateway.description = "gateway description '''\nINJECTED = 'should stay data'\n#"
+
+    python_generator.generate(output_dir, public_api_resources)
+
+    setup_source = tmpdir.join("setup.py").read()
+    tree = ast.parse(setup_source)
+    setup_call = next(
+        node for node in ast.walk(tree) if isinstance(node, ast.Call) and getattr(node.func, "id", "") == "setup"
+    )
+    description_arg = next(keyword for keyword in setup_call.keywords if keyword.arg == "description")
+    assert isinstance(description_arg.value, ast.Constant)
+    assert description_arg.value.value == "an sdk for demo-gateway on bk-apigateway"


### PR DESCRIPTION
## Summary
- Port the Python SDK metadata injection fix to the refactored master SDK path.
- Stop passing `gateway.description` into SDK OpenAPI metadata used by generated `setup.py`.
- Add a regression test that proves a malicious gateway description no longer breaks generated `setup.py` parsing.

## Verification
- Red test before production fix: `python3 -m pytest --nomigrations --ds apigateway.settings -q apigateway/tests/biz/sdk/generators/test_swagger.py::test_python_generator_uses_safe_setup_py_description` failed with `SyntaxError` from generated `setup.py`.
- After fix: `python3 -m pytest --nomigrations --ds apigateway.settings -q apigateway/tests/biz/sdk/generators/test_swagger.py::test_python_generator_uses_safe_setup_py_description` -> `1 passed`.
- `python3 -m pytest --nomigrations --ds apigateway.settings -q apigateway/tests/biz/sdk/generators/test_swagger.py` -> `2 passed`.
- `ruff format --check --config=pyproject.toml --force-exclude apigateway/apigateway/biz/sdk/generators/openapi.py apigateway/apigateway/tests/biz/sdk/generators/test_swagger.py` -> `2 files already formatted`.
- `ruff check --config=pyproject.toml --force-exclude apigateway/apigateway/biz/sdk/generators/openapi.py apigateway/apigateway/tests/biz/sdk/generators/test_swagger.py` -> `All checks passed!`.
- `make lint-check` -> passed.
- `make test` -> blocked by unrelated untracked `apigateway/tests/healthz/test_views.py`, which fails patching `apigateway.healthz.views.requests` because that module has no `requests` attribute.

## Review
- Reviewed the diff for correctness, security, architecture fit, and test adequacy.
- No required review findings remain.