### PR TITLE
fix(resource-doc): avoid echoing unsafe ref values in import errors

### DIFF
--- a/src/dashboard/apigateway/apigateway/biz/resource_doc/importer/parsers.py
+++ b/src/dashboard/apigateway/apigateway/biz/resource_doc/importer/parsers.py
@@ -230,30 +230,30 @@ class SwaggerParser(BaseParser):
         if not isinstance(data, dict):
             raise UnsafeSwaggerRefError(_("swagger 内容无法解析，无法校验 $ref 安全性"))
 
-        unsafe_refs = SwaggerParser._collect_unsafe_refs(data)
+        unsafe_ref_paths = SwaggerParser._collect_unsafe_ref_paths(data)
 
-        if unsafe_refs:
-            # 截断每个 ref 值，防止过长内容注入
-            sanitized = [ref[:120] for ref in unsafe_refs[:5]]
+        if unsafe_ref_paths:
             raise UnsafeSwaggerRefError(
-                _("swagger 中包含不允许的外部 $ref 引用：{refs}").format(refs=", ".join(sanitized))
+                _("swagger 中包含不允许的外部 $ref 引用，位置：{paths}").format(
+                    paths=", ".join(unsafe_ref_paths[:5])
+                )
             )
 
     @staticmethod
-    def _collect_unsafe_refs(node: Any) -> List[str]:
-        """递归收集所有非文档内部的 $ref 值。
+    def _collect_unsafe_ref_paths(node: Any, path: str = "$") -> List[str]:
+        """递归收集所有非文档内部 $ref 所在的 JSON Path。
 
         仅允许以 '#' 开头的纯文档内部引用（如 #/definitions/User）。
         """
-        unsafe: List[str] = []
+        paths: List[str] = []
         if isinstance(node, dict):
             for key, value in node.items():
                 if key == "$ref":
                     if isinstance(value, str) and not value.startswith("#"):
-                        unsafe.append(value)
+                        paths.append(f"{path}.$ref")
                 else:
-                    unsafe.extend(SwaggerParser._collect_unsafe_refs(value))
+                    paths.extend(SwaggerParser._collect_unsafe_ref_paths(value, f"{path}.{key}"))
         elif isinstance(node, list):
-            for item in node:
-                unsafe.extend(SwaggerParser._collect_unsafe_refs(item))
-        return unsafe
+            for i, item in enumerate(node):
+                paths.extend(SwaggerParser._collect_unsafe_ref_paths(item, f"{path}[{i}]"))
+        return paths

--- a/src/dashboard/apigateway/apigateway/tests/apis/open/resource_doc/test_views.py
+++ b/src/dashboard/apigateway/apigateway/tests/apis/open/resource_doc/test_views.py
@@ -15,6 +15,9 @@
 # We undertake not to change the open source license (MIT license) applicable
 # to the current version of the project delivered to anyone in the future.
 #
+from apigateway.biz.resource_doc.exceptions import UnsafeSwaggerRefError
+
+
 class TestDocImportByArchiveApi:
     def test_post(self, request_view, mocker, fake_tgz_file, ignore_related_app_permission, fake_gateway):
         mocker.patch("apigateway.apis.open.resource_doc.views.ArchiveParser.parse", return_value=[])
@@ -38,8 +41,8 @@ class TestDocImportByArchiveApi:
 
 class TestDocImportBySwaggerApi:
     def test_post(self, request_view, mocker, faker, ignore_related_app_permission, fake_gateway):
-        mocker.patch("apigateway.apis.web.resource_doc.views.SwaggerParser.parse", return_value=[])
-        mocker.patch("apigateway.apis.web.resource_doc.views.DocImporter.import_docs")
+        mocker.patch("apigateway.apis.open.resource_doc.views.SwaggerParser.parse", return_value=[])
+        mocker.patch("apigateway.apis.open.resource_doc.views.DocImporter.import_docs")
 
         resp = request_view(
             method="POST",
@@ -55,3 +58,26 @@ class TestDocImportBySwaggerApi:
 
         assert resp.status_code == 200
         assert result["code"] == 0
+
+    def test_post__unsafe_swagger_ref(self, request_view, mocker, faker, ignore_related_app_permission, fake_gateway):
+        mocker.patch(
+            "apigateway.apis.open.resource_doc.views.SwaggerParser.parse",
+            side_effect=UnsafeSwaggerRefError("swagger 中包含不允许的外部 $ref 引用，位置：$.paths./user.get.$ref"),
+        )
+
+        resp = request_view(
+            method="POST",
+            view_name="openapi.resource_doc.import.by_swagger",
+            path_params={"gateway_name": fake_gateway.name},
+            data={
+                "swagger": faker.pystr(),
+                "language": "zh",
+            },
+            gateway=fake_gateway,
+        )
+        result = resp.json()
+
+        assert resp.status_code == 400
+        assert result["result"] is False
+        assert result["code"] == 40002
+        assert result["message"] == "swagger 中包含不允许的外部 $ref 引用，位置：$.paths./user.get.$ref"

--- a/src/dashboard/apigateway/apigateway/tests/apis/web/resource_doc/test_views.py
+++ b/src/dashboard/apigateway/apigateway/tests/apis/web/resource_doc/test_views.py
@@ -18,6 +18,7 @@
 import json
 
 from apigateway.apps.support.constants import DocLanguageEnum
+from apigateway.biz.resource_doc.exceptions import UnsafeSwaggerRefError
 from apigateway.biz.resource_doc.importer.models import ArchiveDoc
 
 
@@ -97,6 +98,33 @@ class TestDocImportBySwaggerApi:
         )
 
         assert resp.status_code == 204
+
+    def test_post__unsafe_swagger_ref(self, request_view, fake_gateway, mocker, faker):
+        mocker.patch(
+            "apigateway.apis.web.resource_doc.views.SwaggerParser.parse",
+            side_effect=UnsafeSwaggerRefError("swagger 中包含不允许的外部 $ref 引用，位置：$.paths./user.get.$ref"),
+        )
+
+        resp = request_view(
+            method="POST",
+            view_name="resource_doc.import.by_swagger",
+            path_params={"gateway_id": fake_gateway.id},
+            data={
+                "selected_resource_docs": [
+                    {
+                        "language": "zh",
+                        "resource_name": "get_user",
+                    }
+                ],
+                "swagger": faker.pystr(),
+                "language": "zh",
+            },
+        )
+        result = resp.json()
+
+        assert resp.status_code == 400
+        assert result["error"]["code"] == "INVALID_ARGUMENT"
+        assert result["error"]["message"] == "swagger 中包含不允许的外部 $ref 引用，位置：$.paths./user.get.$ref"
 
 
 class TestDocExportApi:

--- a/src/dashboard/apigateway/apigateway/tests/biz/resource_doc/importer/test_parsers.py
+++ b/src/dashboard/apigateway/apigateway/tests/biz/resource_doc/importer/test_parsers.py
@@ -277,30 +277,30 @@ paths:
             SwaggerParser._validate_refs(swagger)
 
 
-class TestSwaggerParserCollectUnsafeRefs:
-    """测试 SwaggerParser._collect_unsafe_refs 辅助方法"""
+class TestSwaggerParserCollectUnsafeRefPaths:
+    """测试 SwaggerParser._collect_unsafe_ref_paths 辅助方法"""
 
     def test_empty_dict(self):
-        assert SwaggerParser._collect_unsafe_refs({}) == []
+        assert SwaggerParser._collect_unsafe_ref_paths({}) == []
 
     def test_empty_list(self):
-        assert SwaggerParser._collect_unsafe_refs([]) == []
+        assert SwaggerParser._collect_unsafe_ref_paths([]) == []
 
     def test_safe_ref(self):
         node = {"$ref": "#/definitions/User"}
-        assert SwaggerParser._collect_unsafe_refs(node) == []
+        assert SwaggerParser._collect_unsafe_ref_paths(node) == []
 
     def test_unsafe_ref(self):
         node = {"$ref": "http://evil.com/payload"}
-        assert SwaggerParser._collect_unsafe_refs(node) == ["http://evil.com/payload"]
+        assert SwaggerParser._collect_unsafe_ref_paths(node) == ["$.$ref"]
 
     def test_nested_unsafe_ref(self):
         node = {"paths": {"/test": {"get": {"responses": {"200": {"schema": {"$ref": "/etc/shadow"}}}}}}}
-        assert SwaggerParser._collect_unsafe_refs(node) == ["/etc/shadow"]
+        assert SwaggerParser._collect_unsafe_ref_paths(node) == ["$.paths./test.get.responses.200.schema.$ref"]
 
     def test_list_with_unsafe_ref(self):
         node = [{"$ref": "#/definitions/OK"}, {"$ref": "http://bad.com/x"}]
-        assert SwaggerParser._collect_unsafe_refs(node) == ["http://bad.com/x"]
+        assert SwaggerParser._collect_unsafe_ref_paths(node) == ["$[1].$ref"]
 
     def test_multiple_unsafe_refs(self):
         node = {
@@ -308,7 +308,7 @@ class TestSwaggerParserCollectUnsafeRefs:
             "b": {"$ref": "/etc/passwd"},
             "c": {"$ref": "#/definitions/Safe"},
         }
-        result = SwaggerParser._collect_unsafe_refs(node)
-        assert "http://a.com" in result
-        assert "/etc/passwd" in result
+        result = SwaggerParser._collect_unsafe_ref_paths(node)
+        assert "$.a.$ref" in result
+        assert "$.b.$ref" in result
         assert len(result) == 2


### PR DESCRIPTION
## Summary
- return the JSON Path of unsafe `$ref` entries instead of echoing attacker-controlled ref values in import errors
- add API tests for `UnsafeSwaggerRefError` handling in both open and web resource doc import views
- fix the open API test patch target so it points to the correct view module

## Testing
- not run locally in the current shell environment
