### PR TITLE
fix(mcp-proxy): preserve large integer params without scientific notation

### DIFF
--- a/src/mcp-proxy/pkg/infra/proxy/proxy.go
+++ b/src/mcp-proxy/pkg/infra/proxy/proxy.go
@@ -20,7 +20,6 @@
 package proxy
 
 import (
-	"bytes"
 	"context"
 	"crypto/tls"
 	"encoding/json"
@@ -230,9 +229,7 @@ func decodeHandlerRequest(arguments any) (HandlerRequest, error) {
 	if err != nil {
 		return handlerRequest, err
 	}
-	decoder := json.NewDecoder(bytes.NewReader(argsBytes))
-	decoder.UseNumber()
-	err = decoder.Decode(&handlerRequest)
+	err = json.Unmarshal(argsBytes, &handlerRequest)
 	return handlerRequest, err
 }
 

--- a/src/mcp-proxy/pkg/infra/proxy/proxy.go
+++ b/src/mcp-proxy/pkg/infra/proxy/proxy.go
@@ -20,6 +20,7 @@
 package proxy
 
 import (
+	"bytes"
 	"context"
 	"crypto/tls"
 	"encoding/json"
@@ -221,6 +222,18 @@ func buildToolResult(output any) *mcp.CallToolResult {
 		&mcp.TextContent{Text: text},
 	}
 	return result
+}
+
+func decodeHandlerRequest(arguments any) (HandlerRequest, error) {
+	var handlerRequest HandlerRequest
+	argsBytes, err := json.Marshal(arguments)
+	if err != nil {
+		return handlerRequest, err
+	}
+	decoder := json.NewDecoder(bytes.NewReader(argsBytes))
+	decoder.UseNumber()
+	err = decoder.Decode(&handlerRequest)
+	return handlerRequest, err
 }
 
 func buildMCPTool(toolConfig *ToolConfig, serverName string) *mcp.Tool {
@@ -529,16 +542,9 @@ func genToolHandler(toolApiConfig *ToolConfig, serverName string, rawResponseGet
 			return nil, fmt.Errorf("sign inner jwt failed: %w", err)
 		}
 		auditLog.Info("call tool", zap.Any("request", req.Params.Arguments))
-		var handlerRequest HandlerRequest
-		argsBytes, err := json.Marshal(req.Params.Arguments)
+		handlerRequest, err := decodeHandlerRequest(req.Params.Arguments)
 		if err != nil {
-			auditLog.Error("marshal arguments err", zap.Any("arguments", req.Params.Arguments), zap.Error(err))
-			return nil, err
-		}
-		err = json.Unmarshal(argsBytes, &handlerRequest)
-		if err != nil {
-			auditLog.Error("unmarshal handler request err", zap.String("request",
-				string(argsBytes)), zap.Error(err))
+			auditLog.Error("decode handler request err", zap.Any("arguments", req.Params.Arguments), zap.Error(err))
 			return nil, err
 		}
 		// 创建带日志的 Transport
@@ -591,33 +597,30 @@ func genToolHandler(toolApiConfig *ToolConfig, serverName string, rawResponseGet
 			}
 
 			if handlerRequest.HeaderParam != nil {
-				for k, v := range handlerRequest.HeaderParam {
-					err = req.SetHeaderParam(k, fmt.Sprintf("%v", v))
+				for k, value := range handlerRequest.HeaderParam {
+					err = req.SetHeaderParam(k, value)
 					if err != nil {
-						auditLog.Error("set header param err", zap.String(k,
-							fmt.Sprintf("%v", v)), zap.Error(err))
+						auditLog.Error("set header param err", zap.String(k, value), zap.Error(err))
 						return err
 					}
-					headerInfo[k] = fmt.Sprintf("%v", v)
+					headerInfo[k] = value
 				}
 			}
 			if handlerRequest.QueryParam != nil {
-				for k, v := range handlerRequest.QueryParam {
-					err = req.SetQueryParam(k, fmt.Sprintf("%v", v)) // 使用 SetQueryParam 方法设置查询参数
+				for k, value := range handlerRequest.QueryParam {
+					err = req.SetQueryParam(k, value) // 使用 SetQueryParam 方法设置查询参数
 					if err != nil {
-						auditLog.Error("set query param err", zap.String(k, fmt.Sprintf("%v", v)),
-							zap.Error(err))
+						auditLog.Error("set query param err", zap.String(k, value), zap.Error(err))
 						return err
 					}
 				}
 			}
 
 			if handlerRequest.PathParam != nil {
-				for k, v := range handlerRequest.PathParam {
-					err = req.SetPathParam(k, fmt.Sprintf("%v", v))
+				for k, value := range handlerRequest.PathParam {
+					err = req.SetPathParam(k, value)
 					if err != nil {
-						auditLog.Error("set path param err",
-							zap.String(k, fmt.Sprintf("%v", v)), zap.Error(err))
+						auditLog.Error("set path param err", zap.String(k, value), zap.Error(err))
 						return err
 					}
 				}

--- a/src/mcp-proxy/pkg/infra/proxy/proxy_test.go
+++ b/src/mcp-proxy/pkg/infra/proxy/proxy_test.go
@@ -335,6 +335,49 @@ var _ = Describe("MCPProxy", func() {
 		})
 	})
 
+	Describe("stringifyRequestParamValue", func() {
+		It("should keep large integer values in decimal format", func() {
+			Expect(stringifyRequestParamValue(float64(2005000002))).To(Equal("2005000002"))
+			Expect(stringifyRequestParamValue(json.Number("2005000002"))).To(Equal("2005000002"))
+		})
+
+		It("should keep decimal values without scientific notation", func() {
+			Expect(stringifyRequestParamValue(1.25)).To(Equal("1.25"))
+			Expect(stringifyRequestParamValue(float32(1.25))).To(Equal("1.25"))
+		})
+
+		It("should preserve non-numeric values", func() {
+			Expect(stringifyRequestParamValue("abc123")).To(Equal("abc123"))
+			Expect(stringifyRequestParamValue(true)).To(Equal("true"))
+		})
+	})
+
+	Describe("decodeHandlerRequest", func() {
+		It("should preserve numbers for all request parameter groups", func() {
+			request, err := decodeHandlerRequest(map[string]any{
+				"header_param": map[string]any{"X-Trace-ID": 2005000002},
+				"query_param":  map[string]any{"bk_biz_id": 2005000002, "ratio": 1.25},
+				"path_param":   map[string]any{"bk_biz_id": 2005000002},
+				"body_param": map[string]any{
+					"bk_biz_id": 2005000002,
+					"nested": map[string]any{
+						"id": 2005000003,
+					},
+				},
+			})
+
+			Expect(err).NotTo(HaveOccurred())
+			Expect(request.HeaderParam["X-Trace-ID"]).To(Equal("2005000002"))
+			Expect(request.QueryParam["bk_biz_id"]).To(Equal("2005000002"))
+			Expect(request.QueryParam["ratio"]).To(Equal("1.25"))
+			Expect(request.PathParam["bk_biz_id"]).To(Equal("2005000002"))
+
+			body := request.BodyParam.(map[string]any)
+			Expect(body["bk_biz_id"]).To(Equal(json.Number("2005000002")))
+			Expect(body["nested"].(map[string]any)["id"]).To(Equal(json.Number("2005000003")))
+		})
+	})
+
 	Describe("RegisterPromptsToMCPServer", func() {
 		var proxy *MCPProxy
 

--- a/src/mcp-proxy/pkg/infra/proxy/proxy_test.go
+++ b/src/mcp-proxy/pkg/infra/proxy/proxy_test.go
@@ -372,9 +372,10 @@ var _ = Describe("MCPProxy", func() {
 			Expect(request.QueryParam["ratio"]).To(Equal("1.25"))
 			Expect(request.PathParam["bk_biz_id"]).To(Equal("2005000002"))
 
+			// BodyParam retains standard json.Unmarshal behavior (float64)
 			body := request.BodyParam.(map[string]any)
-			Expect(body["bk_biz_id"]).To(Equal(json.Number("2005000002")))
-			Expect(body["nested"].(map[string]any)["id"]).To(Equal(json.Number("2005000003")))
+			Expect(body["bk_biz_id"]).To(Equal(float64(2005000002)))
+			Expect(body["nested"].(map[string]any)["id"]).To(Equal(float64(2005000003)))
 		})
 	})
 

--- a/src/mcp-proxy/pkg/infra/proxy/types.go
+++ b/src/mcp-proxy/pkg/infra/proxy/types.go
@@ -18,10 +18,62 @@
 
 package proxy
 
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"math"
+	"strconv"
+)
+
+const maxExactFloatInteger = 1<<53 - 1
+
+func stringifyRequestParamValue(value any) string {
+	switch value := value.(type) {
+	case json.Number:
+		return value.String()
+	case float64:
+		if value == math.Trunc(value) && value >= -maxExactFloatInteger && value <= maxExactFloatInteger {
+			return strconv.FormatInt(int64(value), 10)
+		}
+		return strconv.FormatFloat(value, 'f', -1, 64)
+	case float32:
+		return strconv.FormatFloat(float64(value), 'f', -1, 32)
+	case string:
+		return value
+	default:
+		return fmt.Sprintf("%v", value)
+	}
+}
+
+// StringParamMap stores HTTP header/query/path parameters as strings.
+type StringParamMap map[string]string
+
+func (m *StringParamMap) UnmarshalJSON(data []byte) error {
+	if string(data) == "null" {
+		*m = nil
+		return nil
+	}
+
+	var values map[string]any
+	decoder := json.NewDecoder(bytes.NewReader(data))
+	decoder.UseNumber()
+	if err := decoder.Decode(&values); err != nil {
+		return err
+	}
+
+	result := make(StringParamMap, len(values))
+	for key, value := range values {
+		result[key] = stringifyRequestParamValue(value)
+	}
+	*m = result
+	return nil
+}
+
 // HandlerRequest ...
 type HandlerRequest struct {
-	HeaderParam map[string]any `json:"header_param,omitempty"`
-	QueryParam  map[string]any `json:"query_param,omitempty"`
-	PathParam   map[string]any `json:"path_param,omitempty"`
+	HeaderParam StringParamMap `json:"header_param,omitempty"`
+	QueryParam  StringParamMap `json:"query_param,omitempty"`
+	PathParam   StringParamMap `json:"path_param,omitempty"`
 	BodyParam   any            `json:"body_param,omitempty"`
 }

--- a/src/mcp-proxy/pkg/infra/proxy/types.go
+++ b/src/mcp-proxy/pkg/infra/proxy/types.go
@@ -49,6 +49,7 @@ func stringifyRequestParamValue(value any) string {
 // StringParamMap stores HTTP header/query/path parameters as strings.
 type StringParamMap map[string]string
 
+// UnmarshalJSON decodes JSON values into strings, preserving numeric precision.
 func (m *StringParamMap) UnmarshalJSON(data []byte) error {
 	if string(data) == "null" {
 		*m = nil

--- a/src/mcp-proxy/pkg/infra/proxy/types.go
+++ b/src/mcp-proxy/pkg/infra/proxy/types.go
@@ -26,14 +26,24 @@ import (
 	"strconv"
 )
 
-const maxExactFloatInteger = 1<<53 - 1
+// maxSafeFloat64Integer is the largest consecutive integer exactly representable
+// by IEEE 754 double-precision (2^53 - 1). Values beyond this threshold may lose
+// precision when stored as float64, so we avoid int64 conversion for them.
+const maxSafeFloat64Integer = 1<<53 - 1
 
+// stringifyRequestParamValue converts a decoded JSON value to its string representation
+// suitable for HTTP header/query/path parameters. It preserves numeric precision by:
+//   - json.Number: returned directly via String() (primary path when UseNumber is enabled)
+//   - float64/float32: fallback for values not decoded via UseNumber; formats integers
+//     without decimal point and floats without scientific notation
+//   - string: passed through unchanged
+//   - other types (bool, nil, etc.): formatted via fmt.Sprintf
 func stringifyRequestParamValue(value any) string {
 	switch value := value.(type) {
 	case json.Number:
 		return value.String()
 	case float64:
-		if value == math.Trunc(value) && value >= -maxExactFloatInteger && value <= maxExactFloatInteger {
+		if value == math.Trunc(value) && value >= -maxSafeFloat64Integer && value <= maxSafeFloat64Integer {
 			return strconv.FormatInt(int64(value), 10)
 		}
 		return strconv.FormatFloat(value, 'f', -1, 64)
@@ -47,9 +57,13 @@ func stringifyRequestParamValue(value any) string {
 }
 
 // StringParamMap stores HTTP header/query/path parameters as strings.
+// It uses a custom UnmarshalJSON with json.Decoder.UseNumber() to prevent
+// large integers (e.g., 2005000002) from being formatted in scientific notation.
 type StringParamMap map[string]string
 
-// UnmarshalJSON decodes JSON values into strings, preserving numeric precision.
+// UnmarshalJSON decodes JSON object values into strings, preserving numeric precision.
+// Numbers are decoded as json.Number (not float64) to avoid precision loss,
+// then converted to their exact string representation.
 func (m *StringParamMap) UnmarshalJSON(data []byte) error {
 	if string(data) == "null" {
 		*m = nil
@@ -71,7 +85,11 @@ func (m *StringParamMap) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
-// HandlerRequest ...
+// HandlerRequest represents the structured arguments for an MCP tool call.
+// HeaderParam, QueryParam, and PathParam are decoded as StringParamMap — all values
+// are converted to strings at unmarshal time to ensure correct HTTP parameter formatting.
+// BodyParam retains standard json.Unmarshal behavior (numbers as float64) since it is
+// serialized as JSON body and does not require string conversion.
 type HandlerRequest struct {
 	HeaderParam StringParamMap `json:"header_param,omitempty"`
 	QueryParam  StringParamMap `json:"query_param,omitempty"`

--- a/src/mcp-proxy/pkg/infra/proxy/types_test.go
+++ b/src/mcp-proxy/pkg/infra/proxy/types_test.go
@@ -32,9 +32,9 @@ var _ = Describe("Types", func() {
 		Describe("JSON Marshal", func() {
 			It("should marshal and unmarshal correctly", func() {
 				request := proxy.HandlerRequest{
-					HeaderParam: map[string]any{"Content-Type": "application/json"},
-					QueryParam:  map[string]any{"limit": 10, "offset": 0},
-					PathParam:   map[string]any{"id": "123"},
+					HeaderParam: proxy.StringParamMap{"Content-Type": "application/json"},
+					QueryParam:  proxy.StringParamMap{"limit": "10", "offset": "0"},
+					PathParam:   proxy.StringParamMap{"id": "123"},
 					BodyParam:   map[string]any{"name": "test"},
 				}
 
@@ -46,7 +46,7 @@ var _ = Describe("Types", func() {
 				err = json.Unmarshal(data, &result)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(result.HeaderParam["Content-Type"]).To(Equal("application/json"))
-				Expect(result.QueryParam["limit"]).To(Equal(float64(10)))
+				Expect(result.QueryParam["limit"]).To(Equal("10"))
 				Expect(result.PathParam["id"]).To(Equal("123"))
 				Expect(result.BodyParam.(map[string]any)["name"]).To(Equal("test"))
 			})
@@ -60,7 +60,7 @@ var _ = Describe("Types", func() {
 
 			It("should handle partial fields", func() {
 				request := proxy.HandlerRequest{
-					QueryParam: map[string]any{"search": "test"},
+					QueryParam: proxy.StringParamMap{"search": "test"},
 				}
 
 				data, err := json.Marshal(request)
@@ -112,9 +112,78 @@ var _ = Describe("Types", func() {
 				Expect(err).NotTo(HaveOccurred())
 
 				Expect(request.HeaderParam["Authorization"]).To(Equal("Bearer token"))
-				Expect(request.QueryParam["page"]).To(Equal(float64(1)))
+				Expect(request.QueryParam["page"]).To(Equal("1"))
 				Expect(request.PathParam["userId"]).To(Equal("abc123"))
 				Expect(request.BodyParam.(map[string]any)["data"]).To(Equal("test"))
+			})
+		})
+	})
+
+	Describe("StringParamMap", func() {
+		Describe("UnmarshalJSON", func() {
+			It("should convert large integers to decimal strings without scientific notation", func() {
+				jsonStr := `{"bk_biz_id": 2005000002, "trace_id": 9007199254740992}`
+				var m proxy.StringParamMap
+				err := json.Unmarshal([]byte(jsonStr), &m)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(m["bk_biz_id"]).To(Equal("2005000002"))
+				Expect(m["trace_id"]).To(Equal("9007199254740992"))
+			})
+
+			It("should preserve decimal numbers", func() {
+				jsonStr := `{"ratio": 3.14, "rate": 0.001}`
+				var m proxy.StringParamMap
+				err := json.Unmarshal([]byte(jsonStr), &m)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(m["ratio"]).To(Equal("3.14"))
+				Expect(m["rate"]).To(Equal("0.001"))
+			})
+
+			It("should handle string values as-is", func() {
+				jsonStr := `{"name": "hello", "empty": ""}`
+				var m proxy.StringParamMap
+				err := json.Unmarshal([]byte(jsonStr), &m)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(m["name"]).To(Equal("hello"))
+				Expect(m["empty"]).To(Equal(""))
+			})
+
+			It("should handle boolean values", func() {
+				jsonStr := `{"verbose": true, "quiet": false}`
+				var m proxy.StringParamMap
+				err := json.Unmarshal([]byte(jsonStr), &m)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(m["verbose"]).To(Equal("true"))
+				Expect(m["quiet"]).To(Equal("false"))
+			})
+
+			It("should handle null input", func() {
+				jsonStr := `null`
+				var m proxy.StringParamMap
+				err := json.Unmarshal([]byte(jsonStr), &m)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(m).To(BeNil())
+			})
+
+			It("should handle zero and negative numbers", func() {
+				jsonStr := `{"zero": 0, "negative": -100, "neg_float": -1.5}`
+				var m proxy.StringParamMap
+				err := json.Unmarshal([]byte(jsonStr), &m)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(m["zero"]).To(Equal("0"))
+				Expect(m["negative"]).To(Equal("-100"))
+				Expect(m["neg_float"]).To(Equal("-1.5"))
+			})
+
+			It("should handle mixed value types", func() {
+				jsonStr := `{"id": 2005000002, "name": "test", "active": true, "score": 99.5}`
+				var m proxy.StringParamMap
+				err := json.Unmarshal([]byte(jsonStr), &m)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(m["id"]).To(Equal("2005000002"))
+				Expect(m["name"]).To(Equal("test"))
+				Expect(m["active"]).To(Equal("true"))
+				Expect(m["score"]).To(Equal("99.5"))
 			})
 		})
 	})

--- a/src/mcp-proxy/tests/integration/init.sql
+++ b/src/mcp-proxy/tests/integration/init.sql
@@ -246,6 +246,82 @@ VALUES (1, 1, 1, '{
   }
 }', NOW(), NOW());
 
+-- 环境 2 (用于 path 参数测试)
+INSERT INTO `core_stage` (`id`, `api_id`, `name`, `description`, `status`, `created_time`, `updated_time`)
+VALUES (2, 1, 'stage', 'Stage for path param testing', 1, NOW(), NOW());
+
+-- 资源版本 2 (带 path/query 参数的 API，用于测试大整数参数不被科学计数法破坏)
+INSERT INTO `core_resource_version` (`id`, `api_id`, `version`, `schema_version`, `data`, `created_time`, `updated_time`)
+VALUES (2, 1, '2.0.0', '1.0', '{}', NOW(), NOW());
+
+-- 发布记录 2
+INSERT INTO `core_release` (`id`, `api_id`, `stage_id`, `resource_version_id`, `created_time`, `updated_time`)
+VALUES (2, 1, 2, 2, NOW(), NOW());
+
+-- OpenAPI 规范 2 (带 path 参数和 query 参数)
+INSERT INTO `openapi_gateway_resource_version_spec` (`id`, `api_id`, `resource_version_id`, `schema`, `created_time`, `updated_time`)
+VALUES (2, 1, 2, '{
+  "openapi": "3.0.3",
+  "info": {
+    "title": "Test API with Path Params",
+    "version": "2.0.0"
+  },
+  "servers": [
+    {
+      "url": "http://mock-api:8080/api/test-gateway/prod"
+    }
+  ],
+  "paths": {
+    "/anything/{bk_biz_id}/hosts": {
+      "post": {
+        "operationId": "list_biz_hosts",
+        "summary": "List hosts under a business",
+        "description": "Query hosts under the specified business ID",
+        "parameters": [
+          {
+            "name": "bk_biz_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer"
+            },
+            "description": "Business ID"
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer"
+            },
+            "description": "Number of results"
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "fields": {
+                    "type": "array",
+                    "items": {"type": "string"}
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful response"
+          }
+        }
+      }
+    }
+  }
+}', NOW(), NOW());
+
 -- 测试用 MCP Server (SSE 协议)
 -- resource_names 使用分号分隔
 INSERT INTO `mcp_server` (`id`, `name`, `description`, `is_public`, `labels`, `resource_names`, `gateway_id`, `stage_id`, `protocol_type`, `status`, `created_time`, `updated_time`)
@@ -278,3 +354,11 @@ VALUES (2, 2, 'test-app', 'grant', '2099-12-31 23:59:59', NOW(), NOW());
 -- 权限给带工具名映射的 MCP Server
 INSERT INTO `mcp_server_app_permission` (`id`, `mcp_server_id`, `bk_app_code`, `grant_type`, `expires`, `created_time`, `updated_time`)
 VALUES (3, 3, 'test-app', 'grant', '2099-12-31 23:59:59', NOW(), NOW());
+
+-- 测试用 MCP Server (带 path 参数，Streamable HTTP 协议)
+INSERT INTO `mcp_server` (`id`, `name`, `description`, `is_public`, `labels`, `resource_names`, `gateway_id`, `stage_id`, `protocol_type`, `status`, `created_time`, `updated_time`)
+VALUES (4, 'test-path-param-server', 'Test MCP Server with Path Params', 1, '', 'list_biz_hosts', 1, 2, 'streamable_http', 1, NOW(), NOW());
+
+-- 权限给带 path 参数测试的 MCP Server
+INSERT INTO `mcp_server_app_permission` (`id`, `mcp_server_id`, `bk_app_code`, `grant_type`, `expires`, `created_time`, `updated_time`)
+VALUES (4, 4, 'test-app', 'grant', '2099-12-31 23:59:59', NOW(), NOW());

--- a/src/mcp-proxy/tests/integration/streamable_http_test.go
+++ b/src/mcp-proxy/tests/integration/streamable_http_test.go
@@ -407,6 +407,63 @@ var _ = Describe("Streamable HTTP Protocol", func() {
 		})
 	})
 
+	Describe("Large Integer Path/Query Params", func() {
+		It("should preserve large integer path and query params without scientific notation", func() {
+			mcpURL := fmt.Sprintf("%s/%s/mcp", client.BaseURL, "test-path-param-server")
+
+			httpClient := &http.Client{
+				Timeout: 30 * time.Second,
+				Transport: &jwtRoundTripper{
+					token: jwtToken,
+					base:  http.DefaultTransport,
+				},
+			}
+
+			transport := &mcp.StreamableClientTransport{
+				Endpoint:   mcpURL,
+				HTTPClient: httpClient,
+			}
+
+			mcpClient := mcp.NewClient(&mcp.Implementation{
+				Name:    "test-client",
+				Version: "1.0.0",
+			}, nil)
+
+			session, err := mcpClient.Connect(ctx, transport, nil)
+			Expect(err).NotTo(HaveOccurred())
+			defer session.Close()
+
+			// Call tool with large integer path param (bk_biz_id=2005000002)
+			result, err := session.CallTool(ctx, &mcp.CallToolParams{
+				Name: "list_biz_hosts",
+				Arguments: map[string]any{
+					"path_param":  map[string]any{"bk_biz_id": 2005000002},
+					"query_param": map[string]any{"limit": 20},
+					"body_param":  map[string]any{"fields": []string{"bk_host_id", "bk_host_innerip"}},
+				},
+			})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result).NotTo(BeNil())
+			Expect(result.Content).NotTo(BeEmpty())
+
+			// Extract the response envelope and verify the URL contains the correct integer
+			envelope, err := extractToolResponseEnvelope(result)
+			Expect(err).NotTo(HaveOccurred())
+
+			responseBody, ok := envelope["response_body"].(map[string]any)
+			Expect(ok).To(BeTrue())
+
+			// go-httpbin's /anything endpoint echoes back the URL
+			requestURL, ok := responseBody["url"].(string)
+			Expect(ok).To(BeTrue())
+			// The URL should contain "2005000002" as a decimal integer, NOT "2.005000002e+09"
+			Expect(requestURL).To(ContainSubstring("/2005000002/"))
+			Expect(requestURL).NotTo(ContainSubstring("e+"))
+			// Verify query param is also correct
+			Expect(requestURL).To(ContainSubstring("limit=20"))
+		})
+	})
+
 	Describe("Stateless Mode", func() {
 		It("should handle multiple requests without session not found error", func() {
 			mcpURL := fmt.Sprintf("%s/%s/mcp", client.BaseURL, "test-http-server")


### PR DESCRIPTION
## Summary
- Fix path/query/header parameters being formatted in scientific notation (e.g., `2.005000002e+09` instead of `2005000002`) when large integers are passed via MCP tool calls.
- Introduce `StringParamMap` custom type with `UnmarshalJSON` that converts all parameter values to strings at decode time using `json.Number` for precision.
- Add unit tests for `StringParamMap`, `stringifyRequestParamValue`, and `decodeHandlerRequest`.
- Add integration test with path parameter endpoint to verify large integers are preserved in URLs.

## Test plan
- [x] Unit tests pass (`go test -mod=mod ./pkg/infra/proxy/`)
- [ ] Integration tests pass with docker-compose environment
- [ ] Verify large integer path params (e.g., `bk_biz_id=2005000002`) appear correctly in request URLs


Made with [Cursor](https://cursor.com)