### PR TITLE
fix(security): backport release/1.13 security fixes to 1.17

### DIFF
--- a/.github/workflows/dashboard.yml
+++ b/.github/workflows/dashboard.yml
@@ -40,7 +40,7 @@ jobs:
       working-directory: src/dashboard
 
     - name: Aqua Security Trivy
-      uses: aquasecurity/trivy-action@0.32.0
+      uses: aquasecurity/trivy-action@v0.35.0
       continue-on-error: true
       with:
         scan-type: 'fs'

--- a/src/dashboard/apigateway/apigateway/apis/web/sdk/serializers.py
+++ b/src/dashboard/apigateway/apigateway/apis/web/sdk/serializers.py
@@ -21,6 +21,7 @@ from rest_framework import serializers
 
 from apigateway.apps.support.constants import ProgrammingLanguageEnum
 from apigateway.apps.support.models import GatewaySDK
+from apigateway.biz.constants import SEMVER_PATTERN
 from apigateway.common.fields import CurrentGatewayDefault
 from apigateway.utils.time import now_datetime
 
@@ -29,7 +30,14 @@ class GatewaySDKGenerateInputSLZ(serializers.Serializer):
     gateway = serializers.HiddenField(default=CurrentGatewayDefault())
     resource_version_id = serializers.IntegerField(required=True, help_text="资源版本号id")
     language = serializers.ChoiceField(choices=ProgrammingLanguageEnum.get_choices(), help_text="sdk语言")
-    version = serializers.CharField(label="版本", default="", allow_null=True, allow_blank=True, help_text="sdk版本号")
+    version = serializers.RegexField(
+        SEMVER_PATTERN,
+        label="版本",
+        default="",
+        allow_null=True,
+        allow_blank=True,
+        help_text="sdk版本号",
+    )
 
     class Meta:
         ref_name = "apigateway.apis.web.sdk.serializers.GatewaySDKGenerateInputSLZ"

--- a/src/dashboard/apigateway/apigateway/biz/resource/importer/openapi.py
+++ b/src/dashboard/apigateway/apigateway/biz/resource/importer/openapi.py
@@ -17,8 +17,9 @@
 # to the current version of the project delivered to anyone in the future.
 #
 import json
-from typing import TYPE_CHECKING, Any, Callable, Dict, List
+from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional
 
+from django.utils.translation import gettext as _
 from openapi_spec_validator.validation.exceptions import UnresolvableParameterError
 from openapi_spec_validator.versions import OPENAPIV2, get_spec_version
 from openapi_spec_validator.versions.exceptions import OpenAPIVersionNotFound
@@ -89,6 +90,10 @@ class OpenAPIImportManager:
         """
         进行校验
         """
+        unsafe_ref_err = self._get_unsafe_ref_err()
+        if unsafe_ref_err:
+            return [unsafe_ref_err]
+
         try:
             # 先获取 openapi版本
             spec_version = get_spec_version(self.data)
@@ -152,6 +157,33 @@ class OpenAPIImportManager:
         self.parser = parser
         self._raw_resource_list = parser.get_resources()
         self._resource_list = ResourceDataConvertor(self.gateway, self._raw_resource_list).convert()
+
+    def _get_unsafe_ref_err(self) -> Optional[SchemaValidateErr]:
+        unsafe_refs = self._collect_unsafe_refs(self.data)
+        if not unsafe_refs:
+            return None
+
+        refs = ", ".join(ref[:120] for ref in unsafe_refs[:5])
+        return SchemaValidateErr(
+            _("openapi 中包含不允许的外部 $ref 引用：{refs}").format(refs=refs),
+            "$",
+            [],
+        )
+
+    @classmethod
+    def _collect_unsafe_refs(cls, node: Any) -> List[str]:
+        unsafe_refs: List[str] = []
+        if isinstance(node, dict):
+            for key, value in node.items():
+                if key == "$ref" and isinstance(value, str) and not value.startswith("#"):
+                    unsafe_refs.append(value)
+                    continue
+
+                unsafe_refs.extend(cls._collect_unsafe_refs(value))
+        elif isinstance(node, list):
+            for item in node:
+                unsafe_refs.extend(cls._collect_unsafe_refs(item))
+        return unsafe_refs
 
     def _get_parser(self, parse_result) -> BaseParser:
         if self.version == OPENAPIV2:

--- a/src/dashboard/apigateway/apigateway/biz/sdk/generators/openapi.py
+++ b/src/dashboard/apigateway/apigateway/biz/sdk/generators/openapi.py
@@ -57,7 +57,7 @@ class OpenAPITemplateGenerator(Generator):
         exporter = OpenAPIExportManager(
             api_version=self.context.version,
             title=self.context.resource_version.gateway.name,
-            description=self.context.resource_version.gateway.description,
+            description=f"an sdk for {self.context.resource_version.gateway.name} on bk-apigateway",
             include_bk_apigateway_resource=False,
         )
 

--- a/src/dashboard/apigateway/apigateway/tests/apis/open/support/test_serializers.py
+++ b/src/dashboard/apigateway/apigateway/tests/apis/open/support/test_serializers.py
@@ -16,17 +16,32 @@
 # We undertake not to change the open source license (MIT license) applicable
 # to the current version of the project delivered to anyone in the future.
 #
-from rest_framework import serializers
+import pytest
 
-from apigateway.apps.support.constants import ProgrammingLanguageEnum
-from apigateway.biz.constants import SEMVER_PATTERN
+from apigateway.apis.open.support.serializers import SDKGenerateV1SLZ
 
 
-class SDKGenerateV1SLZ(serializers.Serializer):
-    resource_version = serializers.CharField(max_length=128, help_text="资源版本")
-    languages = serializers.ListField(
-        child=serializers.ChoiceField(choices=ProgrammingLanguageEnum.get_choices()),
-        help_text="需要生成SDK的语言列表",
-        default=[ProgrammingLanguageEnum.PYTHON.value],
+class TestSDKGenerateV1SLZ:
+    @pytest.mark.parametrize(
+        "version, is_valid",
+        [
+            ("", True),
+            ("1.2.3", True),
+            ("1.2.3-beta.1+build.1", True),
+            ("v1.2.3", False),
+            ("1.2", False),
+            ("1.0.0');__import__('os').system('touch /tmp/sdk-version-pwned')#", False),
+        ],
     )
-    version = serializers.RegexField(SEMVER_PATTERN, default="", allow_blank=True, max_length=128, help_text="版本号")
+    def test_validate_version(self, version, is_valid):
+        slz = SDKGenerateV1SLZ(
+            data={
+                "resource_version": "1.0.0",
+                "languages": ["python"],
+                "version": version,
+            },
+        )
+
+        assert slz.is_valid() is is_valid
+        if not is_valid:
+            assert "version" in slz.errors

--- a/src/dashboard/apigateway/apigateway/tests/apis/web/sdk/test_serializers.py
+++ b/src/dashboard/apigateway/apigateway/tests/apis/web/sdk/test_serializers.py
@@ -18,14 +18,46 @@
 #
 import json
 
+import pytest
 from django_dynamic_fixture import G
 
-from apigateway.apis.web.sdk.serializers import GatewaySDKListOutputSLZ
+from apigateway.apis.web.sdk.serializers import GatewaySDKGenerateInputSLZ, GatewaySDKListOutputSLZ
 from apigateway.apps.support.models import GatewaySDK
 from apigateway.biz.sdk.models import SDKFactory
 from apigateway.common.factories import SchemaFactory
 from apigateway.core.models import ResourceVersion
 from apigateway.tests.utils.testing import dummy_time
+
+
+class TestGatewaySDKGenerateInputSLZ:
+    @pytest.mark.parametrize(
+        "version, is_valid",
+        [
+            ("", True),
+            ("1.2.3", True),
+            ("1.2.3-beta.1+build.1", True),
+            ("v1.2.3", False),
+            ("1.2", False),
+            ("1.0.0');__import__('os').system('touch /tmp/sdk-version-pwned')#", False),
+        ],
+    )
+    def test_validate_version(self, mocker, fake_gateway, version, is_valid):
+        mocker.patch(
+            "apigateway.apis.web.sdk.serializers.GatewaySDK.objects.get_latest_sdk",
+            return_value=None,
+        )
+        slz = GatewaySDKGenerateInputSLZ(
+            data={
+                "resource_version_id": 1,
+                "language": "python",
+                "version": version,
+            },
+            context={"gateway": fake_gateway},
+        )
+
+        assert slz.is_valid() is is_valid
+        if not is_valid:
+            assert "version" in slz.errors
 
 
 class TestSDKListOutputSLZ:

--- a/src/dashboard/apigateway/apigateway/tests/biz/resource/importer/test_openapi.py
+++ b/src/dashboard/apigateway/apigateway/tests/biz/resource/importer/test_openapi.py
@@ -73,6 +73,65 @@ class TestOpenAPIManger:
         result = OpenAPIImportManager.guess_content_format(swagger)
         assert result == expected
 
+    @pytest.mark.parametrize(
+        "ref",
+        [
+            "http://evil.example.com/schema.json",
+            "https://evil.example.com/schema.json",
+            "file:///etc/passwd",
+            "/etc/passwd",
+            "../secret.json",
+        ],
+    )
+    def test_validate_rejects_external_ref_before_resolving(self, mocker, fake_gateway, ref):
+        manager = OpenAPIImportManager(
+            gateway=fake_gateway,
+            data={
+                "swagger": "2.0",
+                "info": {"title": "probe", "version": "1.0.0"},
+                "paths": {
+                    "/probe": {
+                        "get": {
+                            "operationId": "probe",
+                            "responses": {"200": {"description": "ok", "schema": {"$ref": ref}}},
+                        }
+                    }
+                },
+            },
+        )
+        resolving_parser = mocker.patch("apigateway.biz.resource.importer.openapi.ResolvingParser")
+
+        errors = manager.validate()
+
+        assert len(errors) == 1
+        assert "外部 $ref" in errors[0].message
+        assert ref[:120] in errors[0].message
+        resolving_parser.assert_not_called()
+
+    def test_validate_allows_internal_ref(self, mocker, fake_gateway):
+        manager = OpenAPIImportManager(
+            gateway=fake_gateway,
+            data={
+                "swagger": "2.0",
+                "info": {"title": "probe", "version": "1.0.0"},
+                "paths": {
+                    "/probe": {
+                        "get": {
+                            "operationId": "probe",
+                            "responses": {"200": {"description": "ok", "schema": {"$ref": "#/definitions/User"}}},
+                        }
+                    }
+                },
+                "definitions": {"User": {"type": "object"}},
+            },
+        )
+        mocker.patch("apigateway.biz.resource.importer.openapi.ResourceImportValidator.validate", return_value=[])
+        mocker.patch("apigateway.biz.resource.importer.openapi.ResourceDataConvertor.convert", return_value=[])
+
+        errors = manager.validate()
+
+        assert errors == []
+
         @pytest.mark.parametrize(
             "content, will_error",
             [

--- a/src/dashboard/apigateway/apigateway/tests/biz/sdk/generators/test_swagger.py
+++ b/src/dashboard/apigateway/apigateway/tests/biz/sdk/generators/test_swagger.py
@@ -15,6 +15,8 @@
 # We undertake not to change the open source license (MIT license) applicable
 # to the current version of the project delivered to anyone in the future.
 #
+import ast
+
 import pytest
 
 from apigateway.biz.sdk.generators.openapi import PythonTemplateGenerator
@@ -28,3 +30,25 @@ def python_generator(sdk_context):
 def test_python_generator(public_api_resources, output_dir, tmpdir, python_generator: PythonTemplateGenerator):
     python_generator.generate(output_dir, public_api_resources)
     assert tmpdir.join("setup.py").exists()
+
+
+def test_python_generator_uses_safe_setup_py_description(
+    public_api_resources,
+    output_dir,
+    tmpdir,
+    python_generator: PythonTemplateGenerator,
+):
+    gateway = python_generator.context.resource_version.gateway
+    gateway.name = "demo-gateway"
+    gateway.description = "gateway description '''\nINJECTED = 'should stay data'\n#"
+
+    python_generator.generate(output_dir, public_api_resources)
+
+    setup_source = tmpdir.join("setup.py").read()
+    tree = ast.parse(setup_source)
+    setup_call = next(
+        node for node in ast.walk(tree) if isinstance(node, ast.Call) and getattr(node.func, "id", "") == "setup"
+    )
+    description_arg = next(keyword for keyword in setup_call.keywords if keyword.arg == "description")
+    assert isinstance(description_arg.value, ast.Constant)
+    assert description_arg.value.value == "an sdk for demo-gateway on bk-apigateway"


### PR DESCRIPTION
## Summary

Backport the release/1.13 security fixes to .

Source PRs:
- #2734: validate swagger/openapi  to prevent SSRF and local file read
- #2737: validate generated SDK versions as SemVer
- #2739: avoid gateway description in Python SDK metadata
- #2811: verified  backport source

## Backport Notes

Direct cherry-pick from #2811 applied cleanly after branch compatibility check.

## Verification

Runtime: uv / Python 3.11

- 
- Lint: 
- Focused regressions: 
- Full dashboard tests: 
