### PR TITLE
fix(permission): preserve ITSM approval metadata

### DIFF
--- a/src/dashboard/apigateway/apigateway/apis/web/permission/filters.py
+++ b/src/dashboard/apigateway/apigateway/apis/web/permission/filters.py
@@ -75,6 +75,7 @@ class AppPermissionApplyFilter(filters.FilterSet):
 class AppGatewayPermissionFilter(filters.FilterSet):
     bk_app_code = filters.CharFilter()
     keyword = filters.CharFilter(method="query_filter")
+    grant_type = filters.ChoiceFilter(choices=GrantTypeEnum.get_choices())
     order_by = filters.OrderingFilter(
         choices=[(field, field) for field in ["bk_app_code", "-bk_app_code", "expires", "-expires"]]
     )
@@ -84,6 +85,7 @@ class AppGatewayPermissionFilter(filters.FilterSet):
         fields = [
             "bk_app_code",
             "keyword",
+            "grant_type",
             "order_by",
         ]
 

--- a/src/dashboard/apigateway/apigateway/apis/web/permission/views.py
+++ b/src/dashboard/apigateway/apigateway/apis/web/permission/views.py
@@ -109,6 +109,7 @@ class AppPermissionQuerySetMixin(AppGatewayPermissionQuerySetMixin, AppResourceP
         gateway_permissions = [
             {
                 "bk_app_code": perm.bk_app_code,
+                "grant_type": perm.grant_type,
                 "expires": perm.expires,
                 "grant_dimension": GrantDimensionEnum.API.value,
                 "id": perm.id,
@@ -142,12 +143,8 @@ class AppPermissionListApi(AppPermissionQuerySetMixin, generics.ListAPIView):
     def get_queryset(self):
         query_params = self.request.query_params
         app_gateway_permissions = AppGatewayPermissionFilter(self.request.GET, queryset=self.get_gateway_queryset()).qs
-        # 如果查询维度为资源 或者 授权类型不为 INITIALIZE(网关维度都为INITIALIZE)或者 查询某个资源 都要忽略掉网关维度的
-        if (
-            query_params.get("grant_dimension") == GrantDimensionEnum.RESOURCE.value
-            or (query_params.get("grant_type") and query_params.get("grant_type") != GrantTypeEnum.INITIALIZE.value)
-            or query_params.get("resource_id")
-        ):
+        # 查询维度为资源或查询某个资源时，忽略网关维度权限
+        if query_params.get("grant_dimension") == GrantDimensionEnum.RESOURCE.value or query_params.get("resource_id"):
             app_gateway_permissions = []
 
         app_resource_permissions = AppResourcePermissionFilter(
@@ -323,12 +320,8 @@ class AppPermissionExportApi(AppPermissionQuerySetMixin, generics.CreateAPIView)
             resource_queryset = self.get_resource_queryset()
         elif data["export_type"] == ExportTypeEnum.FILTERED.value:
             gateway_queryset = AppGatewayPermissionFilter(self.request.data, queryset=self.get_gateway_queryset()).qs
-            # 如果查询维度为资源 或者 授权类型不为 INITIALIZE(网关维度都为INITIALIZE)或者 查询某个资源 都要忽略掉网关维度的
-            if (
-                data.get("grant_dimension") == GrantDimensionEnum.RESOURCE.value
-                or (data.get("grant_type") and data.get("grant_type") != GrantTypeEnum.INITIALIZE.value)
-                or data.get("resource_id")
-            ):
+            # 查询维度为资源或查询某个资源时，忽略网关维度权限
+            if data.get("grant_dimension") == GrantDimensionEnum.RESOURCE.value or data.get("resource_id"):
                 gateway_queryset = []
 
             resource_queryset = AppResourcePermissionFilter(

--- a/src/dashboard/apigateway/apigateway/apis/web/personal_workbench/views.py
+++ b/src/dashboard/apigateway/apigateway/apis/web/personal_workbench/views.py
@@ -16,6 +16,7 @@
 # to the current version of the project delivered to anyone in the future.
 #
 
+from django.db.models import Q
 from django.utils.decorators import method_decorator
 from drf_yasg.utils import swagger_auto_schema
 from rest_framework import generics, status
@@ -25,6 +26,7 @@ from apigateway.apps.mcp_server.constants import MCPServerAppPermissionApplyStat
 from apigateway.apps.mcp_server.models import MCPServer, MCPServerAppPermissionApply
 from apigateway.apps.permission.constants import ApplyStatusEnum, GrantDimensionEnum
 from apigateway.apps.permission.models import AppPermissionApply, AppPermissionRecord
+from apigateway.biz.bk_itsm import ITSM_PERMISSION_APPROVAL_HANDLER
 from apigateway.biz.mcp_server import MCPServerPermissionHandler
 from apigateway.biz.permission import ResourcePermissionHandler
 from apigateway.common.tenant.query import (
@@ -82,6 +84,40 @@ class WorkbenchPermissionMixin:
             self.request.user.username,
             get_user_tenant_id(self.request),
         )
+
+    def _get_current_maintainer_gateway_ids(self):
+        username = self.request.user.username
+        tenant_id = get_user_tenant_id(self.request)
+        queryset = Gateway.objects.filter(_maintainers__contains=username)
+        if tenant_id:
+            queryset = gateway_filter_by_user_tenant_id(queryset, tenant_id)
+
+        return [gateway.id for gateway in queryset if gateway.has_permission(username)]
+
+    def _get_handled_gateway_permission_record_queryset(self):
+        username = self.request.user.username
+        tenant_id = get_user_tenant_id(self.request)
+        queryset = AppPermissionRecord.objects.filter(
+            Q(handled_by=username)
+            | Q(
+                handled_by=ITSM_PERMISSION_APPROVAL_HANDLER,
+                gateway_id__in=self._get_current_maintainer_gateway_ids(),
+            )
+        ).exclude(status=ApplyStatusEnum.PENDING.value)
+        return gateway_related_filter_by_user_tenant_id(queryset, tenant_id)
+
+    def _get_handled_mcp_permission_apply_queryset(self):
+        username = self.request.user.username
+        tenant_id = get_user_tenant_id(self.request)
+        queryset = MCPServerAppPermissionApply.objects.filter(
+            Q(handled_by=username)
+            | Q(
+                handled_by=ITSM_PERMISSION_APPROVAL_HANDLER,
+                mcp_server__gateway_id__in=self._get_current_maintainer_gateway_ids(),
+            ),
+            is_deleted=False,
+        ).exclude(status=MCPServerAppPermissionApplyStatusEnum.PENDING.value)
+        return mcp_server_related_filter_by_user_tenant_id(queryset, tenant_id)
 
 
 class ResourcePrefetchMixin:
@@ -157,12 +193,9 @@ class WorkbenchGatewayFilterOptionListApi(WorkbenchPermissionMixin, generics.Lis
             return gateway_filter_by_user_tenant_id(queryset, tenant_id)
 
         if filter_type == WorkbenchFilterTypeEnum.HANDLED.value:
-            # 我的已办：从用户处理过的记录中提取去重的网关
+            # 我的已办：从用户处理过的记录中提取去重的网关；ITSM 回调无实际审批人，按当前用户维护的网关补充
             gateway_ids = (
-                AppPermissionRecord.objects.filter(handled_by=username)
-                .exclude(status=ApplyStatusEnum.PENDING.value)
-                .values_list("gateway_id", flat=True)
-                .distinct()
+                self._get_handled_gateway_permission_record_queryset().values_list("gateway_id", flat=True).distinct()
             )
             queryset = Gateway.objects.filter(id__in=gateway_ids).order_by("name")
             return gateway_filter_by_user_tenant_id(queryset, tenant_id)
@@ -273,10 +306,9 @@ class WorkbenchMCPGatewayFilterOptionListApi(WorkbenchPermissionMixin, generics.
             return gateway_filter_by_user_tenant_id(queryset, tenant_id)
 
         if filter_type == WorkbenchFilterTypeEnum.HANDLED.value:
-            # 我的已办：从用户处理过的 MCP 记录中提取去重的网关
+            # 我的已办：从用户处理过的 MCP 记录中提取去重的网关；ITSM 回调无实际审批人，按当前用户维护的网关补充
             gateway_ids = (
-                MCPServerAppPermissionApply.objects.filter(handled_by=username, is_deleted=False)
-                .exclude(status=MCPServerAppPermissionApplyStatusEnum.PENDING.value)
+                self._get_handled_mcp_permission_apply_queryset()
                 .values_list("mcp_server__gateway_id", flat=True)
                 .distinct()
             )
@@ -427,15 +459,9 @@ class WorkbenchHandledGatewayPermissionListApi(ResourcePrefetchMixin, WorkbenchP
     filterset_class = WorkbenchGatewayPermissionRecordFilter
 
     def get_queryset(self):
-        username = self.request.user.username
-        tenant_id = get_user_tenant_id(self.request)
-        queryset = (
-            AppPermissionRecord.objects.filter(handled_by=username)
-            .exclude(status=ApplyStatusEnum.PENDING.value)
-            .select_related("gateway")
-            .order_by("-handled_time")
+        return (
+            self._get_handled_gateway_permission_record_queryset().select_related("gateway").order_by("-handled_time")
         )
-        return gateway_related_filter_by_user_tenant_id(queryset, tenant_id)
 
 
 @method_decorator(

--- a/src/dashboard/apigateway/apigateway/apis/web/personal_workbench/views.py
+++ b/src/dashboard/apigateway/apigateway/apis/web/personal_workbench/views.py
@@ -83,20 +83,6 @@ class WorkbenchPermissionMixin:
             get_user_tenant_id(self.request),
         )
 
-    def _get_handled_gateway_permission_record_queryset(self):
-        """获取当前用户已处理或通过 ITSM 处理的 API 网关权限申请记录"""
-        return WorkbenchPermissionHandler.get_handled_gateway_permission_record_queryset(
-            self.request.user.username,
-            get_user_tenant_id(self.request),
-        )
-
-    def _get_handled_mcp_permission_apply_queryset(self):
-        """获取当前用户已处理或通过 ITSM 处理的 MCP Server 权限申请记录"""
-        return WorkbenchPermissionHandler.get_handled_mcp_permission_apply_queryset(
-            self.request.user.username,
-            get_user_tenant_id(self.request),
-        )
-
 
 class ResourcePrefetchMixin:
     """批量预取资源详情 Mixin
@@ -173,7 +159,9 @@ class WorkbenchGatewayFilterOptionListApi(WorkbenchPermissionMixin, generics.Lis
         if filter_type == WorkbenchFilterTypeEnum.HANDLED.value:
             # 我的已办：从用户处理过的记录中提取去重的网关；ITSM 回调无实际审批人，按当前用户维护的网关补充
             gateway_ids = (
-                self._get_handled_gateway_permission_record_queryset().values_list("gateway_id", flat=True).distinct()
+                WorkbenchPermissionHandler.get_handled_gateway_permission_record_queryset(username, tenant_id)
+                .values_list("gateway_id", flat=True)
+                .distinct()
             )
             queryset = Gateway.objects.filter(id__in=gateway_ids).order_by("name")
             return gateway_filter_by_user_tenant_id(queryset, tenant_id)
@@ -228,7 +216,9 @@ class WorkbenchMCPServerFilterOptionListApi(WorkbenchPermissionMixin, generics.L
         if filter_type == WorkbenchFilterTypeEnum.HANDLED.value:
             # 我的已办：从用户处理过的记录中提取去重的 MCP Server；ITSM 回调无实际审批人，按当前用户维护的网关补充
             mcp_server_ids = (
-                self._get_handled_mcp_permission_apply_queryset().values_list("mcp_server_id", flat=True).distinct()
+                WorkbenchPermissionHandler.get_handled_mcp_permission_apply_queryset(username, tenant_id)
+                .values_list("mcp_server_id", flat=True)
+                .distinct()
             )
             queryset = MCPServer.objects.select_related("gateway").filter(id__in=mcp_server_ids).order_by("name")
             return gateway_mcp_server_filter_by_user_tenant_id(queryset, tenant_id)
@@ -283,7 +273,7 @@ class WorkbenchMCPGatewayFilterOptionListApi(WorkbenchPermissionMixin, generics.
         if filter_type == WorkbenchFilterTypeEnum.HANDLED.value:
             # 我的已办：从用户处理过的 MCP 记录中提取去重的网关；ITSM 回调无实际审批人，按当前用户维护的网关补充
             gateway_ids = (
-                self._get_handled_mcp_permission_apply_queryset()
+                WorkbenchPermissionHandler.get_handled_mcp_permission_apply_queryset(username, tenant_id)
                 .values_list("mcp_server__gateway_id", flat=True)
                 .distinct()
             )
@@ -435,7 +425,12 @@ class WorkbenchHandledGatewayPermissionListApi(ResourcePrefetchMixin, WorkbenchP
 
     def get_queryset(self):
         return (
-            self._get_handled_gateway_permission_record_queryset().select_related("gateway").order_by("-handled_time")
+            WorkbenchPermissionHandler.get_handled_gateway_permission_record_queryset(
+                self.request.user.username,
+                get_user_tenant_id(self.request),
+            )
+            .select_related("gateway")
+            .order_by("-handled_time")
         )
 
 
@@ -459,7 +454,10 @@ class WorkbenchHandledMCPPermissionListApi(WorkbenchPermissionMixin, generics.Li
 
     def get_queryset(self):
         return (
-            self._get_handled_mcp_permission_apply_queryset()
+            WorkbenchPermissionHandler.get_handled_mcp_permission_apply_queryset(
+                self.request.user.username,
+                get_user_tenant_id(self.request),
+            )
             .select_related("mcp_server", "mcp_server__gateway")
             .order_by("-handled_time")
         )

--- a/src/dashboard/apigateway/apigateway/apis/web/personal_workbench/views.py
+++ b/src/dashboard/apigateway/apigateway/apis/web/personal_workbench/views.py
@@ -158,11 +158,8 @@ class WorkbenchGatewayFilterOptionListApi(WorkbenchPermissionMixin, generics.Lis
 
         if filter_type == WorkbenchFilterTypeEnum.HANDLED.value:
             # 我的已办：从用户处理过的记录中提取去重的网关；ITSM 回调无实际审批人，按当前用户维护的网关补充
-            gateway_ids = (
-                WorkbenchPermissionHandler.get_handled_gateway_permission_record_queryset(username, tenant_id)
-                .values_list("gateway_id", flat=True)
-                .distinct()
-            )
+            queryset = WorkbenchPermissionHandler.get_handled_gateway_permission_record_queryset(username, tenant_id)
+            gateway_ids = queryset.values_list("gateway_id", flat=True).distinct()
             queryset = Gateway.objects.filter(id__in=gateway_ids).order_by("name")
             return gateway_filter_by_user_tenant_id(queryset, tenant_id)
 

--- a/src/dashboard/apigateway/apigateway/apis/web/personal_workbench/views.py
+++ b/src/dashboard/apigateway/apigateway/apis/web/personal_workbench/views.py
@@ -248,12 +248,9 @@ class WorkbenchMCPServerFilterOptionListApi(WorkbenchPermissionMixin, generics.L
             return gateway_mcp_server_filter_by_user_tenant_id(queryset, tenant_id)
 
         if filter_type == WorkbenchFilterTypeEnum.HANDLED.value:
-            # 我的已办：从用户处理过的记录中提取去重的 MCP Server
+            # 我的已办：从用户处理过的记录中提取去重的 MCP Server；ITSM 回调无实际审批人，按当前用户维护的网关补充
             mcp_server_ids = (
-                MCPServerAppPermissionApply.objects.filter(handled_by=username, is_deleted=False)
-                .exclude(status=MCPServerAppPermissionApplyStatusEnum.PENDING.value)
-                .values_list("mcp_server_id", flat=True)
-                .distinct()
+                self._get_handled_mcp_permission_apply_queryset().values_list("mcp_server_id", flat=True).distinct()
             )
             queryset = MCPServer.objects.select_related("gateway").filter(id__in=mcp_server_ids).order_by("name")
             return gateway_mcp_server_filter_by_user_tenant_id(queryset, tenant_id)
@@ -483,15 +480,8 @@ class WorkbenchHandledMCPPermissionListApi(WorkbenchPermissionMixin, generics.Li
     filterset_class = WorkbenchMCPPermissionApplyFilter
 
     def get_queryset(self):
-        username = self.request.user.username
-        tenant_id = get_user_tenant_id(self.request)
-        queryset = (
-            MCPServerAppPermissionApply.objects.filter(
-                handled_by=username,
-                is_deleted=False,
-            )
-            .exclude(status=MCPServerAppPermissionApplyStatusEnum.PENDING.value)
+        return (
+            self._get_handled_mcp_permission_apply_queryset()
             .select_related("mcp_server", "mcp_server__gateway")
             .order_by("-handled_time")
         )
-        return mcp_server_related_filter_by_user_tenant_id(queryset, tenant_id)

--- a/src/dashboard/apigateway/apigateway/apis/web/personal_workbench/views.py
+++ b/src/dashboard/apigateway/apigateway/apis/web/personal_workbench/views.py
@@ -16,19 +16,17 @@
 # to the current version of the project delivered to anyone in the future.
 #
 
-from django.db.models import Q
 from django.utils.decorators import method_decorator
 from drf_yasg.utils import swagger_auto_schema
 from rest_framework import generics, status
 from rest_framework.permissions import IsAuthenticated
 
-from apigateway.apps.mcp_server.constants import MCPServerAppPermissionApplyStatusEnum
 from apigateway.apps.mcp_server.models import MCPServer, MCPServerAppPermissionApply
-from apigateway.apps.permission.constants import ApplyStatusEnum, GrantDimensionEnum
-from apigateway.apps.permission.models import AppPermissionApply, AppPermissionRecord
-from apigateway.biz.bk_itsm import ITSM_PERMISSION_APPROVAL_HANDLER
+from apigateway.apps.permission.constants import GrantDimensionEnum
+from apigateway.apps.permission.models import AppPermissionApply
 from apigateway.biz.mcp_server import MCPServerPermissionHandler
 from apigateway.biz.permission import ResourcePermissionHandler
+from apigateway.biz.personal_workbench import WorkbenchPermissionHandler
 from apigateway.common.tenant.query import (
     gateway_filter_by_user_tenant_id,
     gateway_mcp_server_filter_by_user_tenant_id,
@@ -85,39 +83,19 @@ class WorkbenchPermissionMixin:
             get_user_tenant_id(self.request),
         )
 
-    def _get_current_maintainer_gateway_ids(self):
-        username = self.request.user.username
-        tenant_id = get_user_tenant_id(self.request)
-        queryset = Gateway.objects.filter(_maintainers__contains=username)
-        if tenant_id:
-            queryset = gateway_filter_by_user_tenant_id(queryset, tenant_id)
-
-        return [gateway.id for gateway in queryset if gateway.has_permission(username)]
-
     def _get_handled_gateway_permission_record_queryset(self):
-        username = self.request.user.username
-        tenant_id = get_user_tenant_id(self.request)
-        queryset = AppPermissionRecord.objects.filter(
-            Q(handled_by=username)
-            | Q(
-                handled_by=ITSM_PERMISSION_APPROVAL_HANDLER,
-                gateway_id__in=self._get_current_maintainer_gateway_ids(),
-            )
-        ).exclude(status=ApplyStatusEnum.PENDING.value)
-        return gateway_related_filter_by_user_tenant_id(queryset, tenant_id)
+        """获取当前用户已处理或通过 ITSM 处理的 API 网关权限申请记录"""
+        return WorkbenchPermissionHandler.get_handled_gateway_permission_record_queryset(
+            self.request.user.username,
+            get_user_tenant_id(self.request),
+        )
 
     def _get_handled_mcp_permission_apply_queryset(self):
-        username = self.request.user.username
-        tenant_id = get_user_tenant_id(self.request)
-        queryset = MCPServerAppPermissionApply.objects.filter(
-            Q(handled_by=username)
-            | Q(
-                handled_by=ITSM_PERMISSION_APPROVAL_HANDLER,
-                mcp_server__gateway_id__in=self._get_current_maintainer_gateway_ids(),
-            ),
-            is_deleted=False,
-        ).exclude(status=MCPServerAppPermissionApplyStatusEnum.PENDING.value)
-        return mcp_server_related_filter_by_user_tenant_id(queryset, tenant_id)
+        """获取当前用户已处理或通过 ITSM 处理的 MCP Server 权限申请记录"""
+        return WorkbenchPermissionHandler.get_handled_mcp_permission_apply_queryset(
+            self.request.user.username,
+            get_user_tenant_id(self.request),
+        )
 
 
 class ResourcePrefetchMixin:

--- a/src/dashboard/apigateway/apigateway/apps/bk_itsm/management/system_bk-apigateway.json
+++ b/src/dashboard/apigateway/apigateway/apps/bk_itsm/management/system_bk-apigateway.json
@@ -827,31 +827,31 @@
               "label": "submit",
               "fields": {
                 "instance_approvers": {
-                  "state": "default",
+                  "state": "readonly",
                   "required": true
                 },
                 "bk_app_code": {
-                  "state": "default",
+                  "state": "readonly",
                   "required": true
                 },
                 "gateway_name": {
-                  "state": "default",
+                  "state": "readonly",
                   "required": true
                 },
                 "ticket__title": {
-                  "state": "default",
+                  "state": "readonly",
                   "required": true
                 },
                 "apply_record_id": {
-                  "state": "default",
+                  "state": "readonly",
                   "required": true
                 },
                 "apply_resources": {
-                  "state": "default",
+                  "state": "readonly",
                   "required": true
                 },
                 "grant_dimension": {
-                  "state": "default",
+                  "state": "readonly",
                   "required": true
                 }
               },
@@ -1023,7 +1023,7 @@
                     "tips": "网关权限申请",
                     "type": "text",
                     "class": [],
-                    "state": "default",
+                    "state": "readonly",
                     "title": {
                       "value": "标题",
                       "isHide": false
@@ -1088,7 +1088,7 @@
                     "tips": "申请资源所属网关名",
                     "type": "text",
                     "class": [],
-                    "state": "default",
+                    "state": "readonly",
                     "title": {
                       "value": "网关名",
                       "isHide": false
@@ -1156,7 +1156,7 @@
                     "slot": [],
                     "type": "radio",
                     "class": [],
-                    "state": "default",
+                    "state": "readonly",
                     "title": {
                       "value": "权限维度",
                       "isHide": false
@@ -1245,7 +1245,7 @@
                     "tips": "权限对象",
                     "type": "textarea",
                     "class": [],
-                    "state": "default",
+                    "state": "readonly",
                     "title": {
                       "value": "权限对象",
                       "isHide": false
@@ -1311,7 +1311,7 @@
                     "tips": "申请应用",
                     "type": "text",
                     "class": [],
-                    "state": "default",
+                    "state": "readonly",
                     "title": {
                       "value": "申请应用",
                       "isHide": false
@@ -1380,7 +1380,7 @@
                     "tips": "网关申请单据id",
                     "type": "number",
                     "class": [],
-                    "state": "default",
+                    "state": "readonly",
                     "title": {
                       "value": "网关申请单据id",
                       "isHide": false
@@ -1446,7 +1446,7 @@
                     "tips": "审批人",
                     "type": "multiUser",
                     "class": [],
-                    "state": "default",
+                    "state": "readonly",
                     "title": {
                       "value": "审批人",
                       "isHide": false
@@ -2879,7 +2879,7 @@
                     "tips": "请输入",
                     "type": "text",
                     "class": [],
-                    "state": "default",
+                    "state": "readonly",
                     "title": {
                       "value": "标题",
                       "isHide": false
@@ -2939,7 +2939,7 @@
                     "tips": "申请资源所属网关名",
                     "type": "text",
                     "class": [],
-                    "state": "default",
+                    "state": "readonly",
                     "title": {
                       "value": "网关名",
                       "isHide": false
@@ -3007,7 +3007,7 @@
                     "slot": [],
                     "type": "radio",
                     "class": [],
-                    "state": "default",
+                    "state": "readonly",
                     "title": {
                       "value": "权限维度",
                       "isHide": false
@@ -3096,7 +3096,7 @@
                     "tips": "权限对象",
                     "type": "textarea",
                     "class": [],
-                    "state": "default",
+                    "state": "readonly",
                     "title": {
                       "value": "权限对象",
                       "isHide": false
@@ -3162,7 +3162,7 @@
                     "tips": "申请应用",
                     "type": "text",
                     "class": [],
-                    "state": "default",
+                    "state": "readonly",
                     "title": {
                       "value": "申请应用",
                       "isHide": false
@@ -3231,7 +3231,7 @@
                     "tips": "网关申请单据id",
                     "type": "number",
                     "class": [],
-                    "state": "default",
+                    "state": "readonly",
                     "title": {
                       "value": "网关申请单据id",
                       "isHide": false
@@ -3297,7 +3297,7 @@
                     "tips": "审批人",
                     "type": "multiUser",
                     "class": [],
-                    "state": "default",
+                    "state": "readonly",
                     "title": {
                       "value": "审批人",
                       "isHide": false

--- a/src/dashboard/apigateway/apigateway/apps/permission/admin.py
+++ b/src/dashboard/apigateway/apigateway/apps/permission/admin.py
@@ -29,9 +29,9 @@ from apigateway.apps.permission.models import (
 
 class AppAPIPermissionAdmin(DjangoQLSearchMixin, admin.ModelAdmin):
     djangoql_completion_enabled_by_default = False
-    list_display = ["id", "bk_app_code", "gateway", "expires"]
+    list_display = ["id", "bk_app_code", "gateway", "expires", "grant_type"]
     search_fields = ["bk_app_code", "gateway__id", "gateway__name"]
-    list_filter = ["gateway", "expires"]
+    list_filter = ["gateway", "expires", "grant_type"]
 
 
 class AppResourcePermissionAdmin(DjangoQLSearchMixin, admin.ModelAdmin):

--- a/src/dashboard/apigateway/apigateway/apps/permission/managers.py
+++ b/src/dashboard/apigateway/apigateway/apps/permission/managers.py
@@ -35,12 +35,20 @@ class AppGatewayPermissionManager(models.Manager):
     def filter_public_permission_by_app(self, bk_app_code: str):
         return self.filter(bk_app_code=bk_app_code, gateway__is_public=True)
 
-    def save_permissions(self, gateway, resource_ids=None, bk_app_code=None, grant_type=None, expire_days=None):
+    def save_permissions(
+        self,
+        gateway,
+        resource_ids=None,
+        bk_app_code=None,
+        grant_type=GrantTypeEnum.INITIALIZE.value,
+        expire_days=None,
+    ):
         obj, _ = self.update_or_create(
             gateway=gateway,
             bk_app_code=bk_app_code,
             defaults={
                 "expires": calculate_expires(expire_days),
+                "grant_type": grant_type,
             },
         )
         return obj

--- a/src/dashboard/apigateway/apigateway/apps/permission/migrations/0012_app_gateway_permission_grant_type.py
+++ b/src/dashboard/apigateway/apigateway/apps/permission/migrations/0012_app_gateway_permission_grant_type.py
@@ -16,14 +16,30 @@
 # to the current version of the project delivered to anyone in the future.
 #
 
-from .bk_itsm import ITSM_PERMISSION_APPROVAL_HANDLER, ItsmCallbackResultHandler
+from django.db import migrations, models
 
-__all__ = [
-    # constant
-    "ITSM_PERMISSION_APPROVAL_HANDLER",
-    # Enum
-    # class
-    "ItsmCallbackResultHandler",
-    # functions
-    # others
-]
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("permission", "0011_add_itsm_ticket_id"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="appapipermission",
+            name="grant_type",
+            field=models.CharField(
+                choices=[
+                    ("initialize", "主动授权"),
+                    ("apply", "申请审批"),
+                    ("renew", "续期"),
+                    ("auto_renew", "自动续期"),
+                    ("sync", "按网关授权同步"),
+                ],
+                db_index=True,
+                default="initialize",
+                max_length=16,
+            ),
+        ),
+    ]

--- a/src/dashboard/apigateway/apigateway/apps/permission/models.py
+++ b/src/dashboard/apigateway/apigateway/apps/permission/models.py
@@ -54,6 +54,12 @@ class AppGatewayPermission(TimestampedModelMixin):
     expires = models.DateTimeField(
         default=generate_expire_time, blank=True, null=True, help_text=_("默认过期时间为180天")
     )
+    grant_type = models.CharField(
+        max_length=16,
+        choices=GrantTypeEnum.get_choices(),
+        default=GrantTypeEnum.INITIALIZE.value,
+        db_index=True,
+    )
 
     objects: ClassVar[managers.AppGatewayPermissionManager] = managers.AppGatewayPermissionManager()
 

--- a/src/dashboard/apigateway/apigateway/biz/bk_itsm/bk_itsm.py
+++ b/src/dashboard/apigateway/apigateway/biz/bk_itsm/bk_itsm.py
@@ -35,6 +35,8 @@ from apigateway.utils.time import now_datetime
 
 logger = logging.getLogger(__name__)
 
+ITSM_PERMISSION_APPROVAL_HANDLER = "itsm"
+
 
 class ItsmCallbackResultHandler:
     """处理 ITSM 回调审批结果"""
@@ -146,7 +148,7 @@ class ItsmCallbackResultHandler:
                 apply=apply,
                 status=status_value,
                 comment="",
-                handled_by="itsm",
+                handled_by=ITSM_PERMISSION_APPROVAL_HANDLER,
                 part_resource_ids=None,
             )
 
@@ -197,7 +199,7 @@ class ItsmCallbackResultHandler:
                 else MCPServerAppPermissionApplyStatusEnum.REJECTED.value
             )
             apply.status = status_value
-            apply.handled_by = "itsm"
+            apply.handled_by = ITSM_PERMISSION_APPROVAL_HANDLER
             apply.handled_time = now_datetime()
             apply.save(update_fields=["status", "handled_by", "handled_time"])
 

--- a/src/dashboard/apigateway/apigateway/biz/personal_workbench/__init__.py
+++ b/src/dashboard/apigateway/apigateway/biz/personal_workbench/__init__.py
@@ -1,0 +1,28 @@
+#
+# TencentBlueKing is pleased to support the open source community by making
+# 蓝鲸智云 - API 网关(BlueKing - APIGateway) available.
+# Copyright (C) 2025 Tencent. All rights reserved.
+# Licensed under the MIT License (the "License"); you may not use this file except
+# in compliance with the License. You may obtain a copy of the License at
+#
+#     http://opensource.org/licenses/MIT
+#
+# Unless required by applicable law or agreed to in writing, software distributed under
+# the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+# either express or implied. See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# We undertake not to change the open source license (MIT license) applicable
+# to the current version of the project delivered to anyone in the future.
+#
+
+from .permission import WorkbenchPermissionHandler
+
+__all__ = [
+    # constant
+    # Enum
+    # class
+    "WorkbenchPermissionHandler",
+    # functions
+    # others
+]

--- a/src/dashboard/apigateway/apigateway/biz/personal_workbench/permission.py
+++ b/src/dashboard/apigateway/apigateway/biz/personal_workbench/permission.py
@@ -1,0 +1,60 @@
+#
+# TencentBlueKing is pleased to support the open source community by making
+# 蓝鲸智云 - API 网关(BlueKing - APIGateway) available.
+# Copyright (C) 2025 Tencent. All rights reserved.
+# Licensed under the MIT License (the "License"); you may not use this file except
+# in compliance with the License. You may obtain a copy of the License at
+#
+#     http://opensource.org/licenses/MIT
+#
+# Unless required by applicable law or agreed to in writing, software distributed under
+# the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+# either express or implied. See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# We undertake not to change the open source license (MIT license) applicable
+# to the current version of the project delivered to anyone in the future.
+#
+
+from django.db.models import Q
+from django.db.models.query import QuerySet
+
+from apigateway.apps.mcp_server.constants import MCPServerAppPermissionApplyStatusEnum
+from apigateway.apps.mcp_server.models import MCPServerAppPermissionApply
+from apigateway.apps.permission.constants import ApplyStatusEnum
+from apigateway.apps.permission.models import AppPermissionRecord
+from apigateway.biz.bk_itsm import ITSM_PERMISSION_APPROVAL_HANDLER
+from apigateway.biz.gateway import GatewayHandler
+from apigateway.common.tenant.query import (
+    gateway_related_filter_by_user_tenant_id,
+    mcp_server_related_filter_by_user_tenant_id,
+)
+
+
+class WorkbenchPermissionHandler:
+    @staticmethod
+    def _get_user_gateway_ids(username: str, tenant_id: str) -> list[int]:
+        return [gateway.id for gateway in GatewayHandler.list_gateways_by_user(username, tenant_id)]
+
+    @classmethod
+    def get_handled_gateway_permission_record_queryset(cls, username: str, tenant_id: str) -> QuerySet:
+        queryset = AppPermissionRecord.objects.filter(
+            Q(handled_by=username)
+            | Q(
+                handled_by=ITSM_PERMISSION_APPROVAL_HANDLER,
+                gateway_id__in=cls._get_user_gateway_ids(username, tenant_id),
+            )
+        ).exclude(status=ApplyStatusEnum.PENDING.value)
+        return gateway_related_filter_by_user_tenant_id(queryset, tenant_id)
+
+    @classmethod
+    def get_handled_mcp_permission_apply_queryset(cls, username: str, tenant_id: str) -> QuerySet:
+        queryset = MCPServerAppPermissionApply.objects.filter(
+            Q(handled_by=username)
+            | Q(
+                handled_by=ITSM_PERMISSION_APPROVAL_HANDLER,
+                mcp_server__gateway_id__in=cls._get_user_gateway_ids(username, tenant_id),
+            ),
+            is_deleted=False,
+        ).exclude(status=MCPServerAppPermissionApplyStatusEnum.PENDING.value)
+        return mcp_server_related_filter_by_user_tenant_id(queryset, tenant_id)

--- a/src/dashboard/apigateway/apigateway/tests/apis/web/permission/test_serializers.py
+++ b/src/dashboard/apigateway/apigateway/tests/apis/web/permission/test_serializers.py
@@ -89,6 +89,7 @@ class TestAppPermissionOutputSLZ(TestCase):
             gateway=gateway,
             bk_app_code="test",
             expires=None,
+            grant_type="apply",
         )
 
         app_resource_permission = G(
@@ -120,7 +121,7 @@ class TestAppPermissionOutputSLZ(TestCase):
                 "resource_method": "",
                 "expires": None,
                 "grant_dimension": "api",
-                "grant_type": "initialize",
+                "grant_type": "apply",
                 "renewable": False,
                 "id": app_api_permission.id,
             },

--- a/src/dashboard/apigateway/apigateway/tests/apis/web/personal_workbench/test_views.py
+++ b/src/dashboard/apigateway/apigateway/tests/apis/web/personal_workbench/test_views.py
@@ -26,6 +26,7 @@ from apigateway.apps.mcp_server.constants import MCPServerAppPermissionApplyStat
 from apigateway.apps.mcp_server.models import MCPServer, MCPServerAppPermissionApply
 from apigateway.apps.permission.constants import ApplyStatusEnum, GrantDimensionEnum
 from apigateway.apps.permission.models import AppPermissionApply, AppPermissionRecord
+from apigateway.biz.bk_itsm import ITSM_PERMISSION_APPROVAL_HANDLER
 from apigateway.core.constants import GatewayStatusEnum, StageStatusEnum
 from apigateway.core.models import Gateway, Resource, Stage
 from apigateway.utils.time import now_datetime, timestamp
@@ -211,6 +212,40 @@ class TestWorkbenchGatewayFilterOptionListApi:
 
         gateway_ids = [item["id"] for item in result["data"]]
         assert fake_gateway.id in gateway_ids
+
+    def test_handled_returns_itsm_records_for_maintainer(self, request_view, fake_gateway, fake_other_gateway):
+        """handled 类型：ITSM 回调无实际审批人，返回当前用户维护网关下的 ITSM 已办记录"""
+        G(
+            AppPermissionRecord,
+            gateway=fake_gateway,
+            bk_app_code="app1",
+            applied_by="applicant1",
+            applied_time=now_datetime(),
+            handled_by=ITSM_PERMISSION_APPROVAL_HANDLER,
+            handled_time=now_datetime(),
+            status=ApplyStatusEnum.APPROVED.value,
+        )
+        G(
+            AppPermissionRecord,
+            gateway=fake_other_gateway,
+            bk_app_code="app2",
+            applied_by="applicant2",
+            applied_time=now_datetime(),
+            handled_by=ITSM_PERMISSION_APPROVAL_HANDLER,
+            handled_time=now_datetime(),
+            status=ApplyStatusEnum.APPROVED.value,
+        )
+
+        resp = request_view(
+            method="GET",
+            view_name="workbench.filter_options.gateways",
+            data={"type": "handled"},
+        )
+        result = resp.json()
+
+        gateway_ids = [item["id"] for item in result["data"]]
+        assert fake_gateway.id in gateway_ids
+        assert fake_other_gateway.id not in gateway_ids
 
     def test_default_type_is_pending(self, request_view, fake_gateway):
         """默认 type 为 pending"""
@@ -1350,6 +1385,40 @@ class TestWorkbenchHandledGatewayPermissionListApi:
         assert result["data"]["results"][0]["handled_by"] == FAKE_USERNAME
         assert result["data"]["results"][0]["gateway_id"] == fake_gateway.id
         assert result["data"]["results"][0]["gateway_name"] == fake_gateway.name
+
+    def test_list_includes_itsm_records_for_maintainer(self, request_view, fake_gateway, fake_other_gateway):
+        """测试我的已办 - API 网关：ITSM 回调无实际审批人，按当前用户维护网关补充可见记录"""
+        G(
+            AppPermissionRecord,
+            gateway=fake_gateway,
+            bk_app_code="app1",
+            applied_by="applicant1",
+            applied_time=now_datetime(),
+            handled_by=ITSM_PERMISSION_APPROVAL_HANDLER,
+            handled_time=now_datetime(),
+            status=ApplyStatusEnum.APPROVED.value,
+        )
+        G(
+            AppPermissionRecord,
+            gateway=fake_other_gateway,
+            bk_app_code="app2",
+            applied_by="applicant2",
+            applied_time=now_datetime(),
+            handled_by=ITSM_PERMISSION_APPROVAL_HANDLER,
+            handled_time=now_datetime(),
+            status=ApplyStatusEnum.APPROVED.value,
+        )
+
+        resp = request_view(
+            method="GET",
+            view_name="workbench.permissions.gateway.handled",
+        )
+        result = resp.json()
+
+        assert resp.status_code == 200
+        assert result["data"]["count"] == 1
+        assert result["data"]["results"][0]["bk_app_code"] == "app1"
+        assert result["data"]["results"][0]["handled_by"] == ITSM_PERMISSION_APPROVAL_HANDLER
 
     def test_list_filter_by_status(self, request_view, fake_gateway):
         """测试我的已办 - API 网关：按 status 筛选"""

--- a/src/dashboard/apigateway/apigateway/tests/apis/web/personal_workbench/test_views.py
+++ b/src/dashboard/apigateway/apigateway/tests/apis/web/personal_workbench/test_views.py
@@ -466,6 +466,49 @@ class TestWorkbenchMCPServerFilterOptionListApi:
         assert mcp_item["gateway_id"] == fake_gateway.id
         assert mcp_item["gateway_name"] == fake_gateway.name
 
+    def test_handled_returns_itsm_records_for_maintainer(
+        self,
+        request_view,
+        fake_mcp_server,
+        fake_other_gateway,
+        make_mcp_server,
+    ):
+        """handled 类型：ITSM 回调无实际审批人，返回当前用户维护网关下的 MCP Server"""
+        other_mcp_server = make_mcp_server(fake_other_gateway)
+        G(
+            MCPServerAppPermissionApply,
+            mcp_server=fake_mcp_server,
+            bk_app_code="app1",
+            applied_by="applicant1",
+            applied_time=now_datetime(),
+            handled_by=ITSM_PERMISSION_APPROVAL_HANDLER,
+            handled_time=now_datetime(),
+            status=MCPServerAppPermissionApplyStatusEnum.APPROVED.value,
+            is_deleted=False,
+        )
+        G(
+            MCPServerAppPermissionApply,
+            mcp_server=other_mcp_server,
+            bk_app_code="app2",
+            applied_by="applicant2",
+            applied_time=now_datetime(),
+            handled_by=ITSM_PERMISSION_APPROVAL_HANDLER,
+            handled_time=now_datetime(),
+            status=MCPServerAppPermissionApplyStatusEnum.APPROVED.value,
+            is_deleted=False,
+        )
+
+        resp = request_view(
+            method="GET",
+            view_name="workbench.filter_options.mcp_servers",
+            data={"type": "handled"},
+        )
+        result = resp.json()
+
+        mcp_ids = [item["id"] for item in result["data"]]
+        assert fake_mcp_server.id in mcp_ids
+        assert other_mcp_server.id not in mcp_ids
+
     def test_applied_excludes_deleted(self, request_view, fake_gateway, fake_mcp_server):
         """applied 类型：不返回已删除申请对应的 MCP Server"""
         G(
@@ -628,6 +671,31 @@ class TestWorkbenchMCPGatewayFilterOptionListApi:
 
         gateway_ids = [item["id"] for item in result["data"]]
         assert fake_gateway.id in gateway_ids
+
+    def test_handled_returns_itsm_records_for_maintainer(self, request_view, fake_mcp_server, fake_other_gateway):
+        """handled 类型：ITSM 回调无实际审批人，返回当前用户维护网关下的 MCP 记录网关"""
+        G(
+            MCPServerAppPermissionApply,
+            mcp_server=fake_mcp_server,
+            bk_app_code="app1",
+            applied_by="applicant1",
+            applied_time=now_datetime(),
+            handled_by=ITSM_PERMISSION_APPROVAL_HANDLER,
+            handled_time=now_datetime(),
+            status=MCPServerAppPermissionApplyStatusEnum.APPROVED.value,
+            is_deleted=False,
+        )
+
+        resp = request_view(
+            method="GET",
+            view_name="workbench.filter_options.mcp_gateways",
+            data={"type": "handled"},
+        )
+        result = resp.json()
+
+        gateway_ids = [item["id"] for item in result["data"]]
+        assert fake_mcp_server.gateway_id in gateway_ids
+        assert fake_other_gateway.id not in gateway_ids
 
     def test_applied_excludes_deleted(self, request_view, fake_gateway, fake_mcp_server):
         """applied 类型：不返回已删除申请对应的网关"""
@@ -1611,6 +1679,49 @@ class TestWorkbenchHandledMCPPermissionListApi:
         assert result["data"]["results"][0]["mcp_server"]["id"] == fake_mcp_server.id
         assert result["data"]["results"][0]["mcp_server"]["gateway_id"] == fake_gateway.id
         assert result["data"]["results"][0]["mcp_server"]["gateway_name"] == fake_gateway.name
+
+    def test_list_includes_itsm_records_for_maintainer(
+        self,
+        request_view,
+        fake_mcp_server,
+        fake_other_gateway,
+        make_mcp_server,
+    ):
+        """测试我的已办 - MCP Server：ITSM 回调无实际审批人，按当前用户维护网关补充可见记录"""
+        other_mcp_server = make_mcp_server(fake_other_gateway)
+        G(
+            MCPServerAppPermissionApply,
+            mcp_server=fake_mcp_server,
+            bk_app_code="app1",
+            applied_by="applicant1",
+            applied_time=now_datetime(),
+            handled_by=ITSM_PERMISSION_APPROVAL_HANDLER,
+            handled_time=now_datetime(),
+            status=MCPServerAppPermissionApplyStatusEnum.APPROVED.value,
+            is_deleted=False,
+        )
+        G(
+            MCPServerAppPermissionApply,
+            mcp_server=other_mcp_server,
+            bk_app_code="app2",
+            applied_by="applicant2",
+            applied_time=now_datetime(),
+            handled_by=ITSM_PERMISSION_APPROVAL_HANDLER,
+            handled_time=now_datetime(),
+            status=MCPServerAppPermissionApplyStatusEnum.APPROVED.value,
+            is_deleted=False,
+        )
+
+        resp = request_view(
+            method="GET",
+            view_name="workbench.permissions.mcp.handled",
+        )
+        result = resp.json()
+
+        assert resp.status_code == 200
+        assert result["data"]["count"] == 1
+        assert result["data"]["results"][0]["bk_app_code"] == "app1"
+        assert result["data"]["results"][0]["handled_by"] == ITSM_PERMISSION_APPROVAL_HANDLER
 
     def test_list_includes_rejected(self, request_view, fake_gateway, fake_mcp_server):
         """测试我的已办 - 包含已驳回的记录"""

--- a/src/dashboard/apigateway/apigateway/tests/apps/permission/test_managers.py
+++ b/src/dashboard/apigateway/apigateway/tests/apps/permission/test_managers.py
@@ -22,7 +22,7 @@ import pytest
 from django_dynamic_fixture import G
 
 from apigateway.apps.permission import models
-from apigateway.apps.permission.constants import PermissionApplyExpireDaysEnum
+from apigateway.apps.permission.constants import GrantTypeEnum, PermissionApplyExpireDaysEnum
 from apigateway.core.models import Gateway, Resource
 from apigateway.tests.utils.testing import dummy_time
 from apigateway.utils.time import now_datetime, to_datetime_from_now
@@ -45,6 +45,16 @@ class TestAppAPIPermissionManager:
         G(models.AppGatewayPermission, gateway=gateway_2, bk_app_code=unique_id)
 
         assert models.AppGatewayPermission.objects.filter_public_permission_by_app(unique_id).count() == 1
+
+    def test_save_permissions(self):
+        permission = models.AppGatewayPermission.objects.save_permissions(
+            gateway=self.gateway,
+            bk_app_code="test",
+            grant_type=GrantTypeEnum.APPLY.value,
+            expire_days=180,
+        )
+
+        assert permission.grant_type == GrantTypeEnum.APPLY.value
 
     def test_renew_by_ids(self):
         perm_1 = G(

--- a/src/dashboard/apigateway/apigateway/tests/biz/bk_itsm/test_bk_itsm.py
+++ b/src/dashboard/apigateway/apigateway/tests/biz/bk_itsm/test_bk_itsm.py
@@ -25,9 +25,9 @@ from apigateway.apps.mcp_server.constants import (
     MCPServerAppPermissionGrantTypeEnum,
 )
 from apigateway.apps.mcp_server.models import MCPServer, MCPServerAppPermissionApply
-from apigateway.apps.permission.constants import ApplyStatusEnum, GrantDimensionEnum
-from apigateway.apps.permission.models import AppPermissionApply
-from apigateway.biz.bk_itsm import ItsmCallbackResultHandler
+from apigateway.apps.permission.constants import ApplyStatusEnum, GrantDimensionEnum, GrantTypeEnum
+from apigateway.apps.permission.models import AppGatewayPermission, AppPermissionApply, AppPermissionRecord
+from apigateway.biz.bk_itsm import ITSM_PERMISSION_APPROVAL_HANDLER, ItsmCallbackResultHandler
 from apigateway.utils.time import now_datetime
 
 pytestmark = pytest.mark.django_db
@@ -119,6 +119,46 @@ class TestItsmCallbackResultHandler:
         assert apply.status == ApplyStatusEnum.APPROVED.value
         mock_get_manager.assert_not_called()
 
+    def test_handle_gateway_callback_approved_grant_type_apply(self, fake_gateway):
+        record = G(
+            AppPermissionRecord,
+            gateway=fake_gateway,
+            bk_app_code="test-app",
+            applied_by="admin",
+            applied_time=now_datetime(),
+            _resource_ids="",
+            grant_dimension=GrantDimensionEnum.API.value,
+            status=ApplyStatusEnum.PENDING.value,
+        )
+        apply = G(
+            AppPermissionApply,
+            gateway=fake_gateway,
+            bk_app_code="test-app",
+            applied_by="admin",
+            _resource_ids="",
+            grant_dimension=GrantDimensionEnum.API.value,
+            status=ApplyStatusEnum.PENDING.value,
+            apply_record_id=record.id,
+            itsm_ticket_id="itsm-ticket-004",
+            itsm_callback_token="cb-token-004",
+        )
+
+        ItsmCallbackResultHandler().handle(
+            ticket={
+                "id": "itsm-ticket-004",
+                "approve_result": True,
+                "form_data": {
+                    "apply_record_id": record.id,
+                    "grant_dimension": "gateway",
+                },
+            },
+            callback_token="cb-token-004",
+        )
+
+        permission = AppGatewayPermission.objects.get(gateway=fake_gateway, bk_app_code=apply.bk_app_code)
+        assert permission.grant_type == GrantTypeEnum.APPLY.value
+        assert not AppPermissionApply.objects.filter(id=apply.id).exists()
+
     def test_handle_mcp_callback_approved_updates_apply_and_sync_permissions(self, mocker, fake_gateway, fake_stage):
         mcp_server = G(MCPServer, gateway=fake_gateway, stage=fake_stage)
         apply = G(
@@ -151,7 +191,7 @@ class TestItsmCallbackResultHandler:
 
         apply.refresh_from_db()
         assert apply.status == MCPServerAppPermissionApplyStatusEnum.APPROVED.value
-        assert apply.handled_by == "itsm"
+        assert apply.handled_by == ITSM_PERMISSION_APPROVAL_HANDLER
         assert apply.handled_time is not None
         mock_save_permission.assert_called_once_with(
             mcp_server_id=apply.mcp_server_id,

--- a/src/dashboard/apigateway/apigateway/tests/biz/permission/test_manager.py
+++ b/src/dashboard/apigateway/apigateway/tests/biz/permission/test_manager.py
@@ -21,7 +21,7 @@ from unittest import mock
 import pytest
 from ddf import G
 
-from apigateway.apps.permission.constants import ApplyStatusEnum, GrantDimensionEnum
+from apigateway.apps.permission.constants import ApplyStatusEnum, GrantDimensionEnum, GrantTypeEnum
 from apigateway.apps.permission.models import (
     AppGatewayPermission,
     AppPermissionApply,
@@ -87,7 +87,8 @@ class TestGatewayPermissionDimensionManager:
             part_resource_ids=None,
         )
         assert record.id
-        assert AppGatewayPermission.objects.filter(gateway=fake_gateway, bk_app_code=apply.bk_app_code).count() == 1
+        permission = AppGatewayPermission.objects.get(gateway=fake_gateway, bk_app_code=apply.bk_app_code)
+        assert permission.grant_type == GrantTypeEnum.APPLY.value
         assert AppPermissionApplyStatus.objects.filter(gateway=fake_gateway).count() == 0
 
     def test_handle_permission_apply_rejected(self, fake_gateway):


### PR DESCRIPTION
Why this change was needed:
ITSM-approved gateway permission applications were displayed as active grants because gateway-level permissions did not persist the approval grant type. ITSM callback records were also missing from Personal Workbench handled lists because callbacks do not include the actual approver and store a system handler instead.

What changed:
- Added grant_type to gateway-level permissions and persisted it when saving permissions
- Returned and filtered gateway permission grant types in WebAPI permission lists
- Introduced a shared ITSM permission approval handler constant for callback records
- Included ITSM-handled gateway and MCP permission records in Personal Workbench handled views for current gateway maintainers
- Added regression tests for ITSM approval grant types and handled-list visibility

Problem solved:
Gateway permission approvals now retain and display their correct application-based grant type, and maintainers can see ITSM-approved records in Personal Workbench without requiring an approver value from the callback payload.

### Description

<!-- 关联相关issue Please include a summary of the change and which issue is fixed. -->
<!-- 给出必要的上下文以及review需要的必要信息 Please also include relevant motivation and context. -->

Fixes # (issue)

### Checklist

- [ ] 填写 PR 描述及相关 issue (write PR description and related issue)
- [ ] 代码风格检查通过 (code style check passed)
- [ ] PR 中包含单元测试 (include unit test)
- [ ] 单元测试通过 (unit test passed)
- [ ] 本地开发联调环境验证通过 (local development environment verification passed)
