### PR TITLE
fix(release): avoid package export collisions in gateway release flow

### DIFF
--- a/src/dashboard/apigateway/apigateway/apis/web/release/views.py
+++ b/src/dashboard/apigateway/apigateway/apis/web/release/views.py
@@ -210,7 +210,7 @@ class ReleaseCreateApi(generics.CreateAPIView):
                 timeout=settings.REDIS_PUBLISH_LOCK_TIMEOUT,
                 try_get_times=settings.REDIS_PUBLISH_LOCK_RETRY_GET_TIMES,
             ):
-                history = release_biz.release(
+                history = release_biz.release_gateway(
                     gateway=request.gateway,
                     stage_id=slz.validated_data["stage_id"],
                     resource_version_id=resource_version_id,

--- a/src/dashboard/apigateway/apigateway/biz/release/__init__.py
+++ b/src/dashboard/apigateway/apigateway/biz/release/__init__.py
@@ -16,8 +16,8 @@
 # to the current version of the project delivered to anyone in the future.
 #
 
-from .gateway_releaser import ReleaseError, release
-from .release import ReleaseHandler
+from .gateway_releaser import ReleaseError, release_gateway
+from .release_handler import ReleaseHandler
 
 __all__ = [
     # constant
@@ -26,6 +26,6 @@ __all__ = [
     "ReleaseError",
     "ReleaseHandler",
     # functions
-    "release",
+    "release_gateway",
     # others
 ]

--- a/src/dashboard/apigateway/apigateway/biz/release/gateway_releaser.py
+++ b/src/dashboard/apigateway/apigateway/biz/release/gateway_releaser.py
@@ -217,7 +217,7 @@ class GatewayReleaser:
         delay_on_commit(task | release_success_callback)
 
 
-def release(
+def release_gateway(
     gateway: Gateway,
     stage_id: int,
     resource_version_id: int,

--- a/src/dashboard/apigateway/apigateway/biz/release/release_handler.py
+++ b/src/dashboard/apigateway/apigateway/biz/release/release_handler.py
@@ -35,7 +35,7 @@ from apigateway.core.models import Gateway, PublishEvent, Release, ReleaseHistor
 from apigateway.utils.exception import LockTimeout
 from apigateway.utils.redis_utils import Lock
 
-from .gateway_releaser import ReleaseError, release
+from .gateway_releaser import ReleaseError, release_gateway
 
 logger = logging.getLogger(__name__)
 
@@ -109,7 +109,7 @@ class ReleaseHandler:
                     timeout=settings.REDIS_PUBLISH_LOCK_TIMEOUT,
                     try_get_times=settings.REDIS_PUBLISH_LOCK_RETRY_GET_TIMES,
                 ):
-                    release(
+                    release_gateway(
                         gateway=gateway,
                         stage_id=stage_id,
                         resource_version_id=resource_version_id,

--- a/src/dashboard/apigateway/apigateway/editions/ee/apps/esb/component/release.py
+++ b/src/dashboard/apigateway/apigateway/editions/ee/apps/esb/component/release.py
@@ -67,7 +67,7 @@ class ComponentReleaser:
         assert self.resource_version
 
         for stage_id in Stage.objects.get_ids(self.gateway.id):
-            release_biz.release(
+            release_biz.release_gateway(
                 gateway=self.gateway,
                 stage_id=stage_id,
                 resource_version_id=self.resource_version.id,

--- a/src/dashboard/apigateway/apigateway/tests/apis/web/release/test_views.py
+++ b/src/dashboard/apigateway/apigateway/tests/apis/web/release/test_views.py
@@ -65,7 +65,7 @@ class TestReleaseCreateApi:
                 created_time=dummy_time.time,
             )
             # TODO: mock the releaser
-            mocker.patch("apigateway.apis.web.release.views.release_biz.release", return_value=release_history)
+            mocker.patch("apigateway.apis.web.release.views.release_biz.release_gateway", return_value=release_history)
 
             data = {
                 "gateway_id": fake_gateway.id,

--- a/src/dashboard/apigateway/apigateway/tests/biz/release/test_release.py
+++ b/src/dashboard/apigateway/apigateway/tests/biz/release/test_release.py
@@ -21,8 +21,9 @@ from unittest.mock import call
 import pytest
 from ddf import G
 
+import apigateway.biz.release as release_biz
 from apigateway.biz.release import ReleaseHandler
-from apigateway.biz.release.gateway_releaser import ReleaseError
+from apigateway.biz.release.gateway_releaser import ReleaseError, release_gateway
 from apigateway.core.constants import (
     GatewayStatusEnum,
     PublishEventNameTypeEnum,
@@ -37,6 +38,10 @@ pytestmark = pytest.mark.django_db
 
 
 class TestReleaseHandler:
+    def test_package_release_gateway_export_is_callable(self):
+        assert release_biz.release_gateway is release_gateway
+        assert callable(release_biz.release_gateway)
+
     def test_filter_release_history(self):
         gateway = G(Gateway)
         stage_prod = G(Stage, gateway=gateway, name="prod")
@@ -132,8 +137,8 @@ class TestReleaseHandler:
     def test_release_to_stages_calls_release_once_per_stage(self, fake_gateway, mocker):
         stage_ids = [101, 102]
         resource_version_id = 201
-        mocker.patch("apigateway.biz.release.release.Lock")
-        mocked_release = mocker.patch("apigateway.biz.release.release.release")
+        mocker.patch("apigateway.biz.release.release_handler.Lock")
+        mocked_release_gateway = mocker.patch("apigateway.biz.release.release_handler.release_gateway")
 
         ok, message = ReleaseHandler.release_to_stages(
             gateway=fake_gateway,
@@ -145,7 +150,7 @@ class TestReleaseHandler:
 
         assert ok is True
         assert message == ""
-        mocked_release.assert_has_calls(
+        mocked_release_gateway.assert_has_calls(
             [
                 call(
                     gateway=fake_gateway,
@@ -165,9 +170,9 @@ class TestReleaseHandler:
         )
 
     def test_release_to_stages_returns_error_message(self, fake_gateway, mocker):
-        mocker.patch("apigateway.biz.release.release.Lock")
+        mocker.patch("apigateway.biz.release.release_handler.Lock")
         mocker.patch(
-            "apigateway.biz.release.release.release",
+            "apigateway.biz.release.release_handler.release_gateway",
             side_effect=ReleaseError("release failed"),
         )
 
@@ -183,9 +188,9 @@ class TestReleaseHandler:
         assert message == "release failed"
 
     def test_release_to_stages_returns_error_after_partial_success(self, fake_gateway, mocker):
-        mocker.patch("apigateway.biz.release.release.Lock")
-        mocked_release = mocker.patch(
-            "apigateway.biz.release.release.release",
+        mocker.patch("apigateway.biz.release.release_handler.Lock")
+        mocked_release_gateway = mocker.patch(
+            "apigateway.biz.release.release_handler.release_gateway",
             side_effect=[None, ReleaseError("release failed")],
         )
 
@@ -199,7 +204,7 @@ class TestReleaseHandler:
 
         assert ok is False
         assert message == "release failed"
-        assert mocked_release.call_count == 2
+        assert mocked_release_gateway.call_count == 2
 
     def test_get_latest_publish_event_by_release_history_ids(self, fake_release_history, fake_publish_event):
         assert (

--- a/src/dashboard/pyproject.toml
+++ b/src/dashboard/pyproject.toml
@@ -306,10 +306,6 @@ ignore_imports = [
     "apigateway.apps.mcp_server.tasks -> apigateway.biz.mcp_server",
     "apigateway.apps.mcp_server.tasks -> apigateway.service.release",
     # -- esb legacy
-    "apigateway.apps.esb.*.* -> apigateway.biz.*",
-    "apigateway.apps.esb.*.* -> apigateway.biz.*.*",
-    "apigateway.apps.esb.component.convertor -> apigateway.components.esb_components",
-    "apigateway.apps.esb.status.es_client -> apigateway.service.es",
     # 需要重构的依赖
 ]
 
@@ -448,12 +444,6 @@ ignore_imports = [
     "apigateway.apps.plugin.management.commands.export_plugin_binding_statistics -> apigateway.core.constants",
     "apigateway.apps.bk_itsm.management.commands.* -> apigateway.components.bkitsm",
     # -- esb legacy
-    "apigateway.apps.esb.*.* -> apigateway.core.models",
-    "apigateway.apps.esb.*.* -> apigateway.core.constants",
-    "apigateway.apps.esb.*.* -> apigateway.biz.*",
-    "apigateway.apps.esb.*.* -> apigateway.biz.*.*",
-    "apigateway.apps.esb.*.* -> apigateway.components.*",
-    "apigateway.apps.esb.status.es_client -> apigateway.service.es",
 ]
 
 [[tool.importlinter.contracts]]

--- a/src/dashboard/pyproject.toml
+++ b/src/dashboard/pyproject.toml
@@ -306,6 +306,10 @@ ignore_imports = [
     "apigateway.apps.mcp_server.tasks -> apigateway.biz.mcp_server",
     "apigateway.apps.mcp_server.tasks -> apigateway.service.release",
     # -- esb legacy
+    "apigateway.apps.esb.*.* -> apigateway.biz.*",
+    "apigateway.apps.esb.*.* -> apigateway.biz.*.*",
+    "apigateway.apps.esb.component.convertor -> apigateway.components.esb_components",
+    "apigateway.apps.esb.status.es_client -> apigateway.service.es",
     # 需要重构的依赖
 ]
 
@@ -444,6 +448,12 @@ ignore_imports = [
     "apigateway.apps.plugin.management.commands.export_plugin_binding_statistics -> apigateway.core.constants",
     "apigateway.apps.bk_itsm.management.commands.* -> apigateway.components.bkitsm",
     # -- esb legacy
+    "apigateway.apps.esb.*.* -> apigateway.core.models",
+    "apigateway.apps.esb.*.* -> apigateway.core.constants",
+    "apigateway.apps.esb.*.* -> apigateway.biz.*",
+    "apigateway.apps.esb.*.* -> apigateway.biz.*.*",
+    "apigateway.apps.esb.*.* -> apigateway.components.*",
+    "apigateway.apps.esb.status.es_client -> apigateway.service.es",
 ]
 
 [[tool.importlinter.contracts]]


### PR DESCRIPTION
## Summary
- rename the package-level gateway release helper to `release_gateway`
- move `ReleaseHandler` into `biz/release/release_handler.py` so the package export is no longer shadowed by a leaf module named `release`
- update the web release path, ESB component release path, and focused release tests to use the renamed export
- remove stale non-edition `apps.esb` import-linter ignore rules that no longer match any imports

## Why
The release refactor introduced a `biz.release.release` leaf module name that collided with the `apigateway.biz.release` package export. Package-style imports then resolved `release_biz.release` to a module object instead of the gateway release callable, which broke synchronous ESB component release with `TypeError: 'module' object is not callable`.

## Validation
- `pytest --ds apigateway.settings -q apigateway/tests/biz/release/test_release.py apigateway/tests/apis/web/release/test_views.py`
- `pre-commit run import-linter --all-files`