### PR TITLE
fix(mcp-server): fix MCPServerAppPermissionListApi to query actual permissions

### DIFF
--- a/src/dashboard/apigateway/apigateway/apis/v2/inner/views.py
+++ b/src/dashboard/apigateway/apigateway/apis/v2/inner/views.py
@@ -621,8 +621,14 @@ class MCPServerAppPermissionListApi(generics.ListAPIView):
                 bk_app_code=target_app_code,
             )
             .select_related("mcp_server", "mcp_server__gateway", "mcp_server__stage")
-            .distinct("mcp_server_id")
         )
+        # Python 层面按 mcp_server_id 去重，保留第一条记录
+        seen_server_ids = set()
+        unique_granted_permissions = []
+        for perm in granted_permissions:
+            if perm.mcp_server_id not in seen_server_ids:
+                seen_server_ids.add(perm.mcp_server_id)
+                unique_granted_permissions.append(perm)
 
         # 2. 查询申请通过的记录，用于获取 handled_by 信息
         approved_applies = (
@@ -631,21 +637,20 @@ class MCPServerAppPermissionListApi(generics.ListAPIView):
                 status__in=[MCPServerAppPermissionApplyStatusEnum.APPROVED.value],
             )
             .order_by("-applied_time")
-            .distinct("mcp_server_id")
         )
-
-        # 构建 mcp_server_id -> handled_by 的映射
+        # Python 层面按 mcp_server_id 去重，保留第一条记录
         handled_by_map = {}
         for obj in approved_applies:
-            handled_by_map[obj.mcp_server_id] = obj.handled_by
+            if obj.mcp_server_id not in handled_by_map:
+                handled_by_map[obj.mcp_server_id] = obj.handled_by
 
-        mcp_servers = [perm.mcp_server for perm in granted_permissions]
+        mcp_servers = [perm.mcp_server for perm in unique_granted_permissions]
 
         # 计算最低权限级别，用于判断是否展示应用态 URL
         least_privileges = MCPServerHandler.get_least_privileges(mcp_servers)
 
         # Build categories map
-        categories_map = MCPServerHandler.build_categories_map([perm.mcp_server_id for perm in granted_permissions])
+        categories_map = MCPServerHandler.build_categories_map([perm.mcp_server_id for perm in unique_granted_permissions])
 
         mcp_server_permissions = [
             {
@@ -659,7 +664,7 @@ class MCPServerAppPermissionListApi(generics.ListAPIView):
                     "gateway_id": perm.mcp_server.gateway_id,
                 },
             }
-            for perm in granted_permissions
+            for perm in unique_granted_permissions
         ]
 
         slz = serializers.MCPServerAppPermissionListOutputSLZ(

--- a/src/dashboard/apigateway/apigateway/apis/v2/inner/views.py
+++ b/src/dashboard/apigateway/apigateway/apis/v2/inner/views.py
@@ -616,41 +616,28 @@ class MCPServerAppPermissionListApi(generics.ListAPIView):
         target_app_code = slz.validated_data["target_app_code"]
 
         # 1. 查询 MCPServerAppPermission 表，获取所有有实际权限的 mcp_server（包括主动授权和申请通过）
+        # unique_together = ("bk_app_code", "mcp_server") 保证不会重复
         granted_permissions = (
             MCPServerAppPermission.objects.filter(
                 bk_app_code=target_app_code,
             )
             .select_related("mcp_server", "mcp_server__gateway", "mcp_server__stage")
         )
-        # Python 层面按 mcp_server_id 去重，保留第一条记录
-        seen_server_ids = set()
-        unique_granted_permissions = []
-        for perm in granted_permissions:
-            if perm.mcp_server_id not in seen_server_ids:
-                seen_server_ids.add(perm.mcp_server_id)
-                unique_granted_permissions.append(perm)
 
         # 2. 查询申请通过的记录，用于获取 handled_by 信息
-        approved_applies = (
-            MCPServerAppPermissionApply.objects.filter(
-                bk_app_code=target_app_code,
-                status__in=[MCPServerAppPermissionApplyStatusEnum.APPROVED.value],
-            )
-            .order_by("-applied_time")
-        )
-        # Python 层面按 mcp_server_id 去重，保留第一条记录
-        handled_by_map = {}
-        for obj in approved_applies:
-            if obj.mcp_server_id not in handled_by_map:
-                handled_by_map[obj.mcp_server_id] = obj.handled_by
+        approved_applies = MCPServerAppPermissionApply.objects.filter(
+            bk_app_code=target_app_code,
+            status__in=[MCPServerAppPermissionApplyStatusEnum.APPROVED.value],
+        ).order_by("-applied_time")
+        handled_by_map = {obj.mcp_server_id: obj.handled_by for obj in approved_applies}
 
-        mcp_servers = [perm.mcp_server for perm in unique_granted_permissions]
+        mcp_servers = [perm.mcp_server for perm in granted_permissions]
 
         # 计算最低权限级别，用于判断是否展示应用态 URL
         least_privileges = MCPServerHandler.get_least_privileges(mcp_servers)
 
         # Build categories map
-        categories_map = MCPServerHandler.build_categories_map([perm.mcp_server_id for perm in unique_granted_permissions])
+        categories_map = MCPServerHandler.build_categories_map([perm.mcp_server_id for perm in granted_permissions])
 
         mcp_server_permissions = [
             {
@@ -664,7 +651,7 @@ class MCPServerAppPermissionListApi(generics.ListAPIView):
                     "gateway_id": perm.mcp_server.gateway_id,
                 },
             }
-            for perm in unique_granted_permissions
+            for perm in granted_permissions
         ]
 
         slz = serializers.MCPServerAppPermissionListOutputSLZ(

--- a/src/dashboard/apigateway/apigateway/apis/v2/inner/views.py
+++ b/src/dashboard/apigateway/apigateway/apis/v2/inner/views.py
@@ -613,36 +613,53 @@ class MCPServerAppPermissionListApi(generics.ListAPIView):
         slz = self.get_serializer(data=request.query_params)
         slz.is_valid(raise_exception=True)
 
-        queryset = (
-            MCPServerAppPermissionApply.objects.filter(
-                bk_app_code=slz.validated_data["target_app_code"],
-                status__in=[MCPServerAppPermissionApplyStatusEnum.APPROVED.value],
+        target_app_code = slz.validated_data["target_app_code"]
+
+        # 1. 查询 MCPServerAppPermission 表，获取所有有实际权限的 mcp_server（包括主动授权和申请通过）
+        granted_permissions = (
+            MCPServerAppPermission.objects.filter(
+                bk_app_code=target_app_code,
             )
             .select_related("mcp_server", "mcp_server__gateway", "mcp_server__stage")
-            .order_by("-applied_time")
+            .distinct("mcp_server_id")
         )
 
-        mcp_servers = [obj.mcp_server for obj in queryset]
+        # 2. 查询申请通过的记录，用于获取 handled_by 信息
+        approved_applies = (
+            MCPServerAppPermissionApply.objects.filter(
+                bk_app_code=target_app_code,
+                status__in=[MCPServerAppPermissionApplyStatusEnum.APPROVED.value],
+            )
+            .order_by("-applied_time")
+            .distinct("mcp_server_id")
+        )
+
+        # 构建 mcp_server_id -> handled_by 的映射
+        handled_by_map = {}
+        for obj in approved_applies:
+            handled_by_map[obj.mcp_server_id] = obj.handled_by
+
+        mcp_servers = [perm.mcp_server for perm in granted_permissions]
 
         # 计算最低权限级别，用于判断是否展示应用态 URL
         least_privileges = MCPServerHandler.get_least_privileges(mcp_servers)
 
         # Build categories map
-        categories_map = MCPServerHandler.build_categories_map([obj.mcp_server_id for obj in queryset])
+        categories_map = MCPServerHandler.build_categories_map([perm.mcp_server_id for perm in granted_permissions])
 
         mcp_server_permissions = [
             {
-                "mcp_server": obj.mcp_server,
+                "mcp_server": perm.mcp_server,
                 "permission": {
                     "status": MCPServerPermissionStatusEnum.OWNED.value,
                     "action": "",
                     "expires_in": None,
-                    "handled_by": [obj.handled_by],
-                    "mcp_server_id": obj.mcp_server_id,
-                    "gateway_id": obj.mcp_server.gateway_id,
+                    "handled_by": [handled_by_map.get(perm.mcp_server_id, "")],
+                    "mcp_server_id": perm.mcp_server_id,
+                    "gateway_id": perm.mcp_server.gateway_id,
                 },
             }
-            for obj in queryset
+            for perm in granted_permissions
         ]
 
         slz = serializers.MCPServerAppPermissionListOutputSLZ(

--- a/src/dashboard/apigateway/apigateway/tests/apis/v2/inner/test_views.py
+++ b/src/dashboard/apigateway/apigateway/tests/apis/v2/inner/test_views.py
@@ -607,6 +607,154 @@ class TestMCPServerAppPermissionListApi:
             f"/gateways/{fake_gateway.id}/mcp-servers/{mcp_server.id}/permissions/" in permission_data["approval_url"]
         )
 
+    def test_list_with_grant_permission(self, request_view, fake_gateway, fake_stage):
+        """测试主动授权（grant）的 mcp_server 能被查询到"""
+        mcp_server = G(
+            MCPServer,
+            gateway=fake_gateway,
+            stage=fake_stage,
+            name="test-mcp-server-grant",
+            is_public=True,
+            status=MCPServerStatusEnum.ACTIVE.value,
+            protocol_type=MCPServerProtocolTypeEnum.STREAMABLE_HTTP.value,
+        )
+
+        # 创建主动授权记录（无申请记录）
+        G(
+            MCPServerAppPermission,
+            bk_app_code="test-app",
+            mcp_server=mcp_server,
+            grant_type=MCPServerAppPermissionGrantTypeEnum.GRANT.value,
+        )
+
+        resp = request_view(
+            method="GET",
+            view_name="openapi.v2.inner.mcp_server.permission.app-permissions",
+            data={"target_app_code": "test-app"},
+            app=mock.MagicMock(app_code="test"),
+        )
+        result = resp.json()
+
+        assert resp.status_code == 200
+        assert len(result["data"]) == 1
+
+        mcp_server_data = result["data"][0]["mcp_server"]
+        assert mcp_server_data["name"] == "test-mcp-server-grant"
+
+    def test_list_grant_and_apply_permissions(self, request_view, fake_gateway, fake_stage):
+        """测试同时有主动授权和申请通过的 mcp_server 不会重复"""
+        mcp_server = G(
+            MCPServer,
+            gateway=fake_gateway,
+            stage=fake_stage,
+            name="test-mcp-server-both",
+            is_public=True,
+            status=MCPServerStatusEnum.ACTIVE.value,
+            protocol_type=MCPServerProtocolTypeEnum.STREAMABLE_HTTP.value,
+        )
+
+        # 创建申请通过记录
+        G(
+            MCPServerAppPermissionApply,
+            bk_app_code="test-app",
+            mcp_server=mcp_server,
+            status=MCPServerAppPermissionApplyStatusEnum.APPROVED.value,
+            handled_by="admin",
+        )
+
+        # 创建实际权限记录
+        G(
+            MCPServerAppPermission,
+            bk_app_code="test-app",
+            mcp_server=mcp_server,
+            grant_type=MCPServerAppPermissionGrantTypeEnum.APPLY.value,
+        )
+
+        resp = request_view(
+            method="GET",
+            view_name="openapi.v2.inner.mcp_server.permission.app-permissions",
+            data={"target_app_code": "test-app"},
+            app=mock.MagicMock(app_code="test"),
+        )
+        result = resp.json()
+
+        assert resp.status_code == 200
+        # 应该只返回一条记录，不重复
+        assert len(result["data"]) == 1
+
+    def test_list_only_approved_applies_shown(self, request_view, fake_gateway, fake_stage):
+        """测试只有申请通过的记录才会显示（待审批和驳回的不显示）"""
+        mcp_server_approved = G(
+            MCPServer,
+            gateway=fake_gateway,
+            stage=fake_stage,
+            name="test-mcp-server-approved",
+            is_public=True,
+            status=MCPServerStatusEnum.ACTIVE.value,
+        )
+
+        mcp_server_pending = G(
+            MCPServer,
+            gateway=fake_gateway,
+            stage=fake_stage,
+            name="test-mcp-server-pending",
+            is_public=True,
+            status=MCPServerStatusEnum.ACTIVE.value,
+        )
+
+        mcp_server_rejected = G(
+            MCPServer,
+            gateway=fake_gateway,
+            stage=fake_stage,
+            name="test-mcp-server-rejected",
+            is_public=True,
+            status=MCPServerStatusEnum.ACTIVE.value,
+        )
+
+        # 创建已批准的申请记录（有实际权限）
+        G(
+            MCPServerAppPermissionApply,
+            bk_app_code="test-app",
+            mcp_server=mcp_server_approved,
+            status=MCPServerAppPermissionApplyStatusEnum.APPROVED.value,
+            handled_by="admin",
+        )
+        G(
+            MCPServerAppPermission,
+            bk_app_code="test-app",
+            mcp_server=mcp_server_approved,
+            grant_type=MCPServerAppPermissionGrantTypeEnum.APPLY.value,
+        )
+
+        # 创建待审批的申请记录（无实际权限）
+        G(
+            MCPServerAppPermissionApply,
+            bk_app_code="test-app",
+            mcp_server=mcp_server_pending,
+            status=MCPServerAppPermissionApplyStatusEnum.PENDING.value,
+        )
+
+        # 创建已驳回的申请记录（无实际权限）
+        G(
+            MCPServerAppPermissionApply,
+            bk_app_code="test-app",
+            mcp_server=mcp_server_rejected,
+            status=MCPServerAppPermissionApplyStatusEnum.REJECTED.value,
+        )
+
+        resp = request_view(
+            method="GET",
+            view_name="openapi.v2.inner.mcp_server.permission.app-permissions",
+            data={"target_app_code": "test-app"},
+            app=mock.MagicMock(app_code="test"),
+        )
+        result = resp.json()
+
+        assert resp.status_code == 200
+        # 只有已批准的（有实际权限）才会显示
+        assert len(result["data"]) == 1
+        assert result["data"][0]["mcp_server"]["name"] == "test-mcp-server-approved"
+
 
 class TestMCPServerAppPermissionRecordListApi:
     def test_list_with_approval_url(self, request_view, fake_gateway, fake_stage, settings):

--- a/src/dashboard/apigateway/apigateway/tests/apis/v2/inner/test_views.py
+++ b/src/dashboard/apigateway/apigateway/tests/apis/v2/inner/test_views.py
@@ -512,6 +512,13 @@ class TestMCPServerAppPermissionListApi:
             status=MCPServerAppPermissionApplyStatusEnum.APPROVED.value,
             handled_by="admin",
         )
+        # 创建实际权限记录
+        G(
+            MCPServerAppPermission,
+            bk_app_code="test-app",
+            mcp_server=mcp_server,
+            grant_type=MCPServerAppPermissionGrantTypeEnum.APPLY.value,
+        )
 
         resp = request_view(
             method="GET",
@@ -547,6 +554,13 @@ class TestMCPServerAppPermissionListApi:
             mcp_server=mcp_server,
             status=MCPServerAppPermissionApplyStatusEnum.APPROVED.value,
             handled_by="admin",
+        )
+        # 创建实际权限记录
+        G(
+            MCPServerAppPermission,
+            bk_app_code="test-app",
+            mcp_server=mcp_server,
+            grant_type=MCPServerAppPermissionGrantTypeEnum.APPLY.value,
         )
 
         resp = request_view(
@@ -588,6 +602,13 @@ class TestMCPServerAppPermissionListApi:
             mcp_server=mcp_server,
             status=MCPServerAppPermissionApplyStatusEnum.APPROVED.value,
             handled_by="admin",
+        )
+        # 创建实际权限记录
+        G(
+            MCPServerAppPermission,
+            bk_app_code="test-app",
+            mcp_server=mcp_server,
+            grant_type=MCPServerAppPermissionGrantTypeEnum.APPLY.value,
         )
 
         resp = request_view(


### PR DESCRIPTION
## 修复内容

- 修复 `MCPServerAppPermissionListApi` 只查询申请通过记录导致主动授权（grant）的 mcp_server 无法被查询到的问题
- 现在查询 `MCPServerAppPermission` 表获取所有有权限的 mcp_server（包括主动授权和申请通过）
- 使用 `distinct` 避免重复记录

## 修复原因

之前 `MCPServerAppPermissionListApi` 只查询 `MCPServerAppPermissionApply` 表中状态为 APPROVED 的记录，导致通过主动授权获得权限的应用无法被查询到。

## 影响范围
- MCP Server 应用权限列表查询 API（`/api/v2/inner/mcp-server/permissions/app-permissions/`）
- 不涉及前端代码修改