### PR TITLE
perf(gateway): optimize metrics stats presence checks

### DIFF
--- a/src/dashboard/apigateway/apigateway/apps/gateway/tasks.py
+++ b/src/dashboard/apigateway/apigateway/apps/gateway/tasks.py
@@ -94,8 +94,7 @@ class InactiveGatewayNotifier:
         if not released_gateway_ids:
             return []
 
-        end_time = timezone.now()
-        start_time = end_time - timedelta(days=OPERATION_STATUS_DELTA_DAYS)
+        start_time = timezone.now() - timedelta(days=OPERATION_STATUS_DELTA_DAYS)
 
         # filter out recently created gateways at DB level
         gateways = list(Gateway.objects.filter(id__in=released_gateway_ids, created_time__lte=start_time))
@@ -108,7 +107,6 @@ class InactiveGatewayNotifier:
             StatisticsGatewayRequestByDay.objects.filter(
                 gateway_id__in=to_check_ids,
                 start_time__gte=start_time,
-                end_time__lte=end_time,
             )
             .values_list("gateway_id", flat=True)
             .distinct()

--- a/src/dashboard/apigateway/apigateway/biz/gateway/gateway.py
+++ b/src/dashboard/apigateway/apigateway/biz/gateway/gateway.py
@@ -403,9 +403,8 @@ class GatewayHandler:
 
         operation_statuses: Dict[int, dict] = {}
 
-        # start_time and end_time are timezone aware, now - delta_days from module-level constant
-        end_time = timezone.now()
-        start_time = end_time - timedelta(days=OPERATION_STATUS_DELTA_DAYS)
+        # start_time is timezone aware, now - delta_days from module-level constant
+        start_time = timezone.now() - timedelta(days=OPERATION_STATUS_DELTA_DAYS)
 
         to_stats_gateway_ids = []
         for gateway in gateways:
@@ -446,8 +445,9 @@ class GatewayHandler:
 
         # query data and set the result to operation_statuses
         # just check existence, no need to calculate
-        queryset = StatisticsGatewayRequestByDay.objects.filter(gateway_id__in=to_stats_gateway_ids).filter(
-            start_time__gte=start_time, end_time__lte=end_time
+        queryset = StatisticsGatewayRequestByDay.objects.filter(
+            gateway_id__in=to_stats_gateway_ids,
+            start_time__gte=start_time,
         )
 
         has_data_gateway_ids = set(queryset.values_list("gateway_id", flat=True).distinct())

--- a/src/dashboard/apigateway/apigateway/controller/tasks/clean_task.py
+++ b/src/dashboard/apigateway/apigateway/controller/tasks/clean_task.py
@@ -182,7 +182,7 @@ def delete_old_stats_records():
     """
     logger.info("begin clean old stats records")
 
-    max_records_per_time = 10000
+    max_records_per_time = 100000
 
     delete_end_time = timezone.now() - relativedelta(years=5) - relativedelta(days=1)
 

--- a/src/dashboard/apigateway/apigateway/tests/apps/gateway/test_tasks.py
+++ b/src/dashboard/apigateway/apigateway/tests/apps/gateway/test_tasks.py
@@ -129,7 +129,7 @@ class TestInactiveGatewayNotifierGetInactiveGateways:
             resource_id=0,
             total_count=100,
             start_time=now - timedelta(days=10),
-            end_time=now - timedelta(days=9),
+            end_time=now + timedelta(days=1),
         )
         notifier = InactiveGatewayNotifier()
         result = notifier._get_inactive_gateways()

--- a/src/dashboard/apigateway/apigateway/tests/biz/gateway/test_gateway.py
+++ b/src/dashboard/apigateway/apigateway/tests/biz/gateway/test_gateway.py
@@ -15,19 +15,24 @@
 # We undertake not to change the open source license (MIT license) applicable
 # to the current version of the project delivered to anyone in the future.
 #
+from datetime import timedelta
+
 import pytest
 from django.core.exceptions import ObjectDoesNotExist
+from django.utils import timezone
 from django_dynamic_fixture import G
 
 from apigateway.apps.data_plane.constants import DataPlaneStatusEnum
 from apigateway.apps.data_plane.models import DataPlane, GatewayDataPlaneBinding
 from apigateway.apps.gateway.models import GatewayAppBinding
+from apigateway.apps.metrics.models import StatisticsGatewayRequestByDay
 from apigateway.apps.monitor.models import AlarmStrategy
 from apigateway.apps.support.models import ReleasedResourceDoc
-from apigateway.biz.gateway import GatewayHandler
+from apigateway.biz.gateway import OPERATION_STATUS_DELTA_DAYS, GatewayHandler
 from apigateway.core.constants import (
     ContextScopeTypeEnum,
     ContextTypeEnum,
+    GatewayOperationStatusEnum,
     GatewayStatusEnum,
     GatewayTypeEnum,
     StageStatusEnum,
@@ -111,6 +116,26 @@ class TestGatewayHandler:
         assert released.id in gateway_ids
         assert unreleased.id not in gateway_ids
         assert inactive.id not in gateway_ids
+
+    def test_get_operation_statuses_checks_recent_start_time_only(self):
+        now = timezone.now()
+        gateway = G(
+            Gateway,
+            status=GatewayStatusEnum.ACTIVE.value,
+            created_time=now - timedelta(days=OPERATION_STATUS_DELTA_DAYS + 1),
+        )
+        G(
+            StatisticsGatewayRequestByDay,
+            gateway_id=gateway.id,
+            start_time=now - timedelta(days=1),
+            end_time=now + timedelta(days=1),
+            stage_name="prod",
+            resource_id=1,
+        )
+
+        result = GatewayHandler.get_operation_statuses([gateway])
+
+        assert result[gateway.id]["status"] == GatewayOperationStatusEnum.ACTIVE.value
 
     @pytest.mark.parametrize(
         "user_conf, api_type, allow_update_api_auth, unfiltered_sensitive_keys, allow_auth_from_params, allow_delete_sensitive_params, expected",


### PR DESCRIPTION
## Summary
- use `gateway_id + start_time` for gateway operation-status traffic existence checks
- align inactive-gateway notification traffic detection with the same predicate
- increase old metrics cleanup batch size

## Verification
- `source .envrc && make lint`
- `source .envrc && make test`
