### PR TITLE
refactor(personal-workbench): fix pending filter data source, add approvers and status filter

### DIFF
--- a/src/dashboard/apigateway/apigateway/apis/web/personal_workbench/filters.py
+++ b/src/dashboard/apigateway/apigateway/apis/web/personal_workbench/filters.py
@@ -18,14 +18,56 @@
 
 from django.db.models import Q
 from django_filters import rest_framework as filters
+from rest_framework.exceptions import ValidationError
 
 from apigateway.apps.mcp_server.constants import MCPServerAppPermissionApplyStatusEnum
 from apigateway.apps.mcp_server.models import MCPServerAppPermissionApply
 from apigateway.apps.permission.constants import ApplyStatusEnum, GrantDimensionEnum
 from apigateway.apps.permission.models import AppPermissionApply, AppPermissionRecord
+from apigateway.utils.time import utctime
 
 
-class WorkbenchGatewayPermissionApplyFilter(filters.FilterSet):
+class TimeRangeFilterMixin:
+    def filter_queryset(self, queryset):
+        time_start = self.form.cleaned_data.get("time_start")
+        time_end = self.form.cleaned_data.get("time_end")
+        if time_start is not None and time_end is not None and time_start > time_end:
+            raise ValidationError({"time_end": "time_end 必须大于等于 time_start"})
+
+        return super().filter_queryset(queryset)
+
+
+class CreatedTimeRangeFilterMixin(TimeRangeFilterMixin):
+    def filter_created_time_start(self, queryset, name, value):
+        return queryset.filter(created_time__gte=utctime(int(value)).datetime)
+
+    def filter_created_time_end(self, queryset, name, value):
+        return queryset.filter(created_time__lte=utctime(int(value)).datetime)
+
+
+class AppliedTimeRangeFilterMixin(TimeRangeFilterMixin):
+    def filter_applied_time_start(self, queryset, name, value):
+        return queryset.filter(applied_time__gte=utctime(int(value)).datetime)
+
+    def filter_applied_time_end(self, queryset, name, value):
+        return queryset.filter(applied_time__lte=utctime(int(value)).datetime)
+
+
+class KeywordFilterMixin:
+    def keyword_filter(self, queryset, name, value):
+        return queryset.filter(Q(bk_app_code__icontains=value) | Q(gateway__name__icontains=value))
+
+
+class MCPKeywordFilterMixin:
+    def keyword_filter(self, queryset, name, value):
+        return queryset.filter(
+            Q(bk_app_code__icontains=value)
+            | Q(mcp_server__name__icontains=value)
+            | Q(mcp_server__title__icontains=value)
+        )
+
+
+class WorkbenchGatewayPermissionApplyFilter(CreatedTimeRangeFilterMixin, KeywordFilterMixin, filters.FilterSet):
     """个人工作台 - API 网关权限申请筛选器"""
 
     bk_app_code = filters.CharFilter(lookup_expr="icontains")
@@ -33,72 +75,99 @@ class WorkbenchGatewayPermissionApplyFilter(filters.FilterSet):
     gateway_id = filters.NumberFilter(field_name="gateway_id")
     grant_dimension = filters.ChoiceFilter(choices=GrantDimensionEnum.get_choices())
     status = filters.ChoiceFilter(choices=ApplyStatusEnum.get_choices())
+    time_start = filters.NumberFilter(method="filter_created_time_start")
+    time_end = filters.NumberFilter(method="filter_created_time_end")
     keyword = filters.CharFilter(method="keyword_filter")
 
     class Meta:
         model = AppPermissionApply
-        fields = ["bk_app_code", "applied_by", "gateway_id", "grant_dimension", "status", "keyword"]
+        fields = [
+            "bk_app_code",
+            "applied_by",
+            "gateway_id",
+            "grant_dimension",
+            "status",
+            "time_start",
+            "time_end",
+            "keyword",
+        ]
 
-    def keyword_filter(self, queryset, name, value):
-        return queryset.filter(Q(bk_app_code__icontains=value) | Q(gateway__name__icontains=value))
 
-
-class WorkbenchGatewayPendingPermissionApplyFilter(filters.FilterSet):
+class WorkbenchGatewayPendingPermissionApplyFilter(CreatedTimeRangeFilterMixin, KeywordFilterMixin, filters.FilterSet):
     """个人工作台 - API 网关待办权限申请筛选器"""
 
     bk_app_code = filters.CharFilter(lookup_expr="icontains")
     applied_by = filters.CharFilter(lookup_expr="icontains")
     gateway_id = filters.NumberFilter(field_name="gateway_id")
     grant_dimension = filters.ChoiceFilter(choices=GrantDimensionEnum.get_choices())
+    time_start = filters.NumberFilter(method="filter_created_time_start")
+    time_end = filters.NumberFilter(method="filter_created_time_end")
     keyword = filters.CharFilter(method="keyword_filter")
 
     class Meta:
         model = AppPermissionApply
-        fields = ["bk_app_code", "applied_by", "gateway_id", "grant_dimension", "keyword"]
+        fields = [
+            "bk_app_code",
+            "applied_by",
+            "gateway_id",
+            "grant_dimension",
+            "time_start",
+            "time_end",
+            "keyword",
+        ]
 
-    def keyword_filter(self, queryset, name, value):
-        return queryset.filter(Q(bk_app_code__icontains=value) | Q(gateway__name__icontains=value))
 
-
-class WorkbenchGatewayPermissionRecordFilter(filters.FilterSet):
+class WorkbenchGatewayPermissionRecordFilter(AppliedTimeRangeFilterMixin, KeywordFilterMixin, filters.FilterSet):
     """个人工作台 - API 网关已办记录筛选器"""
 
     bk_app_code = filters.CharFilter(lookup_expr="icontains")
     applied_by = filters.CharFilter(lookup_expr="icontains")
     gateway_id = filters.NumberFilter(field_name="gateway_id")
     grant_dimension = filters.ChoiceFilter(choices=GrantDimensionEnum.get_choices())
+    status = filters.ChoiceFilter(choices=ApplyStatusEnum.get_choices())
+    time_start = filters.NumberFilter(method="filter_applied_time_start")
+    time_end = filters.NumberFilter(method="filter_applied_time_end")
     keyword = filters.CharFilter(method="keyword_filter")
 
     class Meta:
         model = AppPermissionRecord
-        fields = ["bk_app_code", "applied_by", "gateway_id", "grant_dimension", "keyword"]
+        fields = [
+            "bk_app_code",
+            "applied_by",
+            "gateway_id",
+            "grant_dimension",
+            "status",
+            "time_start",
+            "time_end",
+            "keyword",
+        ]
 
-    def keyword_filter(self, queryset, name, value):
-        return queryset.filter(Q(bk_app_code__icontains=value) | Q(gateway__name__icontains=value))
 
-
-class WorkbenchMCPPendingPermissionApplyFilter(filters.FilterSet):
+class WorkbenchMCPPendingPermissionApplyFilter(AppliedTimeRangeFilterMixin, MCPKeywordFilterMixin, filters.FilterSet):
     """个人工作台 - MCP Server 待办权限申请筛选器"""
 
     bk_app_code = filters.CharFilter(lookup_expr="icontains")
     applied_by = filters.CharFilter(lookup_expr="icontains")
     gateway_id = filters.NumberFilter(field_name="mcp_server__gateway_id")
     mcp_server_id = filters.NumberFilter(field_name="mcp_server_id")
+    time_start = filters.NumberFilter(method="filter_applied_time_start")
+    time_end = filters.NumberFilter(method="filter_applied_time_end")
     keyword = filters.CharFilter(method="keyword_filter")
 
     class Meta:
         model = MCPServerAppPermissionApply
-        fields = ["bk_app_code", "applied_by", "gateway_id", "mcp_server_id", "keyword"]
+        fields = [
+            "bk_app_code",
+            "applied_by",
+            "gateway_id",
+            "mcp_server_id",
+            "time_start",
+            "time_end",
+            "keyword",
+        ]
 
-    def keyword_filter(self, queryset, name, value):
-        return queryset.filter(
-            Q(bk_app_code__icontains=value)
-            | Q(mcp_server__name__icontains=value)
-            | Q(mcp_server__title__icontains=value)
-        )
 
-
-class WorkbenchMCPPermissionApplyFilter(filters.FilterSet):
+class WorkbenchMCPPermissionApplyFilter(AppliedTimeRangeFilterMixin, MCPKeywordFilterMixin, filters.FilterSet):
     """个人工作台 - MCP Server 权限申请筛选器"""
 
     bk_app_code = filters.CharFilter(lookup_expr="icontains")
@@ -106,15 +175,19 @@ class WorkbenchMCPPermissionApplyFilter(filters.FilterSet):
     gateway_id = filters.NumberFilter(field_name="mcp_server__gateway_id")
     mcp_server_id = filters.NumberFilter(field_name="mcp_server_id")
     status = filters.ChoiceFilter(choices=MCPServerAppPermissionApplyStatusEnum.get_choices())
+    time_start = filters.NumberFilter(method="filter_applied_time_start")
+    time_end = filters.NumberFilter(method="filter_applied_time_end")
     keyword = filters.CharFilter(method="keyword_filter")
 
     class Meta:
         model = MCPServerAppPermissionApply
-        fields = ["bk_app_code", "applied_by", "gateway_id", "mcp_server_id", "status", "keyword"]
-
-    def keyword_filter(self, queryset, name, value):
-        return queryset.filter(
-            Q(bk_app_code__icontains=value)
-            | Q(mcp_server__name__icontains=value)
-            | Q(mcp_server__title__icontains=value)
-        )
+        fields = [
+            "bk_app_code",
+            "applied_by",
+            "gateway_id",
+            "mcp_server_id",
+            "status",
+            "time_start",
+            "time_end",
+            "keyword",
+        ]

--- a/src/dashboard/apigateway/apigateway/apis/web/personal_workbench/filters.py
+++ b/src/dashboard/apigateway/apigateway/apis/web/personal_workbench/filters.py
@@ -43,6 +43,23 @@ class WorkbenchGatewayPermissionApplyFilter(filters.FilterSet):
         return queryset.filter(Q(bk_app_code__icontains=value) | Q(gateway__name__icontains=value))
 
 
+class WorkbenchGatewayPendingPermissionApplyFilter(filters.FilterSet):
+    """个人工作台 - API 网关待办权限申请筛选器"""
+
+    bk_app_code = filters.CharFilter(lookup_expr="icontains")
+    applied_by = filters.CharFilter(lookup_expr="icontains")
+    gateway_id = filters.NumberFilter(field_name="gateway_id")
+    grant_dimension = filters.ChoiceFilter(choices=GrantDimensionEnum.get_choices())
+    keyword = filters.CharFilter(method="keyword_filter")
+
+    class Meta:
+        model = AppPermissionApply
+        fields = ["bk_app_code", "applied_by", "gateway_id", "grant_dimension", "keyword"]
+
+    def keyword_filter(self, queryset, name, value):
+        return queryset.filter(Q(bk_app_code__icontains=value) | Q(gateway__name__icontains=value))
+
+
 class WorkbenchGatewayPermissionRecordFilter(filters.FilterSet):
     """个人工作台 - API 网关已办记录筛选器"""
 
@@ -58,6 +75,27 @@ class WorkbenchGatewayPermissionRecordFilter(filters.FilterSet):
 
     def keyword_filter(self, queryset, name, value):
         return queryset.filter(Q(bk_app_code__icontains=value) | Q(gateway__name__icontains=value))
+
+
+class WorkbenchMCPPendingPermissionApplyFilter(filters.FilterSet):
+    """个人工作台 - MCP Server 待办权限申请筛选器"""
+
+    bk_app_code = filters.CharFilter(lookup_expr="icontains")
+    applied_by = filters.CharFilter(lookup_expr="icontains")
+    gateway_id = filters.NumberFilter(field_name="mcp_server__gateway_id")
+    mcp_server_id = filters.NumberFilter(field_name="mcp_server_id")
+    keyword = filters.CharFilter(method="keyword_filter")
+
+    class Meta:
+        model = MCPServerAppPermissionApply
+        fields = ["bk_app_code", "applied_by", "gateway_id", "mcp_server_id", "keyword"]
+
+    def keyword_filter(self, queryset, name, value):
+        return queryset.filter(
+            Q(bk_app_code__icontains=value)
+            | Q(mcp_server__name__icontains=value)
+            | Q(mcp_server__title__icontains=value)
+        )
 
 
 class WorkbenchMCPPermissionApplyFilter(filters.FilterSet):

--- a/src/dashboard/apigateway/apigateway/apis/web/personal_workbench/filters.py
+++ b/src/dashboard/apigateway/apigateway/apis/web/personal_workbench/filters.py
@@ -21,7 +21,7 @@ from django_filters import rest_framework as filters
 
 from apigateway.apps.mcp_server.constants import MCPServerAppPermissionApplyStatusEnum
 from apigateway.apps.mcp_server.models import MCPServerAppPermissionApply
-from apigateway.apps.permission.constants import GrantDimensionEnum
+from apigateway.apps.permission.constants import ApplyStatusEnum, GrantDimensionEnum
 from apigateway.apps.permission.models import AppPermissionApply, AppPermissionRecord
 
 
@@ -32,11 +32,12 @@ class WorkbenchGatewayPermissionApplyFilter(filters.FilterSet):
     applied_by = filters.CharFilter(lookup_expr="icontains")
     gateway_id = filters.NumberFilter(field_name="gateway_id")
     grant_dimension = filters.ChoiceFilter(choices=GrantDimensionEnum.get_choices())
+    status = filters.ChoiceFilter(choices=ApplyStatusEnum.get_choices())
     keyword = filters.CharFilter(method="keyword_filter")
 
     class Meta:
         model = AppPermissionApply
-        fields = ["bk_app_code", "applied_by", "gateway_id", "grant_dimension", "keyword"]
+        fields = ["bk_app_code", "applied_by", "gateway_id", "grant_dimension", "status", "keyword"]
 
     def keyword_filter(self, queryset, name, value):
         return queryset.filter(Q(bk_app_code__icontains=value) | Q(gateway__name__icontains=value))

--- a/src/dashboard/apigateway/apigateway/apis/web/personal_workbench/serializers.py
+++ b/src/dashboard/apigateway/apigateway/apis/web/personal_workbench/serializers.py
@@ -29,6 +29,7 @@ from apigateway.apps.permission.constants import (
 )
 from apigateway.apps.permission.models import AppPermissionApply, AppPermissionRecord
 from apigateway.biz.permission.permission import ResourcePermissionHandler
+from apigateway.common.fields import TimestampField
 from apigateway.core.models import Gateway, Resource
 from apigateway.service.bk_itsm import ItsmPermissionApplyHelper
 
@@ -101,6 +102,8 @@ class WorkbenchGatewayPendingPermissionQueryInputSLZ(serializers.Serializer):
     grant_dimension = serializers.ChoiceField(
         choices=GrantDimensionEnum.get_choices(), required=False, help_text="授权维度"
     )
+    time_start = TimestampField(allow_null=True, required=False, help_text="申请时间开始")
+    time_end = TimestampField(allow_null=True, required=False, help_text="申请时间结束")
     keyword = serializers.CharField(
         required=False, allow_blank=True, help_text="搜索关键字（模糊匹配网关名称或应用ID）"
     )
@@ -125,6 +128,8 @@ class WorkbenchMCPPendingPermissionQueryInputSLZ(serializers.Serializer):
     applied_by = serializers.CharField(required=False, allow_blank=True, help_text="申请人")
     gateway_id = serializers.IntegerField(required=False, help_text="网关 ID")
     mcp_server_id = serializers.IntegerField(required=False, help_text="MCP Server ID")
+    time_start = TimestampField(allow_null=True, required=False, help_text="申请时间开始")
+    time_end = TimestampField(allow_null=True, required=False, help_text="申请时间结束")
     keyword = serializers.CharField(
         required=False, allow_blank=True, help_text="搜索关键字（模糊匹配 MCP Server 名称、展示名称或应用ID）"
     )

--- a/src/dashboard/apigateway/apigateway/apis/web/personal_workbench/serializers.py
+++ b/src/dashboard/apigateway/apigateway/apis/web/personal_workbench/serializers.py
@@ -23,6 +23,7 @@ from rest_framework import serializers
 from apigateway.apps.mcp_server.constants import MCPServerAppPermissionApplyStatusEnum
 from apigateway.apps.mcp_server.models import MCPServer, MCPServerAppPermissionApply
 from apigateway.apps.permission.constants import (
+    ApplyStatusEnum,
     GrantDimensionEnum,
     PermissionApplyExpireDaysEnum,
 )
@@ -100,6 +101,7 @@ class WorkbenchGatewayPermissionQueryInputSLZ(serializers.Serializer):
     grant_dimension = serializers.ChoiceField(
         choices=GrantDimensionEnum.get_choices(), required=False, help_text="授权维度"
     )
+    status = serializers.ChoiceField(choices=ApplyStatusEnum.get_choices(), required=False, help_text="审批状态")
     keyword = serializers.CharField(
         required=False, allow_blank=True, help_text="搜索关键字（模糊匹配网关名称或应用ID）"
     )
@@ -115,6 +117,9 @@ class WorkbenchMCPPermissionQueryInputSLZ(serializers.Serializer):
     applied_by = serializers.CharField(required=False, allow_blank=True, help_text="申请人")
     gateway_id = serializers.IntegerField(required=False, help_text="网关 ID")
     mcp_server_id = serializers.IntegerField(required=False, help_text="MCP Server ID")
+    status = serializers.ChoiceField(
+        choices=MCPServerAppPermissionApplyStatusEnum.get_choices(), required=False, help_text="审批状态"
+    )
     keyword = serializers.CharField(
         required=False, allow_blank=True, help_text="搜索关键字（模糊匹配 MCP Server 名称或应用ID）"
     )
@@ -151,13 +156,14 @@ class ResourceDetailMixin:
 
 
 class WorkbenchGatewayPermissionApplyOutputSLZ(ResourceDetailMixin, serializers.ModelSerializer):
-    """个人工作台 - API 网关代办/我的申请 输出序列化器"""
+    """个人工作台 - API 网关待办/我的申请 输出序列化器"""
 
     gateway_id = serializers.IntegerField(read_only=True, help_text="网关 ID")
     gateway_name = serializers.SerializerMethodField(help_text="网关名称")
     expire_days_display = serializers.SerializerMethodField(help_text="权限期限显示")
     grant_dimension_display = serializers.SerializerMethodField(help_text="授权维度显示")
     applied_by = serializers.SerializerMethodField(help_text="申请人")
+    approvers = serializers.SerializerMethodField(help_text="审批人")
     itsm_ticket_url = serializers.SerializerMethodField(help_text="ITSM 单据中心链接")
     resources = serializers.SerializerMethodField(help_text="资源维度时的资源列表")
 
@@ -176,6 +182,7 @@ class WorkbenchGatewayPermissionApplyOutputSLZ(ResourceDetailMixin, serializers.
             "resources",
             "reason",
             "applied_by",
+            "approvers",
             "created_time",
             "status",
             "itsm_ticket_id",
@@ -199,6 +206,9 @@ class WorkbenchGatewayPermissionApplyOutputSLZ(ResourceDetailMixin, serializers.
             obj.gateway.tenant_mode,
             obj.gateway.tenant_id,
         )
+
+    def get_approvers(self, obj) -> list[str]:
+        return obj.gateway.maintainers
 
     def get_itsm_ticket_url(self, obj) -> str:
         return ItsmPermissionApplyHelper.build_ticket_url(obj.itsm_ticket_id)
@@ -284,10 +294,11 @@ class WorkbenchMCPServerBaseSLZ(serializers.Serializer):
 
 
 class WorkbenchMCPPermissionApplyOutputSLZ(serializers.ModelSerializer):
-    """个人工作台 - MCP Server 代办/我的申请 输出序列化器"""
+    """个人工作台 - MCP Server 待办/我的申请 输出序列化器"""
 
     mcp_server = WorkbenchMCPServerBaseSLZ(help_text="MCP Server 信息")
     applied_by = serializers.SerializerMethodField(help_text="申请人")
+    approvers = serializers.SerializerMethodField(help_text="审批人")
     itsm_ticket_url = serializers.SerializerMethodField(help_text="ITSM 单据中心链接")
     status_display = serializers.SerializerMethodField(help_text="审批状态显示")
 
@@ -299,6 +310,7 @@ class WorkbenchMCPPermissionApplyOutputSLZ(serializers.ModelSerializer):
             "bk_app_code",
             "mcp_server",
             "applied_by",
+            "approvers",
             "applied_time",
             "reason",
             "expire_days",
@@ -317,6 +329,9 @@ class WorkbenchMCPPermissionApplyOutputSLZ(serializers.ModelSerializer):
             gateway.tenant_mode,
             gateway.tenant_id,
         )
+
+    def get_approvers(self, obj) -> list[str]:
+        return obj.mcp_server.gateway.maintainers
 
     def get_itsm_ticket_url(self, obj) -> str:
         return ItsmPermissionApplyHelper.build_ticket_url(obj.itsm_ticket_id)

--- a/src/dashboard/apigateway/apigateway/apis/web/personal_workbench/serializers.py
+++ b/src/dashboard/apigateway/apigateway/apis/web/personal_workbench/serializers.py
@@ -92,8 +92,8 @@ class WorkbenchMCPServerFilterOptionSLZ(serializers.ModelSerializer):
 # 修改查询参数时需同步修改对应的 FilterSet 以保持一致性。
 
 
-class WorkbenchGatewayPermissionQueryInputSLZ(serializers.Serializer):
-    """个人工作台 - API 网关权限查询输入（仅用于文档生成，实际过滤由 FilterSet 处理）"""
+class WorkbenchGatewayPendingPermissionQueryInputSLZ(serializers.Serializer):
+    """个人工作台 - API 网关待办权限查询输入（仅用于文档生成，实际过滤由 FilterSet 处理）"""
 
     bk_app_code = serializers.CharField(required=False, allow_blank=True, help_text="蓝鲸应用 ID")
     applied_by = serializers.CharField(required=False, allow_blank=True, help_text="申请人")
@@ -101,27 +101,43 @@ class WorkbenchGatewayPermissionQueryInputSLZ(serializers.Serializer):
     grant_dimension = serializers.ChoiceField(
         choices=GrantDimensionEnum.get_choices(), required=False, help_text="授权维度"
     )
-    status = serializers.ChoiceField(choices=ApplyStatusEnum.get_choices(), required=False, help_text="审批状态")
     keyword = serializers.CharField(
         required=False, allow_blank=True, help_text="搜索关键字（模糊匹配网关名称或应用ID）"
     )
 
     class Meta:
+        ref_name = "apigateway.apis.web.personal_workbench.serializers.WorkbenchGatewayPendingPermissionQueryInputSLZ"
+
+
+class WorkbenchGatewayPermissionQueryInputSLZ(WorkbenchGatewayPendingPermissionQueryInputSLZ):
+    """个人工作台 - API 网关权限查询输入（仅用于文档生成，实际过滤由 FilterSet 处理）"""
+
+    status = serializers.ChoiceField(choices=ApplyStatusEnum.get_choices(), required=False, help_text="审批状态")
+
+    class Meta:
         ref_name = "apigateway.apis.web.personal_workbench.serializers.WorkbenchGatewayPermissionQueryInputSLZ"
 
 
-class WorkbenchMCPPermissionQueryInputSLZ(serializers.Serializer):
-    """个人工作台 - MCP Server 权限查询输入（仅用于文档生成，实际过滤由 FilterSet 处理）"""
+class WorkbenchMCPPendingPermissionQueryInputSLZ(serializers.Serializer):
+    """个人工作台 - MCP Server 待办权限查询输入（仅用于文档生成，实际过滤由 FilterSet 处理）"""
 
     bk_app_code = serializers.CharField(required=False, allow_blank=True, help_text="蓝鲸应用 ID")
     applied_by = serializers.CharField(required=False, allow_blank=True, help_text="申请人")
     gateway_id = serializers.IntegerField(required=False, help_text="网关 ID")
     mcp_server_id = serializers.IntegerField(required=False, help_text="MCP Server ID")
+    keyword = serializers.CharField(
+        required=False, allow_blank=True, help_text="搜索关键字（模糊匹配 MCP Server 名称、展示名称或应用ID）"
+    )
+
+    class Meta:
+        ref_name = "apigateway.apis.web.personal_workbench.serializers.WorkbenchMCPPendingPermissionQueryInputSLZ"
+
+
+class WorkbenchMCPPermissionQueryInputSLZ(WorkbenchMCPPendingPermissionQueryInputSLZ):
+    """个人工作台 - MCP Server 权限查询输入（仅用于文档生成，实际过滤由 FilterSet 处理）"""
+
     status = serializers.ChoiceField(
         choices=MCPServerAppPermissionApplyStatusEnum.get_choices(), required=False, help_text="审批状态"
-    )
-    keyword = serializers.CharField(
-        required=False, allow_blank=True, help_text="搜索关键字（模糊匹配 MCP Server 名称或应用ID）"
     )
 
     class Meta:
@@ -163,7 +179,7 @@ class WorkbenchGatewayPermissionApplyOutputSLZ(ResourceDetailMixin, serializers.
     expire_days_display = serializers.SerializerMethodField(help_text="权限期限显示")
     grant_dimension_display = serializers.SerializerMethodField(help_text="授权维度显示")
     applied_by = serializers.SerializerMethodField(help_text="申请人")
-    approvers = serializers.SerializerMethodField(help_text="审批人")
+    approvers = serializers.SerializerMethodField(help_text="当前网关管理员列表（潜在审批人，非历史实际审批人）")
     itsm_ticket_url = serializers.SerializerMethodField(help_text="ITSM 单据中心链接")
     resources = serializers.SerializerMethodField(help_text="资源维度时的资源列表")
 
@@ -298,7 +314,7 @@ class WorkbenchMCPPermissionApplyOutputSLZ(serializers.ModelSerializer):
 
     mcp_server = WorkbenchMCPServerBaseSLZ(help_text="MCP Server 信息")
     applied_by = serializers.SerializerMethodField(help_text="申请人")
-    approvers = serializers.SerializerMethodField(help_text="审批人")
+    approvers = serializers.SerializerMethodField(help_text="当前网关管理员列表（潜在审批人，非历史实际审批人）")
     itsm_ticket_url = serializers.SerializerMethodField(help_text="ITSM 单据中心链接")
     status_display = serializers.SerializerMethodField(help_text="审批状态显示")
 

--- a/src/dashboard/apigateway/apigateway/apis/web/personal_workbench/views.py
+++ b/src/dashboard/apigateway/apigateway/apis/web/personal_workbench/views.py
@@ -25,7 +25,8 @@ from apigateway.apps.mcp_server.constants import MCPServerAppPermissionApplyStat
 from apigateway.apps.mcp_server.models import MCPServer, MCPServerAppPermissionApply
 from apigateway.apps.permission.constants import ApplyStatusEnum, GrantDimensionEnum
 from apigateway.apps.permission.models import AppPermissionApply, AppPermissionRecord
-from apigateway.biz.gateway.gateway import GatewayHandler
+from apigateway.biz.mcp_server import MCPServerPermissionHandler
+from apigateway.biz.permission.permission import ResourcePermissionHandler
 from apigateway.common.tenant.query import (
     gateway_filter_by_user_tenant_id,
     gateway_mcp_server_filter_by_user_tenant_id,
@@ -38,16 +39,20 @@ from apigateway.utils.responses import OKJsonResponse
 
 from .constants import WorkbenchFilterTypeEnum
 from .filters import (
+    WorkbenchGatewayPendingPermissionApplyFilter,
     WorkbenchGatewayPermissionApplyFilter,
     WorkbenchGatewayPermissionRecordFilter,
+    WorkbenchMCPPendingPermissionApplyFilter,
     WorkbenchMCPPermissionApplyFilter,
 )
 from .serializers import (
     WorkbenchFilterOptionQueryInputSLZ,
     WorkbenchGatewayFilterOptionSLZ,
+    WorkbenchGatewayPendingPermissionQueryInputSLZ,
     WorkbenchGatewayPermissionApplyOutputSLZ,
     WorkbenchGatewayPermissionQueryInputSLZ,
     WorkbenchGatewayPermissionRecordOutputSLZ,
+    WorkbenchMCPPendingPermissionQueryInputSLZ,
     WorkbenchMCPPermissionApplyOutputSLZ,
     WorkbenchMCPPermissionHandledOutputSLZ,
     WorkbenchMCPPermissionQueryInputSLZ,
@@ -64,28 +69,18 @@ class WorkbenchPermissionMixin:
 
     permission_classes = [IsAuthenticated]
 
-    def _get_maintainer_gateway_ids(self):
-        """获取当前用户作为 maintainer 管理的网关 ID 列表"""
-        username = self.request.user.username
-        tenant_id = get_user_tenant_id(self.request)
-        gateways = GatewayHandler.list_gateways_by_user(username, tenant_id)
-        return [gw.id for gw in gateways]
-
     def _get_pending_gateway_permission_apply_queryset(self):
         """获取当前用户待审批的 API 网关权限申请列表"""
-        gateway_ids = self._get_maintainer_gateway_ids()
-        return AppPermissionApply.objects.filter(
-            gateway_id__in=gateway_ids,
-            status=ApplyStatusEnum.PENDING.value,
+        return ResourcePermissionHandler.get_pending_apply_queryset_for_maintainer(
+            self.request.user.username,
+            get_user_tenant_id(self.request),
         )
 
     def _get_pending_mcp_permission_apply_queryset(self):
         """获取当前用户待审批的 MCP Server 权限申请列表"""
-        gateway_ids = self._get_maintainer_gateway_ids()
-        return MCPServerAppPermissionApply.objects.filter(
-            mcp_server__gateway_id__in=gateway_ids,
-            status=MCPServerAppPermissionApplyStatusEnum.PENDING.value,
-            is_deleted=False,
+        return MCPServerPermissionHandler.get_pending_apply_queryset_for_gateway_maintainer(
+            self.request.user.username,
+            get_user_tenant_id(self.request),
         )
 
 
@@ -309,7 +304,7 @@ class WorkbenchMCPGatewayFilterOptionListApi(WorkbenchPermissionMixin, generics.
     name="get",
     decorator=swagger_auto_schema(
         operation_description="个人工作台 - 我的待办 - API 网关权限申请列表",
-        query_serializer=WorkbenchGatewayPermissionQueryInputSLZ,
+        query_serializer=WorkbenchGatewayPendingPermissionQueryInputSLZ,
         responses={status.HTTP_200_OK: WorkbenchGatewayPermissionApplyOutputSLZ(many=True)},
         tags=["WebAPI.PersonalWorkbench"],
     ),
@@ -321,7 +316,7 @@ class WorkbenchPendingGatewayPermissionListApi(ResourcePrefetchMixin, WorkbenchP
     """
 
     serializer_class = WorkbenchGatewayPermissionApplyOutputSLZ
-    filterset_class = WorkbenchGatewayPermissionApplyFilter
+    filterset_class = WorkbenchGatewayPendingPermissionApplyFilter
 
     def get_queryset(self):
         return self._get_pending_gateway_permission_apply_queryset().select_related("gateway").order_by("-id")
@@ -331,7 +326,7 @@ class WorkbenchPendingGatewayPermissionListApi(ResourcePrefetchMixin, WorkbenchP
     name="get",
     decorator=swagger_auto_schema(
         operation_description="个人工作台 - 我的待办 - MCP Server 权限申请列表",
-        query_serializer=WorkbenchMCPPermissionQueryInputSLZ,
+        query_serializer=WorkbenchMCPPendingPermissionQueryInputSLZ,
         responses={status.HTTP_200_OK: WorkbenchMCPPermissionApplyOutputSLZ(many=True)},
         tags=["WebAPI.PersonalWorkbench"],
     ),
@@ -343,7 +338,7 @@ class WorkbenchPendingMCPPermissionListApi(WorkbenchPermissionMixin, generics.Li
     """
 
     serializer_class = WorkbenchMCPPermissionApplyOutputSLZ
-    filterset_class = WorkbenchMCPPermissionApplyFilter
+    filterset_class = WorkbenchMCPPendingPermissionApplyFilter
 
     def get_queryset(self):
         return (

--- a/src/dashboard/apigateway/apigateway/apis/web/personal_workbench/views.py
+++ b/src/dashboard/apigateway/apigateway/apis/web/personal_workbench/views.py
@@ -71,6 +71,23 @@ class WorkbenchPermissionMixin:
         gateways = GatewayHandler.list_gateways_by_user(username, tenant_id)
         return [gw.id for gw in gateways]
 
+    def _get_pending_gateway_permission_apply_queryset(self):
+        """获取当前用户待审批的 API 网关权限申请列表"""
+        gateway_ids = self._get_maintainer_gateway_ids()
+        return AppPermissionApply.objects.filter(
+            gateway_id__in=gateway_ids,
+            status=ApplyStatusEnum.PENDING.value,
+        )
+
+    def _get_pending_mcp_permission_apply_queryset(self):
+        """获取当前用户待审批的 MCP Server 权限申请列表"""
+        gateway_ids = self._get_maintainer_gateway_ids()
+        return MCPServerAppPermissionApply.objects.filter(
+            mcp_server__gateway_id__in=gateway_ids,
+            status=MCPServerAppPermissionApplyStatusEnum.PENDING.value,
+            is_deleted=False,
+        )
+
 
 class ResourcePrefetchMixin:
     """批量预取资源详情 Mixin
@@ -155,8 +172,10 @@ class WorkbenchGatewayFilterOptionListApi(WorkbenchPermissionMixin, generics.Lis
             queryset = Gateway.objects.filter(id__in=gateway_ids).order_by("name")
             return gateway_filter_by_user_tenant_id(queryset, tenant_id)
 
-        # pending（默认）：当前用户作为 maintainer 管理的网关
-        gateway_ids = self._get_maintainer_gateway_ids()
+        # pending（默认）：从当前用户待审批的 API 网关权限申请中提取去重的网关
+        gateway_ids = (
+            self._get_pending_gateway_permission_apply_queryset().values_list("gateway_id", flat=True).distinct()
+        )
         return Gateway.objects.filter(id__in=gateway_ids).order_by("name")
 
     def list(self, request, *args, **kwargs):
@@ -211,9 +230,11 @@ class WorkbenchMCPServerFilterOptionListApi(WorkbenchPermissionMixin, generics.L
             queryset = MCPServer.objects.select_related("gateway").filter(id__in=mcp_server_ids).order_by("name")
             return gateway_mcp_server_filter_by_user_tenant_id(queryset, tenant_id)
 
-        # pending（默认）：当前用户作为 maintainer 管理的网关下的 MCP Server
-        gateway_ids = self._get_maintainer_gateway_ids()
-        return MCPServer.objects.select_related("gateway").filter(gateway_id__in=gateway_ids).order_by("name")
+        # pending（默认）：从当前用户待审批的 MCP Server 权限申请中提取去重的 MCP Server
+        mcp_server_ids = (
+            self._get_pending_mcp_permission_apply_queryset().values_list("mcp_server_id", flat=True).distinct()
+        )
+        return MCPServer.objects.select_related("gateway").filter(id__in=mcp_server_ids).order_by("name")
 
     def list(self, request, *args, **kwargs):
         queryset = self.get_queryset()
@@ -267,8 +288,12 @@ class WorkbenchMCPGatewayFilterOptionListApi(WorkbenchPermissionMixin, generics.
             queryset = Gateway.objects.filter(id__in=gateway_ids).order_by("name")
             return gateway_filter_by_user_tenant_id(queryset, tenant_id)
 
-        # pending（默认）：当前用户作为 maintainer 管理的网关
-        gateway_ids = self._get_maintainer_gateway_ids()
+        # pending（默认）：从当前用户待审批的 MCP Server 权限申请中提取去重的网关
+        gateway_ids = (
+            self._get_pending_mcp_permission_apply_queryset()
+            .values_list("mcp_server__gateway_id", flat=True)
+            .distinct()
+        )
         return Gateway.objects.filter(id__in=gateway_ids).order_by("name")
 
     def list(self, request, *args, **kwargs):
@@ -277,20 +302,20 @@ class WorkbenchMCPGatewayFilterOptionListApi(WorkbenchPermissionMixin, generics.
         return OKJsonResponse(data=slz.data)
 
 
-# ========== 我的代办 ==========
+# ========== 我的待办 ==========
 
 
 @method_decorator(
     name="get",
     decorator=swagger_auto_schema(
-        operation_description="个人工作台 - 我的代办 - API 网关权限申请列表",
+        operation_description="个人工作台 - 我的待办 - API 网关权限申请列表",
         query_serializer=WorkbenchGatewayPermissionQueryInputSLZ,
         responses={status.HTTP_200_OK: WorkbenchGatewayPermissionApplyOutputSLZ(many=True)},
         tags=["WebAPI.PersonalWorkbench"],
     ),
 )
 class WorkbenchPendingGatewayPermissionListApi(ResourcePrefetchMixin, WorkbenchPermissionMixin, generics.ListAPIView):
-    """我的代办 - API 网关
+    """我的待办 - API 网关
 
     展示当前用户作为网关管理员（maintainer）待审批的权限申请单
     """
@@ -299,28 +324,20 @@ class WorkbenchPendingGatewayPermissionListApi(ResourcePrefetchMixin, WorkbenchP
     filterset_class = WorkbenchGatewayPermissionApplyFilter
 
     def get_queryset(self):
-        gateway_ids = self._get_maintainer_gateway_ids()
-        return (
-            AppPermissionApply.objects.filter(
-                gateway_id__in=gateway_ids,
-                status=ApplyStatusEnum.PENDING.value,
-            )
-            .select_related("gateway")
-            .order_by("-id")
-        )
+        return self._get_pending_gateway_permission_apply_queryset().select_related("gateway").order_by("-id")
 
 
 @method_decorator(
     name="get",
     decorator=swagger_auto_schema(
-        operation_description="个人工作台 - 我的代办 - MCP Server 权限申请列表",
+        operation_description="个人工作台 - 我的待办 - MCP Server 权限申请列表",
         query_serializer=WorkbenchMCPPermissionQueryInputSLZ,
         responses={status.HTTP_200_OK: WorkbenchMCPPermissionApplyOutputSLZ(many=True)},
         tags=["WebAPI.PersonalWorkbench"],
     ),
 )
 class WorkbenchPendingMCPPermissionListApi(WorkbenchPermissionMixin, generics.ListAPIView):
-    """我的代办 - MCP Server
+    """我的待办 - MCP Server
 
     展示当前用户作为 MCP Server 所属网关管理员待审批的申请单
     """
@@ -329,13 +346,8 @@ class WorkbenchPendingMCPPermissionListApi(WorkbenchPermissionMixin, generics.Li
     filterset_class = WorkbenchMCPPermissionApplyFilter
 
     def get_queryset(self):
-        gateway_ids = self._get_maintainer_gateway_ids()
         return (
-            MCPServerAppPermissionApply.objects.filter(
-                mcp_server__gateway_id__in=gateway_ids,
-                status=MCPServerAppPermissionApplyStatusEnum.PENDING.value,
-                is_deleted=False,
-            )
+            self._get_pending_mcp_permission_apply_queryset()
             .select_related("mcp_server", "mcp_server__gateway")
             .order_by("-id")
         )

--- a/src/dashboard/apigateway/apigateway/biz/gateway/gateway.py
+++ b/src/dashboard/apigateway/apigateway/biz/gateway/gateway.py
@@ -63,8 +63,7 @@ OPERATION_STATUS_DELTA_DAYS = 180
 class GatewayHandler:
     @staticmethod
     def list_gateways_by_user(username: str, tenant_id: str = "") -> List[Gateway]:
-        """获取用户有权限的的网关列表"""
-
+        """获取用户有权限的网关列表"""
         queryset = Gateway.objects.filter(_maintainers__contains=username)
         if tenant_id:
             queryset = gateway_filter_by_user_tenant_id(queryset, tenant_id)

--- a/src/dashboard/apigateway/apigateway/biz/mcp_server/permission.py
+++ b/src/dashboard/apigateway/apigateway/biz/mcp_server/permission.py
@@ -29,10 +29,9 @@ from apigateway.apps.mcp_server.constants import (
 )
 from apigateway.apps.mcp_server.models import MCPServer, MCPServerAppPermissionApply
 from apigateway.apps.permission.constants import FormattedGrantDimensionEnum
+from apigateway.biz.gateway import GatewayHandler
 from apigateway.common.error_codes import error_codes
-from apigateway.common.tenant.query import gateway_filter_by_user_tenant_id
 from apigateway.core.constants import GatewayStatusEnum, StageStatusEnum
-from apigateway.core.models import Gateway
 from apigateway.service.bk_itsm import ItsmPermissionApplyHelper
 from apigateway.utils.time import now_datetime
 
@@ -43,11 +42,7 @@ class MCPServerPermissionHandler:
     @staticmethod
     def get_pending_apply_queryset_for_gateway_maintainer(username: str, tenant_id: str):
         """获取指定用户作为网关管理员待审批的 MCP Server 权限申请列表"""
-        queryset = Gateway.objects.filter(_maintainers__contains=username)
-        if tenant_id:
-            queryset = gateway_filter_by_user_tenant_id(queryset, tenant_id)
-
-        gateway_ids = [gateway.id for gateway in queryset if gateway.has_permission(username)]
+        gateway_ids = [gateway.id for gateway in GatewayHandler.list_gateways_by_user(username, tenant_id)]
         return MCPServerAppPermissionApply.objects.filter(
             mcp_server__gateway_id__in=gateway_ids,
             status=MCPServerAppPermissionApplyStatusEnum.PENDING.value,

--- a/src/dashboard/apigateway/apigateway/biz/mcp_server/permission.py
+++ b/src/dashboard/apigateway/apigateway/biz/mcp_server/permission.py
@@ -29,6 +29,7 @@ from apigateway.apps.mcp_server.constants import (
 )
 from apigateway.apps.mcp_server.models import MCPServer, MCPServerAppPermissionApply
 from apigateway.apps.permission.constants import FormattedGrantDimensionEnum
+from apigateway.biz.gateway.gateway import GatewayHandler
 from apigateway.common.error_codes import error_codes
 from apigateway.core.constants import GatewayStatusEnum, StageStatusEnum
 from apigateway.service.bk_itsm import ItsmPermissionApplyHelper
@@ -38,6 +39,17 @@ logger = logging.getLogger(__name__)
 
 
 class MCPServerPermissionHandler:
+    @staticmethod
+    def get_pending_apply_queryset_for_gateway_maintainer(username: str, tenant_id: str):
+        """获取指定用户作为网关管理员待审批的 MCP Server 权限申请列表"""
+        gateways = GatewayHandler.list_gateways_by_user(username, tenant_id)
+        gateway_ids = [gateway.id for gateway in gateways]
+        return MCPServerAppPermissionApply.objects.filter(
+            mcp_server__gateway_id__in=gateway_ids,
+            status=MCPServerAppPermissionApplyStatusEnum.PENDING.value,
+            is_deleted=False,
+        )
+
     @staticmethod
     def create_apply(bk_app_code: str, mcp_server_ids: List[int], reason: str, applied_by: str):
         queryset = MCPServer.objects.filter(

--- a/src/dashboard/apigateway/apigateway/biz/mcp_server/permission.py
+++ b/src/dashboard/apigateway/apigateway/biz/mcp_server/permission.py
@@ -29,9 +29,10 @@ from apigateway.apps.mcp_server.constants import (
 )
 from apigateway.apps.mcp_server.models import MCPServer, MCPServerAppPermissionApply
 from apigateway.apps.permission.constants import FormattedGrantDimensionEnum
-from apigateway.biz.gateway.gateway import GatewayHandler
 from apigateway.common.error_codes import error_codes
+from apigateway.common.tenant.query import gateway_filter_by_user_tenant_id
 from apigateway.core.constants import GatewayStatusEnum, StageStatusEnum
+from apigateway.core.models import Gateway
 from apigateway.service.bk_itsm import ItsmPermissionApplyHelper
 from apigateway.utils.time import now_datetime
 
@@ -42,8 +43,11 @@ class MCPServerPermissionHandler:
     @staticmethod
     def get_pending_apply_queryset_for_gateway_maintainer(username: str, tenant_id: str):
         """获取指定用户作为网关管理员待审批的 MCP Server 权限申请列表"""
-        gateways = GatewayHandler.list_gateways_by_user(username, tenant_id)
-        gateway_ids = [gateway.id for gateway in gateways]
+        queryset = Gateway.objects.filter(_maintainers__contains=username)
+        if tenant_id:
+            queryset = gateway_filter_by_user_tenant_id(queryset, tenant_id)
+
+        gateway_ids = [gateway.id for gateway in queryset if gateway.has_permission(username)]
         return MCPServerAppPermissionApply.objects.filter(
             mcp_server__gateway_id__in=gateway_ids,
             status=MCPServerAppPermissionApplyStatusEnum.PENDING.value,

--- a/src/dashboard/apigateway/apigateway/biz/mcp_server/permission.py
+++ b/src/dashboard/apigateway/apigateway/biz/mcp_server/permission.py
@@ -29,9 +29,10 @@ from apigateway.apps.mcp_server.constants import (
 )
 from apigateway.apps.mcp_server.models import MCPServer, MCPServerAppPermissionApply
 from apigateway.apps.permission.constants import FormattedGrantDimensionEnum
-from apigateway.biz.gateway import GatewayHandler
 from apigateway.common.error_codes import error_codes
+from apigateway.common.tenant.query import gateway_filter_by_user_tenant_id
 from apigateway.core.constants import GatewayStatusEnum, StageStatusEnum
+from apigateway.core.models import Gateway
 from apigateway.service.bk_itsm import ItsmPermissionApplyHelper
 from apigateway.utils.time import now_datetime
 
@@ -42,7 +43,11 @@ class MCPServerPermissionHandler:
     @staticmethod
     def get_pending_apply_queryset_for_gateway_maintainer(username: str, tenant_id: str):
         """获取指定用户作为网关管理员待审批的 MCP Server 权限申请列表"""
-        gateway_ids = [gateway.id for gateway in GatewayHandler.list_gateways_by_user(username, tenant_id)]
+        queryset = Gateway.objects.filter(_maintainers__contains=username)
+        if tenant_id:
+            queryset = gateway_filter_by_user_tenant_id(queryset, tenant_id)
+
+        gateway_ids = [gateway.id for gateway in queryset if gateway.has_permission(username)]
         return MCPServerAppPermissionApply.objects.filter(
             mcp_server__gateway_id__in=gateway_ids,
             status=MCPServerAppPermissionApplyStatusEnum.PENDING.value,

--- a/src/dashboard/apigateway/apigateway/biz/permission/permission.py
+++ b/src/dashboard/apigateway/apigateway/biz/permission/permission.py
@@ -21,12 +21,15 @@ from typing import List
 from django.conf import settings
 
 from apigateway.apps.permission.constants import (
+    ApplyStatusEnum,
     GrantTypeEnum,
 )
 from apigateway.apps.permission.models import (
     AppGatewayPermission,
+    AppPermissionApply,
     AppResourcePermission,
 )
+from apigateway.biz.gateway.gateway import GatewayHandler
 from apigateway.common.tenant.constants import (
     TENANT_ID_OPERATION,
     TenantModeEnum,
@@ -37,6 +40,16 @@ from apigateway.core.models import Gateway
 
 
 class ResourcePermissionHandler:
+    @staticmethod
+    def get_pending_apply_queryset_for_maintainer(username: str, tenant_id: str):
+        """获取指定用户作为网关管理员待审批的 API 网关权限申请列表"""
+        gateways = GatewayHandler.list_gateways_by_user(username, tenant_id)
+        gateway_ids = [gateway.id for gateway in gateways]
+        return AppPermissionApply.objects.filter(
+            gateway_id__in=gateway_ids,
+            status=ApplyStatusEnum.PENDING.value,
+        )
+
     @staticmethod
     def grant_or_renewal_expire_soon(
         gateway: Gateway, resource_id: int, bk_app_code: str, expire_days: int, expires_soon_seconds: int = 300

--- a/src/dashboard/apigateway/apigateway/biz/permission/permission.py
+++ b/src/dashboard/apigateway/apigateway/biz/permission/permission.py
@@ -29,11 +29,11 @@ from apigateway.apps.permission.models import (
     AppPermissionApply,
     AppResourcePermission,
 )
-from apigateway.biz.gateway import GatewayHandler
 from apigateway.common.tenant.constants import (
     TENANT_ID_OPERATION,
     TenantModeEnum,
 )
+from apigateway.common.tenant.query import gateway_filter_by_user_tenant_id
 from apigateway.components.bkauth import get_app_tenant_info_cached
 from apigateway.components.bkuser import query_display_names_cached
 from apigateway.core.models import Gateway
@@ -43,7 +43,11 @@ class ResourcePermissionHandler:
     @staticmethod
     def get_pending_apply_queryset_for_maintainer(username: str, tenant_id: str):
         """获取指定用户作为网关管理员待审批的 API 网关权限申请列表"""
-        gateway_ids = [gateway.id for gateway in GatewayHandler.list_gateways_by_user(username, tenant_id)]
+        queryset = Gateway.objects.filter(_maintainers__contains=username)
+        if tenant_id:
+            queryset = gateway_filter_by_user_tenant_id(queryset, tenant_id)
+
+        gateway_ids = [gateway.id for gateway in queryset if gateway.has_permission(username)]
         return AppPermissionApply.objects.filter(
             gateway_id__in=gateway_ids,
             status=ApplyStatusEnum.PENDING.value,

--- a/src/dashboard/apigateway/apigateway/biz/permission/permission.py
+++ b/src/dashboard/apigateway/apigateway/biz/permission/permission.py
@@ -29,11 +29,11 @@ from apigateway.apps.permission.models import (
     AppPermissionApply,
     AppResourcePermission,
 )
+from apigateway.biz.gateway import GatewayHandler
 from apigateway.common.tenant.constants import (
     TENANT_ID_OPERATION,
     TenantModeEnum,
 )
-from apigateway.common.tenant.query import gateway_filter_by_user_tenant_id
 from apigateway.components.bkauth import get_app_tenant_info_cached
 from apigateway.components.bkuser import query_display_names_cached
 from apigateway.core.models import Gateway
@@ -43,11 +43,7 @@ class ResourcePermissionHandler:
     @staticmethod
     def get_pending_apply_queryset_for_maintainer(username: str, tenant_id: str):
         """获取指定用户作为网关管理员待审批的 API 网关权限申请列表"""
-        queryset = Gateway.objects.filter(_maintainers__contains=username)
-        if tenant_id:
-            queryset = gateway_filter_by_user_tenant_id(queryset, tenant_id)
-
-        gateway_ids = [gateway.id for gateway in queryset if gateway.has_permission(username)]
+        gateway_ids = [gateway.id for gateway in GatewayHandler.list_gateways_by_user(username, tenant_id)]
         return AppPermissionApply.objects.filter(
             gateway_id__in=gateway_ids,
             status=ApplyStatusEnum.PENDING.value,

--- a/src/dashboard/apigateway/apigateway/biz/permission/permission.py
+++ b/src/dashboard/apigateway/apigateway/biz/permission/permission.py
@@ -29,11 +29,11 @@ from apigateway.apps.permission.models import (
     AppPermissionApply,
     AppResourcePermission,
 )
-from apigateway.biz.gateway.gateway import GatewayHandler
 from apigateway.common.tenant.constants import (
     TENANT_ID_OPERATION,
     TenantModeEnum,
 )
+from apigateway.common.tenant.query import gateway_filter_by_user_tenant_id
 from apigateway.components.bkauth import get_app_tenant_info_cached
 from apigateway.components.bkuser import query_display_names_cached
 from apigateway.core.models import Gateway
@@ -43,8 +43,11 @@ class ResourcePermissionHandler:
     @staticmethod
     def get_pending_apply_queryset_for_maintainer(username: str, tenant_id: str):
         """获取指定用户作为网关管理员待审批的 API 网关权限申请列表"""
-        gateways = GatewayHandler.list_gateways_by_user(username, tenant_id)
-        gateway_ids = [gateway.id for gateway in gateways]
+        queryset = Gateway.objects.filter(_maintainers__contains=username)
+        if tenant_id:
+            queryset = gateway_filter_by_user_tenant_id(queryset, tenant_id)
+
+        gateway_ids = [gateway.id for gateway in queryset if gateway.has_permission(username)]
         return AppPermissionApply.objects.filter(
             gateway_id__in=gateway_ids,
             status=ApplyStatusEnum.PENDING.value,

--- a/src/dashboard/apigateway/apigateway/tests/apis/web/personal_workbench/test_serializers.py
+++ b/src/dashboard/apigateway/apigateway/tests/apis/web/personal_workbench/test_serializers.py
@@ -59,6 +59,7 @@ class TestWorkbenchGatewayPermissionApplyOutputSLZ:
         assert data["id"] == apply_record.id
         assert data["bk_app_code"] == "test_app"
         assert data["applied_by"] == "test_user"
+        assert data["approvers"] == fake_gateway.maintainers
         assert data["gateway_id"] == fake_gateway.id
         assert data["gateway_name"] == fake_gateway.name
         assert data["status"] == ApplyStatusEnum.PENDING.value
@@ -158,6 +159,7 @@ class TestWorkbenchMCPPermissionApplyOutputSLZ:
         assert data["id"] == apply_record.id
         assert data["bk_app_code"] == "test_app"
         assert data["applied_by"] == "test_user"
+        assert data["approvers"] == fake_gateway.maintainers
         assert data["mcp_server"]["id"] == mcp_server.id
         assert data["mcp_server"]["name"] == "test-mcp"
         assert data["mcp_server"]["title"] == "Test MCP Server"

--- a/src/dashboard/apigateway/apigateway/tests/apis/web/personal_workbench/test_views.py
+++ b/src/dashboard/apigateway/apigateway/tests/apis/web/personal_workbench/test_views.py
@@ -25,7 +25,7 @@ from apigateway.apps.mcp_server.models import MCPServer, MCPServerAppPermissionA
 from apigateway.apps.permission.constants import ApplyStatusEnum, GrantDimensionEnum
 from apigateway.apps.permission.models import AppPermissionApply, AppPermissionRecord
 from apigateway.core.constants import GatewayStatusEnum, StageStatusEnum
-from apigateway.core.models import Gateway, Resource
+from apigateway.core.models import Gateway, Resource, Stage
 from apigateway.utils.time import now_datetime
 
 pytestmark = pytest.mark.django_db
@@ -80,6 +80,32 @@ def fake_mcp_server(fake_gateway, fake_stage, faker):
         is_public=True,
         _resource_names="resource1;resource2",
     )
+
+
+@pytest.fixture
+def make_mcp_server(faker):
+    """创建指定网关下的 MCP Server"""
+
+    def _make_mcp_server(gateway):
+        stage = G(
+            Stage,
+            gateway=gateway,
+            status=StageStatusEnum.ACTIVE.value,
+            name=faker.pystr()[:20],
+            description=faker.pystr(),
+        )
+        return G(
+            MCPServer,
+            name=faker.pystr()[:20],
+            gateway=gateway,
+            stage=stage,
+            status=MCPServerStatusEnum.ACTIVE.value,
+            description=faker.pystr(),
+            is_public=True,
+            _resource_names="resource1;resource2",
+        )
+
+    return _make_mcp_server
 
 
 # ==================== 筛选下拉选项 - 网关 ====================
@@ -328,6 +354,29 @@ class TestWorkbenchMCPServerFilterOptionListApi:
         mcp_ids = [item["id"] for item in result["data"]]
         assert fake_mcp_server.id not in mcp_ids
 
+    def test_pending_excludes_non_maintainer_mcp_servers(self, request_view, fake_other_gateway, make_mcp_server):
+        """pending 类型：不返回非 maintainer 网关下存在待审批申请的 MCP Server"""
+        mcp_server = make_mcp_server(fake_other_gateway)
+        G(
+            MCPServerAppPermissionApply,
+            mcp_server=mcp_server,
+            bk_app_code="app1",
+            applied_by="applicant1",
+            applied_time=now_datetime(),
+            status=MCPServerAppPermissionApplyStatusEnum.PENDING.value,
+            is_deleted=False,
+        )
+
+        resp = request_view(
+            method="GET",
+            view_name="workbench.filter_options.mcp_servers",
+            data={"type": "pending"},
+        )
+        result = resp.json()
+
+        mcp_ids = [item["id"] for item in result["data"]]
+        assert mcp_server.id not in mcp_ids
+
     def test_applied_returns_mcp_servers_from_my_applies(self, request_view, fake_gateway, fake_mcp_server):
         """applied 类型：返回当前用户申请过的 MCP Server"""
         G(
@@ -474,8 +523,19 @@ class TestWorkbenchMCPGatewayFilterOptionListApi:
         gateway_ids = [item["id"] for item in result["data"]]
         assert fake_gateway.id not in gateway_ids
 
-    def test_pending_excludes_non_maintainer_gateways(self, request_view, fake_other_gateway):
-        """pending 类型：不返回非 maintainer 的网关"""
+    def test_pending_excludes_non_maintainer_gateways(self, request_view, fake_other_gateway, make_mcp_server):
+        """pending 类型：不返回非 maintainer 网关下存在待审批 MCP 申请的网关"""
+        mcp_server = make_mcp_server(fake_other_gateway)
+        G(
+            MCPServerAppPermissionApply,
+            mcp_server=mcp_server,
+            bk_app_code="app1",
+            applied_by="applicant1",
+            applied_time=now_datetime(),
+            status=MCPServerAppPermissionApplyStatusEnum.PENDING.value,
+            is_deleted=False,
+        )
+
         resp = request_view(
             method="GET",
             view_name="workbench.filter_options.mcp_gateways",

--- a/src/dashboard/apigateway/apigateway/tests/apis/web/personal_workbench/test_views.py
+++ b/src/dashboard/apigateway/apigateway/tests/apis/web/personal_workbench/test_views.py
@@ -86,8 +86,16 @@ def fake_mcp_server(fake_gateway, fake_stage, faker):
 
 
 class TestWorkbenchGatewayFilterOptionListApi:
-    def test_pending_returns_maintainer_gateways(self, request_view, fake_gateway):
-        """pending 类型：返回当前用户作为 maintainer 的网关"""
+    def test_pending_returns_gateways_from_pending_applies(self, request_view, fake_gateway):
+        """pending 类型：返回我的待办权限列表关联的网关"""
+        G(
+            AppPermissionApply,
+            gateway=fake_gateway,
+            bk_app_code="app1",
+            applied_by="applicant1",
+            status=ApplyStatusEnum.PENDING.value,
+        )
+
         resp = request_view(
             method="GET",
             view_name="workbench.filter_options.gateways",
@@ -99,8 +107,28 @@ class TestWorkbenchGatewayFilterOptionListApi:
         gateway_ids = [item["id"] for item in result["data"]]
         assert fake_gateway.id in gateway_ids
 
+    def test_pending_excludes_gateways_without_pending_apply(self, request_view, fake_gateway):
+        """pending 类型：不返回没有待审批申请的网关"""
+        resp = request_view(
+            method="GET",
+            view_name="workbench.filter_options.gateways",
+            data={"type": "pending"},
+        )
+        result = resp.json()
+
+        gateway_ids = [item["id"] for item in result["data"]]
+        assert fake_gateway.id not in gateway_ids
+
     def test_pending_excludes_non_maintainer_gateways(self, request_view, fake_other_gateway):
         """pending 类型：不返回非 maintainer 的网关"""
+        G(
+            AppPermissionApply,
+            gateway=fake_other_gateway,
+            bk_app_code="app1",
+            applied_by="applicant1",
+            status=ApplyStatusEnum.PENDING.value,
+        )
+
         resp = request_view(
             method="GET",
             view_name="workbench.filter_options.gateways",
@@ -158,6 +186,14 @@ class TestWorkbenchGatewayFilterOptionListApi:
 
     def test_default_type_is_pending(self, request_view, fake_gateway):
         """默认 type 为 pending"""
+        G(
+            AppPermissionApply,
+            gateway=fake_gateway,
+            bk_app_code="app1",
+            applied_by="applicant1",
+            status=ApplyStatusEnum.PENDING.value,
+        )
+
         resp = request_view(
             method="GET",
             view_name="workbench.filter_options.gateways",
@@ -229,6 +265,14 @@ class TestWorkbenchGatewayFilterOptionListApi:
             tenant_mode="single",
             tenant_id="default",
         )
+        for gateway in [gw_z, gw_a]:
+            G(
+                AppPermissionApply,
+                gateway=gateway,
+                bk_app_code="app1",
+                applied_by="applicant1",
+                status=ApplyStatusEnum.PENDING.value,
+            )
 
         resp = request_view(
             method="GET",
@@ -245,8 +289,18 @@ class TestWorkbenchGatewayFilterOptionListApi:
 
 
 class TestWorkbenchMCPServerFilterOptionListApi:
-    def test_pending_returns_maintainer_mcp_servers(self, request_view, fake_gateway, fake_mcp_server):
-        """pending 类型：返回当前用户作为 maintainer 管理的网关下的 MCP Server"""
+    def test_pending_returns_mcp_servers_from_pending_applies(self, request_view, fake_gateway, fake_mcp_server):
+        """pending 类型：返回我的待办权限列表关联的 MCP Server"""
+        G(
+            MCPServerAppPermissionApply,
+            mcp_server=fake_mcp_server,
+            bk_app_code="app1",
+            applied_by="applicant1",
+            applied_time=now_datetime(),
+            status=MCPServerAppPermissionApplyStatusEnum.PENDING.value,
+            is_deleted=False,
+        )
+
         resp = request_view(
             method="GET",
             view_name="workbench.filter_options.mcp_servers",
@@ -261,6 +315,18 @@ class TestWorkbenchMCPServerFilterOptionListApi:
         mcp_item = next(item for item in result["data"] if item["id"] == fake_mcp_server.id)
         assert mcp_item["gateway_id"] == fake_gateway.id
         assert mcp_item["gateway_name"] == fake_gateway.name
+
+    def test_pending_excludes_mcp_servers_without_pending_apply(self, request_view, fake_mcp_server):
+        """pending 类型：不返回没有待审批申请的 MCP Server"""
+        resp = request_view(
+            method="GET",
+            view_name="workbench.filter_options.mcp_servers",
+            data={"type": "pending"},
+        )
+        result = resp.json()
+
+        mcp_ids = [item["id"] for item in result["data"]]
+        assert fake_mcp_server.id not in mcp_ids
 
     def test_applied_returns_mcp_servers_from_my_applies(self, request_view, fake_gateway, fake_mcp_server):
         """applied 类型：返回当前用户申请过的 MCP Server"""
@@ -373,8 +439,18 @@ class TestWorkbenchMCPServerFilterOptionListApi:
 
 
 class TestWorkbenchMCPGatewayFilterOptionListApi:
-    def test_pending_returns_maintainer_gateways(self, request_view, fake_gateway):
-        """pending 类型：返回当前用户作为 maintainer 的网关"""
+    def test_pending_returns_gateways_from_pending_mcp_applies(self, request_view, fake_gateway, fake_mcp_server):
+        """pending 类型：返回我的待办权限列表关联的网关"""
+        G(
+            MCPServerAppPermissionApply,
+            mcp_server=fake_mcp_server,
+            bk_app_code="app1",
+            applied_by="applicant1",
+            applied_time=now_datetime(),
+            status=MCPServerAppPermissionApplyStatusEnum.PENDING.value,
+            is_deleted=False,
+        )
+
         resp = request_view(
             method="GET",
             view_name="workbench.filter_options.mcp_gateways",
@@ -385,6 +461,18 @@ class TestWorkbenchMCPGatewayFilterOptionListApi:
         assert resp.status_code == 200
         gateway_ids = [item["id"] for item in result["data"]]
         assert fake_gateway.id in gateway_ids
+
+    def test_pending_excludes_gateways_without_pending_mcp_apply(self, request_view, fake_gateway):
+        """pending 类型：不返回没有待审批 MCP 申请的网关"""
+        resp = request_view(
+            method="GET",
+            view_name="workbench.filter_options.mcp_gateways",
+            data={"type": "pending"},
+        )
+        result = resp.json()
+
+        gateway_ids = [item["id"] for item in result["data"]]
+        assert fake_gateway.id not in gateway_ids
 
     def test_pending_excludes_non_maintainer_gateways(self, request_view, fake_other_gateway):
         """pending 类型：不返回非 maintainer 的网关"""
@@ -476,12 +564,12 @@ class TestWorkbenchMCPGatewayFilterOptionListApi:
         assert resp.status_code == 400
 
 
-# ==================== 我的代办 - API 网关 ====================
+# ==================== 我的待办 - API 网关 ====================
 
 
 class TestWorkbenchPendingGatewayPermissionListApi:
     def test_list(self, request_view, fake_gateway):
-        """测试我的代办 - API 网关：当前用户是 maintainer 的网关下有待审批的申请单"""
+        """测试我的待办 - API 网关：当前用户是 maintainer 的网关下有待审批的申请单"""
         G(
             AppPermissionApply,
             gateway=fake_gateway,
@@ -505,7 +593,7 @@ class TestWorkbenchPendingGatewayPermissionListApi:
         assert result["data"]["results"][0]["gateway_name"] == fake_gateway.name
 
     def test_list_excludes_non_maintainer_gateway(self, request_view, fake_gateway, fake_other_gateway):
-        """测试我的代办 - 不返回非 maintainer 网关的申请"""
+        """测试我的待办 - 不返回非 maintainer 网关的申请"""
         G(
             AppPermissionApply,
             gateway=fake_other_gateway,
@@ -524,7 +612,7 @@ class TestWorkbenchPendingGatewayPermissionListApi:
         assert result["data"]["count"] == 0
 
     def test_list_excludes_substring_maintainer_gateway(self, request_view, fake_substring_gateway):
-        """测试我的代办 - 用户名 admin 不应匹配 maintainer 为 superadmin 的网关（子串精确过滤）"""
+        """测试我的待办 - 用户名 admin 不应匹配 maintainer 为 superadmin 的网关（子串精确过滤）"""
         G(
             AppPermissionApply,
             gateway=fake_substring_gateway,
@@ -543,7 +631,7 @@ class TestWorkbenchPendingGatewayPermissionListApi:
         assert result["data"]["count"] == 0
 
     def test_list_excludes_non_pending(self, request_view, fake_gateway):
-        """测试我的代办 - 不返回已审批或已驳回的申请"""
+        """测试我的待办 - 不返回已审批或已驳回的申请"""
         G(
             AppPermissionApply,
             gateway=fake_gateway,
@@ -562,7 +650,7 @@ class TestWorkbenchPendingGatewayPermissionListApi:
         assert result["data"]["count"] == 0
 
     def test_list_filter_by_bk_app_code(self, request_view, fake_gateway):
-        """测试我的代办 - 按 bk_app_code 筛选"""
+        """测试我的待办 - 按 bk_app_code 筛选"""
         G(
             AppPermissionApply,
             gateway=fake_gateway,
@@ -590,7 +678,7 @@ class TestWorkbenchPendingGatewayPermissionListApi:
         assert result["data"]["results"][0]["bk_app_code"] == "target_app"
 
     def test_list_empty(self, request_view):
-        """测试我的代办 - 空数据"""
+        """测试我的待办 - 空数据"""
         resp = request_view(
             method="GET",
             view_name="workbench.permissions.gateway.pending",
@@ -651,12 +739,12 @@ class TestWorkbenchPendingGatewayPermissionListApi:
         assert result["data"]["results"][0]["resources"] == []
 
 
-# ==================== 我的代办 - MCP Server ====================
+# ==================== 我的待办 - MCP Server ====================
 
 
 class TestWorkbenchPendingMCPPermissionListApi:
     def test_list(self, request_view, fake_gateway, fake_mcp_server):
-        """测试我的代办 - MCP Server：当前用户是 maintainer 的网关下有待审批的 MCP 申请"""
+        """测试我的待办 - MCP Server：当前用户是 maintainer 的网关下有待审批的 MCP 申请"""
         G(
             MCPServerAppPermissionApply,
             mcp_server=fake_mcp_server,
@@ -681,7 +769,7 @@ class TestWorkbenchPendingMCPPermissionListApi:
         assert result["data"]["results"][0]["mcp_server"]["gateway_name"] == fake_gateway.name
 
     def test_list_excludes_substring_maintainer_gateway(self, request_view, fake_substring_gateway, fake_stage, faker):
-        """测试我的代办 - MCP Server：用户名 admin 不应匹配 maintainer 为 superadmin 的网关"""
+        """测试我的待办 - MCP Server：用户名 admin 不应匹配 maintainer 为 superadmin 的网关"""
         fake_stage.status = StageStatusEnum.ACTIVE.value
         fake_stage.save()
 
@@ -715,7 +803,7 @@ class TestWorkbenchPendingMCPPermissionListApi:
         assert result["data"]["count"] == 0
 
     def test_list_excludes_deleted(self, request_view, fake_gateway, fake_mcp_server):
-        """测试我的代办 - 不返回已删除的 MCP 申请"""
+        """测试我的待办 - 不返回已删除的 MCP 申请"""
         G(
             MCPServerAppPermissionApply,
             mcp_server=fake_mcp_server,
@@ -736,7 +824,7 @@ class TestWorkbenchPendingMCPPermissionListApi:
         assert result["data"]["count"] == 0
 
     def test_list_empty(self, request_view):
-        """测试我的代办 - MCP Server 空数据"""
+        """测试我的待办 - MCP Server 空数据"""
         resp = request_view(
             method="GET",
             view_name="workbench.permissions.mcp.pending",
@@ -748,7 +836,7 @@ class TestWorkbenchPendingMCPPermissionListApi:
         assert result["data"]["results"] == []
 
     def test_list_filter_by_gateway_id(self, request_view, fake_gateway, fake_mcp_server):
-        """测试我的代办 - MCP Server 按 gateway_id 筛选"""
+        """测试我的待办 - MCP Server 按 gateway_id 筛选"""
         G(
             MCPServerAppPermissionApply,
             mcp_server=fake_mcp_server,
@@ -806,6 +894,7 @@ class TestWorkbenchMyApplyGatewayPermissionListApi:
         assert resp.status_code == 200
         assert result["data"]["count"] == 1
         assert result["data"]["results"][0]["applied_by"] == FAKE_USERNAME
+        assert result["data"]["results"][0]["approvers"] == fake_gateway.maintainers
         assert result["data"]["results"][0]["gateway_id"] == fake_gateway.id
         assert result["data"]["results"][0]["gateway_name"] == fake_gateway.name
 
@@ -847,6 +936,28 @@ class TestWorkbenchMyApplyGatewayPermissionListApi:
 
         assert resp.status_code == 200
         assert result["data"]["count"] == 2
+
+    def test_list_filter_by_status(self, request_view, fake_gateway):
+        """测试我的申请 - API 网关按状态筛选"""
+        for status_val in [ApplyStatusEnum.PENDING.value, ApplyStatusEnum.APPROVED.value]:
+            G(
+                AppPermissionApply,
+                gateway=fake_gateway,
+                bk_app_code=status_val,
+                applied_by=FAKE_USERNAME,
+                status=status_val,
+            )
+
+        resp = request_view(
+            method="GET",
+            view_name="workbench.permissions.gateway.applied",
+            data={"status": ApplyStatusEnum.APPROVED.value},
+        )
+        result = resp.json()
+
+        assert resp.status_code == 200
+        assert result["data"]["count"] == 1
+        assert result["data"]["results"][0]["status"] == ApplyStatusEnum.APPROVED.value
 
     def test_list_with_resource_dimension_returns_resources(self, request_view, fake_gateway):
         """测试我的申请 - 资源维度应返回资源详情列表"""
@@ -923,6 +1034,7 @@ class TestWorkbenchMyApplyMCPPermissionListApi:
         assert resp.status_code == 200
         assert result["data"]["count"] == 1
         assert result["data"]["results"][0]["applied_by"] == FAKE_USERNAME
+        assert result["data"]["results"][0]["approvers"] == fake_gateway.maintainers
         assert result["data"]["results"][0]["mcp_server"]["gateway_id"] == fake_gateway.id
         assert result["data"]["results"][0]["mcp_server"]["gateway_name"] == fake_gateway.name
 
@@ -946,6 +1058,33 @@ class TestWorkbenchMyApplyMCPPermissionListApi:
 
         assert resp.status_code == 200
         assert result["data"]["count"] == 0
+
+    def test_list_filter_by_status(self, request_view, fake_gateway, fake_mcp_server):
+        """测试我的申请 - MCP Server 按状态筛选"""
+        for status_val in [
+            MCPServerAppPermissionApplyStatusEnum.PENDING.value,
+            MCPServerAppPermissionApplyStatusEnum.APPROVED.value,
+        ]:
+            G(
+                MCPServerAppPermissionApply,
+                mcp_server=fake_mcp_server,
+                bk_app_code=status_val,
+                applied_by=FAKE_USERNAME,
+                applied_time=now_datetime(),
+                status=status_val,
+                is_deleted=False,
+            )
+
+        resp = request_view(
+            method="GET",
+            view_name="workbench.permissions.mcp.applied",
+            data={"status": MCPServerAppPermissionApplyStatusEnum.APPROVED.value},
+        )
+        result = resp.json()
+
+        assert resp.status_code == 200
+        assert result["data"]["count"] == 1
+        assert result["data"]["results"][0]["status"] == MCPServerAppPermissionApplyStatusEnum.APPROVED.value
 
 
 # ==================== 我的已办 - API 网关 ====================

--- a/src/dashboard/apigateway/apigateway/tests/apis/web/personal_workbench/test_views.py
+++ b/src/dashboard/apigateway/apigateway/tests/apis/web/personal_workbench/test_views.py
@@ -17,6 +17,8 @@
 # to the current version of the project delivered to anyone in the future.
 #
 
+import datetime
+
 import pytest
 from ddf import G
 
@@ -26,7 +28,7 @@ from apigateway.apps.permission.constants import ApplyStatusEnum, GrantDimension
 from apigateway.apps.permission.models import AppPermissionApply, AppPermissionRecord
 from apigateway.core.constants import GatewayStatusEnum, StageStatusEnum
 from apigateway.core.models import Gateway, Resource, Stage
-from apigateway.utils.time import now_datetime
+from apigateway.utils.time import now_datetime, timestamp
 
 pytestmark = pytest.mark.django_db
 
@@ -737,6 +739,55 @@ class TestWorkbenchPendingGatewayPermissionListApi:
         assert result["data"]["count"] == 1
         assert result["data"]["results"][0]["bk_app_code"] == "target_app"
 
+    def test_list_filter_by_applied_time_range(self, request_view, fake_gateway):
+        """测试我的待办 - API 网关按申请时间范围筛选"""
+        current_time = now_datetime()
+        old_time = current_time - datetime.timedelta(days=2)
+        old_apply = G(
+            AppPermissionApply,
+            gateway=fake_gateway,
+            bk_app_code="old_app",
+            applied_by="applicant",
+            status=ApplyStatusEnum.PENDING.value,
+        )
+        AppPermissionApply.objects.filter(id=old_apply.id).update(created_time=old_time)
+        current_apply = G(
+            AppPermissionApply,
+            gateway=fake_gateway,
+            bk_app_code="current_app",
+            applied_by="applicant",
+            status=ApplyStatusEnum.PENDING.value,
+        )
+        AppPermissionApply.objects.filter(id=current_apply.id).update(created_time=current_time)
+
+        resp = request_view(
+            method="GET",
+            view_name="workbench.permissions.gateway.pending",
+            data={
+                "time_start": timestamp(current_time - datetime.timedelta(minutes=1)),
+                "time_end": timestamp(current_time + datetime.timedelta(minutes=1)),
+            },
+        )
+        result = resp.json()
+
+        assert resp.status_code == 200
+        assert result["data"]["count"] == 1
+        assert result["data"]["results"][0]["bk_app_code"] == "current_app"
+
+    def test_list_invalid_time_range(self, request_view):
+        """测试我的待办 - API 网关申请时间范围参数非法"""
+        current_time = now_datetime()
+        resp = request_view(
+            method="GET",
+            view_name="workbench.permissions.gateway.pending",
+            data={
+                "time_start": timestamp(current_time + datetime.timedelta(minutes=1)),
+                "time_end": timestamp(current_time - datetime.timedelta(minutes=1)),
+            },
+        )
+
+        assert resp.status_code == 400
+
     def test_list_empty(self, request_view):
         """测试我的待办 - 空数据"""
         resp = request_view(
@@ -760,8 +811,8 @@ class TestWorkbenchPendingGatewayPermissionListApi:
             status=ApplyStatusEnum.PENDING.value,
             grant_dimension=GrantDimensionEnum.RESOURCE.value,
         )
-        apply_obj._resource_ids = f"{resource.id}"
-        apply_obj.save()
+        apply_obj.resource_ids = [resource.id]
+        apply_obj.save(update_fields=["_resource_ids"])
 
         resp = request_view(
             method="GET",
@@ -929,6 +980,57 @@ class TestWorkbenchPendingMCPPermissionListApi:
         assert resp.status_code == 200
         assert result["data"]["count"] == 0
 
+    def test_list_filter_by_applied_time_range(self, request_view, fake_gateway, fake_mcp_server):
+        """测试我的待办 - MCP Server 按申请时间范围筛选"""
+        current_time = now_datetime()
+        old_time = current_time - datetime.timedelta(days=2)
+        G(
+            MCPServerAppPermissionApply,
+            mcp_server=fake_mcp_server,
+            bk_app_code="old_app",
+            applied_by="applicant",
+            applied_time=old_time,
+            status=MCPServerAppPermissionApplyStatusEnum.PENDING.value,
+            is_deleted=False,
+        )
+        G(
+            MCPServerAppPermissionApply,
+            mcp_server=fake_mcp_server,
+            bk_app_code="current_app",
+            applied_by="applicant",
+            applied_time=current_time,
+            status=MCPServerAppPermissionApplyStatusEnum.PENDING.value,
+            is_deleted=False,
+        )
+
+        resp = request_view(
+            method="GET",
+            view_name="workbench.permissions.mcp.pending",
+            data={
+                "time_start": timestamp(current_time - datetime.timedelta(minutes=1)),
+                "time_end": timestamp(current_time + datetime.timedelta(minutes=1)),
+            },
+        )
+        result = resp.json()
+
+        assert resp.status_code == 200
+        assert result["data"]["count"] == 1
+        assert result["data"]["results"][0]["bk_app_code"] == "current_app"
+
+    def test_list_invalid_time_range(self, request_view):
+        """测试我的待办 - MCP Server 申请时间范围参数非法"""
+        current_time = now_datetime()
+        resp = request_view(
+            method="GET",
+            view_name="workbench.permissions.mcp.pending",
+            data={
+                "time_start": timestamp(current_time + datetime.timedelta(minutes=1)),
+                "time_end": timestamp(current_time - datetime.timedelta(minutes=1)),
+            },
+        )
+
+        assert resp.status_code == 400
+
 
 # ==================== 我的申请 - API 网关 ====================
 
@@ -1018,6 +1120,41 @@ class TestWorkbenchMyApplyGatewayPermissionListApi:
         assert resp.status_code == 200
         assert result["data"]["count"] == 1
         assert result["data"]["results"][0]["status"] == ApplyStatusEnum.APPROVED.value
+
+    def test_list_filter_by_applied_time_range(self, request_view, fake_gateway):
+        """测试我的申请 - API 网关按申请时间范围筛选"""
+        current_time = now_datetime()
+        old_time = current_time - datetime.timedelta(days=2)
+        old_apply = G(
+            AppPermissionApply,
+            gateway=fake_gateway,
+            bk_app_code="old_app",
+            applied_by=FAKE_USERNAME,
+            status=ApplyStatusEnum.PENDING.value,
+        )
+        AppPermissionApply.objects.filter(id=old_apply.id).update(created_time=old_time)
+        current_apply = G(
+            AppPermissionApply,
+            gateway=fake_gateway,
+            bk_app_code="current_app",
+            applied_by=FAKE_USERNAME,
+            status=ApplyStatusEnum.PENDING.value,
+        )
+        AppPermissionApply.objects.filter(id=current_apply.id).update(created_time=current_time)
+
+        resp = request_view(
+            method="GET",
+            view_name="workbench.permissions.gateway.applied",
+            data={
+                "time_start": timestamp(current_time - datetime.timedelta(minutes=1)),
+                "time_end": timestamp(current_time + datetime.timedelta(minutes=1)),
+            },
+        )
+        result = resp.json()
+
+        assert resp.status_code == 200
+        assert result["data"]["count"] == 1
+        assert result["data"]["results"][0]["bk_app_code"] == "current_app"
 
     def test_list_with_resource_dimension_returns_resources(self, request_view, fake_gateway):
         """测试我的申请 - 资源维度应返回资源详情列表"""
@@ -1146,6 +1283,43 @@ class TestWorkbenchMyApplyMCPPermissionListApi:
         assert result["data"]["count"] == 1
         assert result["data"]["results"][0]["status"] == MCPServerAppPermissionApplyStatusEnum.APPROVED.value
 
+    def test_list_filter_by_applied_time_range(self, request_view, fake_gateway, fake_mcp_server):
+        """测试我的申请 - MCP Server 按申请时间范围筛选"""
+        current_time = now_datetime()
+        old_time = current_time - datetime.timedelta(days=2)
+        G(
+            MCPServerAppPermissionApply,
+            mcp_server=fake_mcp_server,
+            bk_app_code="old_app",
+            applied_by=FAKE_USERNAME,
+            applied_time=old_time,
+            status=MCPServerAppPermissionApplyStatusEnum.PENDING.value,
+            is_deleted=False,
+        )
+        G(
+            MCPServerAppPermissionApply,
+            mcp_server=fake_mcp_server,
+            bk_app_code="current_app",
+            applied_by=FAKE_USERNAME,
+            applied_time=current_time,
+            status=MCPServerAppPermissionApplyStatusEnum.PENDING.value,
+            is_deleted=False,
+        )
+
+        resp = request_view(
+            method="GET",
+            view_name="workbench.permissions.mcp.applied",
+            data={
+                "time_start": timestamp(current_time - datetime.timedelta(minutes=1)),
+                "time_end": timestamp(current_time + datetime.timedelta(minutes=1)),
+            },
+        )
+        result = resp.json()
+
+        assert resp.status_code == 200
+        assert result["data"]["count"] == 1
+        assert result["data"]["results"][0]["bk_app_code"] == "current_app"
+
 
 # ==================== 我的已办 - API 网关 ====================
 
@@ -1176,6 +1350,79 @@ class TestWorkbenchHandledGatewayPermissionListApi:
         assert result["data"]["results"][0]["handled_by"] == FAKE_USERNAME
         assert result["data"]["results"][0]["gateway_id"] == fake_gateway.id
         assert result["data"]["results"][0]["gateway_name"] == fake_gateway.name
+
+    def test_list_filter_by_status(self, request_view, fake_gateway):
+        """测试我的已办 - API 网关：按 status 筛选"""
+        G(
+            AppPermissionRecord,
+            gateway=fake_gateway,
+            bk_app_code="approved_app",
+            applied_by="applicant1",
+            applied_time=now_datetime(),
+            handled_by=FAKE_USERNAME,
+            handled_time=now_datetime(),
+            status=ApplyStatusEnum.APPROVED.value,
+        )
+        G(
+            AppPermissionRecord,
+            gateway=fake_gateway,
+            bk_app_code="rejected_app",
+            applied_by="applicant2",
+            applied_time=now_datetime(),
+            handled_by=FAKE_USERNAME,
+            handled_time=now_datetime(),
+            status=ApplyStatusEnum.REJECTED.value,
+        )
+
+        resp = request_view(
+            method="GET",
+            view_name="workbench.permissions.gateway.handled",
+            data={"status": ApplyStatusEnum.REJECTED.value},
+        )
+        result = resp.json()
+
+        assert resp.status_code == 200
+        assert result["data"]["count"] == 1
+        assert result["data"]["results"][0]["bk_app_code"] == "rejected_app"
+
+    def test_list_filter_by_applied_time_range(self, request_view, fake_gateway):
+        """测试我的已办 - API 网关按申请时间范围筛选"""
+        current_time = now_datetime()
+        old_time = current_time - datetime.timedelta(days=2)
+        G(
+            AppPermissionRecord,
+            gateway=fake_gateway,
+            bk_app_code="old_app",
+            applied_by="applicant1",
+            applied_time=old_time,
+            handled_by=FAKE_USERNAME,
+            handled_time=current_time,
+            status=ApplyStatusEnum.APPROVED.value,
+        )
+        G(
+            AppPermissionRecord,
+            gateway=fake_gateway,
+            bk_app_code="current_app",
+            applied_by="applicant2",
+            applied_time=current_time,
+            handled_by=FAKE_USERNAME,
+            handled_time=current_time,
+            status=ApplyStatusEnum.APPROVED.value,
+        )
+
+        resp = request_view(
+            method="GET",
+            view_name="workbench.permissions.gateway.handled",
+            data={
+                "time_start": timestamp(current_time - datetime.timedelta(minutes=1)),
+                "time_end": timestamp(current_time + datetime.timedelta(minutes=1)),
+            },
+        )
+        result = resp.json()
+
+        assert resp.status_code == 200
+        assert result["data"]["count"] == 1
+        assert result["data"]["results"][0]["bk_app_code"] == "current_app"
 
     def test_list_excludes_pending(self, request_view, fake_gateway):
         """测试我的已办 - 不返回 pending 状态的记录"""
@@ -1247,8 +1494,8 @@ class TestWorkbenchHandledGatewayPermissionListApi:
             status=ApplyStatusEnum.APPROVED.value,
             grant_dimension=GrantDimensionEnum.RESOURCE.value,
         )
-        record._resource_ids = f"{resource.id}"
-        record.save()
+        record.resource_ids = [resource.id]
+        record.save(update_fields=["_resource_ids"])
 
         resp = request_view(
             method="GET",
@@ -1318,6 +1565,47 @@ class TestWorkbenchHandledMCPPermissionListApi:
 
         assert resp.status_code == 200
         assert result["data"]["count"] == 1
+
+    def test_list_filter_by_applied_time_range(self, request_view, fake_gateway, fake_mcp_server):
+        """测试我的已办 - MCP Server 按申请时间范围筛选"""
+        current_time = now_datetime()
+        old_time = current_time - datetime.timedelta(days=2)
+        G(
+            MCPServerAppPermissionApply,
+            mcp_server=fake_mcp_server,
+            bk_app_code="old_app",
+            applied_by="applicant1",
+            applied_time=old_time,
+            handled_by=FAKE_USERNAME,
+            handled_time=current_time,
+            status=MCPServerAppPermissionApplyStatusEnum.APPROVED.value,
+            is_deleted=False,
+        )
+        G(
+            MCPServerAppPermissionApply,
+            mcp_server=fake_mcp_server,
+            bk_app_code="current_app",
+            applied_by="applicant2",
+            applied_time=current_time,
+            handled_by=FAKE_USERNAME,
+            handled_time=current_time,
+            status=MCPServerAppPermissionApplyStatusEnum.APPROVED.value,
+            is_deleted=False,
+        )
+
+        resp = request_view(
+            method="GET",
+            view_name="workbench.permissions.mcp.handled",
+            data={
+                "time_start": timestamp(current_time - datetime.timedelta(minutes=1)),
+                "time_end": timestamp(current_time + datetime.timedelta(minutes=1)),
+            },
+        )
+        result = resp.json()
+
+        assert resp.status_code == 200
+        assert result["data"]["count"] == 1
+        assert result["data"]["results"][0]["bk_app_code"] == "current_app"
 
     def test_list_excludes_pending(self, request_view, fake_gateway, fake_mcp_server):
         """测试我的已办 - 不返回 pending 状态的记录"""


### PR DESCRIPTION
### Description

- Unify '代办' to '待办' in personal workbench API and tests
- Fix pending filter options (gateway/mcp-server/mcp-gateway) to source from pending permission applies instead of all maintainer gateways
- Extract _get_pending_*_permission_apply_queryset() for reuse between list and filter APIs
- Add approvers field to gateway and MCP permission apply output serializers
- Add status filter to gateway permission apply filter and input serializer
- Add corresponding unit tests