### PR TITLE
fix(stage): allow unused default backend to remain unconfigured

### DIFF
--- a/src/dashboard/apigateway/apigateway/apis/open/stage/serializers.py
+++ b/src/dashboard/apigateway/apigateway/apis/open/stage/serializers.py
@@ -303,7 +303,9 @@ class StageSLZ(ExtensibleFieldMixin, serializers.ModelSerializer):
     )
     proxy_http = StageProxyHTTPConfigSLZ(required=False)
 
-    backends = serializers.ListSerializer(help_text="后端配置", child=BackendSLZ(), allow_null=True, required=False)
+    backends = serializers.ListSerializer(
+        help_text="后端配置", child=BackendSLZ(), allow_null=True, allow_empty=False, required=False
+    )
 
     plugin_configs = serializers.ListSerializer(
         help_text="插件配置", child=PluginConfigSLZ(), allow_null=True, required=False

--- a/src/dashboard/apigateway/apigateway/apis/open/stage/serializers.py
+++ b/src/dashboard/apigateway/apigateway/apis/open/stage/serializers.py
@@ -412,30 +412,10 @@ class StageSLZ(ExtensibleFieldMixin, serializers.ModelSerializer):
             )
             backend_configs.append(backend_config)
 
-        # 4. create other backend config with empty host (skip default)
-        backends = (
-            Backend.objects.filter(gateway=instance.gateway).exclude(name__in=names).exclude(name=DEFAULT_BACKEND_NAME)
-        )
-        config = {
-            "type": "node",
-            "timeout": 30,
-            "loadbalance": "roundrobin",
-            "hosts": [{"scheme": "http", "host": "", "weight": 100}],
-        }
-
-        for backend in backends:
-            backend_config = BackendConfig(
-                gateway=instance.gateway,
-                backend=backend,
-                stage=instance,
-                config=config,
-            )
-            backend_configs.append(backend_config)
-
         if backend_configs:
             BackendConfig.objects.bulk_create(backend_configs)
 
-        # 5. sync stage plugin
+        # 4. sync stage plugin
         self._sync_plugins(instance.gateway_id, instance.id, validated_data.get("plugin_configs", None))
 
         return instance

--- a/src/dashboard/apigateway/apigateway/apis/open/stage/serializers.py
+++ b/src/dashboard/apigateway/apigateway/apis/open/stage/serializers.py
@@ -412,8 +412,10 @@ class StageSLZ(ExtensibleFieldMixin, serializers.ModelSerializer):
             )
             backend_configs.append(backend_config)
 
-        # 4. create other backend config with empty host
-        backends = Backend.objects.filter(gateway=instance.gateway).exclude(name__in=names)
+        # 4. create other backend config with empty host (skip default)
+        backends = (
+            Backend.objects.filter(gateway=instance.gateway).exclude(name__in=names).exclude(name=DEFAULT_BACKEND_NAME)
+        )
         config = {
             "type": "node",
             "timeout": 30,

--- a/src/dashboard/apigateway/apigateway/apis/v2/sync/serializers.py
+++ b/src/dashboard/apigateway/apigateway/apis/v2/sync/serializers.py
@@ -475,28 +475,10 @@ class StageSyncInputSLZ(ExtensibleFieldMixin, serializers.ModelSerializer):
             )
             backend_configs.append(backend_config)
 
-        # 4. create other backend config with empty host
-        backends = Backend.objects.filter(gateway=instance.gateway).exclude(name__in=names)
-        config = {
-            "type": "node",
-            "timeout": 30,
-            "loadbalance": "roundrobin",
-            "hosts": [{"scheme": "http", "host": "", "weight": 100}],
-        }
-
-        for backend in backends:
-            backend_config = BackendConfig(
-                gateway=instance.gateway,
-                backend=backend,
-                stage=instance,
-                config=config,
-            )
-            backend_configs.append(backend_config)
-
         if backend_configs:
             BackendConfig.objects.bulk_create(backend_configs)
 
-        # 5. sync stage plugin
+        # 4. sync stage plugin
         self._sync_plugins(instance.gateway_id, instance.id, validated_data.get("plugin_configs", None))
 
         return instance

--- a/src/dashboard/apigateway/apigateway/apis/v2/sync/serializers.py
+++ b/src/dashboard/apigateway/apigateway/apis/v2/sync/serializers.py
@@ -392,7 +392,9 @@ class StageSyncInputSLZ(ExtensibleFieldMixin, serializers.ModelSerializer):
         default=dict,
     )
 
-    backends = serializers.ListSerializer(help_text="后端配置", child=BackendSLZ(), allow_null=False, required=True)
+    backends = serializers.ListSerializer(
+        help_text="后端配置", child=BackendSLZ(), allow_null=False, allow_empty=False, required=True
+    )
 
     plugin_configs = serializers.ListSerializer(
         help_text="插件配置", child=PluginConfigSLZ(), allow_null=True, required=False

--- a/src/dashboard/apigateway/apigateway/apis/web/resource_version/serializers.py
+++ b/src/dashboard/apigateway/apigateway/apis/web/resource_version/serializers.py
@@ -84,7 +84,9 @@ class ResourceInfoSLZ(serializers.Serializer):
 
             # 后端服务配置
             if backend and "resource_backend_configs" in self.context:
-                backend_info["config"] = self.context["resource_backend_configs"][backend_id].config
+                backend_config = self.context["resource_backend_configs"].get(backend_id)
+                if backend_config:
+                    backend_info["config"] = backend_config.config
 
             proxy["backend"] = backend_info
 

--- a/src/dashboard/apigateway/apigateway/biz/validators.py
+++ b/src/dashboard/apigateway/apigateway/biz/validators.py
@@ -32,14 +32,13 @@ from apigateway.common.constants import STAGE_VAR_NAME_PATTERN, CallSourceTypeEn
 from apigateway.common.mixins.contexts import GetGatewayFromContextMixin
 from apigateway.core import constants as core_constants
 from apigateway.core.constants import (
-    DEFAULT_BACKEND_NAME,
     HOST_WITHOUT_SCHEME_PATTERN,
     BackendTypeEnum,
     GatewayStatusEnum,
     HashOnTypeEnum,
     LoadBalanceTypeEnum,
 )
-from apigateway.core.models import BackendConfig, Gateway, Proxy, Resource, ResourceVersion, Stage
+from apigateway.core.models import Backend, BackendConfig, Gateway, Proxy, Resource, ResourceVersion, Stage
 
 from .constants import (
     APP_CODE_PATTERN,
@@ -220,24 +219,30 @@ class PublishValidator:
                     if resource["proxy"].get("backend_id", None)
                 }
             )
-            backend_configs = list(BackendConfig.objects.filter(stage=self.stage, backend_id__in=backend_ids))
         else:
             # 校验编辑区的资源所绑定的后端服务
             resource_ids = Resource.objects.filter(gateway=self.gateway).values_list("id", flat=True)
-            backend_ids = (
+            backend_ids = list(
                 Proxy.objects.filter(resource_id__in=resource_ids).values_list("backend_id", flat=True).distinct()
             )
-            backend_configs = list(BackendConfig.objects.filter(stage=self.stage, backend_id__in=backend_ids))
 
-        # default backend config 校验
-        default_backend_config = BackendConfig.objects.filter(
-            stage=self.stage, backend__name=DEFAULT_BACKEND_NAME
-        ).get()
+        backend_configs = list(BackendConfig.objects.filter(stage=self.stage, backend_id__in=backend_ids))
+        configured_backend_ids = {bc.backend_id for bc in backend_configs}
 
-        all_backend_configs = backend_configs + [default_backend_config]
-        for backend_config in all_backend_configs:
-            for host in backend_config.config["hosts"]:
-                if not core_constants.HOST_WITHOUT_SCHEME_PATTERN.match(host["host"]):
+        # 检查资源用到的 backend 是否都有 stage 配置
+        missing_backend_ids = set(backend_ids) - configured_backend_ids
+        if missing_backend_ids:
+            missing_backends = list(Backend.objects.filter(id__in=missing_backend_ids).values_list("name", flat=True))
+            raise ReleaseValidationError(
+                _("网关环境【{stage_name}】缺少后端服务【{backends}】的配置，请在网关 `后端服务` 中进行配置。").format(
+                    stage_name=self.stage.name,
+                    backends=", ".join(missing_backends),
+                )
+            )
+
+        for backend_config in backend_configs:
+            for host in backend_config.config.get("hosts", []):
+                if not core_constants.HOST_WITHOUT_SCHEME_PATTERN.match(host.get("host", "")):
                     raise ReleaseValidationError(
                         _(
                             "网关环境【{stage_name}】中的配置【后端服务 {backend_name} 地址】不合法。请在网关 `后端服务` 中进行配置。"

--- a/src/dashboard/apigateway/apigateway/biz/validators.py
+++ b/src/dashboard/apigateway/apigateway/biz/validators.py
@@ -32,6 +32,7 @@ from apigateway.common.constants import STAGE_VAR_NAME_PATTERN, CallSourceTypeEn
 from apigateway.common.mixins.contexts import GetGatewayFromContextMixin
 from apigateway.core import constants as core_constants
 from apigateway.core.constants import (
+    DEFAULT_BACKEND_NAME,
     HOST_WITHOUT_SCHEME_PATTERN,
     BackendTypeEnum,
     GatewayStatusEnum,
@@ -203,36 +204,75 @@ class PublishValidator:
         self.stage = stage
         self.resource_version = resource_version
 
+    def _get_resource_version_backend_ids(self, resource_version):
+        backend_ids = set()
+        used_default_backend = False
+        for resource in resource_version.data:
+            backend_id = resource["proxy"].get("backend_id")
+            if backend_id:
+                backend_ids.add(backend_id)
+            else:
+                used_default_backend = True
+        return backend_ids, used_default_backend
+
+    def _get_editing_backend_ids(self):
+        resource_ids = Resource.objects.filter(gateway=self.gateway).values_list("id", flat=True)
+        proxies = Proxy.objects.filter(resource_id__in=resource_ids)
+        backend_ids = set(proxies.filter(backend_id__isnull=False).values_list("backend_id", flat=True).distinct())
+        used_default_backend = proxies.filter(backend_id__isnull=True).exists()
+        return backend_ids, used_default_backend
+
+    def _add_default_backend_id_if_used(self, backend_ids, used_default_backend):
+        if not used_default_backend:
+            return []
+
+        default_backend = Backend.objects.filter(gateway=self.gateway, name=DEFAULT_BACKEND_NAME).first()
+        if default_backend:
+            backend_ids.add(default_backend.id)
+            return []
+
+        return [DEFAULT_BACKEND_NAME]
+
+    def _raise_invalid_backend_config(self, backend_config):
+        raise ReleaseValidationError(
+            _(
+                "网关环境【{stage_name}】中的配置【后端服务 {backend_name} 地址】不合法。请在网关 `后端服务` 中进行配置。"
+            ).format(
+                stage_name=self.stage.name,
+                backend_name=backend_config.backend.name,
+            )
+        )
+
+    def _validate_backend_hosts(self, backend_configs):
+        for backend_config in backend_configs:
+            hosts = backend_config.config.get("hosts")
+            if not hosts:
+                self._raise_invalid_backend_config(backend_config)
+
+            for host in hosts:
+                if not core_constants.HOST_WITHOUT_SCHEME_PATTERN.match(host.get("host", "")):
+                    self._raise_invalid_backend_config(backend_config)
+
     def _validate_stage_backends(self):
         """校验待发布环境的backend配置"""
-        resource_version = self.resource_version
-
-        if not resource_version:
-            # 如果没有指定版本，则使用当前网关的最新版本
-            resource_version = ResourceVersion.objects.get_latest_version(self.gateway.id)
+        resource_version = self.resource_version or ResourceVersion.objects.get_latest_version(self.gateway.id)
 
         if resource_version and resource_version.data:
-            backend_ids = list(
-                {
-                    resource["proxy"]["backend_id"]
-                    for resource in resource_version.data
-                    if resource["proxy"].get("backend_id", None)
-                }
-            )
+            backend_ids, used_default_backend = self._get_resource_version_backend_ids(resource_version)
         else:
-            # 校验编辑区的资源所绑定的后端服务
-            resource_ids = Resource.objects.filter(gateway=self.gateway).values_list("id", flat=True)
-            backend_ids = list(
-                Proxy.objects.filter(resource_id__in=resource_ids).values_list("backend_id", flat=True).distinct()
-            )
+            backend_ids, used_default_backend = self._get_editing_backend_ids()
 
+        missing_backend_names = self._add_default_backend_id_if_used(backend_ids, used_default_backend)
         backend_configs = list(BackendConfig.objects.filter(stage=self.stage, backend_id__in=backend_ids))
         configured_backend_ids = {bc.backend_id for bc in backend_configs}
 
         # 检查资源用到的 backend 是否都有 stage 配置
-        missing_backend_ids = set(backend_ids) - configured_backend_ids
-        if missing_backend_ids:
-            missing_backends = list(Backend.objects.filter(id__in=missing_backend_ids).values_list("name", flat=True))
+        missing_backend_ids = backend_ids - configured_backend_ids
+        if missing_backend_ids or missing_backend_names:
+            missing_backends = list(
+                Backend.objects.filter(id__in=missing_backend_ids).order_by("name").values_list("name", flat=True)
+            )
+            missing_backends.extend(missing_backend_names)
             raise ReleaseValidationError(
                 _("网关环境【{stage_name}】缺少后端服务【{backends}】的配置，请在网关 `后端服务` 中进行配置。").format(
                     stage_name=self.stage.name,
@@ -240,17 +280,7 @@ class PublishValidator:
                 )
             )
 
-        for backend_config in backend_configs:
-            for host in backend_config.config.get("hosts", []):
-                if not core_constants.HOST_WITHOUT_SCHEME_PATTERN.match(host.get("host", "")):
-                    raise ReleaseValidationError(
-                        _(
-                            "网关环境【{stage_name}】中的配置【后端服务 {backend_name} 地址】不合法。请在网关 `后端服务` 中进行配置。"
-                        ).format(
-                            stage_name=self.stage.name,
-                            backend_name=backend_config.backend.name,
-                        )
-                    )
+        self._validate_backend_hosts(backend_configs)
 
     def _validate_stage_plugins(self):
         """校验待发布环境的plugin配置"""

--- a/src/dashboard/apigateway/apigateway/biz/validators.py
+++ b/src/dashboard/apigateway/apigateway/biz/validators.py
@@ -203,21 +203,6 @@ class PublishValidator:
         self.stage = stage
         self.resource_version = resource_version
 
-    def _get_resource_version_backend_ids(self, resource_version):
-        return {
-            resource["proxy"].get("backend_id")
-            for resource in resource_version.data
-            if resource["proxy"].get("backend_id")
-        }
-
-    def _get_editing_backend_ids(self):
-        resource_ids = Resource.objects.filter(gateway=self.gateway).values_list("id", flat=True)
-        return set(
-            Proxy.objects.filter(resource_id__in=resource_ids, backend_id__isnull=False)
-            .values_list("backend_id", flat=True)
-            .distinct()
-        )
-
     def _raise_invalid_backend_config(self, backend_config):
         raise ReleaseValidationError(
             _(
@@ -243,9 +228,11 @@ class PublishValidator:
         resource_version = self.resource_version or ResourceVersion.objects.get_latest_version(self.gateway.id)
 
         if resource_version and resource_version.data:
-            backend_ids = self._get_resource_version_backend_ids(resource_version)
+            backend_ids = {resource["proxy"]["backend_id"] for resource in resource_version.data}
         else:
-            backend_ids = self._get_editing_backend_ids()
+            backend_ids = set(
+                Proxy.objects.filter(resource__gateway=self.gateway).values_list("backend_id", flat=True).distinct()
+            )
 
         backend_configs = list(BackendConfig.objects.filter(stage=self.stage, backend_id__in=backend_ids))
         configured_backend_ids = {bc.backend_id for bc in backend_configs}

--- a/src/dashboard/apigateway/apigateway/biz/validators.py
+++ b/src/dashboard/apigateway/apigateway/biz/validators.py
@@ -32,7 +32,6 @@ from apigateway.common.constants import STAGE_VAR_NAME_PATTERN, CallSourceTypeEn
 from apigateway.common.mixins.contexts import GetGatewayFromContextMixin
 from apigateway.core import constants as core_constants
 from apigateway.core.constants import (
-    DEFAULT_BACKEND_NAME,
     HOST_WITHOUT_SCHEME_PATTERN,
     BackendTypeEnum,
     GatewayStatusEnum,
@@ -205,33 +204,19 @@ class PublishValidator:
         self.resource_version = resource_version
 
     def _get_resource_version_backend_ids(self, resource_version):
-        backend_ids = set()
-        used_default_backend = False
-        for resource in resource_version.data:
-            backend_id = resource["proxy"].get("backend_id")
-            if backend_id:
-                backend_ids.add(backend_id)
-            else:
-                used_default_backend = True
-        return backend_ids, used_default_backend
+        return {
+            resource["proxy"].get("backend_id")
+            for resource in resource_version.data
+            if resource["proxy"].get("backend_id")
+        }
 
     def _get_editing_backend_ids(self):
         resource_ids = Resource.objects.filter(gateway=self.gateway).values_list("id", flat=True)
-        proxies = Proxy.objects.filter(resource_id__in=resource_ids)
-        backend_ids = set(proxies.filter(backend_id__isnull=False).values_list("backend_id", flat=True).distinct())
-        used_default_backend = proxies.filter(backend_id__isnull=True).exists()
-        return backend_ids, used_default_backend
-
-    def _add_default_backend_id_if_used(self, backend_ids, used_default_backend):
-        if not used_default_backend:
-            return []
-
-        default_backend = Backend.objects.filter(gateway=self.gateway, name=DEFAULT_BACKEND_NAME).first()
-        if default_backend:
-            backend_ids.add(default_backend.id)
-            return []
-
-        return [DEFAULT_BACKEND_NAME]
+        return set(
+            Proxy.objects.filter(resource_id__in=resource_ids, backend_id__isnull=False)
+            .values_list("backend_id", flat=True)
+            .distinct()
+        )
 
     def _raise_invalid_backend_config(self, backend_config):
         raise ReleaseValidationError(
@@ -258,21 +243,19 @@ class PublishValidator:
         resource_version = self.resource_version or ResourceVersion.objects.get_latest_version(self.gateway.id)
 
         if resource_version and resource_version.data:
-            backend_ids, used_default_backend = self._get_resource_version_backend_ids(resource_version)
+            backend_ids = self._get_resource_version_backend_ids(resource_version)
         else:
-            backend_ids, used_default_backend = self._get_editing_backend_ids()
+            backend_ids = self._get_editing_backend_ids()
 
-        missing_backend_names = self._add_default_backend_id_if_used(backend_ids, used_default_backend)
         backend_configs = list(BackendConfig.objects.filter(stage=self.stage, backend_id__in=backend_ids))
         configured_backend_ids = {bc.backend_id for bc in backend_configs}
 
         # 检查资源用到的 backend 是否都有 stage 配置
         missing_backend_ids = backend_ids - configured_backend_ids
-        if missing_backend_ids or missing_backend_names:
+        if missing_backend_ids:
             missing_backends = list(
                 Backend.objects.filter(id__in=missing_backend_ids).order_by("name").values_list("name", flat=True)
             )
-            missing_backends.extend(missing_backend_names)
             raise ReleaseValidationError(
                 _("网关环境【{stage_name}】缺少后端服务【{backends}】的配置，请在网关 `后端服务` 中进行配置。").format(
                     stage_name=self.stage.name,

--- a/src/dashboard/apigateway/apigateway/tests/apis/open/stage/test_views.py
+++ b/src/dashboard/apigateway/apigateway/tests/apis/open/stage/test_views.py
@@ -134,6 +134,31 @@ class TestStageSyncViewSet:
         assert result["code"] == 0
         assert stage.status == 0
 
+    def test_sync_with_empty_backends_returns_error(self, mocker, unique_gateway_name, request_factory):
+        mocker.patch(
+            "apigateway.apis.open.stage.views.OpenAPIGatewayRelatedAppPermission.has_permission",
+            return_value=True,
+        )
+
+        gateway = G(Gateway, name=unique_gateway_name, is_public=False)
+        request = request_factory.post(
+            f"/api/v1/apis/{unique_gateway_name}/stages/sync/",
+            data={
+                "name": "prod",
+                "description": "desc",
+                "vars": {},
+                "backends": [],
+            },
+        )
+        request.gateway = gateway
+
+        view = views.StageSyncViewSet.as_view({"post": "sync"})
+        response = view(request, gateway_name=unique_gateway_name)
+        result = get_response_json(response)
+
+        assert response.status_code == 400
+        assert "backends" in str(result)
+
     def test_sync_backends(self, fake_plugin_type_bk_header_rewrite, mocker, unique_gateway_name, request_factory):
         mocker.patch(
             "apigateway.apis.open.stage.views.OpenAPIGatewayRelatedAppPermission.has_permission",

--- a/src/dashboard/apigateway/apigateway/tests/apis/open/stage/test_views.py
+++ b/src/dashboard/apigateway/apigateway/tests/apis/open/stage/test_views.py
@@ -146,6 +146,7 @@ class TestStageSyncViewSet:
         )
 
         gateway = G(Gateway, name=unique_gateway_name, is_public=False)
+        omitted_backend = G(Backend, gateway=gateway, name="service2")
 
         request = request_factory.post(
             f"/api/v1/apis/{unique_gateway_name}/stages/sync/",
@@ -204,6 +205,7 @@ class TestStageSyncViewSet:
         assert stage.status == 0
         assert len(Backend.objects.filter(gateway=gateway, name__in=["default", "service1"])) == 2
         assert len(BackendConfig.objects.filter(backend__name__in=["default", "service1"])) == 2
+        assert not BackendConfig.objects.filter(backend=omitted_backend, stage=stage).exists()
         assert BackendConfig.objects.get(backend__name="default").config == {
             "type": "node",
             "timeout": 60,

--- a/src/dashboard/apigateway/apigateway/tests/apis/v2/sync/test_views.py
+++ b/src/dashboard/apigateway/apigateway/tests/apis/v2/sync/test_views.py
@@ -119,6 +119,26 @@ class TestSyncApi:
         assert resp.status_code == 200
         assert not BackendConfig.objects.filter(backend=omitted_backend, stage__name="prod").exists()
 
+    def test_stage_sync_with_empty_backends_returns_error(self, request_view, fake_gateway, disable_app_permission):
+        fake_gateway.name = "test-stage-sync-empty-backends"
+        fake_gateway.save()
+
+        resp = request_view(
+            method="POST",
+            gateway=fake_gateway,
+            view_name="openapi.v2.sync.gateway.stages.sync",
+            path_params={"gateway_name": fake_gateway.name},
+            data={
+                "name": "prod",
+                "description": "desc",
+                "vars": {},
+                "backends": [],
+            },
+        )
+
+        assert resp.status_code == 400
+        assert "backends" in str(resp.json()["error"])
+
     def test_gateway_sync_with_nonexistent_data_planes_returns_error(
         self, mocker, request_view, unique_gateway_name, disable_app_permission, default_data_plane
     ):

--- a/src/dashboard/apigateway/apigateway/tests/apis/v2/sync/test_views.py
+++ b/src/dashboard/apigateway/apigateway/tests/apis/v2/sync/test_views.py
@@ -25,7 +25,7 @@ from apigateway.apps.data_plane.models import DataPlane
 from apigateway.apps.mcp_server.models import MCPServer, MCPServerAppPermission, MCPServerCategory
 from apigateway.apps.permission.models import AppGatewayPermission, AppResourcePermission
 from apigateway.biz.resource import ResourceOpenAPISchemaVersionHandler
-from apigateway.core.models import Resource
+from apigateway.core.models import Backend, BackendConfig, Resource
 
 
 @pytest.fixture()
@@ -86,6 +86,38 @@ class TestSyncApi:
             assert set(data_plane_ids) == {default_data_plane.id, bp_data_plane.id}
         else:
             assert set(data_plane_ids) == {default_data_plane.id}
+
+    def test_stage_sync_does_not_create_empty_config_for_omitted_backend(
+        self, request_view, fake_gateway, disable_app_permission
+    ):
+        fake_gateway.name = "test-stage-sync"
+        fake_gateway.save()
+        omitted_backend = G(Backend, gateway=fake_gateway, name="service2")
+
+        resp = request_view(
+            method="POST",
+            gateway=fake_gateway,
+            view_name="openapi.v2.sync.gateway.stages.sync",
+            path_params={"gateway_name": fake_gateway.name},
+            data={
+                "name": "prod",
+                "description": "desc",
+                "vars": {},
+                "backends": [
+                    {
+                        "name": "service1",
+                        "config": {
+                            "timeout": 60,
+                            "loadbalance": "roundrobin",
+                            "hosts": [{"host": "http://www.a.com"}],
+                        },
+                    }
+                ],
+            },
+        )
+
+        assert resp.status_code == 200
+        assert not BackendConfig.objects.filter(backend=omitted_backend, stage__name="prod").exists()
 
     def test_gateway_sync_with_nonexistent_data_planes_returns_error(
         self, mocker, request_view, unique_gateway_name, disable_app_permission, default_data_plane

--- a/src/dashboard/apigateway/apigateway/tests/biz/test_validators.py
+++ b/src/dashboard/apigateway/apigateway/tests/biz/test_validators.py
@@ -405,7 +405,7 @@ class TestPublishValidator:
         )
 
         publish_validator = PublishValidator(fake_gateway, fake_stage, resource_version)
-        publish_validator._validate_stage_backends()
+        assert publish_validator._validate_stage_backends() is None
 
     def test_validate_stage_backends_without_default_backend(
         self, fake_stage, fake_backend, fake_default_empty_backend, fake_resource, fake_gateway
@@ -414,7 +414,39 @@ class TestPublishValidator:
         测试编辑区资源没有绑定 default backend 时，不校验 default backend 配置
         """
         publish_validator = PublishValidator(fake_gateway, fake_stage, None)
-        publish_validator._validate_stage_backends()
+        assert publish_validator._validate_stage_backends() is None
+
+    def test_validate_stage_backends_implicit_default_backend(
+        self, fake_stage, fake_default_empty_backend, fake_gateway
+    ):
+        """
+        测试资源版本中资源未显式绑定后端服务时，需要校验 default backend 配置
+        """
+        resource_version = G(
+            ResourceVersion,
+            gateway=fake_gateway,
+            version="1",
+            _data=json.dumps(
+                [
+                    {
+                        "id": 1,
+                        "name": "legacy_resource",
+                        "proxy": {
+                            "id": 28,
+                            "type": "http",
+                            "backend_id": None,
+                            "config": json.dumps(
+                                {"method": "ANY", "path": "/api/v2/", "match_subpath": False, "timeout": 0}
+                            ),
+                        },
+                    }
+                ]
+            ),
+        )
+
+        publish_validator = PublishValidator(fake_gateway, fake_stage, resource_version)
+        with pytest.raises(ReleaseValidationError):
+            publish_validator._validate_stage_backends()
 
     def test_validate_stage_backends_missing_used_backend_config(self, fake_stage, fake_gateway):
         """

--- a/src/dashboard/apigateway/apigateway/tests/biz/test_validators.py
+++ b/src/dashboard/apigateway/apigateway/tests/biz/test_validators.py
@@ -411,10 +411,46 @@ class TestPublishValidator:
         self, fake_stage, fake_backend, fake_default_empty_backend, fake_resource, fake_gateway
     ):
         """
-        测试编辑区资源没有绑定default backend（host为空）的情况
+        测试编辑区资源没有绑定 default backend 时，不校验 default backend 配置
         """
         publish_validator = PublishValidator(fake_gateway, fake_stage, None)
-        with pytest.raises(Exception):
+        publish_validator._validate_stage_backends()
+
+    def test_validate_stage_backends_missing_used_backend_config(self, fake_stage, fake_gateway):
+        """
+        测试资源绑定的后端服务在当前环境缺少配置时，发布校验失败
+        """
+        backend = G(
+            Backend,
+            gateway=fake_gateway,
+            type="http",
+            name="backend-without-config",
+            description="test",
+        )
+        resource_version = G(
+            ResourceVersion,
+            gateway=fake_gateway,
+            version="1",
+            _data=json.dumps(
+                [
+                    {
+                        "id": 1,
+                        "name": "approval_add_workitems",
+                        "proxy": {
+                            "id": 28,
+                            "type": "http",
+                            "backend_id": backend.id,
+                            "config": json.dumps(
+                                {"method": "ANY", "path": "/api/v2/", "match_subpath": False, "timeout": 0}
+                            ),
+                        },
+                    }
+                ]
+            ),
+        )
+
+        publish_validator = PublishValidator(fake_gateway, fake_stage, resource_version)
+        with pytest.raises(ReleaseValidationError):
             publish_validator._validate_stage_backends()
 
 

--- a/src/dashboard/apigateway/apigateway/tests/biz/test_validators.py
+++ b/src/dashboard/apigateway/apigateway/tests/biz/test_validators.py
@@ -416,38 +416,6 @@ class TestPublishValidator:
         publish_validator = PublishValidator(fake_gateway, fake_stage, None)
         assert publish_validator._validate_stage_backends() is None
 
-    def test_validate_stage_backends_implicit_default_backend(
-        self, fake_stage, fake_default_empty_backend, fake_gateway
-    ):
-        """
-        测试资源版本中资源未显式绑定后端服务时，需要校验 default backend 配置
-        """
-        resource_version = G(
-            ResourceVersion,
-            gateway=fake_gateway,
-            version="1",
-            _data=json.dumps(
-                [
-                    {
-                        "id": 1,
-                        "name": "legacy_resource",
-                        "proxy": {
-                            "id": 28,
-                            "type": "http",
-                            "backend_id": None,
-                            "config": json.dumps(
-                                {"method": "ANY", "path": "/api/v2/", "match_subpath": False, "timeout": 0}
-                            ),
-                        },
-                    }
-                ]
-            ),
-        )
-
-        publish_validator = PublishValidator(fake_gateway, fake_stage, resource_version)
-        with pytest.raises(ReleaseValidationError):
-            publish_validator._validate_stage_backends()
-
     def test_validate_stage_backends_missing_used_backend_config(self, fake_stage, fake_gateway):
         """
         测试资源绑定的后端服务在当前环境缺少配置时，发布校验失败


### PR DESCRIPTION
### Description

- Validate only backend services actually referenced by resources during release validation
- Allow the default backend service to remain unconfigured when no resource uses it
- Return a clear validation error when a referenced backend lacks stage configuration
- Avoid creating empty default backend configs during OpenAPI stage sync
- Guard resource version serialization when backend config is absent
- Update publish validation tests for the new behavior

### Tests

- `cd src/dashboard && python -m ruff check apigateway/apigateway/biz/validators.py apigateway/apigateway/apis/web/resource_version/serializers.py apigateway/apigateway/apis/open/stage/serializers.py apigateway/apigateway/tests/biz/test_validators.py`
- `cd src/dashboard/apigateway && export PYTHONDONTWRITEBYTECODE=1 && . apigateway/conf/unittest_env && pytest --ds apigateway.settings --reuse-db apigateway/tests/biz/test_validators.py::TestPublishValidator -q`
- `cd src/dashboard/apigateway && export PYTHONDONTWRITEBYTECODE=1 && . apigateway/conf/unittest_env && pytest --ds apigateway.settings --reuse-db apigateway/tests/apis/open/stage/test_views.py::TestStageSyncViewSet::test_sync_backends apigateway/tests/apis/web/resource_version/test_serializers.py::TestResourceVersionRetrieveOutputSLZ -q`
