### PR TITLE
fix(config): enable ITSM permission apply by default and add MCP observability flag

### DIFF
--- a/src/dashboard/apigateway/apigateway/conf/default.py
+++ b/src/dashboard/apigateway/apigateway/conf/default.py
@@ -588,7 +588,7 @@ BK_ITSM4_CALLBACK_PATH = env.str(
 # ITSM 单据中心 URL 模板，使用 {ticket_id} 占位符
 BK_ITSM4_TICKET_URL_TEMPLATE = env.str("BK_ITSM4_TICKET_URL_TEMPLATE", default="")
 # 是否启用 ITSM 权限申请工单（环境变量名保持兼容）
-ENABLE_ITSM4_PERMISSION_APPLY = env.bool("BK_ITSM4_PERMISSION_APPLY_ENABLED", default=False)
+ENABLE_ITSM4_PERMISSION_APPLY = env.bool("BK_ITSM4_PERMISSION_APPLY_ENABLED", default=True)
 
 # ==============================================================================
 # 网关全局配置

--- a/src/dashboard/apigateway/apigateway/conf/utils.py
+++ b/src/dashboard/apigateway/apigateway/conf/utils.py
@@ -210,6 +210,8 @@ def get_default_feature_flags(
         "ENABLE_GATEWAY_OPERATION_STATUS": enable_gateway_operation_status,
         # 是否启用 MCP Prompt 功能
         "ENABLE_MCP_SERVER_PROMPT": env.bool("FEATURE_FLAG_ENABLE_MCP_SERVER_PROMPT", False),
+        # 是否开启 MCP 可观测功能
+        "ENABLE_MCP_SERVER_OBSERVABILITY": env.bool("FEATURE_FLAG_ENABLE_MCP_SERVER_OBSERVABILITY", False),
         # 是否启用健康检查
         "ENABLE_HEALTH_CHECK": env.bool("FEATURE_FLAG_ENABLE_HEALTH_CHECK", False),
         # 是否开启 MCP Server OAuth2 公开客户端模式


### PR DESCRIPTION
## Summary

- Change the default value of `ENABLE_ITSM4_PERMISSION_APPLY` to `True` so ITSM permission apply workflow is enabled by default
- Register `ENABLE_MCP_SERVER_OBSERVABILITY` in default feature flags, allowing MCP Server observability to be controlled via the `FEATURE_FLAG_ENABLE_MCP_SERVER_OBSERVABILITY` environment variable

## Test plan

- [ ] Verify that when `BK_ITSM4_PERMISSION_APPLY_ENABLED` is not set, the frontend feature flag `ENABLE_ITSM4_PERMISSION_APPLY` is `true`
- [ ] Verify that after setting `FEATURE_FLAG_ENABLE_MCP_SERVER_OBSERVABILITY=true`, the frontend correctly exposes MCP observability entry points