### PR TITLE
feat(mcp-server): add gateway-level MCPServer app permission list and export APIs

### DIFF
--- a/src/dashboard/apigateway/apigateway/apis/web/mcp_server/serializers.py
+++ b/src/dashboard/apigateway/apigateway/apis/web/mcp_server/serializers.py
@@ -958,6 +958,8 @@ class GatewayMCPServerAppPermissionListOutputSLZ(serializers.Serializer):
     )
     grant_type_display = serializers.SerializerMethodField(help_text="授权类型展示")
 
+    _dt_field = serializers.DateTimeField()
+
     class Meta:
         ref_name = "apigateway.apis.web.mcp_server.serializers.GatewayMCPServerAppPermissionListOutputSLZ"
 
@@ -980,7 +982,7 @@ class GatewayMCPServerAppPermissionListOutputSLZ(serializers.Serializer):
     def get_effective_time(self, obj):
         apply_record = self._get_apply_record(obj)
         effective_time = apply_record.handled_time if apply_record and apply_record.handled_time else obj.created_time
-        return serializers.DateTimeField().to_representation(effective_time)
+        return self._dt_field.to_representation(effective_time)
 
     def get_handled_by(self, obj):
         apply_record = self._get_apply_record(obj)

--- a/src/dashboard/apigateway/apigateway/apis/web/mcp_server/serializers.py
+++ b/src/dashboard/apigateway/apigateway/apis/web/mcp_server/serializers.py
@@ -22,6 +22,7 @@ from typing import Any, Dict, List
 from django.utils.translation import gettext_lazy as _
 from rest_framework import serializers
 
+from apigateway.apis.web.constants import ExportTypeEnum
 from apigateway.apps.mcp_server.constants import (
     FEATURED_MCP_CATEGORY_NAME,
     MCP_AGENT_CLIENT_CHOICES_WITHOUT_AIDEV,
@@ -924,3 +925,92 @@ class MCPServerBatchConfigOutputSLZ(serializers.Serializer):
 
     class Meta:
         ref_name = "apigateway.apis.web.mcp_server.serializers.MCPServerBatchConfigOutputSLZ"
+
+
+class GatewayMCPServerAppPermissionListInputSLZ(serializers.Serializer):
+    """网关下 MCPServer 应用权限列表输入序列化器"""
+
+    mcp_server_id = serializers.IntegerField(required=False, help_text="MCPServer ID")
+    bk_app_code = serializers.CharField(required=False, allow_blank=True, default="", help_text="蓝鲸应用 ID")
+    grant_type = serializers.ChoiceField(
+        choices=MCPServerAppPermissionGrantTypeEnum.get_choices(),
+        required=False,
+        allow_blank=True,
+        default="",
+        help_text="授权类型",
+    )
+
+    class Meta:
+        ref_name = "apigateway.apis.web.mcp_server.serializers.GatewayMCPServerAppPermissionListInputSLZ"
+
+
+class GatewayMCPServerAppPermissionListOutputSLZ(serializers.Serializer):
+    """网关下 MCPServer 应用权限列表输出序列化器"""
+
+    id = serializers.IntegerField(read_only=True)
+    mcp_server = MCPServerBaseSLZ()
+    bk_app_code = serializers.CharField(read_only=True, help_text="蓝鲸应用 ID")
+    applied_by = serializers.SerializerMethodField(help_text="申请人")
+    effective_time = serializers.SerializerMethodField(help_text="生效时间")
+    handled_by = serializers.SerializerMethodField(help_text="审批人/授权人")
+    grant_type = serializers.ChoiceField(
+        read_only=True, choices=MCPServerAppPermissionGrantTypeEnum.get_choices(), help_text="授权类型"
+    )
+    grant_type_display = serializers.SerializerMethodField(help_text="授权类型展示")
+
+    class Meta:
+        ref_name = "apigateway.apis.web.mcp_server.serializers.GatewayMCPServerAppPermissionListOutputSLZ"
+
+    def _get_apply_record(self, obj):
+        if obj.grant_type != MCPServerAppPermissionGrantTypeEnum.APPLY.value:
+            return None
+        return self.context.get("apply_record_map", {}).get((obj.mcp_server_id, obj.bk_app_code))
+
+    def get_applied_by(self, obj):
+        apply_record = self._get_apply_record(obj)
+        if apply_record:
+            return ResourcePermissionHandler.convert_applied_by_to_display_name(
+                obj.bk_app_code,
+                apply_record.applied_by,
+                self.context.get("gateway_tenant_mode"),
+                self.context.get("gateway_tenant_id"),
+            )
+        return obj.updated_by or obj.created_by or ""
+
+    def get_effective_time(self, obj):
+        apply_record = self._get_apply_record(obj)
+        effective_time = apply_record.handled_time if apply_record and apply_record.handled_time else obj.created_time
+        return serializers.DateTimeField().to_representation(effective_time)
+
+    def get_handled_by(self, obj):
+        apply_record = self._get_apply_record(obj)
+        if apply_record:
+            return apply_record.handled_by
+        return obj.created_by or obj.updated_by or ""
+
+    def get_grant_type_display(self, obj):
+        return _(MCPServerAppPermissionGrantTypeEnum.get_choice_label(obj.grant_type))
+
+
+class GatewayMCPServerAppPermissionExportInputSLZ(GatewayMCPServerAppPermissionListInputSLZ):
+    """网关下 MCPServer 应用权限导出输入序列化器"""
+
+    export_type = serializers.ChoiceField(
+        choices=ExportTypeEnum.get_choices(),
+        required=True,
+        help_text="导出类型：all(全部), filtered(按筛选条件), selected(选中)",
+    )
+    selected_ids = serializers.ListField(
+        child=serializers.IntegerField(),
+        required=False,
+        default=list,
+        help_text="选中的权限 ID 列表，当 export_type 为 selected 时必填",
+    )
+
+    class Meta:
+        ref_name = "apigateway.apis.web.mcp_server.serializers.GatewayMCPServerAppPermissionExportInputSLZ"
+
+    def validate(self, data):
+        if data["export_type"] == ExportTypeEnum.SELECTED.value and not data.get("selected_ids"):
+            raise serializers.ValidationError(_("导出已选中权限时，已选中权限不能为空。"))
+        return data

--- a/src/dashboard/apigateway/apigateway/apis/web/mcp_server/serializers.py
+++ b/src/dashboard/apigateway/apigateway/apis/web/mcp_server/serializers.py
@@ -958,8 +958,6 @@ class GatewayMCPServerAppPermissionListOutputSLZ(serializers.Serializer):
     )
     grant_type_display = serializers.SerializerMethodField(help_text="授权类型展示")
 
-    _dt_field = serializers.DateTimeField()
-
     class Meta:
         ref_name = "apigateway.apis.web.mcp_server.serializers.GatewayMCPServerAppPermissionListOutputSLZ"
 
@@ -982,7 +980,7 @@ class GatewayMCPServerAppPermissionListOutputSLZ(serializers.Serializer):
     def get_effective_time(self, obj):
         apply_record = self._get_apply_record(obj)
         effective_time = apply_record.handled_time if apply_record and apply_record.handled_time else obj.created_time
-        return self._dt_field.to_representation(effective_time)
+        return serializers.DateTimeField().to_representation(effective_time)
 
     def get_handled_by(self, obj):
         apply_record = self._get_apply_record(obj)

--- a/src/dashboard/apigateway/apigateway/apis/web/mcp_server/urls.py
+++ b/src/dashboard/apigateway/apigateway/apis/web/mcp_server/urls.py
@@ -19,6 +19,8 @@
 from django.urls import include, path
 
 from .views import (
+    GatewayMCPServerAppPermissionExportApi,
+    GatewayMCPServerAppPermissionListApi,
     MCPServerAppPermissionAppCodeListApi,
     MCPServerAppPermissionApplyApplicantListApi,
     MCPServerAppPermissionApplyListApi,
@@ -51,6 +53,18 @@ urlpatterns = [
         "-/permissions/",
         include(
             [
+                # 网关下 MCPServer 应用权限列表
+                path(
+                    "app-permissions/",
+                    GatewayMCPServerAppPermissionListApi.as_view(),
+                    name="mcp_server.gateway_app_permission.list",
+                ),
+                # 网关下 MCPServer 应用权限导出
+                path(
+                    "app-permissions/-/export/",
+                    GatewayMCPServerAppPermissionExportApi.as_view(),
+                    name="mcp_server.gateway_app_permission.export",
+                ),
                 # 有权限的 bk_app_code 列表（网关级别）
                 path(
                     "app-permission-app-codes/",

--- a/src/dashboard/apigateway/apigateway/apis/web/mcp_server/views.py
+++ b/src/dashboard/apigateway/apigateway/apis/web/mcp_server/views.py
@@ -1090,13 +1090,25 @@ class MCPServerBatchConfigApi(generics.CreateAPIView):
         return OKJsonResponse(data=output_slz.data)
 
 
-class GatewayMCPServerAppPermissionQuerySetMixin:
-    def get_queryset(self):
-        return MCPServerAppPermission.objects.filter(mcp_server__gateway=self.request.gateway).select_related(
+@method_decorator(
+    name="get",
+    decorator=swagger_auto_schema(
+        operation_description="获取网关下 MCPServer 应用权限列表",
+        query_serializer=GatewayMCPServerAppPermissionListInputSLZ,
+        responses={status.HTTP_200_OK: GatewayMCPServerAppPermissionListOutputSLZ(many=True)},
+        tags=["WebAPI.MCPServer"],
+    ),
+)
+class GatewayMCPServerAppPermissionListApi(generics.ListAPIView):
+    def list(self, request, *args, **kwargs):
+        slz = GatewayMCPServerAppPermissionListInputSLZ(data=request.query_params)
+        slz.is_valid(raise_exception=True)
+
+        queryset = MCPServerAppPermission.objects.filter(mcp_server__gateway=self.request.gateway).select_related(
             "mcp_server"
         )
 
-    def filter_queryset_by_params(self, queryset, data):
+        data = slz.validated_data
         mcp_server_id = data.get("mcp_server_id")
         bk_app_code = data.get("bk_app_code")
         grant_type = data.get("grant_type")
@@ -1108,56 +1120,17 @@ class GatewayMCPServerAppPermissionQuerySetMixin:
         if grant_type:
             queryset = queryset.filter(grant_type=grant_type)
 
-        return queryset
-
-    def get_apply_record_map(self, permissions):
-        mcp_server_ids = [permission.mcp_server_id for permission in permissions]
-        bk_app_codes = [permission.bk_app_code for permission in permissions]
-        apply_records = MCPServerAppPermissionApply.objects.filter(
-            mcp_server_id__in=mcp_server_ids,
-            bk_app_code__in=bk_app_codes,
-            status=MCPServerAppPermissionApplyStatusEnum.APPROVED.value,
-            is_deleted=False,
-        ).order_by("-handled_time", "-id")
-
-        apply_record_map = {}
-        for apply_record in apply_records:
-            key = (apply_record.mcp_server_id, apply_record.bk_app_code)
-            if key not in apply_record_map:
-                apply_record_map[key] = apply_record
-        return apply_record_map
-
-    def get_app_permission_serializer_context(self, permissions):
-        return {
-            "gateway_tenant_mode": self.request.gateway.tenant_mode,
-            "gateway_tenant_id": self.request.gateway.tenant_id,
-            "apply_record_map": self.get_apply_record_map(permissions),
-        }
-
-
-@method_decorator(
-    name="get",
-    decorator=swagger_auto_schema(
-        operation_description="获取网关下 MCPServer 应用权限列表",
-        query_serializer=GatewayMCPServerAppPermissionListInputSLZ,
-        responses={status.HTTP_200_OK: GatewayMCPServerAppPermissionListOutputSLZ(many=True)},
-        tags=["WebAPI.MCPServer"],
-    ),
-)
-class GatewayMCPServerAppPermissionListApi(GatewayMCPServerAppPermissionQuerySetMixin, generics.ListAPIView):
-    def list(self, request, *args, **kwargs):
-        slz = GatewayMCPServerAppPermissionListInputSLZ(data=request.query_params)
-        slz.is_valid(raise_exception=True)
-
-        queryset = self.filter_queryset_by_params(self.get_queryset(), slz.validated_data).order_by(
-            "mcp_server__name", "bk_app_code"
-        )
+        queryset = queryset.order_by("mcp_server__name", "bk_app_code")
         page = self.paginate_queryset(queryset)
 
         slz = GatewayMCPServerAppPermissionListOutputSLZ(
             page,
             many=True,
-            context=self.get_app_permission_serializer_context(page),
+            context={
+                "gateway_tenant_mode": self.request.gateway.tenant_mode,
+                "gateway_tenant_id": self.request.gateway.tenant_id,
+                "apply_record_map": MCPServerHandler.get_app_permission_apply_record_map(page),
+            },
         )
         return self.get_paginated_response(slz.data)
 
@@ -1171,15 +1144,26 @@ class GatewayMCPServerAppPermissionListApi(GatewayMCPServerAppPermissionQuerySet
         tags=["WebAPI.MCPServer"],
     ),
 )
-class GatewayMCPServerAppPermissionExportApi(GatewayMCPServerAppPermissionQuerySetMixin, generics.CreateAPIView):
+class GatewayMCPServerAppPermissionExportApi(generics.CreateAPIView):
     def create(self, request, *args, **kwargs):
         slz = GatewayMCPServerAppPermissionExportInputSLZ(data=request.data)
         slz.is_valid(raise_exception=True)
 
         data = slz.validated_data
-        queryset = self.get_queryset()
+        queryset = MCPServerAppPermission.objects.filter(mcp_server__gateway=self.request.gateway).select_related(
+            "mcp_server"
+        )
+
         if data["export_type"] == ExportTypeEnum.FILTERED.value:
-            queryset = self.filter_queryset_by_params(queryset, data)
+            mcp_server_id = data.get("mcp_server_id")
+            bk_app_code = data.get("bk_app_code")
+            grant_type = data.get("grant_type")
+            if mcp_server_id:
+                queryset = queryset.filter(mcp_server_id=mcp_server_id)
+            if bk_app_code:
+                queryset = queryset.filter(bk_app_code__icontains=bk_app_code)
+            if grant_type:
+                queryset = queryset.filter(grant_type=grant_type)
         elif data["export_type"] == ExportTypeEnum.SELECTED.value:
             queryset = queryset.filter(id__in=data["selected_ids"])
 
@@ -1187,7 +1171,11 @@ class GatewayMCPServerAppPermissionExportApi(GatewayMCPServerAppPermissionQueryS
         slz = GatewayMCPServerAppPermissionListOutputSLZ(
             permissions,
             many=True,
-            context=self.get_app_permission_serializer_context(permissions),
+            context={
+                "gateway_tenant_mode": self.request.gateway.tenant_mode,
+                "gateway_tenant_id": self.request.gateway.tenant_id,
+                "apply_record_map": MCPServerHandler.get_app_permission_apply_record_map(permissions),
+            },
         )
 
         content = self._get_csv_content(slz.data)

--- a/src/dashboard/apigateway/apigateway/apis/web/mcp_server/views.py
+++ b/src/dashboard/apigateway/apigateway/apis/web/mcp_server/views.py
@@ -17,6 +17,9 @@
 #
 
 
+import csv
+from io import StringIO
+
 from django.db import transaction
 from django.db.models import Q
 from django.utils.decorators import method_decorator
@@ -24,6 +27,7 @@ from django.utils.translation import gettext as _
 from drf_yasg.utils import swagger_auto_schema
 from rest_framework import generics, status
 
+from apigateway.apis.web.constants import ExportTypeEnum
 from apigateway.apps.audit.constants import OpTypeEnum
 from apigateway.apps.mcp_server.constants import (
     FEATURED_MCP_CATEGORY_NAME,
@@ -50,10 +54,13 @@ from apigateway.common.tenant.user_credentials import get_user_credentials_from_
 from apigateway.core.models import Stage
 from apigateway.service.resource_version import get_resource_names_set
 from apigateway.utils.django import get_model_dict
-from apigateway.utils.responses import OKJsonResponse
+from apigateway.utils.responses import DownloadableResponse, OKJsonResponse
 from apigateway.utils.time import now_datetime
 
 from .serializers import (
+    GatewayMCPServerAppPermissionExportInputSLZ,
+    GatewayMCPServerAppPermissionListInputSLZ,
+    GatewayMCPServerAppPermissionListOutputSLZ,
     MCPServerAppPermissionAppCodeListInputSLZ,
     MCPServerAppPermissionAppCodeListOutputSLZ,
     MCPServerAppPermissionApplyApplicantListInputSLZ,
@@ -730,6 +737,7 @@ class MCPServerAppPermissionListCreateApi(MCPServerAppPermissionQuerySetMixin, g
             bk_app_code=data["bk_app_code"],
             grant_type=MCPServerAppPermissionGrantTypeEnum.GRANT.value,
             expire_days=None,
+            operator=request.user.username,
         )
 
         MCPServerHandler.sync_permissions(kwargs["mcp_server_id"])
@@ -863,6 +871,7 @@ class MCPServerAppPermissionApplyUpdateStatusApi(MCPServerAppPermissionApplyQuer
                 bk_app_code=slz.instance.bk_app_code,
                 grant_type=MCPServerAppPermissionGrantTypeEnum.APPLY.value,
                 expire_days=None,
+                operator=request.user.username,
             )
 
             MCPServerHandler.sync_permissions(kwargs["mcp_server_id"])
@@ -1079,3 +1088,148 @@ class MCPServerBatchConfigApi(generics.CreateAPIView):
 
         output_slz = MCPServerBatchConfigOutputSLZ(result)
         return OKJsonResponse(data=output_slz.data)
+
+
+class GatewayMCPServerAppPermissionQuerySetMixin:
+    def get_queryset(self):
+        return MCPServerAppPermission.objects.filter(mcp_server__gateway=self.request.gateway).select_related(
+            "mcp_server"
+        )
+
+    def filter_queryset_by_params(self, queryset, data):
+        mcp_server_id = data.get("mcp_server_id")
+        bk_app_code = data.get("bk_app_code")
+        grant_type = data.get("grant_type")
+
+        if mcp_server_id:
+            queryset = queryset.filter(mcp_server_id=mcp_server_id)
+        if bk_app_code:
+            queryset = queryset.filter(bk_app_code__icontains=bk_app_code)
+        if grant_type:
+            queryset = queryset.filter(grant_type=grant_type)
+
+        return queryset
+
+    def get_apply_record_map(self, permissions):
+        mcp_server_ids = [permission.mcp_server_id for permission in permissions]
+        bk_app_codes = [permission.bk_app_code for permission in permissions]
+        apply_records = MCPServerAppPermissionApply.objects.filter(
+            mcp_server_id__in=mcp_server_ids,
+            bk_app_code__in=bk_app_codes,
+            status=MCPServerAppPermissionApplyStatusEnum.APPROVED.value,
+            is_deleted=False,
+        ).order_by("-handled_time", "-id")
+
+        apply_record_map = {}
+        for apply_record in apply_records:
+            key = (apply_record.mcp_server_id, apply_record.bk_app_code)
+            if key not in apply_record_map:
+                apply_record_map[key] = apply_record
+        return apply_record_map
+
+    def get_app_permission_serializer_context(self, permissions):
+        return {
+            "gateway_tenant_mode": self.request.gateway.tenant_mode,
+            "gateway_tenant_id": self.request.gateway.tenant_id,
+            "apply_record_map": self.get_apply_record_map(permissions),
+        }
+
+
+@method_decorator(
+    name="get",
+    decorator=swagger_auto_schema(
+        operation_description="获取网关下 MCPServer 应用权限列表",
+        query_serializer=GatewayMCPServerAppPermissionListInputSLZ,
+        responses={status.HTTP_200_OK: GatewayMCPServerAppPermissionListOutputSLZ(many=True)},
+        tags=["WebAPI.MCPServer"],
+    ),
+)
+class GatewayMCPServerAppPermissionListApi(GatewayMCPServerAppPermissionQuerySetMixin, generics.ListAPIView):
+    def list(self, request, *args, **kwargs):
+        slz = GatewayMCPServerAppPermissionListInputSLZ(data=request.query_params)
+        slz.is_valid(raise_exception=True)
+
+        queryset = self.filter_queryset_by_params(self.get_queryset(), slz.validated_data).order_by(
+            "mcp_server__name", "bk_app_code"
+        )
+        page = self.paginate_queryset(queryset)
+
+        slz = GatewayMCPServerAppPermissionListOutputSLZ(
+            page,
+            many=True,
+            context=self.get_app_permission_serializer_context(page),
+        )
+        return self.get_paginated_response(slz.data)
+
+
+@method_decorator(
+    name="post",
+    decorator=swagger_auto_schema(
+        operation_description="导出网关下 MCPServer 应用权限列表",
+        request_body=GatewayMCPServerAppPermissionExportInputSLZ,
+        responses={status.HTTP_200_OK: "file/csv"},
+        tags=["WebAPI.MCPServer"],
+    ),
+)
+class GatewayMCPServerAppPermissionExportApi(GatewayMCPServerAppPermissionQuerySetMixin, generics.CreateAPIView):
+    def create(self, request, *args, **kwargs):
+        slz = GatewayMCPServerAppPermissionExportInputSLZ(data=request.data)
+        slz.is_valid(raise_exception=True)
+
+        data = slz.validated_data
+        queryset = self.get_queryset()
+        if data["export_type"] == ExportTypeEnum.FILTERED.value:
+            queryset = self.filter_queryset_by_params(queryset, data)
+        elif data["export_type"] == ExportTypeEnum.SELECTED.value:
+            queryset = queryset.filter(id__in=data["selected_ids"])
+
+        permissions = list(queryset.order_by("mcp_server__name", "bk_app_code"))
+        slz = GatewayMCPServerAppPermissionListOutputSLZ(
+            permissions,
+            many=True,
+            context=self.get_app_permission_serializer_context(permissions),
+        )
+
+        content = self._get_csv_content(slz.data)
+        filename = f"{self.request.gateway.name}-mcp_server_app_permissions.csv"
+
+        response = DownloadableResponse(content, filename=filename)
+        response.charset = "utf-8-sig" if "windows" in request.headers.get("User-Agent", "").lower() else "utf-8"
+        return response
+
+    def _get_csv_content(self, data):
+        headers = [
+            "mcp_server_name",
+            "bk_app_code",
+            "applied_by",
+            "effective_time",
+            "handled_by",
+            "grant_type_display",
+        ]
+        header_row = {
+            "mcp_server_name": _("MCPServer名称"),
+            "bk_app_code": _("蓝鲸应用ID"),
+            "applied_by": _("申请人"),
+            "effective_time": _("生效时间"),
+            "handled_by": _("审批人/授权人"),
+            "grant_type_display": _("授权类型"),
+        }
+
+        rows = [
+            {
+                "mcp_server_name": item["mcp_server"]["name"],
+                "bk_app_code": item["bk_app_code"],
+                "applied_by": item["applied_by"],
+                "effective_time": item["effective_time"],
+                "handled_by": item["handled_by"],
+                "grant_type_display": item["grant_type_display"],
+            }
+            for item in data
+        ]
+
+        content = StringIO()
+        io_csv = csv.DictWriter(content, fieldnames=headers, extrasaction="ignore")
+        io_csv.writerow(header_row)
+        io_csv.writerows(rows)
+
+        return content.getvalue()

--- a/src/dashboard/apigateway/apigateway/apis/web/mcp_server/views.py
+++ b/src/dashboard/apigateway/apigateway/apis/web/mcp_server/views.py
@@ -1090,6 +1090,22 @@ class MCPServerBatchConfigApi(generics.CreateAPIView):
         return OKJsonResponse(data=output_slz.data)
 
 
+def _filter_gateway_app_permissions(queryset, data):
+    """根据筛选条件过滤网关级 MCPServer 应用权限"""
+    mcp_server_id = data.get("mcp_server_id")
+    bk_app_code = data.get("bk_app_code")
+    grant_type = data.get("grant_type")
+
+    if mcp_server_id:
+        queryset = queryset.filter(mcp_server_id=mcp_server_id)
+    if bk_app_code:
+        queryset = queryset.filter(bk_app_code__icontains=bk_app_code)
+    if grant_type:
+        queryset = queryset.filter(grant_type=grant_type)
+
+    return queryset
+
+
 @method_decorator(
     name="get",
     decorator=swagger_auto_schema(
@@ -1108,18 +1124,7 @@ class GatewayMCPServerAppPermissionListApi(generics.ListAPIView):
             "mcp_server"
         )
 
-        data = slz.validated_data
-        mcp_server_id = data.get("mcp_server_id")
-        bk_app_code = data.get("bk_app_code")
-        grant_type = data.get("grant_type")
-
-        if mcp_server_id:
-            queryset = queryset.filter(mcp_server_id=mcp_server_id)
-        if bk_app_code:
-            queryset = queryset.filter(bk_app_code__icontains=bk_app_code)
-        if grant_type:
-            queryset = queryset.filter(grant_type=grant_type)
-
+        queryset = _filter_gateway_app_permissions(queryset, slz.validated_data)
         queryset = queryset.order_by("mcp_server__name", "bk_app_code")
         page = self.paginate_queryset(queryset)
 
@@ -1155,15 +1160,7 @@ class GatewayMCPServerAppPermissionExportApi(generics.CreateAPIView):
         )
 
         if data["export_type"] == ExportTypeEnum.FILTERED.value:
-            mcp_server_id = data.get("mcp_server_id")
-            bk_app_code = data.get("bk_app_code")
-            grant_type = data.get("grant_type")
-            if mcp_server_id:
-                queryset = queryset.filter(mcp_server_id=mcp_server_id)
-            if bk_app_code:
-                queryset = queryset.filter(bk_app_code__icontains=bk_app_code)
-            if grant_type:
-                queryset = queryset.filter(grant_type=grant_type)
+            queryset = _filter_gateway_app_permissions(queryset, data)
         elif data["export_type"] == ExportTypeEnum.SELECTED.value:
             queryset = queryset.filter(id__in=data["selected_ids"])
 

--- a/src/dashboard/apigateway/apigateway/apps/mcp_server/managers.py
+++ b/src/dashboard/apigateway/apigateway/apps/mcp_server/managers.py
@@ -24,20 +24,34 @@ from apigateway.common.time import calculate_renew_time
 
 
 class MCPServerAppPermissionManager(models.Manager):
-    def save_permission(self, mcp_server_id: int, bk_app_code: str, grant_type: str, expire_days=None):
+    def save_permission(self, mcp_server_id: int, bk_app_code: str, grant_type: str, expire_days=None, operator=""):
+        expires = calculate_renew_time(expire_days)
+        defaults = {
+            "grant_type": grant_type,
+            "expires": expires,
+        }
+        if operator:
+            defaults.update(
+                {
+                    "created_by": operator,
+                    "updated_by": operator,
+                }
+            )
+
         instance, created = self.get_or_create(
             mcp_server_id=mcp_server_id,
             bk_app_code=bk_app_code,
-            defaults={
-                "grant_type": grant_type,
-                "expires": calculate_renew_time(expire_days),
-            },
+            defaults=defaults,
         )
 
         if not created:
             instance.grant_type = grant_type
-            instance.expires = calculate_renew_time(expire_days)
-            instance.save(update_fields=["grant_type", "expires"])
+            instance.expires = expires
+            update_fields = ["grant_type", "expires"]
+            if operator:
+                instance.updated_by = operator
+                update_fields.append("updated_by")
+            instance.save(update_fields=update_fields)
 
 
 class MCPServerAppPermissionApplyManager(models.Manager):

--- a/src/dashboard/apigateway/apigateway/biz/mcp_server/mcp_server.py
+++ b/src/dashboard/apigateway/apigateway/biz/mcp_server/mcp_server.py
@@ -448,7 +448,7 @@ class MCPServerHandler:
         return risks
 
     @staticmethod
-    def get_app_permission_apply_record_map(permissions) -> Dict[tuple, Any]:
+    def get_app_permission_apply_record_map(permissions: Sequence[MCPServerAppPermission]) -> Dict[tuple, Any]:
         """根据已授权记录列表，批量查询对应的审批记录并构建映射。
 
         Args:

--- a/src/dashboard/apigateway/apigateway/biz/mcp_server/mcp_server.py
+++ b/src/dashboard/apigateway/apigateway/biz/mcp_server/mcp_server.py
@@ -31,6 +31,7 @@ from apigateway.apps.mcp_server.constants import (
     FEATURED_MCP_CATEGORY_NAME,
     OFFICIAL_MCP_CATEGORY_NAME,
     MCPAgentClientTypeEnum,
+    MCPServerAppPermissionApplyStatusEnum,
     MCPServerAppPermissionGrantTypeEnum,
     MCPServerExtendTypeEnum,
     MCPServerLeastPrivilegeEnum,
@@ -42,6 +43,7 @@ from apigateway.apps.mcp_server.constants import (
 from apigateway.apps.mcp_server.models import (
     MCPServer,
     MCPServerAppPermission,
+    MCPServerAppPermissionApply,
     MCPServerCategory,
     MCPServerExtend,
 )
@@ -444,6 +446,35 @@ class MCPServerHandler:
                 risks[mcp_server.id] = risk_tools
 
         return risks
+
+    @staticmethod
+    def get_app_permission_apply_record_map(permissions) -> Dict[tuple, Any]:
+        """根据已授权记录列表，批量查询对应的审批记录并构建映射。
+
+        Args:
+            permissions: MCPServerAppPermission 实例列表
+
+        Returns:
+            {(mcp_server_id, bk_app_code): MCPServerAppPermissionApply} 映射
+        """
+        if not permissions:
+            return {}
+
+        mcp_server_ids = [p.mcp_server_id for p in permissions]
+        bk_app_codes = [p.bk_app_code for p in permissions]
+        apply_records = MCPServerAppPermissionApply.objects.filter(
+            mcp_server_id__in=mcp_server_ids,
+            bk_app_code__in=bk_app_codes,
+            status=MCPServerAppPermissionApplyStatusEnum.APPROVED.value,
+            is_deleted=False,
+        ).order_by("-handled_time", "-id")
+
+        apply_record_map = {}
+        for apply_record in apply_records:
+            key = (apply_record.mcp_server_id, apply_record.bk_app_code)
+            if key not in apply_record_map:
+                apply_record_map[key] = apply_record
+        return apply_record_map
 
     @staticmethod
     def get_least_privileges(

--- a/src/dashboard/apigateway/apigateway/tests/apis/web/mcp_server/test_serializers.py
+++ b/src/dashboard/apigateway/apigateway/tests/apis/web/mcp_server/test_serializers.py
@@ -22,14 +22,27 @@ from uuid import uuid4
 import pytest
 from ddf import G
 
+from apigateway.apis.web.constants import ExportTypeEnum
 from apigateway.apis.web.mcp_server.serializers import (
+    GatewayMCPServerAppPermissionExportInputSLZ,
+    GatewayMCPServerAppPermissionListInputSLZ,
+    GatewayMCPServerAppPermissionListOutputSLZ,
     MCPServerCategoryOutputSLZ,
     MCPServerCreateInputSLZ,
     MCPServerListInputSLZ,
     MCPServerUpdateInputSLZ,
 )
-from apigateway.apps.mcp_server.constants import MCPServerStatusEnum
-from apigateway.apps.mcp_server.models import MCPServer, MCPServerCategory
+from apigateway.apps.mcp_server.constants import (
+    MCPServerAppPermissionApplyStatusEnum,
+    MCPServerAppPermissionGrantTypeEnum,
+    MCPServerStatusEnum,
+)
+from apigateway.apps.mcp_server.models import (
+    MCPServer,
+    MCPServerAppPermission,
+    MCPServerAppPermissionApply,
+    MCPServerCategory,
+)
 from apigateway.common.constants import CallSourceTypeEnum, LanguageCodeEnum
 
 pytestmark = pytest.mark.django_db
@@ -506,3 +519,194 @@ class TestMCPServerUpdateInputSLZOAuth2:
         )
         assert slz.is_valid(), slz.errors
         assert "oauth2_public_client_enabled" not in slz.validated_data
+
+
+class TestGatewayMCPServerAppPermissionListInputSLZ:
+    """测试网关级 MCPServer 应用权限列表输入序列化器"""
+
+    def test_validate_empty(self):
+        slz = GatewayMCPServerAppPermissionListInputSLZ(data={})
+        assert slz.is_valid(), slz.errors
+
+    def test_validate_with_mcp_server_id(self):
+        slz = GatewayMCPServerAppPermissionListInputSLZ(data={"mcp_server_id": 1})
+        assert slz.is_valid(), slz.errors
+        assert slz.validated_data["mcp_server_id"] == 1
+
+    def test_validate_with_bk_app_code(self):
+        slz = GatewayMCPServerAppPermissionListInputSLZ(data={"bk_app_code": "test-app"})
+        assert slz.is_valid(), slz.errors
+        assert slz.validated_data["bk_app_code"] == "test-app"
+
+    def test_validate_with_grant_type(self):
+        slz = GatewayMCPServerAppPermissionListInputSLZ(
+            data={"grant_type": MCPServerAppPermissionGrantTypeEnum.APPLY.value}
+        )
+        assert slz.is_valid(), slz.errors
+        assert slz.validated_data["grant_type"] == MCPServerAppPermissionGrantTypeEnum.APPLY.value
+
+    def test_validate_with_all_params(self):
+        slz = GatewayMCPServerAppPermissionListInputSLZ(
+            data={
+                "mcp_server_id": 1,
+                "bk_app_code": "test-app",
+                "grant_type": MCPServerAppPermissionGrantTypeEnum.GRANT.value,
+            }
+        )
+        assert slz.is_valid(), slz.errors
+        assert slz.validated_data["mcp_server_id"] == 1
+        assert slz.validated_data["bk_app_code"] == "test-app"
+        assert slz.validated_data["grant_type"] == MCPServerAppPermissionGrantTypeEnum.GRANT.value
+
+
+class TestGatewayMCPServerAppPermissionListOutputSLZ:
+    """测试网关级 MCPServer 应用权限列表输出序列化器"""
+
+    def test_output_grant_type(self, fake_gateway, fake_stage):
+        """测试主动授权类型的序列化输出"""
+        mcp_server = G(
+            MCPServer,
+            gateway=fake_gateway,
+            stage=fake_stage,
+            name="test-mcp",
+            title="测试MCP",
+        )
+        permission = G(
+            MCPServerAppPermission,
+            mcp_server=mcp_server,
+            bk_app_code="test-app",
+            grant_type=MCPServerAppPermissionGrantTypeEnum.GRANT.value,
+        )
+        slz = GatewayMCPServerAppPermissionListOutputSLZ(permission, context={})
+        data = slz.data
+        assert data["bk_app_code"] == "test-app"
+        assert data["grant_type"] == MCPServerAppPermissionGrantTypeEnum.GRANT.value
+        assert data["mcp_server"]["name"] == "test-mcp"
+        assert data["mcp_server"]["id"] == mcp_server.id
+
+    def test_output_apply_type_with_record(self, fake_gateway, fake_stage):
+        """测试申请授权类型（有关联审批记录）的序列化输出"""
+        mcp_server = G(
+            MCPServer,
+            gateway=fake_gateway,
+            stage=fake_stage,
+            name="test-mcp",
+        )
+        permission = G(
+            MCPServerAppPermission,
+            mcp_server=mcp_server,
+            bk_app_code="test-app",
+            grant_type=MCPServerAppPermissionGrantTypeEnum.APPLY.value,
+        )
+        apply_record = G(
+            MCPServerAppPermissionApply,
+            mcp_server=mcp_server,
+            bk_app_code="test-app",
+            applied_by="test_user",
+            handled_by="admin",
+            status=MCPServerAppPermissionApplyStatusEnum.APPROVED.value,
+            is_deleted=False,
+        )
+        slz = GatewayMCPServerAppPermissionListOutputSLZ(
+            permission,
+            context={"apply_record_map": {(mcp_server.id, "test-app"): apply_record}},
+        )
+        data = slz.data
+        assert data["bk_app_code"] == "test-app"
+        assert data["grant_type"] == MCPServerAppPermissionGrantTypeEnum.APPLY.value
+        # APPLY 类型应该通过审批单获取 handled_by
+        assert data["handled_by"] == "admin"
+
+    def test_output_apply_type_without_record(self, fake_gateway, fake_stage):
+        """测试申请授权类型（无关联审批记录）的序列化输出，应回退到 permission 字段"""
+        mcp_server = G(
+            MCPServer,
+            gateway=fake_gateway,
+            stage=fake_stage,
+            name="test-mcp",
+        )
+        permission = G(
+            MCPServerAppPermission,
+            mcp_server=mcp_server,
+            bk_app_code="test-app",
+            grant_type=MCPServerAppPermissionGrantTypeEnum.APPLY.value,
+            created_by="creator_user",
+            updated_by="updater_user",
+        )
+        slz = GatewayMCPServerAppPermissionListOutputSLZ(permission, context={})
+        data = slz.data
+        assert data["bk_app_code"] == "test-app"
+        assert data["grant_type"] == MCPServerAppPermissionGrantTypeEnum.APPLY.value
+        # 无审批记录时，applied_by 回退到 updated_by
+        assert data["applied_by"] == "updater_user"
+
+    def test_output_grant_type_with_operator(self, fake_gateway, fake_stage):
+        """测试主动授权类型时，handled_by 返回操作人"""
+        mcp_server = G(
+            MCPServer,
+            gateway=fake_gateway,
+            stage=fake_stage,
+            name="test-mcp",
+        )
+        permission = G(
+            MCPServerAppPermission,
+            mcp_server=mcp_server,
+            bk_app_code="test-app",
+            grant_type=MCPServerAppPermissionGrantTypeEnum.GRANT.value,
+            created_by="grant_user",
+        )
+        slz = GatewayMCPServerAppPermissionListOutputSLZ(permission, context={})
+        data = slz.data
+        assert data["handled_by"] == "grant_user"
+
+
+class TestGatewayMCPServerAppPermissionExportInputSLZ:
+    """测试网关级 MCPServer 应用权限导出输入序列化器"""
+
+    def test_validate_export_type_all(self):
+        slz = GatewayMCPServerAppPermissionExportInputSLZ(data={"export_type": ExportTypeEnum.ALL.value})
+        assert slz.is_valid(), slz.errors
+        assert slz.validated_data["export_type"] == ExportTypeEnum.ALL.value
+
+    def test_validate_export_type_filtered(self):
+        slz = GatewayMCPServerAppPermissionExportInputSLZ(data={"export_type": ExportTypeEnum.FILTERED.value})
+        assert slz.is_valid(), slz.errors
+        assert slz.validated_data["export_type"] == ExportTypeEnum.FILTERED.value
+
+    def test_validate_export_type_selected(self):
+        slz = GatewayMCPServerAppPermissionExportInputSLZ(
+            data={"export_type": ExportTypeEnum.SELECTED.value, "selected_ids": [1, 2, 3]}
+        )
+        assert slz.is_valid(), slz.errors
+        assert slz.validated_data["export_type"] == ExportTypeEnum.SELECTED.value
+        assert slz.validated_data["selected_ids"] == [1, 2, 3]
+
+    def test_validate_export_type_selected_without_ids(self):
+        slz = GatewayMCPServerAppPermissionExportInputSLZ(data={"export_type": ExportTypeEnum.SELECTED.value})
+        assert not slz.is_valid()
+        assert "non_field_errors" in slz.errors
+
+    def test_validate_export_type_selected_with_empty_ids(self):
+        slz = GatewayMCPServerAppPermissionExportInputSLZ(
+            data={"export_type": ExportTypeEnum.SELECTED.value, "selected_ids": []}
+        )
+        assert not slz.is_valid()
+        assert "non_field_errors" in slz.errors
+
+    def test_validate_export_type_missing(self):
+        slz = GatewayMCPServerAppPermissionExportInputSLZ(data={})
+        assert not slz.is_valid()
+        assert "export_type" in slz.errors
+
+    def test_validate_with_filter_params(self):
+        slz = GatewayMCPServerAppPermissionExportInputSLZ(
+            data={
+                "export_type": ExportTypeEnum.FILTERED.value,
+                "mcp_server_id": 1,
+                "bk_app_code": "test",
+                "grant_type": MCPServerAppPermissionGrantTypeEnum.GRANT.value,
+            }
+        )
+        assert slz.is_valid(), slz.errors
+        assert slz.validated_data["mcp_server_id"] == 1
+        assert slz.validated_data["bk_app_code"] == "test"

--- a/src/dashboard/apigateway/apigateway/tests/apis/web/mcp_server/test_views.py
+++ b/src/dashboard/apigateway/apigateway/tests/apis/web/mcp_server/test_views.py
@@ -22,6 +22,7 @@ import json
 import pytest
 from ddf import G
 
+from apigateway.apis.web.constants import ExportTypeEnum
 from apigateway.apps.mcp_server.constants import (
     FEATURED_MCP_CATEGORY_NAME,
     OFFICIAL_MCP_CATEGORY_NAME,
@@ -3362,3 +3363,239 @@ class TestMCPServerBatchConfigApi:
         )
 
         assert resp.status_code == 404
+
+
+class TestGatewayMCPServerAppPermissionListApi:
+    """测试网关级 MCPServer 应用权限列表 API"""
+
+    def test_list(self, request_view, fake_gateway, fake_mcp_server):
+        G(
+            MCPServerAppPermission,
+            mcp_server=fake_mcp_server,
+            bk_app_code="app1",
+            grant_type=MCPServerAppPermissionGrantTypeEnum.GRANT.value,
+        )
+        G(
+            MCPServerAppPermission,
+            mcp_server=fake_mcp_server,
+            bk_app_code="app2",
+            grant_type=MCPServerAppPermissionGrantTypeEnum.APPLY.value,
+        )
+
+        resp = request_view(
+            method="GET",
+            view_name="mcp_server.gateway_app_permission.list",
+            path_params={"gateway_id": fake_gateway.id},
+            gateway=fake_gateway,
+        )
+        assert resp.status_code == 200
+        result = resp.json()
+        assert result["data"]["count"] == 2
+
+    def test_list_filter_by_mcp_server_id(self, request_view, fake_gateway, fake_mcp_server, fake_stage, faker):
+        another_mcp = G(
+            MCPServer,
+            gateway=fake_gateway,
+            stage=fake_stage,
+            name=faker.pystr()[:20],
+            status=MCPServerStatusEnum.ACTIVE.value,
+        )
+        G(
+            MCPServerAppPermission,
+            mcp_server=fake_mcp_server,
+            bk_app_code="app1",
+            grant_type=MCPServerAppPermissionGrantTypeEnum.GRANT.value,
+        )
+        G(
+            MCPServerAppPermission,
+            mcp_server=another_mcp,
+            bk_app_code="app2",
+            grant_type=MCPServerAppPermissionGrantTypeEnum.GRANT.value,
+        )
+
+        resp = request_view(
+            method="GET",
+            view_name="mcp_server.gateway_app_permission.list",
+            path_params={"gateway_id": fake_gateway.id},
+            gateway=fake_gateway,
+            data={"mcp_server_id": fake_mcp_server.id},
+        )
+        assert resp.status_code == 200
+        result = resp.json()
+        assert result["data"]["count"] == 1
+        assert result["data"]["results"][0]["bk_app_code"] == "app1"
+
+    def test_list_filter_by_bk_app_code(self, request_view, fake_gateway, fake_mcp_server):
+        G(
+            MCPServerAppPermission,
+            mcp_server=fake_mcp_server,
+            bk_app_code="target-app",
+            grant_type=MCPServerAppPermissionGrantTypeEnum.GRANT.value,
+        )
+        G(
+            MCPServerAppPermission,
+            mcp_server=fake_mcp_server,
+            bk_app_code="other-app",
+            grant_type=MCPServerAppPermissionGrantTypeEnum.GRANT.value,
+        )
+
+        resp = request_view(
+            method="GET",
+            view_name="mcp_server.gateway_app_permission.list",
+            path_params={"gateway_id": fake_gateway.id},
+            gateway=fake_gateway,
+            data={"bk_app_code": "target"},
+        )
+        assert resp.status_code == 200
+        result = resp.json()
+        assert result["data"]["count"] == 1
+        assert result["data"]["results"][0]["bk_app_code"] == "target-app"
+
+    def test_list_filter_by_grant_type(self, request_view, fake_gateway, fake_mcp_server):
+        G(
+            MCPServerAppPermission,
+            mcp_server=fake_mcp_server,
+            bk_app_code="grant-app",
+            grant_type=MCPServerAppPermissionGrantTypeEnum.GRANT.value,
+        )
+        G(
+            MCPServerAppPermission,
+            mcp_server=fake_mcp_server,
+            bk_app_code="apply-app",
+            grant_type=MCPServerAppPermissionGrantTypeEnum.APPLY.value,
+        )
+
+        resp = request_view(
+            method="GET",
+            view_name="mcp_server.gateway_app_permission.list",
+            path_params={"gateway_id": fake_gateway.id},
+            gateway=fake_gateway,
+            data={"grant_type": MCPServerAppPermissionGrantTypeEnum.GRANT.value},
+        )
+        assert resp.status_code == 200
+        result = resp.json()
+        assert result["data"]["count"] == 1
+        assert result["data"]["results"][0]["grant_type"] == MCPServerAppPermissionGrantTypeEnum.GRANT.value
+
+    def test_list_empty(self, request_view, fake_gateway):
+        resp = request_view(
+            method="GET",
+            view_name="mcp_server.gateway_app_permission.list",
+            path_params={"gateway_id": fake_gateway.id},
+            gateway=fake_gateway,
+        )
+        assert resp.status_code == 200
+        result = resp.json()
+        assert result["data"]["count"] == 0
+
+    def test_list_returns_mcp_server_info(self, request_view, fake_gateway, fake_mcp_server):
+        G(
+            MCPServerAppPermission,
+            mcp_server=fake_mcp_server,
+            bk_app_code="app1",
+            grant_type=MCPServerAppPermissionGrantTypeEnum.GRANT.value,
+        )
+
+        resp = request_view(
+            method="GET",
+            view_name="mcp_server.gateway_app_permission.list",
+            path_params={"gateway_id": fake_gateway.id},
+            gateway=fake_gateway,
+        )
+        assert resp.status_code == 200
+        result = resp.json()
+        item = result["data"]["results"][0]
+        assert "mcp_server" in item
+        assert item["mcp_server"]["id"] == fake_mcp_server.id
+        assert item["mcp_server"]["name"] == fake_mcp_server.name
+        assert "grant_type_display" in item
+
+
+class TestGatewayMCPServerAppPermissionExportApi:
+    """测试网关级 MCPServer 应用权限导出 API"""
+
+    def test_export_all(self, request_view, fake_gateway, fake_mcp_server):
+        G(
+            MCPServerAppPermission,
+            mcp_server=fake_mcp_server,
+            bk_app_code="app1",
+            grant_type=MCPServerAppPermissionGrantTypeEnum.GRANT.value,
+        )
+
+        resp = request_view(
+            method="POST",
+            view_name="mcp_server.gateway_app_permission.export",
+            path_params={"gateway_id": fake_gateway.id},
+            gateway=fake_gateway,
+            data={"export_type": ExportTypeEnum.ALL.value},
+        )
+        assert resp.status_code == 200
+
+    def test_export_filtered(self, request_view, fake_gateway, fake_mcp_server):
+        G(
+            MCPServerAppPermission,
+            mcp_server=fake_mcp_server,
+            bk_app_code="app1",
+            grant_type=MCPServerAppPermissionGrantTypeEnum.GRANT.value,
+        )
+        G(
+            MCPServerAppPermission,
+            mcp_server=fake_mcp_server,
+            bk_app_code="app2",
+            grant_type=MCPServerAppPermissionGrantTypeEnum.APPLY.value,
+        )
+
+        resp = request_view(
+            method="POST",
+            view_name="mcp_server.gateway_app_permission.export",
+            path_params={"gateway_id": fake_gateway.id},
+            gateway=fake_gateway,
+            data={
+                "export_type": ExportTypeEnum.FILTERED.value,
+                "grant_type": MCPServerAppPermissionGrantTypeEnum.GRANT.value,
+            },
+        )
+        assert resp.status_code == 200
+
+    def test_export_selected(self, request_view, fake_gateway, fake_mcp_server):
+        permission = G(
+            MCPServerAppPermission,
+            mcp_server=fake_mcp_server,
+            bk_app_code="app1",
+            grant_type=MCPServerAppPermissionGrantTypeEnum.GRANT.value,
+        )
+
+        resp = request_view(
+            method="POST",
+            view_name="mcp_server.gateway_app_permission.export",
+            path_params={"gateway_id": fake_gateway.id},
+            gateway=fake_gateway,
+            data={
+                "export_type": ExportTypeEnum.SELECTED.value,
+                "selected_ids": [permission.id],
+            },
+        )
+        assert resp.status_code == 200
+
+    def test_export_selected_empty_ids(self, request_view, fake_gateway):
+        resp = request_view(
+            method="POST",
+            view_name="mcp_server.gateway_app_permission.export",
+            path_params={"gateway_id": fake_gateway.id},
+            gateway=fake_gateway,
+            data={
+                "export_type": ExportTypeEnum.SELECTED.value,
+                "selected_ids": [],
+            },
+        )
+        assert resp.status_code == 400
+
+    def test_export_missing_export_type(self, request_view, fake_gateway):
+        resp = request_view(
+            method="POST",
+            view_name="mcp_server.gateway_app_permission.export",
+            path_params={"gateway_id": fake_gateway.id},
+            gateway=fake_gateway,
+            data={},
+        )
+        assert resp.status_code == 400

--- a/src/dashboard/apigateway/apigateway/tests/biz/mcp_server/test_mcp_server.py
+++ b/src/dashboard/apigateway/apigateway/tests/biz/mcp_server/test_mcp_server.py
@@ -23,18 +23,26 @@ from ddf import G
 
 from apigateway.apps.mcp_server.constants import (
     OFFICIAL_MCP_CATEGORY_NAME,
+    MCPServerAppPermissionApplyStatusEnum,
+    MCPServerAppPermissionGrantTypeEnum,
     MCPServerExtendTypeEnum,
     MCPServerLeastPrivilegeEnum,
     MCPServerStatusEnum,
 )
-from apigateway.apps.mcp_server.models import MCPServer, MCPServerAppPermission, MCPServerCategory, MCPServerExtend
+from apigateway.apps.mcp_server.models import (
+    MCPServer,
+    MCPServerAppPermission,
+    MCPServerAppPermissionApply,
+    MCPServerCategory,
+    MCPServerExtend,
+)
 from apigateway.apps.permission.constants import GrantTypeEnum
 from apigateway.apps.permission.models import AppResourcePermission
 from apigateway.biz.mcp_server import MCPServerHandler
 from apigateway.core.constants import GatewayStatusEnum, StageStatusEnum
 from apigateway.core.models import Gateway, Release, Resource, ResourceVersion, Stage
 from apigateway.tests.utils.testing import create_gateway
-from apigateway.utils.time import NeverExpiresTime
+from apigateway.utils.time import NeverExpiresTime, now_datetime
 
 
 class TestMCPServerHandler:
@@ -1921,3 +1929,178 @@ class TestMCPServerHandler:
 
         assert "server-app" in result["mcpServers"]
         assert "server-user" in result["mcpServers"]
+
+
+class TestMCPServerHandlerAppPermissionApplyRecordMap:
+    """测试 get_app_permission_apply_record_map 方法"""
+
+    def test_empty_permissions(self):
+        result = MCPServerHandler.get_app_permission_apply_record_map([])
+        assert result == {}
+
+    def test_no_approved_apply_records(self, fake_gateway, fake_stage):
+        """测试权限存在但无对应审批记录时返回空映射"""
+        mcp_server = G(MCPServer, gateway=fake_gateway, stage=fake_stage)
+        permission = G(
+            MCPServerAppPermission,
+            mcp_server=mcp_server,
+            bk_app_code="app1",
+            grant_type=MCPServerAppPermissionGrantTypeEnum.APPLY.value,
+        )
+        # 不创建审批记录
+
+        result = MCPServerHandler.get_app_permission_apply_record_map([permission])
+        assert result == {}
+
+    def test_with_approved_apply_record(self, fake_gateway, fake_stage):
+        """测试有已审批记录时正确返回映射"""
+        mcp_server = G(MCPServer, gateway=fake_gateway, stage=fake_stage)
+        permission = G(
+            MCPServerAppPermission,
+            mcp_server=mcp_server,
+            bk_app_code="app1",
+            grant_type=MCPServerAppPermissionGrantTypeEnum.APPLY.value,
+        )
+        apply_record = G(
+            MCPServerAppPermissionApply,
+            mcp_server=mcp_server,
+            bk_app_code="app1",
+            applied_by="test_user",
+            status=MCPServerAppPermissionApplyStatusEnum.APPROVED.value,
+            is_deleted=False,
+        )
+
+        result = MCPServerHandler.get_app_permission_apply_record_map([permission])
+        assert len(result) == 1
+        assert (mcp_server.id, "app1") in result
+        assert result[(mcp_server.id, "app1")].id == apply_record.id
+
+    def test_dedup_multiple_records(self, fake_gateway, fake_stage):
+        """测试同一 (mcp_server_id, bk_app_code) 有多条审批记录时取最新"""
+        mcp_server = G(MCPServer, gateway=fake_gateway, stage=fake_stage)
+        permission = G(
+            MCPServerAppPermission,
+            mcp_server=mcp_server,
+            bk_app_code="app1",
+            grant_type=MCPServerAppPermissionGrantTypeEnum.APPLY.value,
+        )
+        old_time = now_datetime()
+        new_time = old_time
+
+        G(
+            MCPServerAppPermissionApply,
+            mcp_server=mcp_server,
+            bk_app_code="app1",
+            applied_by="old_user",
+            status=MCPServerAppPermissionApplyStatusEnum.APPROVED.value,
+            is_deleted=False,
+            handled_time=old_time,
+        )
+        new_apply = G(
+            MCPServerAppPermissionApply,
+            mcp_server=mcp_server,
+            bk_app_code="app1",
+            applied_by="new_user",
+            status=MCPServerAppPermissionApplyStatusEnum.APPROVED.value,
+            is_deleted=False,
+            handled_time=new_time,
+        )
+
+        result = MCPServerHandler.get_app_permission_apply_record_map([permission])
+        assert len(result) == 1
+        assert result[(mcp_server.id, "app1")].applied_by == "new_user"
+
+    def test_ignores_non_approved_and_deleted(self, fake_gateway, fake_stage):
+        """测试忽略未审批和已删除的审批记录"""
+        mcp_server = G(MCPServer, gateway=fake_gateway, stage=fake_stage)
+        permission = G(
+            MCPServerAppPermission,
+            mcp_server=mcp_server,
+            bk_app_code="app1",
+            grant_type=MCPServerAppPermissionGrantTypeEnum.APPLY.value,
+        )
+        # 创建 PENDING 状态的记录（应被忽略）
+        G(
+            MCPServerAppPermissionApply,
+            mcp_server=mcp_server,
+            bk_app_code="app1",
+            applied_by="pending_user",
+            status=MCPServerAppPermissionApplyStatusEnum.PENDING.value,
+            is_deleted=False,
+        )
+        # 创建已删除的 APPROVED 记录（应被忽略）
+        G(
+            MCPServerAppPermissionApply,
+            mcp_server=mcp_server,
+            bk_app_code="app1",
+            applied_by="deleted_user",
+            status=MCPServerAppPermissionApplyStatusEnum.APPROVED.value,
+            is_deleted=True,
+        )
+
+        result = MCPServerHandler.get_app_permission_apply_record_map([permission])
+        assert result == {}
+
+    def test_multiple_permissions(self, fake_gateway, fake_stage):
+        """测试多条权限记录混合场景"""
+        mcp_server_1 = G(MCPServer, gateway=fake_gateway, stage=fake_stage)
+        mcp_server_2 = G(MCPServer, gateway=fake_gateway, stage=fake_stage)
+
+        perm_1 = G(
+            MCPServerAppPermission,
+            mcp_server=mcp_server_1,
+            bk_app_code="app1",
+            grant_type=MCPServerAppPermissionGrantTypeEnum.APPLY.value,
+        )
+        perm_2 = G(
+            MCPServerAppPermission,
+            mcp_server=mcp_server_1,
+            bk_app_code="app2",
+            grant_type=MCPServerAppPermissionGrantTypeEnum.APPLY.value,
+        )
+        perm_3 = G(
+            MCPServerAppPermission,
+            mcp_server=mcp_server_2,
+            bk_app_code="app1",
+            grant_type=MCPServerAppPermissionGrantTypeEnum.APPLY.value,
+        )
+        # perm_4 是 GRANT 类型，不需要审批记录
+        perm_4 = G(
+            MCPServerAppPermission,
+            mcp_server=mcp_server_2,
+            bk_app_code="app2",
+            grant_type=MCPServerAppPermissionGrantTypeEnum.GRANT.value,
+        )
+
+        apply_1 = G(
+            MCPServerAppPermissionApply,
+            mcp_server=mcp_server_1,
+            bk_app_code="app1",
+            applied_by="user1",
+            status=MCPServerAppPermissionApplyStatusEnum.APPROVED.value,
+            is_deleted=False,
+        )
+        apply_2 = G(
+            MCPServerAppPermissionApply,
+            mcp_server=mcp_server_1,
+            bk_app_code="app2",
+            applied_by="user2",
+            status=MCPServerAppPermissionApplyStatusEnum.APPROVED.value,
+            is_deleted=False,
+        )
+        apply_3 = G(
+            MCPServerAppPermissionApply,
+            mcp_server=mcp_server_2,
+            bk_app_code="app1",
+            applied_by="user3",
+            status=MCPServerAppPermissionApplyStatusEnum.APPROVED.value,
+            is_deleted=False,
+        )
+
+        result = MCPServerHandler.get_app_permission_apply_record_map([perm_1, perm_2, perm_3, perm_4])
+        # 只有 APPLY 类型才在映射中，perm_4(GRANT) 没有审批记录
+        assert len(result) == 3
+        assert result[(mcp_server_1.id, "app1")] == apply_1
+        assert result[(mcp_server_1.id, "app2")] == apply_2
+        assert result[(mcp_server_2.id, "app1")] == apply_3
+        assert (mcp_server_2.id, "app2") not in result

--- a/src/dashboard/apigateway/apigateway/tests/biz/mcp_server/test_permission.py
+++ b/src/dashboard/apigateway/apigateway/tests/biz/mcp_server/test_permission.py
@@ -375,3 +375,60 @@ class TestMCPServerPermissionHandlerItsm:
 
         permission = MCPServerAppPermission.objects.get(mcp_server_id=mcp_server.id, bk_app_code="test-app")
         assert permission.grant_type == GrantTypeEnum.SYNC.value
+
+    def test_save_permission_with_operator_new_record(self, fake_gateway, fake_stage):
+        """测试 save_permission 带 operator 参数创建新记录"""
+        mcp_server = G(MCPServer, gateway=fake_gateway, stage=fake_stage)
+
+        MCPServerAppPermission.objects.save_permission(
+            mcp_server_id=mcp_server.id,
+            bk_app_code="test-app",
+            grant_type=GrantTypeEnum.INITIALIZE.value,
+            expire_days=None,
+            operator="admin_user",
+        )
+
+        permission = MCPServerAppPermission.objects.get(mcp_server_id=mcp_server.id, bk_app_code="test-app")
+        assert permission.created_by == "admin_user"
+        assert permission.updated_by == "admin_user"
+
+    def test_save_permission_with_operator_existing_record(self, fake_gateway, fake_stage):
+        """测试 save_permission 带 operator 参数更新已有记录"""
+        mcp_server = G(MCPServer, gateway=fake_gateway, stage=fake_stage)
+
+        MCPServerAppPermission.objects.save_permission(
+            mcp_server_id=mcp_server.id,
+            bk_app_code="test-app",
+            grant_type=GrantTypeEnum.APPLY.value,
+            expire_days=None,
+            operator="first_user",
+        )
+
+        MCPServerAppPermission.objects.save_permission(
+            mcp_server_id=mcp_server.id,
+            bk_app_code="test-app",
+            grant_type=GrantTypeEnum.INITIALIZE.value,
+            expire_days=None,
+            operator="second_user",
+        )
+
+        permission = MCPServerAppPermission.objects.get(mcp_server_id=mcp_server.id, bk_app_code="test-app")
+        # created_by 保持首次写入的值，不会被覆盖
+        assert permission.created_by == "first_user"
+        # updated_by 应更新为新 operator
+        assert permission.updated_by == "second_user"
+
+    def test_save_permission_without_operator(self, fake_gateway, fake_stage):
+        """测试 save_permission 不带 operator 参数"""
+        mcp_server = G(MCPServer, gateway=fake_gateway, stage=fake_stage)
+
+        MCPServerAppPermission.objects.save_permission(
+            mcp_server_id=mcp_server.id,
+            bk_app_code="test-app",
+            grant_type=GrantTypeEnum.INITIALIZE.value,
+            expire_days=None,
+        )
+
+        permission = MCPServerAppPermission.objects.get(mcp_server_id=mcp_server.id, bk_app_code="test-app")
+        assert permission.created_by is None
+        assert permission.updated_by is None


### PR DESCRIPTION
## What

Add gateway-level MCPServer app permission list and export APIs.

### APIs Added
- GET /-/permissions/app-permissions/ — 网关下 MCPServer 应用权限列表
- POST /-/permissions/app-permissions/-/export/ — 导出该列表

### Key Changes
1. New GatewayMCPServerAppPermissionListApi and GatewayMCPServerAppPermissionExportApi views
2. Added GatewayMCPServerAppPermissionListInputSLZ / ListOutputSLZ / ExportInputSLZ serializers
3. Extended save_permission with optional operator to record created_by/updated_by
4. Supports both GRANT and APPLY grant types with applicant/handler info

### Files Changed
- serializers.py — +90 lines
- views.py — +156/-8 lines
- urls.py — +14 lines
- managers.py — +28/-8 lines