### PR TITLE
fix(resource): released stages display by querying actual release records

### DIFF
--- a/src/dashboard/apigateway/apigateway/apis/web/resource/serializers.py
+++ b/src/dashboard/apigateway/apigateway/apis/web/resource/serializers.py
@@ -408,6 +408,7 @@ class ResourceOutputSLZ(serializers.ModelSerializer):
     backend = serializers.SerializerMethodField(help_text="后端服务")
     labels = serializers.SerializerMethodField(help_text="标签列表")
     schema = serializers.SerializerMethodField(help_text="参数协议")
+    released_stages = serializers.SerializerMethodField(help_text="已使用的环境列表")
 
     class Meta:
         ref_name = "apigateway.apis.web.resource.serializers.ResourceOutputSLZ"
@@ -427,6 +428,7 @@ class ResourceOutputSLZ(serializers.ModelSerializer):
             "backend",
             "labels",
             "schema",
+            "released_stages",
         ]
         read_only_fields = fields
 
@@ -482,6 +484,9 @@ class ResourceOutputSLZ(serializers.ModelSerializer):
         # 填充路径参数
         parameters = extract_openapi_parameters_from_path(obj.path)
         return {"parameters": parameters}
+
+    def get_released_stages(self, obj):
+        return self.context.get("released_stages", [])
 
 
 class ResourceBatchUpdateInputSLZ(serializers.Serializer):

--- a/src/dashboard/apigateway/apigateway/apis/web/resource/views.py
+++ b/src/dashboard/apigateway/apigateway/apis/web/resource/views.py
@@ -228,7 +228,7 @@ class ResourceRetrieveUpdateDestroyApi(ResourceQuerySetMixin, generics.RetrieveU
         instance = self.get_object()
 
         # 查询资源已发布到的环境
-        released_stages = ResourceVersionHandler.get_released_stage_names(instance.id)
+        released_stages = ResourceVersionHandler.get_released_stage_names(instance.gateway_id, instance.id)
 
         slz = ResourceOutputSLZ(
             instance,

--- a/src/dashboard/apigateway/apigateway/apis/web/resource/views.py
+++ b/src/dashboard/apigateway/apigateway/apis/web/resource/views.py
@@ -226,6 +226,10 @@ class ResourceRetrieveUpdateDestroyApi(ResourceQuerySetMixin, generics.RetrieveU
 
     def retrieve(self, request, *args, **kwargs):
         instance = self.get_object()
+
+        # 查询资源已发布到的环境
+        released_stages = ResourceVersionHandler.get_released_stage_names(instance.id)
+
         slz = ResourceOutputSLZ(
             instance,
             context={
@@ -233,6 +237,7 @@ class ResourceRetrieveUpdateDestroyApi(ResourceQuerySetMixin, generics.RetrieveU
                 "labels": ResourceLabelHandler.get_labels([instance.id]),
                 "proxy": Proxy.objects.get(resource_id=instance.id),
                 "resource_id_to_schema": ResourceHandler.get_id_to_schema([instance.id]),
+                "released_stages": released_stages,
             },
         )
         return OKJsonResponse(data=slz.data)

--- a/src/dashboard/apigateway/apigateway/biz/resource_version/resource_version.py
+++ b/src/dashboard/apigateway/apigateway/biz/resource_version/resource_version.py
@@ -174,6 +174,8 @@ class ResourceVersionHandler:
         resource_version_ids = ReleasedResource.objects.get_released_resource_version_ids_by_resource(
             gateway_id, resource_id
         )
+        if not resource_version_ids:
+            return []
         return Release.objects.get_released_stage_names_by_resource_versions(gateway_id, resource_version_ids)
 
     @staticmethod

--- a/src/dashboard/apigateway/apigateway/biz/resource_version/resource_version.py
+++ b/src/dashboard/apigateway/apigateway/biz/resource_version/resource_version.py
@@ -169,17 +169,12 @@ class ResourceVersionHandler:
         return resource_version
 
     @staticmethod
-    def get_released_stage_names(resource_id: int) -> List[str]:
+    def get_released_stage_names(gateway_id: int, resource_id: int) -> List[str]:
         """获取资源已发布到的环境名称列表"""
-        return list(
-            Release.objects.filter(
-                resource_version_id__in=ReleasedResource.objects.filter(resource_id=resource_id).values_list(
-                    "resource_version_id", flat=True
-                )
-            )
-            .values_list("stage__name", flat=True)
-            .distinct()
+        resource_version_ids = ReleasedResource.objects.get_released_resource_version_ids_by_resource(
+            gateway_id, resource_id
         )
+        return Release.objects.get_released_stage_names_by_resource_versions(gateway_id, resource_version_ids)
 
     @staticmethod
     def get_released_public_resources(gateway_id: int, stage_name: Optional[str] = None) -> List[dict]:

--- a/src/dashboard/apigateway/apigateway/biz/resource_version/resource_version.py
+++ b/src/dashboard/apigateway/apigateway/biz/resource_version/resource_version.py
@@ -169,6 +169,19 @@ class ResourceVersionHandler:
         return resource_version
 
     @staticmethod
+    def get_released_stage_names(resource_id: int) -> List[str]:
+        """获取资源已发布到的环境名称列表"""
+        return list(
+            Release.objects.filter(
+                resource_version_id__in=ReleasedResource.objects.filter(resource_id=resource_id).values_list(
+                    "resource_version_id", flat=True
+                )
+            )
+            .values_list("stage__name", flat=True)
+            .distinct()
+        )
+
+    @staticmethod
     def get_released_public_resources(gateway_id: int, stage_name: Optional[str] = None) -> List[dict]:
         """
         获取已发布的所有资源，将各环境发布的资源合并

--- a/src/dashboard/apigateway/apigateway/core/managers.py
+++ b/src/dashboard/apigateway/apigateway/core/managers.py
@@ -148,7 +148,7 @@ class ReleaseManager(models.Manager):
         queryset = self.filter(stage__status=StageStatusEnum.ACTIVE.value)
 
         if gateway is not None:
-            queryset = self.filter(gateway_id=gateway.id)
+            queryset = queryset.filter(gateway_id=gateway.id)
 
         if resource_version_ids is not None:
             queryset = queryset.filter(resource_version_id__in=resource_version_ids)
@@ -180,6 +180,22 @@ class ReleaseManager(models.Manager):
             resource_version_id: [stage["name"] for stage in stages]
             for resource_version_id, stages in released_stages.items()
         }
+
+    def get_released_stage_names_by_resource_versions(
+        self, gateway_id: int, resource_version_ids: List[int]
+    ) -> List[str]:
+        if not resource_version_ids:
+            return []
+
+        return sorted(
+            set(
+                self.filter(
+                    gateway_id=gateway_id,
+                    stage__status=StageStatusEnum.ACTIVE.value,
+                    resource_version_id__in=resource_version_ids,
+                ).values_list("stage__name", flat=True)
+            )
+        )
 
     def get_or_create_release(self, gateway, stage, resource_version, comment, username):
         """
@@ -229,6 +245,16 @@ class ReleaseManager(models.Manager):
 
 
 class ReleasedResourceManager(models.Manager):
+    def get_released_resource_version_ids_by_resource(self, gateway_id: int, resource_id: int) -> List[int]:
+        return list(
+            self.filter(
+                gateway_id=gateway_id,
+                resource_id=resource_id,
+            )
+            .values_list("resource_version_id", flat=True)
+            .distinct()
+        )
+
     def save_released_resource(self, resource_version, force: bool = False) -> None:
         """保存资源版本中的资源配置"""
         queryset = self.filter(resource_version_id=resource_version.id)

--- a/src/dashboard/apigateway/apigateway/tests/apis/web/resource/test_views.py
+++ b/src/dashboard/apigateway/apigateway/tests/apis/web/resource/test_views.py
@@ -32,7 +32,19 @@ from apigateway.apps.label.models import APILabel, ResourceLabel
 from apigateway.biz.resource import ResourceHandler
 from apigateway.biz.resource.savers import ResourcesSaver
 from apigateway.core import constants
-from apigateway.core.models import Backend, BackendConfig, Context, Proxy, Resource, Stage
+from apigateway.core.constants import StageStatusEnum
+from apigateway.core.models import (
+    Backend,
+    BackendConfig,
+    Context,
+    Gateway,
+    Proxy,
+    Release,
+    ReleasedResource,
+    Resource,
+    ResourceVersion,
+    Stage,
+)
 from apigateway.service.contexts import ResourceAuthContext
 
 
@@ -150,6 +162,38 @@ class TestResourceRetrieveUpdateDestroyApi:
 
         assert resp.status_code == 200
         assert result["data"]["id"] == fake_resource.id
+
+    def test_retrieve_with_released_stages(self, fake_resource, request_view):
+        fake_gateway = fake_resource.gateway
+        resource_version = G(ResourceVersion, gateway=fake_gateway)
+        G(
+            ReleasedResource,
+            gateway=fake_gateway,
+            resource_version_id=resource_version.id,
+            resource_id=fake_resource.id,
+            resource_name=fake_resource.name,
+            resource_method=fake_resource.method,
+            resource_path=fake_resource.path,
+            data={},
+        )
+        prod_stage = G(Stage, gateway=fake_gateway, name="prod", status=StageStatusEnum.ACTIVE.value)
+        G(Release, gateway=fake_gateway, stage=prod_stage, resource_version=resource_version)
+        offline_stage = G(Stage, gateway=fake_gateway, name="offline", status=StageStatusEnum.INACTIVE.value)
+        G(Release, gateway=fake_gateway, stage=offline_stage, resource_version=resource_version)
+
+        other_gateway = G(Gateway)
+        other_stage = G(Stage, gateway=other_gateway, name="other", status=StageStatusEnum.ACTIVE.value)
+        G(Release, gateway=other_gateway, stage=other_stage, resource_version=resource_version)
+
+        resp = request_view(
+            method="GET",
+            view_name="resource.retrieve_update_destroy",
+            path_params={"gateway_id": fake_gateway.id, "id": fake_resource.id},
+        )
+        result = resp.json()
+
+        assert resp.status_code == 200
+        assert result["data"]["released_stages"] == ["prod"]
 
     def test_update(self, request_view, fake_resource):
         fake_gateway = fake_resource.gateway

--- a/src/dashboard/apigateway/apigateway/tests/biz/resource_version/test_resource_version.py
+++ b/src/dashboard/apigateway/apigateway/tests/biz/resource_version/test_resource_version.py
@@ -26,6 +26,7 @@ from apigateway.apps.openapi.models import OpenAPIFileResourceSchemaVersion, Ope
 from apigateway.apps.support.models import GatewaySDK, ReleasedResourceDoc, ResourceDocVersion
 from apigateway.biz.resource import ResourceHandler
 from apigateway.biz.resource_version import ResourceVersionHandler
+from apigateway.core.constants import StageStatusEnum
 from apigateway.core.models import Gateway, Release, ReleasedResource, ResourceVersion, Stage
 from apigateway.utils.time import now_datetime
 
@@ -145,6 +146,45 @@ class TestResourceVersionHandler:
 
         get_released_resource_version_ids_mock.assert_called_once_with(gateway_id, stage_name)
         get_resources_mock.assert_called()
+
+    @pytest.mark.parametrize(
+        "release_stage_specs, expected",
+        [
+            ([], []),
+            ([("prod", StageStatusEnum.ACTIVE.value)], ["prod"]),
+            (
+                [
+                    ("test", StageStatusEnum.ACTIVE.value),
+                    ("prod", StageStatusEnum.ACTIVE.value),
+                    ("offline", StageStatusEnum.INACTIVE.value),
+                ],
+                ["prod", "test"],
+            ),
+        ],
+    )
+    def test_get_released_stage_names(self, fake_gateway, fake_resource, release_stage_specs, expected):
+        resource_version = G(ResourceVersion, gateway=fake_gateway)
+        G(
+            ReleasedResource,
+            gateway=fake_gateway,
+            resource_version_id=resource_version.id,
+            resource_id=fake_resource.id,
+            resource_name=fake_resource.name,
+            resource_method=fake_resource.method,
+            resource_path=fake_resource.path,
+            data={},
+        )
+
+        for stage_name, stage_status in release_stage_specs:
+            stage = G(Stage, gateway=fake_gateway, name=stage_name, status=stage_status)
+            G(Release, gateway=fake_gateway, stage=stage, resource_version=resource_version)
+
+        other_gateway = G(Gateway)
+        other_stage = G(Stage, gateway=other_gateway, name="other", status=StageStatusEnum.ACTIVE.value)
+        G(Release, gateway=other_gateway, stage=other_stage, resource_version=resource_version)
+
+        result = ResourceVersionHandler.get_released_stage_names(fake_gateway.id, fake_resource.id)
+        assert result == expected
 
     def test_get_latest_created_time(self, fake_gateway):
         result = ResourceVersionHandler.get_latest_created_time(fake_gateway.id)

--- a/src/dashboard/apigateway/apigateway/tests/core/test_managers.py
+++ b/src/dashboard/apigateway/apigateway/tests/core/test_managers.py
@@ -192,11 +192,13 @@ class TestReleaseManager:
         stage_prod = G(Stage, gateway=gateway, name="prod", status=1)
         stage_test = G(Stage, gateway=gateway, name="test", status=1)
         stage_dev = G(Stage, gateway=gateway, name="dev", status=1)
+        stage_offline = G(Stage, gateway=gateway, name="offline", status=StageStatusEnum.INACTIVE.value)
         resource_version_1 = G(ResourceVersion, gateway=gateway)
         resource_version_2 = G(ResourceVersion, gateway=gateway)
         G(Release, gateway=gateway, stage=stage_prod, resource_version=resource_version_1)
         G(Release, gateway=gateway, stage=stage_dev, resource_version=resource_version_2)
         G(Release, gateway=gateway, stage=stage_test, resource_version=resource_version_1)
+        G(Release, gateway=gateway, stage=stage_offline, resource_version=resource_version_1)
 
         data = [
             {

--- a/src/dashboard/apigateway/apigateway/tests/core/test_managers.py
+++ b/src/dashboard/apigateway/apigateway/tests/core/test_managers.py
@@ -260,6 +260,27 @@ class TestReleaseManager:
         result = Release.objects.get_resource_version_released_stage_names([1])
         assert result == {1: ["prod", "test"]}
 
+    def test_get_released_stage_names_by_resource_versions(self):
+        gateway = G(Gateway)
+        other_gateway = G(Gateway)
+        resource_version_1 = G(ResourceVersion, gateway=gateway)
+        resource_version_2 = G(ResourceVersion, gateway=gateway)
+
+        stage_test = G(Stage, gateway=gateway, name="test", status=StageStatusEnum.ACTIVE.value)
+        stage_prod = G(Stage, gateway=gateway, name="prod", status=StageStatusEnum.ACTIVE.value)
+        stage_offline = G(Stage, gateway=gateway, name="offline", status=StageStatusEnum.INACTIVE.value)
+        stage_other = G(Stage, gateway=other_gateway, name="other", status=StageStatusEnum.ACTIVE.value)
+
+        G(Release, gateway=gateway, stage=stage_test, resource_version=resource_version_1)
+        G(Release, gateway=gateway, stage=stage_prod, resource_version=resource_version_2)
+        G(Release, gateway=gateway, stage=stage_offline, resource_version=resource_version_1)
+        G(Release, gateway=other_gateway, stage=stage_other, resource_version=resource_version_1)
+
+        result = Release.objects.get_released_stage_names_by_resource_versions(
+            gateway.id, [resource_version_1.id, resource_version_2.id]
+        )
+        assert result == ["prod", "test"]
+
     def test_save_release(self):
         gateway = G(Gateway)
         stage_1 = G(Stage, gateway=gateway)


### PR DESCRIPTION
- 修复资源详情页"已使用的环境"显示不正确的 bug。原逻辑通过 BackendConfig 返回所有环境，不区分资源是否实际发布到该环境。新增 released_stages 字段到资源详情 API，需要前端同步修改。
- 资源详情接口 GET /gateways/{gateway_id}/resources/{id}/ 新增返回字段，示例："released_stages": ["prod", "dev"]