### PR TITLE
fix(e2e): stabilize e2e by using unique resource version and compatible polling

### DIFF
--- a/test/cases/dashboard/01-open-api/01-v2-sync/05-create-resource-version.bru
+++ b/test/cases/dashboard/01-open-api/01-v2-sync/05-create-resource-version.bru
@@ -15,17 +15,19 @@ headers {
   Content-Type: application/json
 }
 
+script:pre-request {
+  // 生成唯一 resource_version，避免重复执行导致同版本多条记录。
+  const resourceVersion = `1.0.${Date.now()}`;
+  bru.setVar("resource_version", resourceVersion);
+}
+
 body:json {
   {
-    "version": "1.0.0",
+    "version": "{{resource_version}}",
     "comment": "e2e test version"
   }
 }
 
 assert {
   res.status: lte 201
-}
-
-script:post-response {
-  bru.setVar("resource_version", "1.0.0");
 }

--- a/test/cases/dashboard/01-open-api/02-v2-open/05-gateway-resource-detail.bru
+++ b/test/cases/dashboard/01-open-api/02-v2-open/05-gateway-resource-detail.bru
@@ -51,7 +51,9 @@ script:pre-request {
     if (pollStatus === 200) {
       return;
     }
-    await bru.sleep(intervalMs);
+    // 兼容旧版本 Bruno CLI（无 bru.sleep）
+    const waitUntil = Date.now() + intervalMs;
+    while (Date.now() < waitUntil) {}
   }
   throw new Error(
     "Resource detail still returning non-200 after " + maxAttempts + " attempts (" +


### PR DESCRIPTION
- 出错e2e测试样例：05-create-resource-version、05-gateway-resource-detail
- 原因：资源版本固定导致重复执行冲突；Bruno 运行环境不支持 bru.sleep
- 解决方法：资源版本改为每次运行唯一；轮询等待改为兼容写法