### PR TITLE
fix(resource-doc): use static error message for unsafe swagger ref errors

### DIFF
--- a/src/dashboard/apigateway/apigateway/apis/web/resource_doc/views.py
+++ b/src/dashboard/apigateway/apigateway/apis/web/resource_doc/views.py
@@ -124,8 +124,8 @@ class DocImportBySwaggerApi(generics.CreateAPIView):
                 swagger=slz.validated_data["swagger"],
                 language=DocLanguageEnum(slz.validated_data["language"]),
             )
-        except UnsafeSwaggerRefError as err:
-            raise error_codes.INVALID_ARGUMENT.format(str(err), replace=True)
+        except UnsafeSwaggerRefError:
+            raise error_codes.INVALID_ARGUMENT.format(_("swagger 中包含不安全的外部 $ref 引用。"), replace=True)
         except (ExpandSwaggerError, SchemaValidationError):
             raise error_codes.INVALID_ARGUMENT.format(_("swagger 描述内容不符合规范。"))
         except GenerateMarkdownError:

--- a/src/dashboard/apigateway/apigateway/biz/resource_doc/importer/parsers.py
+++ b/src/dashboard/apigateway/apigateway/biz/resource_doc/importer/parsers.py
@@ -230,30 +230,24 @@ class SwaggerParser(BaseParser):
         if not isinstance(data, dict):
             raise UnsafeSwaggerRefError(_("swagger 内容无法解析，无法校验 $ref 安全性"))
 
-        unsafe_ref_paths = SwaggerParser._collect_unsafe_ref_paths(data)
-
-        if unsafe_ref_paths:
-            raise UnsafeSwaggerRefError(
-                _("swagger 中包含不允许的外部 $ref 引用，位置：{paths}").format(
-                    paths=", ".join(unsafe_ref_paths[:5])
-                )
-            )
+        if SwaggerParser._has_unsafe_refs(data):
+            raise UnsafeSwaggerRefError(_("swagger 中包含不安全的外部 $ref 引用。"))
 
     @staticmethod
-    def _collect_unsafe_ref_paths(node: Any, path: str = "$") -> List[str]:
-        """递归收集所有非文档内部 $ref 所在的 JSON Path。
+    def _has_unsafe_refs(node: Any) -> bool:
+        """迭代检查是否存在非文档内部 $ref 引用。"""
+        stack: List[Any] = [node]
 
-        仅允许以 '#' 开头的纯文档内部引用（如 #/definitions/User）。
-        """
-        paths: List[str] = []
-        if isinstance(node, dict):
-            for key, value in node.items():
-                if key == "$ref":
-                    if isinstance(value, str) and not value.startswith("#"):
-                        paths.append(f"{path}.$ref")
-                else:
-                    paths.extend(SwaggerParser._collect_unsafe_ref_paths(value, f"{path}.{key}"))
-        elif isinstance(node, list):
-            for i, item in enumerate(node):
-                paths.extend(SwaggerParser._collect_unsafe_ref_paths(item, f"{path}[{i}]"))
-        return paths
+        while stack:
+            current_node = stack.pop()
+            if isinstance(current_node, dict):
+                for key, value in current_node.items():
+                    if key == "$ref":
+                        if isinstance(value, str) and not value.startswith("#"):
+                            return True
+                    else:
+                        stack.append(value)
+            elif isinstance(current_node, list):
+                stack.extend(current_node)
+
+        return False

--- a/src/dashboard/apigateway/apigateway/tests/apis/web/resource_doc/test_views.py
+++ b/src/dashboard/apigateway/apigateway/tests/apis/web/resource_doc/test_views.py
@@ -102,7 +102,7 @@ class TestDocImportBySwaggerApi:
     def test_post__unsafe_swagger_ref(self, request_view, fake_gateway, mocker, faker):
         mocker.patch(
             "apigateway.apis.web.resource_doc.views.SwaggerParser.parse",
-            side_effect=UnsafeSwaggerRefError("swagger 中包含不允许的外部 $ref 引用，位置：$.paths./user.get.$ref"),
+            side_effect=UnsafeSwaggerRefError("any attacker controlled content"),
         )
 
         resp = request_view(
@@ -124,7 +124,9 @@ class TestDocImportBySwaggerApi:
 
         assert resp.status_code == 400
         assert result["error"]["code"] == "INVALID_ARGUMENT"
-        assert result["error"]["message"] == "swagger 中包含不允许的外部 $ref 引用，位置：$.paths./user.get.$ref"
+        # 固定错误消息，不回显异常中的攻击者可控内容
+        assert "any attacker controlled content" not in result["error"]["message"]
+        assert "swagger" in result["error"]["message"]
 
 
 class TestDocExportApi:

--- a/src/dashboard/apigateway/apigateway/tests/biz/resource_doc/importer/test_parsers.py
+++ b/src/dashboard/apigateway/apigateway/tests/biz/resource_doc/importer/test_parsers.py
@@ -277,30 +277,30 @@ paths:
             SwaggerParser._validate_refs(swagger)
 
 
-class TestSwaggerParserCollectUnsafeRefPaths:
-    """测试 SwaggerParser._collect_unsafe_ref_paths 辅助方法"""
+class TestSwaggerParserHasUnsafeRefs:
+    """测试 SwaggerParser._has_unsafe_refs 辅助方法"""
 
     def test_empty_dict(self):
-        assert SwaggerParser._collect_unsafe_ref_paths({}) == []
+        assert SwaggerParser._has_unsafe_refs({}) is False
 
     def test_empty_list(self):
-        assert SwaggerParser._collect_unsafe_ref_paths([]) == []
+        assert SwaggerParser._has_unsafe_refs([]) is False
 
     def test_safe_ref(self):
         node = {"$ref": "#/definitions/User"}
-        assert SwaggerParser._collect_unsafe_ref_paths(node) == []
+        assert SwaggerParser._has_unsafe_refs(node) is False
 
     def test_unsafe_ref(self):
         node = {"$ref": "http://evil.com/payload"}
-        assert SwaggerParser._collect_unsafe_ref_paths(node) == ["$.$ref"]
+        assert SwaggerParser._has_unsafe_refs(node) is True
 
     def test_nested_unsafe_ref(self):
         node = {"paths": {"/test": {"get": {"responses": {"200": {"schema": {"$ref": "/etc/shadow"}}}}}}}
-        assert SwaggerParser._collect_unsafe_ref_paths(node) == ["$.paths./test.get.responses.200.schema.$ref"]
+        assert SwaggerParser._has_unsafe_refs(node) is True
 
     def test_list_with_unsafe_ref(self):
         node = [{"$ref": "#/definitions/OK"}, {"$ref": "http://bad.com/x"}]
-        assert SwaggerParser._collect_unsafe_ref_paths(node) == ["$[1].$ref"]
+        assert SwaggerParser._has_unsafe_refs(node) is True
 
     def test_multiple_unsafe_refs(self):
         node = {
@@ -308,7 +308,11 @@ class TestSwaggerParserCollectUnsafeRefPaths:
             "b": {"$ref": "/etc/passwd"},
             "c": {"$ref": "#/definitions/Safe"},
         }
-        result = SwaggerParser._collect_unsafe_ref_paths(node)
-        assert "$.a.$ref" in result
-        assert "$.b.$ref" in result
-        assert len(result) == 2
+        assert SwaggerParser._has_unsafe_refs(node) is True
+
+    def test_all_safe_refs(self):
+        node = {
+            "a": {"$ref": "#/definitions/A"},
+            "b": {"$ref": "#/definitions/B"},
+        }
+        assert SwaggerParser._has_unsafe_refs(node) is False


### PR DESCRIPTION
## What changed
- Replaced `except UnsafeSwaggerRefError as err` with a bare except
- Used a fixed, static error message instead of echoing `str(err)`

## Why
The previous implementation passed `str(err)` directly to the API error response. Since the error message contains JSON paths built from attacker-controlled Swagger keys via raw string concatenation (`f"{path}.{key}"`), a malicious key like `<img src=x onerror=alert(1)>` would be reflected in the API response, potentially enabling XSS if the frontend renders it without escaping.

## Problem solved
Attacker-controlled content from Swagger document keys is no longer reflected in API error responses, eliminating the reflected XSS vector.