### PR TITLE
fix(test): handle streamable HTTP MCP SSE responses

### DIFF
--- a/test/cases/dashboard/01-open-api/03-mcp-server/01-app-streamable-http-initialize.bru
+++ b/test/cases/dashboard/01-open-api/03-mcp-server/01-app-streamable-http-initialize.bru
@@ -32,17 +32,32 @@ body:json {
   }
 }
 
-assert {
-  res.status: eq 200
-  res.body.jsonrpc: eq 2.0
-  res.body.result.protocolVersion: isDefined
-  res.body.result.serverInfo.name: isDefined
+tests {
+  function jsonRpcBody() {
+    var body = res.getBody();
+    if (typeof body === "string") {
+      var match = body.match(/(?:^|\n)data:\s*(\{.*\})(?:\r?\n|$)/);
+      return JSON.parse(match ? match[1] : body);
+    }
+    return body;
+  }
+
+  test("status is 200", function() {
+    expect(res.getStatus()).to.equal(200);
+  });
+
+  test("initialize response is valid", function() {
+    var data = jsonRpcBody();
+    expect(data.jsonrpc).to.equal("2.0");
+    expect(data.result).to.not.be.undefined;
+    expect(data.result.protocolVersion).to.not.be.undefined;
+    expect(data.result.serverInfo.name).to.not.be.undefined;
+  });
 }
 
 script:post-response {
   var sessionId = res.headers['mcp-session-id'];
-  if (!sessionId) {
-    throw new Error('No mcp-session-id found in response headers');
+  if (sessionId) {
+    bru.setVar("app_streamable_session_id", sessionId);
   }
-  bru.setVar("app_streamable_session_id", sessionId);
 }

--- a/test/cases/dashboard/01-open-api/03-mcp-server/02-app-streamable-http-tools-list.bru
+++ b/test/cases/dashboard/01-open-api/03-mcp-server/02-app-streamable-http-tools-list.bru
@@ -14,7 +14,6 @@ headers {
   X-Bkapi-Authorization: {"bk_app_code": "{{bk_app_code}}", "bk_app_secret": "{{bk_app_secret}}"}
   Content-Type: application/json
   Accept: application/json, text/event-stream
-  Mcp-Session-Id: {{app_streamable_session_id}}
 }
 
 body:json {
@@ -26,8 +25,24 @@ body:json {
   }
 }
 
-assert {
-  res.status: eq 200
-  res.body.jsonrpc: eq 2.0
-  res.body.result.tools: isDefined
+tests {
+  function jsonRpcBody() {
+    var body = res.getBody();
+    if (typeof body === "string") {
+      var match = body.match(/(?:^|\n)data:\s*(\{.*\})(?:\r?\n|$)/);
+      return JSON.parse(match ? match[1] : body);
+    }
+    return body;
+  }
+
+  test("status is 200", function() {
+    expect(res.getStatus()).to.equal(200);
+  });
+
+  test("tools/list response is valid", function() {
+    var data = jsonRpcBody();
+    expect(data.jsonrpc).to.equal("2.0");
+    expect(data.result).to.not.be.undefined;
+    expect(data.result.tools).to.not.be.undefined;
+  });
 }

--- a/test/cases/dashboard/01-open-api/03-mcp-server/03-app-streamable-http-tools-call.bru
+++ b/test/cases/dashboard/01-open-api/03-mcp-server/03-app-streamable-http-tools-call.bru
@@ -14,7 +14,6 @@ headers {
   X-Bkapi-Authorization: {"bk_app_code": "{{bk_app_code}}", "bk_app_secret": "{{bk_app_secret}}"}
   Content-Type: application/json
   Accept: application/json, text/event-stream
-  Mcp-Session-Id: {{app_streamable_session_id}}
 }
 
 body:json {
@@ -29,8 +28,24 @@ body:json {
   }
 }
 
-assert {
-  res.status: eq 200
-  res.body.jsonrpc: eq 2.0
-  res.body.result.content: isDefined
+tests {
+  function jsonRpcBody() {
+    var body = res.getBody();
+    if (typeof body === "string") {
+      var match = body.match(/(?:^|\n)data:\s*(\{.*\})(?:\r?\n|$)/);
+      return JSON.parse(match ? match[1] : body);
+    }
+    return body;
+  }
+
+  test("status is 200", function() {
+    expect(res.getStatus()).to.equal(200);
+  });
+
+  test("tools/call response is valid", function() {
+    var data = jsonRpcBody();
+    expect(data.jsonrpc).to.equal("2.0");
+    expect(data.result).to.not.be.undefined;
+    expect(data.result.content).to.not.be.undefined;
+  });
 }

--- a/test/cases/dashboard/01-open-api/03-mcp-server/04-user-streamable-http-initialize.bru
+++ b/test/cases/dashboard/01-open-api/03-mcp-server/04-user-streamable-http-initialize.bru
@@ -32,17 +32,32 @@ body:json {
   }
 }
 
-assert {
-  res.status: eq 200
-  res.body.jsonrpc: eq 2.0
-  res.body.result.protocolVersion: isDefined
-  res.body.result.serverInfo.name: isDefined
+tests {
+  function jsonRpcBody() {
+    var body = res.getBody();
+    if (typeof body === "string") {
+      var match = body.match(/(?:^|\n)data:\s*(\{.*\})(?:\r?\n|$)/);
+      return JSON.parse(match ? match[1] : body);
+    }
+    return body;
+  }
+
+  test("status is 200", function() {
+    expect(res.getStatus()).to.equal(200);
+  });
+
+  test("initialize response is valid", function() {
+    var data = jsonRpcBody();
+    expect(data.jsonrpc).to.equal("2.0");
+    expect(data.result).to.not.be.undefined;
+    expect(data.result.protocolVersion).to.not.be.undefined;
+    expect(data.result.serverInfo.name).to.not.be.undefined;
+  });
 }
 
 script:post-response {
   var sessionId = res.headers['mcp-session-id'];
-  if (!sessionId) {
-    throw new Error('No mcp-session-id found in response headers');
+  if (sessionId) {
+    bru.setVar("user_streamable_session_id", sessionId);
   }
-  bru.setVar("user_streamable_session_id", sessionId);
 }

--- a/test/cases/dashboard/01-open-api/03-mcp-server/05-user-streamable-http-tools-list.bru
+++ b/test/cases/dashboard/01-open-api/03-mcp-server/05-user-streamable-http-tools-list.bru
@@ -14,7 +14,6 @@ headers {
   X-Bkapi-Authorization: {"bk_app_code": "{{bk_app_code}}", "bk_app_secret": "{{bk_app_secret}}", "access_token": "{{access_token}}"}
   Content-Type: application/json
   Accept: application/json, text/event-stream
-  Mcp-Session-Id: {{user_streamable_session_id}}
 }
 
 body:json {
@@ -26,8 +25,24 @@ body:json {
   }
 }
 
-assert {
-  res.status: eq 200
-  res.body.jsonrpc: eq 2.0
-  res.body.result.tools: isDefined
+tests {
+  function jsonRpcBody() {
+    var body = res.getBody();
+    if (typeof body === "string") {
+      var match = body.match(/(?:^|\n)data:\s*(\{.*\})(?:\r?\n|$)/);
+      return JSON.parse(match ? match[1] : body);
+    }
+    return body;
+  }
+
+  test("status is 200", function() {
+    expect(res.getStatus()).to.equal(200);
+  });
+
+  test("tools/list response is valid", function() {
+    var data = jsonRpcBody();
+    expect(data.jsonrpc).to.equal("2.0");
+    expect(data.result).to.not.be.undefined;
+    expect(data.result.tools).to.not.be.undefined;
+  });
 }

--- a/test/cases/dashboard/01-open-api/03-mcp-server/06-user-streamable-http-tools-call.bru
+++ b/test/cases/dashboard/01-open-api/03-mcp-server/06-user-streamable-http-tools-call.bru
@@ -14,7 +14,6 @@ headers {
   X-Bkapi-Authorization: {"bk_app_code": "{{bk_app_code}}", "bk_app_secret": "{{bk_app_secret}}", "access_token": "{{access_token}}"}
   Content-Type: application/json
   Accept: application/json, text/event-stream
-  Mcp-Session-Id: {{user_streamable_session_id}}
 }
 
 body:json {
@@ -29,8 +28,24 @@ body:json {
   }
 }
 
-assert {
-  res.status: eq 200
-  res.body.jsonrpc: eq 2.0
-  res.body.result.content: isDefined
+tests {
+  function jsonRpcBody() {
+    var body = res.getBody();
+    if (typeof body === "string") {
+      var match = body.match(/(?:^|\n)data:\s*(\{.*\})(?:\r?\n|$)/);
+      return JSON.parse(match ? match[1] : body);
+    }
+    return body;
+  }
+
+  test("status is 200", function() {
+    expect(res.getStatus()).to.equal(200);
+  });
+
+  test("tools/call response is valid", function() {
+    var data = jsonRpcBody();
+    expect(data.jsonrpc).to.equal("2.0");
+    expect(data.result).to.not.be.undefined;
+    expect(data.result.content).to.not.be.undefined;
+  });
 }


### PR DESCRIPTION
## Summary
- parse JSON-RPC payloads from Streamable HTTP SSE data lines in Bruno cases
- assert jsonrpc as the protocol string "2.0"
- remove unnecessary Mcp-Session-Id headers from stateless tools/list and tools/call requests

## Testing
- pre-commit hooks passed during commit