### PR TITLE
fix(sdk): pass Maven mirror URL during package

### DIFF
--- a/src/dashboard/apigateway/apigateway/biz/sdk/distributors/__init__.py
+++ b/src/dashboard/apigateway/apigateway/biz/sdk/distributors/__init__.py
@@ -16,7 +16,7 @@
 # to the current version of the project delivered to anyone in the future.
 #
 from .bkrepo import GenericDistributor
-from .maven import MAVEN_CENTRAL_URL, MavenSourceDistributor
+from .maven import MavenSourceDistributor
 from .pypi import PypiSourceDistributor
 
 try:
@@ -26,7 +26,6 @@ except ImportError:
 
 __all__ = [
     # constant
-    "MAVEN_CENTRAL_URL",
     # Enum
     # class
     "GenericDistributor",

--- a/src/dashboard/apigateway/apigateway/biz/sdk/distributors/maven.py
+++ b/src/dashboard/apigateway/apigateway/biz/sdk/distributors/maven.py
@@ -29,9 +29,6 @@ from apigateway.utils.maven import RepositoryConfig
 
 logger = logging.getLogger(__name__)
 
-# Maven Central 官方仓库地址，作为镜像源的默认值
-MAVEN_CENTRAL_URL = "https://repo.maven.apache.org/maven2"
-
 
 @dataclass
 class MavenSourceDistributor(Distributor):
@@ -69,9 +66,6 @@ class MavenSourceDistributor(Distributor):
         env = os.environ.copy()
         env["HOME"] = source_dir
 
-        # 镜像源 URL，如果未配置则使用 Maven Central 官方地址
-        mirror_url = self.repository_config.mirror_url or MAVEN_CENTRAL_URL
-
         command = [
             "mvn",
             "-s",
@@ -87,7 +81,7 @@ class MavenSourceDistributor(Distributor):
             "-Durl=" + self.repository_config.repository_url,
             "-Dusername=" + self.repository_config.username,
             "-Dpassword=" + self.repository_config.password,
-            "-DmirrorUrl=" + mirror_url,
+            "-DmirrorUrl=" + self.repository_config.mirror_url,
         ]
 
         # 如果配置了跳过 SSL 证书校验（用于内网 HTTPS 部署的 bkrepo）

--- a/src/dashboard/apigateway/apigateway/biz/sdk/packagers/maven.py
+++ b/src/dashboard/apigateway/apigateway/biz/sdk/packagers/maven.py
@@ -18,17 +18,24 @@
 import logging
 import os
 import subprocess
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from pathlib import Path
-from typing import List
+from typing import ClassVar, List
 
 from apigateway.biz.sdk.models import Packager
+from apigateway.utils.maven import RepositoryConfig
 
 logger = logging.getLogger(__name__)
 
 
 @dataclass
 class SourcePackager(Packager):
+    repository: ClassVar[str] = "default"
+    repository_config: RepositoryConfig = field(init=False)
+
+    def __post_init__(self):
+        self.repository_config = RepositoryConfig.by_name(self.repository)
+
     def pack(self, output_dir: str) -> List[str]:
         # 保存当前工作目录
         original_dir = os.getcwd()
@@ -42,6 +49,7 @@ class SourcePackager(Packager):
                     str(Path(original_dir) / "apigateway/biz/sdk/maven/settings.xml"),
                     "clean",
                     "package",
+                    "-DmirrorUrl=" + self.repository_config.mirror_url,
                 ],
                 env={"HOME": output_dir},
                 cwd=output_dir,

--- a/src/dashboard/apigateway/apigateway/conf/utils.py
+++ b/src/dashboard/apigateway/apigateway/conf/utils.py
@@ -308,7 +308,7 @@ def get_bkrepo_config(env: Env) -> dict:
                 "username": env.str("DEFAULT_MAVEN_USERNAME", "bk_apigateway"),
                 "password": env.str("DEFAULT_MAVEN_PASSWORD", "bk_apigateway"),
                 "ssl_insecure": env.bool("DEFAULT_MAVEN_SSL_INSECURE", False),
-                "mirror_url": env.str("DEFAULT_MAVEN_MIRROR_URL", ""),
+                "mirror_url": env.str("DEFAULT_MAVEN_MIRROR_URL", "https://repo.maven.apache.org/maven2"),
             }
         },
     }

--- a/src/dashboard/apigateway/apigateway/tests/biz/sdk/distributors/test_maven.py
+++ b/src/dashboard/apigateway/apigateway/tests/biz/sdk/distributors/test_maven.py
@@ -21,7 +21,7 @@ import pytest
 
 from apigateway.apps.support.constants import ProgrammingLanguageEnum
 from apigateway.biz.sdk import DistributeError
-from apigateway.biz.sdk.distributors import MAVEN_CENTRAL_URL, MavenSourceDistributor
+from apigateway.biz.sdk.distributors import MavenSourceDistributor
 
 
 @pytest.fixture
@@ -31,14 +31,19 @@ def sdk_context(sdk_context):
 
 
 @pytest.fixture
-def maven_config_base(faker):
+def default_maven_mirror_url(settings):
+    return settings.MAVEN_MIRRORS_CONFIG["default"]["mirror_url"]
+
+
+@pytest.fixture
+def maven_config_base(faker, default_maven_mirror_url):
     return {
         "repository_url": faker.url(),
         "repository_id": "test-maven",
         "username": faker.user_name(),
         "password": faker.password(),
         "ssl_insecure": False,
-        "mirror_url": "",
+        "mirror_url": default_maven_mirror_url,
     }
 
 
@@ -78,7 +83,15 @@ class TestMavenSourceDistributor:
 
         assert "com/tencent/bkapi/test-sdk/1.0.0/test-sdk-1.0.0.jar" in url
 
-    def test_distribute_with_ssl_insecure(self, sdk_context, settings, output_dir, tmpdir, faker):
+    def test_distribute_with_ssl_insecure(
+        self,
+        sdk_context,
+        settings,
+        output_dir,
+        tmpdir,
+        faker,
+        default_maven_mirror_url,
+    ):
         """测试配置了 ssl_insecure 时命令包含 SSL 跳过参数"""
         settings.MAVEN_MIRRORS_CONFIG = {
             "default": {
@@ -87,7 +100,7 @@ class TestMavenSourceDistributor:
                 "username": faker.user_name(),
                 "password": faker.password(),
                 "ssl_insecure": True,
-                "mirror_url": "",
+                "mirror_url": default_maven_mirror_url,
             }
         }
         distributor = MavenSourceDistributor(context=sdk_context)
@@ -153,8 +166,8 @@ class TestMavenSourceDistributor:
             command = call_args[0][0]
             assert f"-DmirrorUrl={mirror_url}" in command
 
-    def test_distribute_without_mirror_url_uses_default(self, distributor, output_dir, tmpdir):
-        """测试未配置镜像源时使用 Maven Central 作为默认值"""
+    def test_distribute_with_default_mirror_url(self, distributor, output_dir, tmpdir):
+        """测试使用 settings 中的默认镜像源"""
         # 创建一个假的 jar 文件
         jar_file = tmpdir.join("test.jar")
         jar_file.write("fake jar content")
@@ -164,10 +177,10 @@ class TestMavenSourceDistributor:
 
             distributor.distribute(output_dir, [str(jar_file)])
 
-            # 验证命令中使用了 Maven Central 作为默认镜像源
+            # 验证命令中使用 settings 中的默认镜像源
             call_args = mock_run.call_args
             command = call_args[0][0]
-            assert f"-DmirrorUrl={MAVEN_CENTRAL_URL}" in command
+            assert f"-DmirrorUrl={distributor.repository_config.mirror_url}" in command
 
     def test_distribute_empty_files(self, distributor, output_dir):
         """测试空文件列表时不执行任何操作"""

--- a/src/dashboard/apigateway/apigateway/tests/biz/sdk/packagers/test_maven.py
+++ b/src/dashboard/apigateway/apigateway/tests/biz/sdk/packagers/test_maven.py
@@ -1,0 +1,72 @@
+#
+# TencentBlueKing is pleased to support the open source community by making
+# 蓝鲸智云 - API 网关(BlueKing - APIGateway) available.
+# Copyright (C) 2025 Tencent. All rights reserved.
+# Licensed under the MIT License (the "License"); you may not use this file except
+# in compliance with the License. You may obtain a copy of the License at
+#
+#     http://opensource.org/licenses/MIT
+#
+# Unless required by applicable law or agreed to in writing, software distributed under
+# the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+# either express or implied. See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# We undertake not to change the open source license (MIT license) applicable
+# to the current version of the project delivered to anyone in the future.
+#
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from apigateway.apps.support.constants import ProgrammingLanguageEnum
+from apigateway.biz.sdk.packagers import MavenSourcePackager
+
+
+@pytest.fixture
+def sdk_context(sdk_context):
+    sdk_context.language = ProgrammingLanguageEnum.JAVA
+    return sdk_context
+
+
+@pytest.fixture
+def packager(sdk_context):
+    return MavenSourcePackager(context=sdk_context)
+
+
+def _create_jar_file(output_dir):
+    target_dir = output_dir.join("target")
+    target_dir.mkdir()
+    jar_file = target_dir.join("test.jar")
+    jar_file.write("fake jar content")
+
+
+def test_pack_with_mirror_url(settings, output_dir, tmpdir, sdk_context):
+    mirror_url = "https://maven.aliyun.com/repository/public"
+    settings.MAVEN_MIRRORS_CONFIG = {
+        "default": {
+            "mirror_url": mirror_url,
+        }
+    }
+    packager = MavenSourcePackager(context=sdk_context)
+    _create_jar_file(tmpdir)
+
+    with patch("subprocess.run") as mock_run:
+        mock_run.return_value = MagicMock(returncode=0, stdout="", stderr="")
+
+        packager.pack(output_dir)
+
+    command = mock_run.call_args[0][0]
+    assert f"-DmirrorUrl={mirror_url}" in command
+
+
+def test_pack_with_default_mirror_url(settings, output_dir, tmpdir, packager):
+    _create_jar_file(tmpdir)
+
+    with patch("subprocess.run") as mock_run:
+        mock_run.return_value = MagicMock(returncode=0, stdout="", stderr="")
+
+        packager.pack(output_dir)
+
+    command = mock_run.call_args[0][0]
+    assert f"-DmirrorUrl={settings.MAVEN_MIRRORS_CONFIG['default']['mirror_url']}" in command


### PR DESCRIPTION
## Summary

- Configure Maven Central as the default Maven mirror URL in dashboard settings
- Pass the configured `mirrorUrl` to `mvn clean package` for Java SDK packaging
- Keep deploy/package mirror handling consistent and update related tests

## Test

- `uv run ruff check apigateway/apigateway/conf/utils.py apigateway/apigateway/utils/maven.py apigateway/apigateway/biz/sdk/packagers/maven.py apigateway/apigateway/biz/sdk/distributors/maven.py apigateway/apigateway/biz/sdk/distributors/__init__.py apigateway/apigateway/tests/biz/sdk/packagers/test_maven.py apigateway/apigateway/tests/biz/sdk/distributors/test_maven.py`
- `uv run bash -lc 'cd apigateway && set -a && . apigateway/conf/unittest_env && set +a && python -m pytest --nomigrations --ds apigateway.settings -q --tb=short apigateway/tests/biz/sdk/packagers/test_maven.py apigateway/tests/biz/sdk/distributors/test_maven.py'`
