### PR TITLE
fix(resource): escape import validation errors

### DIFF
--- a/src/dashboard/apigateway/apigateway/biz/resource/importer/schema.py
+++ b/src/dashboard/apigateway/apigateway/biz/resource/importer/schema.py
@@ -17,6 +17,7 @@
 #  to the current version of the project delivered to anyone in the future.
 #  #
 from functools import partial
+from html import escape as html_escape
 from importlib.resources import as_file, files
 from os import path
 from typing import Any, Dict, Hashable, Iterator, List, Mapping, Optional, Tuple
@@ -417,9 +418,9 @@ class SchemaValidateErr:
             json_path (str): 指示错误位置的JSON路径表达式。
             absolute_path (List[str]): 错误的绝对路径列表。
         """
-        self.message = message
-        self.json_path = json_path
-        self.absolute_path = absolute_path
+        self.message = html_escape(message)
+        self.json_path = html_escape(json_path)
+        self.absolute_path = [html_escape(path) if isinstance(path, str) else path for path in absolute_path]
 
     def to_dict(self):
         """将对象转换为字典。"""

--- a/src/dashboard/apigateway/apigateway/tests/biz/resource/importer/test_schema.py
+++ b/src/dashboard/apigateway/apigateway/tests/biz/resource/importer/test_schema.py
@@ -19,6 +19,7 @@
 import pytest
 
 from apigateway.biz.resource.importer.schema import (
+    SchemaValidateErr,
     convert_openapi2_formdata_to_openapi,
     convert_openapi2_parameters_to_openapi,
     convert_openapi2_response_headers_to_openapi,
@@ -30,6 +31,18 @@ from apigateway.biz.resource.importer.schema import (
 
 
 class TestSchema:
+    def test_schema_validate_err_escapes_html(self):
+        err = SchemaValidateErr(
+            "<img src=x onerror=alert(1)>",
+            "$.paths./<img src=x onerror=alert(1)>",
+            ["paths", "/<img src=x onerror=alert(1)>"],
+        )
+
+        result = err.to_dict()
+        assert result["message"] == "&lt;img src=x onerror=alert(1)&gt;"
+        assert result["json_path"] == "$.paths./&lt;img src=x onerror=alert(1)&gt;"
+        assert result["absolute_path"] == ["paths", "/&lt;img src=x onerror=alert(1)&gt;"]
+
     def test_convert_openapi2_formdata_to_openapi(self):
         formdata_params = [
             {"name": "file", "type": "file", "required": True},


### PR DESCRIPTION
## Summary
- HTML-escape import validation error message, json_path, and absolute_path fields before returning them to clients.
- Add a regression test for HTML content in schema validation errors.

## Verification
- `source .venv/bin/activate && cd apigateway && export PYTHONDONTWRITEBYTECODE=1 && . apigateway/conf/unittest_env && pytest apigateway/tests/biz/resource/importer/test_schema.py::TestSchema::test_schema_validate_err_escapes_html -q --ds apigateway.settings` -> 1 passed
- `source .venv/bin/activate && cd apigateway && export PYTHONDONTWRITEBYTECODE=1 && . apigateway/conf/unittest_env && pytest apigateway/tests/biz/resource/importer/test_schema.py -q --ds apigateway.settings` -> 8 passed
- `source .venv/bin/activate && make lint-check` -> passed
- `source .venv/bin/activate && make test` -> 2739 passed
