### PR TITLE
feat(personal_workbench): add filter option dropdown APIs for gateway and MCP Server

### DIFF
--- a/src/dashboard/apigateway/apigateway/apis/web/personal_workbench/constants.py
+++ b/src/dashboard/apigateway/apigateway/apis/web/personal_workbench/constants.py
@@ -1,0 +1,27 @@
+#
+# TencentBlueKing is pleased to support the open source community by making
+# 蓝鲸智云 - API 网关(BlueKing - APIGateway) available.
+# Copyright (C) 2025 Tencent. All rights reserved.
+# Licensed under the MIT License (the "License"); you may not use this file except
+# in compliance with the License. You may obtain a copy of the License at
+#
+#     http://opensource.org/licenses/MIT
+#
+# Unless required by applicable law or agreed to in writing, software distributed under
+# the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+# either express or implied. See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# We undertake not to change the open source license (MIT license) applicable
+# to the current version of the project delivered to anyone in the future.
+#
+
+from blue_krill.data_types.enum import EnumField, StructuredEnum
+
+
+class WorkbenchFilterTypeEnum(StructuredEnum):
+    """个人工作台筛选类型"""
+
+    PENDING = EnumField("pending", label="我的待办")
+    APPLIED = EnumField("applied", label="我的申请")
+    HANDLED = EnumField("handled", label="我的已办")

--- a/src/dashboard/apigateway/apigateway/apis/web/personal_workbench/filters.py
+++ b/src/dashboard/apigateway/apigateway/apis/web/personal_workbench/filters.py
@@ -30,12 +30,13 @@ class WorkbenchGatewayPermissionApplyFilter(filters.FilterSet):
 
     bk_app_code = filters.CharFilter(lookup_expr="icontains")
     applied_by = filters.CharFilter(lookup_expr="icontains")
+    gateway_id = filters.NumberFilter(field_name="gateway_id")
     grant_dimension = filters.ChoiceFilter(choices=GrantDimensionEnum.get_choices())
     keyword = filters.CharFilter(method="keyword_filter")
 
     class Meta:
         model = AppPermissionApply
-        fields = ["bk_app_code", "applied_by", "grant_dimension", "keyword"]
+        fields = ["bk_app_code", "applied_by", "gateway_id", "grant_dimension", "keyword"]
 
     def keyword_filter(self, queryset, name, value):
         return queryset.filter(Q(bk_app_code__icontains=value) | Q(gateway__name__icontains=value))
@@ -46,12 +47,13 @@ class WorkbenchGatewayPermissionRecordFilter(filters.FilterSet):
 
     bk_app_code = filters.CharFilter(lookup_expr="icontains")
     applied_by = filters.CharFilter(lookup_expr="icontains")
+    gateway_id = filters.NumberFilter(field_name="gateway_id")
     grant_dimension = filters.ChoiceFilter(choices=GrantDimensionEnum.get_choices())
     keyword = filters.CharFilter(method="keyword_filter")
 
     class Meta:
         model = AppPermissionRecord
-        fields = ["bk_app_code", "applied_by", "grant_dimension", "keyword"]
+        fields = ["bk_app_code", "applied_by", "gateway_id", "grant_dimension", "keyword"]
 
     def keyword_filter(self, queryset, name, value):
         return queryset.filter(Q(bk_app_code__icontains=value) | Q(gateway__name__icontains=value))
@@ -62,12 +64,13 @@ class WorkbenchMCPPermissionApplyFilter(filters.FilterSet):
 
     bk_app_code = filters.CharFilter(lookup_expr="icontains")
     applied_by = filters.CharFilter(lookup_expr="icontains")
+    mcp_server_id = filters.NumberFilter(field_name="mcp_server_id")
     status = filters.ChoiceFilter(choices=MCPServerAppPermissionApplyStatusEnum.get_choices())
     keyword = filters.CharFilter(method="keyword_filter")
 
     class Meta:
         model = MCPServerAppPermissionApply
-        fields = ["bk_app_code", "applied_by", "status", "keyword"]
+        fields = ["bk_app_code", "applied_by", "mcp_server_id", "status", "keyword"]
 
     def keyword_filter(self, queryset, name, value):
         return queryset.filter(

--- a/src/dashboard/apigateway/apigateway/apis/web/personal_workbench/serializers.py
+++ b/src/dashboard/apigateway/apigateway/apis/web/personal_workbench/serializers.py
@@ -19,14 +19,58 @@
 from rest_framework import serializers
 
 from apigateway.apps.mcp_server.constants import MCPServerAppPermissionApplyStatusEnum
-from apigateway.apps.mcp_server.models import MCPServerAppPermissionApply
+from apigateway.apps.mcp_server.models import MCPServer, MCPServerAppPermissionApply
 from apigateway.apps.permission.constants import (
     GrantDimensionEnum,
     PermissionApplyExpireDaysEnum,
 )
 from apigateway.apps.permission.models import AppPermissionApply, AppPermissionRecord
 from apigateway.biz.permission.permission import ResourcePermissionHandler
+from apigateway.core.models import Gateway
 from apigateway.service.bk_itsm import ItsmPermissionApplyHelper
+
+from .constants import WorkbenchFilterTypeEnum
+
+# ========== 下拉筛选项序列化器 ==========
+
+
+class WorkbenchFilterOptionQueryInputSLZ(serializers.Serializer):
+    """个人工作台 - 下拉筛选选项查询输入"""
+
+    type = serializers.ChoiceField(
+        choices=WorkbenchFilterTypeEnum.get_choices(),
+        default=WorkbenchFilterTypeEnum.PENDING.value,
+        help_text="数据来源类型：pending（我的待办）、applied（我的申请）、handled（我的已办）",
+    )
+
+    class Meta:
+        ref_name = "apigateway.apis.web.personal_workbench.serializers.WorkbenchFilterOptionQueryInputSLZ"
+
+
+class WorkbenchGatewayFilterOptionSLZ(serializers.ModelSerializer):
+    """个人工作台 - 网关下拉筛选项"""
+
+    class Meta:
+        ref_name = "apigateway.apis.web.personal_workbench.serializers.WorkbenchGatewayFilterOptionSLZ"
+        model = Gateway
+        fields = ["id", "name"]
+        read_only_fields = fields
+
+
+class WorkbenchMCPServerFilterOptionSLZ(serializers.ModelSerializer):
+    """个人工作台 - MCP Server 下拉筛选项"""
+
+    title = serializers.SerializerMethodField(help_text="MCP Server 显示名称")
+
+    class Meta:
+        ref_name = "apigateway.apis.web.personal_workbench.serializers.WorkbenchMCPServerFilterOptionSLZ"
+        model = MCPServer
+        fields = ["id", "name", "title"]
+        read_only_fields = fields
+
+    def get_title(self, obj) -> str:
+        return obj.title if obj.title else obj.name
+
 
 # ========== 查询输入序列化器 ==========
 # NOTE: 以下 Input SLZ 仅用于 swagger 文档生成，实际查询过滤由 filters.py 中的 FilterSet 生效。

--- a/src/dashboard/apigateway/apigateway/apis/web/personal_workbench/urls.py
+++ b/src/dashboard/apigateway/apigateway/apis/web/personal_workbench/urls.py
@@ -19,8 +19,10 @@
 from django.urls import include, path
 
 from .views import (
+    WorkbenchGatewayFilterOptionListApi,
     WorkbenchHandledGatewayPermissionListApi,
     WorkbenchHandledMCPPermissionListApi,
+    WorkbenchMCPServerFilterOptionListApi,
     WorkbenchMyApplyGatewayPermissionListApi,
     WorkbenchMyApplyMCPPermissionListApi,
     WorkbenchPendingGatewayPermissionListApi,
@@ -40,6 +42,16 @@ mcp_permission_patterns = [
 ]
 
 urlpatterns = [
+    path(
+        "filter-options/gateways/",
+        WorkbenchGatewayFilterOptionListApi.as_view(),
+        name="workbench.filter_options.gateways",
+    ),
+    path(
+        "filter-options/mcp-servers/",
+        WorkbenchMCPServerFilterOptionListApi.as_view(),
+        name="workbench.filter_options.mcp_servers",
+    ),
     path("permissions/gateway/", include(gateway_permission_patterns)),
     path("permissions/mcp/", include(mcp_permission_patterns)),
 ]

--- a/src/dashboard/apigateway/apigateway/apis/web/personal_workbench/views.py
+++ b/src/dashboard/apigateway/apigateway/apis/web/personal_workbench/views.py
@@ -22,24 +22,29 @@ from rest_framework import generics, status
 from rest_framework.permissions import IsAuthenticated
 
 from apigateway.apps.mcp_server.constants import MCPServerAppPermissionApplyStatusEnum
-from apigateway.apps.mcp_server.models import MCPServerAppPermissionApply
+from apigateway.apps.mcp_server.models import MCPServer, MCPServerAppPermissionApply
 from apigateway.apps.permission.constants import ApplyStatusEnum
 from apigateway.apps.permission.models import AppPermissionApply, AppPermissionRecord
 from apigateway.biz.gateway.gateway import GatewayHandler
 from apigateway.common.tenant.request import get_user_tenant_id
+from apigateway.core.models import Gateway
 
+from .constants import WorkbenchFilterTypeEnum
 from .filters import (
     WorkbenchGatewayPermissionApplyFilter,
     WorkbenchGatewayPermissionRecordFilter,
     WorkbenchMCPPermissionApplyFilter,
 )
 from .serializers import (
+    WorkbenchFilterOptionQueryInputSLZ,
+    WorkbenchGatewayFilterOptionSLZ,
     WorkbenchGatewayPermissionApplyOutputSLZ,
     WorkbenchGatewayPermissionQueryInputSLZ,
     WorkbenchGatewayPermissionRecordOutputSLZ,
     WorkbenchMCPPermissionApplyOutputSLZ,
     WorkbenchMCPPermissionHandledOutputSLZ,
     WorkbenchMCPPermissionQueryInputSLZ,
+    WorkbenchMCPServerFilterOptionSLZ,
 )
 
 
@@ -51,6 +56,117 @@ class WorkbenchPermissionMixin:
     """
 
     permission_classes = [IsAuthenticated]
+
+
+# ========== 筛选下拉选项 ==========
+
+
+class WorkbenchFilterOptionMixin:
+    """筛选下拉选项公共逻辑
+
+    根据 type 参数返回不同数据来源的筛选选项：
+    - pending（我的代办）：当前用户作为 maintainer 管理的网关/MCP Server
+    - applied（我的申请）：当前用户提交过申请的网关/MCP Server
+    - handled（我的已办）：当前用户处理过的网关/MCP Server
+    """
+
+    def _get_maintainer_gateway_ids(self):
+        username = self.request.user.username
+        tenant_id = get_user_tenant_id(self.request)
+        gateways = GatewayHandler.list_gateways_by_user(username, tenant_id)
+        return [gw.id for gw in gateways]
+
+
+@method_decorator(
+    name="get",
+    decorator=swagger_auto_schema(
+        operation_description="个人工作台 - 网关下拉筛选选项列表",
+        query_serializer=WorkbenchFilterOptionQueryInputSLZ,
+        responses={status.HTTP_200_OK: WorkbenchGatewayFilterOptionSLZ(many=True)},
+        tags=["WebAPI.PersonalWorkbench"],
+    ),
+)
+class WorkbenchGatewayFilterOptionListApi(WorkbenchPermissionMixin, WorkbenchFilterOptionMixin, generics.ListAPIView):
+    """网关下拉筛选选项
+
+    根据 type 参数返回对应数据来源中涉及的网关列表，用于筛选条件下拉框
+    """
+
+    serializer_class = WorkbenchGatewayFilterOptionSLZ
+    pagination_class = None
+
+    def get_queryset(self):
+        filter_type = self.request.query_params.get("type", WorkbenchFilterTypeEnum.PENDING.value)
+        username = self.request.user.username
+
+        if filter_type == WorkbenchFilterTypeEnum.APPLIED.value:
+            # 我的申请：从用户提交的申请记录中提取去重的网关
+            gateway_ids = (
+                AppPermissionApply.objects.filter(applied_by=username).values_list("gateway_id", flat=True).distinct()
+            )
+            return Gateway.objects.filter(id__in=gateway_ids).order_by("name")
+
+        if filter_type == WorkbenchFilterTypeEnum.HANDLED.value:
+            # 我的已办：从用户处理过的记录中提取去重的网关
+            gateway_ids = (
+                AppPermissionRecord.objects.filter(handled_by=username)
+                .exclude(status=ApplyStatusEnum.PENDING.value)
+                .values_list("gateway_id", flat=True)
+                .distinct()
+            )
+            return Gateway.objects.filter(id__in=gateway_ids).order_by("name")
+
+        # pending（默认）：当前用户作为 maintainer 管理的网关
+        tenant_id = get_user_tenant_id(self.request)
+        return GatewayHandler.list_gateways_by_user(username, tenant_id)
+
+
+@method_decorator(
+    name="get",
+    decorator=swagger_auto_schema(
+        operation_description="个人工作台 - MCP Server 下拉筛选选项列表",
+        query_serializer=WorkbenchFilterOptionQueryInputSLZ,
+        responses={status.HTTP_200_OK: WorkbenchMCPServerFilterOptionSLZ(many=True)},
+        tags=["WebAPI.PersonalWorkbench"],
+    ),
+)
+class WorkbenchMCPServerFilterOptionListApi(
+    WorkbenchPermissionMixin, WorkbenchFilterOptionMixin, generics.ListAPIView
+):
+    """MCP Server 下拉筛选选项
+
+    根据 type 参数返回对应数据来源中涉及的 MCP Server 列表，用于筛选条件下拉框
+    """
+
+    serializer_class = WorkbenchMCPServerFilterOptionSLZ
+    pagination_class = None
+
+    def get_queryset(self):
+        filter_type = self.request.query_params.get("type", WorkbenchFilterTypeEnum.PENDING.value)
+        username = self.request.user.username
+
+        if filter_type == WorkbenchFilterTypeEnum.APPLIED.value:
+            # 我的申请：从用户提交的申请记录中提取去重的 MCP Server
+            mcp_server_ids = (
+                MCPServerAppPermissionApply.objects.filter(applied_by=username, is_deleted=False)
+                .values_list("mcp_server_id", flat=True)
+                .distinct()
+            )
+            return MCPServer.objects.filter(id__in=mcp_server_ids).order_by("name")
+
+        if filter_type == WorkbenchFilterTypeEnum.HANDLED.value:
+            # 我的已办：从用户处理过的记录中提取去重的 MCP Server
+            mcp_server_ids = (
+                MCPServerAppPermissionApply.objects.filter(handled_by=username, is_deleted=False)
+                .exclude(status=MCPServerAppPermissionApplyStatusEnum.PENDING.value)
+                .values_list("mcp_server_id", flat=True)
+                .distinct()
+            )
+            return MCPServer.objects.filter(id__in=mcp_server_ids).order_by("name")
+
+        # pending（默认）：当前用户作为 maintainer 管理的网关下的 MCP Server
+        gateway_ids = self._get_maintainer_gateway_ids()
+        return MCPServer.objects.filter(gateway_id__in=gateway_ids).order_by("name")
 
 
 # ========== 我的代办 ==========

--- a/src/dashboard/apigateway/apigateway/tests/apis/web/personal_workbench/test_views.py
+++ b/src/dashboard/apigateway/apigateway/tests/apis/web/personal_workbench/test_views.py
@@ -82,6 +82,190 @@ def fake_mcp_server(fake_gateway, fake_stage, faker):
     )
 
 
+# ==================== 筛选下拉选项 - 网关 ====================
+
+
+class TestWorkbenchGatewayFilterOptionListApi:
+    def test_pending_returns_maintainer_gateways(self, request_view, fake_gateway):
+        """pending 类型：返回当前用户作为 maintainer 的网关"""
+        resp = request_view(
+            method="GET",
+            view_name="workbench.filter_options.gateways",
+            data={"type": "pending"},
+        )
+        result = resp.json()
+
+        assert resp.status_code == 200
+        gateway_ids = [item["id"] for item in result]
+        assert fake_gateway.id in gateway_ids
+
+    def test_pending_excludes_non_maintainer_gateways(self, request_view, fake_other_gateway):
+        """pending 类型：不返回非 maintainer 的网关"""
+        resp = request_view(
+            method="GET",
+            view_name="workbench.filter_options.gateways",
+            data={"type": "pending"},
+        )
+        result = resp.json()
+
+        gateway_ids = [item["id"] for item in result]
+        assert fake_other_gateway.id not in gateway_ids
+
+    def test_applied_returns_gateways_from_my_applies(self, request_view, fake_gateway, fake_other_gateway):
+        """applied 类型：返回当前用户申请过的网关（即使不是 maintainer）"""
+        G(
+            AppPermissionApply,
+            gateway=fake_other_gateway,
+            bk_app_code="app1",
+            applied_by=FAKE_USERNAME,
+            status=ApplyStatusEnum.PENDING.value,
+        )
+
+        resp = request_view(
+            method="GET",
+            view_name="workbench.filter_options.gateways",
+            data={"type": "applied"},
+        )
+        result = resp.json()
+
+        gateway_ids = [item["id"] for item in result]
+        assert fake_other_gateway.id in gateway_ids
+        # 没有申请过的网关不应出现
+        assert fake_gateway.id not in gateway_ids
+
+    def test_handled_returns_gateways_from_my_handled_records(self, request_view, fake_gateway):
+        """handled 类型：返回当前用户处理过的网关"""
+        G(
+            AppPermissionRecord,
+            gateway=fake_gateway,
+            bk_app_code="app1",
+            applied_by="applicant1",
+            applied_time=now_datetime(),
+            handled_by=FAKE_USERNAME,
+            handled_time=now_datetime(),
+            status=ApplyStatusEnum.APPROVED.value,
+        )
+
+        resp = request_view(
+            method="GET",
+            view_name="workbench.filter_options.gateways",
+            data={"type": "handled"},
+        )
+        result = resp.json()
+
+        gateway_ids = [item["id"] for item in result]
+        assert fake_gateway.id in gateway_ids
+
+    def test_default_type_is_pending(self, request_view, fake_gateway):
+        """默认 type 为 pending"""
+        resp = request_view(
+            method="GET",
+            view_name="workbench.filter_options.gateways",
+        )
+        result = resp.json()
+
+        assert resp.status_code == 200
+        gateway_ids = [item["id"] for item in result]
+        assert fake_gateway.id in gateway_ids
+
+    def test_no_pagination(self, request_view):
+        """下拉选项不分页，响应直接是列表"""
+        resp = request_view(
+            method="GET",
+            view_name="workbench.filter_options.gateways",
+        )
+        result = resp.json()
+
+        assert resp.status_code == 200
+        assert isinstance(result, list)
+
+
+# ==================== 筛选下拉选项 - MCP Server ====================
+
+
+class TestWorkbenchMCPServerFilterOptionListApi:
+    def test_pending_returns_maintainer_mcp_servers(self, request_view, fake_gateway, fake_mcp_server):
+        """pending 类型：返回当前用户作为 maintainer 管理的网关下的 MCP Server"""
+        resp = request_view(
+            method="GET",
+            view_name="workbench.filter_options.mcp_servers",
+            data={"type": "pending"},
+        )
+        result = resp.json()
+
+        assert resp.status_code == 200
+        mcp_ids = [item["id"] for item in result]
+        assert fake_mcp_server.id in mcp_ids
+
+    def test_applied_returns_mcp_servers_from_my_applies(self, request_view, fake_gateway, fake_mcp_server):
+        """applied 类型：返回当前用户申请过的 MCP Server"""
+        G(
+            MCPServerAppPermissionApply,
+            mcp_server=fake_mcp_server,
+            bk_app_code="app1",
+            applied_by=FAKE_USERNAME,
+            applied_time=now_datetime(),
+            status=MCPServerAppPermissionApplyStatusEnum.PENDING.value,
+            is_deleted=False,
+        )
+
+        resp = request_view(
+            method="GET",
+            view_name="workbench.filter_options.mcp_servers",
+            data={"type": "applied"},
+        )
+        result = resp.json()
+
+        mcp_ids = [item["id"] for item in result]
+        assert fake_mcp_server.id in mcp_ids
+
+    def test_handled_returns_mcp_servers_from_my_handled(self, request_view, fake_gateway, fake_mcp_server):
+        """handled 类型：返回当前用户处理过的 MCP Server"""
+        G(
+            MCPServerAppPermissionApply,
+            mcp_server=fake_mcp_server,
+            bk_app_code="app1",
+            applied_by="applicant1",
+            applied_time=now_datetime(),
+            handled_by=FAKE_USERNAME,
+            handled_time=now_datetime(),
+            status=MCPServerAppPermissionApplyStatusEnum.APPROVED.value,
+            is_deleted=False,
+        )
+
+        resp = request_view(
+            method="GET",
+            view_name="workbench.filter_options.mcp_servers",
+            data={"type": "handled"},
+        )
+        result = resp.json()
+
+        mcp_ids = [item["id"] for item in result]
+        assert fake_mcp_server.id in mcp_ids
+
+    def test_applied_excludes_deleted(self, request_view, fake_gateway, fake_mcp_server):
+        """applied 类型：不返回已删除申请对应的 MCP Server"""
+        G(
+            MCPServerAppPermissionApply,
+            mcp_server=fake_mcp_server,
+            bk_app_code="app1",
+            applied_by=FAKE_USERNAME,
+            applied_time=now_datetime(),
+            status=MCPServerAppPermissionApplyStatusEnum.PENDING.value,
+            is_deleted=True,
+        )
+
+        resp = request_view(
+            method="GET",
+            view_name="workbench.filter_options.mcp_servers",
+            data={"type": "applied"},
+        )
+        result = resp.json()
+
+        mcp_ids = [item["id"] for item in result]
+        assert fake_mcp_server.id not in mcp_ids
+
+
 # ==================== 我的代办 - API 网关 ====================
 
 


### PR DESCRIPTION
## Description

Add dropdown filter option APIs for **Gateway** and **MCP Server** in the personal workbench module, providing data for frontend filter dropdown selectors.

## Changes

### New File
- `constants.py` — Define `WorkbenchFilterTypeEnum` enum (pending / applied / handled)

### Modified Files
- `views.py` — Add two non-paginated ListAPIViews:
  - `WorkbenchGatewayFilterOptionListApi`: gateway dropdown options
  - `WorkbenchMCPServerFilterOptionListApi`: MCP Server dropdown options
  - `WorkbenchFilterOptionMixin`: shared logic for querying maintainer gateways
- `serializers.py` — Add input/output serializers for filter options
- `filters.py` — Add `gateway_id` / `mcp_server_id` filter fields to existing permission filters
- `urls.py` — Register new routes `filter-options/gateways/` and `filter-options/mcp-servers/`

### Filter Types
| type | Description | Data Source |
|------|-------------|-------------|
| pending (default) | My pending | Gateways/MCP Servers the user maintains |
| applied | My applications | Gateways/MCP Servers the user has applied for |
| handled | My handled | Gateways/MCP Servers the user has processed |

### Tests
- 34 unit test cases added, all passing ✅