### PR TITLE
fix(mcp-server): fix permission APIs to query actual permissions

### DIFF
--- a/src/dashboard/apigateway/apigateway/apis/v2/inner/views.py
+++ b/src/dashboard/apigateway/apigateway/apis/v2/inner/views.py
@@ -37,7 +37,7 @@ from apigateway.apps.mcp_server.constants import (
     MCPServerPermissionStatusEnum,
     MCPServerStatusEnum,
 )
-from apigateway.apps.mcp_server.models import MCPServer, MCPServerAppPermissionApply
+from apigateway.apps.mcp_server.models import MCPServer, MCPServerAppPermission, MCPServerAppPermissionApply
 from apigateway.apps.permission.constants import GrantDimensionEnum, PermissionApplyExpireDaysEnum
 from apigateway.apps.permission.models import AppPermissionRecord
 from apigateway.apps.permission.tasks import send_mail_for_perm_apply
@@ -481,11 +481,23 @@ class MCPServerPermissionListApi(generics.ListAPIView):
         if keyword:
             queryset = queryset.filter(Q(name__icontains=keyword) | Q(description__icontains=keyword))
 
+        mcp_server_ids = list(queryset.values_list("id", flat=True))
+        target_app_code = data["target_app_code"]
+
+        # 1. 查询 MCPServerAppPermission（实际权限表），覆盖主动授权（grant）和申请通过（apply）两种场景
+        granted_mcp_server_ids: set = set(
+            MCPServerAppPermission.objects.filter(
+                bk_app_code=target_app_code,
+                mcp_server_id__in=mcp_server_ids,
+            ).values_list("mcp_server_id", flat=True)
+        )
+
+        # 2. 查询 MCPServerAppPermissionApply（申请记录表），用于展示申请状态和处理人
         mcp_server_permission_status: Dict[int, str] = {}
         mcp_server_permission_apply_status = (
             MCPServerAppPermissionApply.objects.filter(
-                bk_app_code=data["target_app_code"],
-                mcp_server_id__in=list(queryset.values_list("id", flat=True)),
+                bk_app_code=target_app_code,
+                mcp_server_id__in=mcp_server_ids,
                 is_deleted=False,
             )
             .order_by("-applied_time")
@@ -497,6 +509,10 @@ class MCPServerPermissionListApi(generics.ListAPIView):
             mcp_server_permission_handled_by[obj["mcp_server_id"]] = obj["handled_by"]
             if not mcp_server_permission_status.get(obj["mcp_server_id"]):
                 mcp_server_permission_status[obj["mcp_server_id"]] = obj["status"]
+
+        # 3. 已有实际权限的 mcp_server，状态覆盖为 OWNED
+        for mcp_server_id in granted_mcp_server_ids:
+            mcp_server_permission_status[mcp_server_id] = MCPServerPermissionStatusEnum.OWNED.value
 
         mcp_server_permissions = []
         # Build categories map for queryset

--- a/src/dashboard/apigateway/apigateway/tests/apis/v2/inner/test_views.py
+++ b/src/dashboard/apigateway/apigateway/tests/apis/v2/inner/test_views.py
@@ -26,10 +26,12 @@ import apigateway.apis.v2.inner.serializers as inner_serializers
 import apigateway.apis.v2.inner.views as inner_views
 from apigateway.apps.mcp_server.constants import (
     MCPServerAppPermissionApplyStatusEnum,
+    MCPServerAppPermissionGrantTypeEnum,
+    MCPServerPermissionStatusEnum,
     MCPServerProtocolTypeEnum,
     MCPServerStatusEnum,
 )
-from apigateway.apps.mcp_server.models import MCPServer, MCPServerAppPermissionApply
+from apigateway.apps.mcp_server.models import MCPServer, MCPServerAppPermission, MCPServerAppPermissionApply
 from apigateway.apps.permission.models import AppPermissionRecord
 from apigateway.core.constants import GatewayStatusEnum, StageStatusEnum
 from apigateway.core.models import Gateway, Release, Stage
@@ -204,6 +206,186 @@ class TestMCPServerPermissionListApi:
 
         mcp_server_data = result["data"][0]["mcp_server"]
         assert mcp_server_data["protocol_type"] == MCPServerProtocolTypeEnum.STREAMABLE_HTTP.value
+
+    def test_list_with_grant_permission(self, request_view, fake_gateway, fake_stage):
+        """测试主动授权（grant）的 mcp_server 状态为 OWNED"""
+        mcp_server = G(
+            MCPServer,
+            gateway=fake_gateway,
+            stage=fake_stage,
+            name="test-mcp-server-grant",
+            is_public=True,
+            status=MCPServerStatusEnum.ACTIVE.value,
+        )
+
+        # 创建主动授权记录
+        G(
+            MCPServerAppPermission,
+            bk_app_code="test-app",
+            mcp_server=mcp_server,
+            grant_type=MCPServerAppPermissionGrantTypeEnum.GRANT.value,
+        )
+
+        resp = request_view(
+            method="GET",
+            view_name="openapi.v2.inner.mcp_server.permission.list",
+            data={"target_app_code": "test-app"},
+            app=mock.MagicMock(app_code="test"),
+        )
+        result = resp.json()
+
+        assert resp.status_code == 200
+        assert len(result["data"]) == 1
+
+        permission_data = result["data"][0]["permission"]
+        assert permission_data["status"] == MCPServerPermissionStatusEnum.OWNED.value
+
+    def test_list_with_apply_approved_permission(self, request_view, fake_gateway, fake_stage):
+        """测试申请通过（apply）且有实际权限的 mcp_server 状态为 OWNED"""
+        mcp_server = G(
+            MCPServer,
+            gateway=fake_gateway,
+            stage=fake_stage,
+            name="test-mcp-server-apply-approved",
+            is_public=True,
+            status=MCPServerStatusEnum.ACTIVE.value,
+        )
+
+        # 创建申请通过记录
+        G(
+            MCPServerAppPermissionApply,
+            bk_app_code="test-app",
+            mcp_server=mcp_server,
+            applied_by="test-user",
+            applied_time=timezone.now(),
+            status=MCPServerAppPermissionApplyStatusEnum.APPROVED.value,
+        )
+
+        # 创建实际权限记录（申请通过后会创建）
+        G(
+            MCPServerAppPermission,
+            bk_app_code="test-app",
+            mcp_server=mcp_server,
+            grant_type=MCPServerAppPermissionGrantTypeEnum.APPLY.value,
+        )
+
+        resp = request_view(
+            method="GET",
+            view_name="openapi.v2.inner.mcp_server.permission.list",
+            data={"target_app_code": "test-app"},
+            app=mock.MagicMock(app_code="test"),
+        )
+        result = resp.json()
+
+        assert resp.status_code == 200
+        assert len(result["data"]) == 1
+
+        permission_data = result["data"][0]["permission"]
+        assert permission_data["status"] == MCPServerPermissionStatusEnum.OWNED.value
+
+    def test_list_with_pending_apply_no_grant(self, request_view, fake_gateway, fake_stage):
+        """测试只有申请记录（待审批）且无实际权限的 mcp_server 状态为 PENDING"""
+        mcp_server = G(
+            MCPServer,
+            gateway=fake_gateway,
+            stage=fake_stage,
+            name="test-mcp-server-pending",
+            is_public=True,
+            status=MCPServerStatusEnum.ACTIVE.value,
+        )
+
+        # 创建待审批申请记录
+        G(
+            MCPServerAppPermissionApply,
+            bk_app_code="test-app",
+            mcp_server=mcp_server,
+            applied_by="test-user",
+            applied_time=timezone.now(),
+            status=MCPServerAppPermissionApplyStatusEnum.PENDING.value,
+        )
+
+        resp = request_view(
+            method="GET",
+            view_name="openapi.v2.inner.mcp_server.permission.list",
+            data={"target_app_code": "test-app"},
+            app=mock.MagicMock(app_code="test"),
+        )
+        result = resp.json()
+
+        assert resp.status_code == 200
+        assert len(result["data"]) == 1
+
+        permission_data = result["data"][0]["permission"]
+        assert permission_data["status"] == MCPServerPermissionStatusEnum.PENDING.value
+
+    def test_list_with_no_permission(self, request_view, fake_gateway, fake_stage):
+        """测试没有任何权限记录的 mcp_server 状态为 NEED_APPLY"""
+        G(
+            MCPServer,
+            gateway=fake_gateway,
+            stage=fake_stage,
+            name="test-mcp-server-no-permission",
+            is_public=True,
+            status=MCPServerStatusEnum.ACTIVE.value,
+        )
+
+        resp = request_view(
+            method="GET",
+            view_name="openapi.v2.inner.mcp_server.permission.list",
+            data={"target_app_code": "test-app"},
+            app=mock.MagicMock(app_code="test"),
+        )
+        result = resp.json()
+
+        assert resp.status_code == 200
+        assert len(result["data"]) == 1
+
+        permission_data = result["data"][0]["permission"]
+        assert permission_data["status"] == MCPServerPermissionStatusEnum.NEED_APPLY.value
+
+    def test_list_grant_overrides_apply_status(self, request_view, fake_gateway, fake_stage):
+        """测试主动授权（grant）优先级高于申请记录状态"""
+        mcp_server = G(
+            MCPServer,
+            gateway=fake_gateway,
+            stage=fake_stage,
+            name="test-mcp-server-grant-overrides",
+            is_public=True,
+            status=MCPServerStatusEnum.ACTIVE.value,
+        )
+
+        # 创建驳回的申请记录
+        G(
+            MCPServerAppPermissionApply,
+            bk_app_code="test-app",
+            mcp_server=mcp_server,
+            applied_by="test-user",
+            applied_time=timezone.now(),
+            status=MCPServerAppPermissionApplyStatusEnum.REJECTED.value,
+        )
+
+        # 创建主动授权记录（覆盖驳回状态）
+        G(
+            MCPServerAppPermission,
+            bk_app_code="test-app",
+            mcp_server=mcp_server,
+            grant_type=MCPServerAppPermissionGrantTypeEnum.GRANT.value,
+        )
+
+        resp = request_view(
+            method="GET",
+            view_name="openapi.v2.inner.mcp_server.permission.list",
+            data={"target_app_code": "test-app"},
+            app=mock.MagicMock(app_code="test"),
+        )
+        result = resp.json()
+
+        assert resp.status_code == 200
+        assert len(result["data"]) == 1
+
+        permission_data = result["data"][0]["permission"]
+        # 主动授权应该覆盖驳回状态
+        assert permission_data["status"] == MCPServerPermissionStatusEnum.OWNED.value
 
 
 class TestMCPServerAppPermissionApplyCreateApi:


### PR DESCRIPTION
## 修复内容

### 1. MCPServerPermissionListApi（权限列表查询）
- 修复返回某个应用有权限的 mcpserver 列表信息时，漏掉了主动授权（grant）的情况
- 现在会先查询 `MCPServerAppPermission` 表获取实际权限，对于已有实际权限的 mcp_server，状态覆盖为 `OWNED`
- 保持了原有申请记录查询逻辑，用于展示申请状态和处理人

### 2. MCPServerAppPermissionListApi（应用权限列表查询）
- 修复只查询申请通过记录导致主动授权（grant）的 mcp_server 无法被查询到的问题
- 现在查询 `MCPServerAppPermission` 表获取所有有权限的 mcp_server（包括主动授权和申请通过）
- 使用 `distinct` 避免重复记录

## 修复原因
之前两个 API 都只查询申请记录表，导致通过主动授权获得权限的应用被错误地显示为"待申请"状态或无法被查询到。

## 影响范围
- MCP Server 权限列表查询 API
- MCP Server 应用权限列表查询 API
- 不涉及前端代码修改