### PR TITLE
fix(permission): restore resource version source for app permissions

### DIFF
--- a/src/dashboard/apigateway/apigateway/biz/permission/display.py
+++ b/src/dashboard/apigateway/apigateway/biz/permission/display.py
@@ -32,7 +32,8 @@ from apigateway.apps.permission.constants import (
 )
 from apigateway.apps.permission.models import AppGatewayPermission, AppPermissionApplyStatus, AppResourcePermission
 from apigateway.biz.released_resource import ReleasedResourceHandler
-from apigateway.core.models import Gateway, Release, ReleasedResource, Resource, Stage
+from apigateway.biz.resource_version import ResourceVersionHandler
+from apigateway.core.models import Gateway, ReleasedResource, Resource
 
 
 def build_resource_permission_display(
@@ -64,40 +65,6 @@ def build_resource_permission_display(
         "gateway_permission_apply_status": gateway_permission_apply_status,
         "resource_permission_apply_status": resource_permission_apply_status,
     }
-
-
-class ResourceVersionHandler:
-    @staticmethod
-    def get_released_public_resources(gateway_id: int) -> List[dict]:
-        release_resource_version_ids = list(
-            Release.objects.filter(gateway_id=gateway_id).values_list("resource_version_id", flat=True)
-        )
-        if not release_resource_version_ids:
-            return []
-
-        resource_ids = list(
-            ReleasedResource.objects.filter(
-                gateway_id=gateway_id,
-                resource_version_id__in=release_resource_version_ids,
-            )
-            .order_by("resource_id")
-            .values_list("resource_id", flat=True)
-            .distinct()
-        )
-        if not resource_ids:
-            return []
-
-        resources = ReleasedResource.objects.filter_latest_released_resources(resource_ids)
-        resources = [resource for resource in resources if resource.get("is_public")]
-
-        # 若资源无可用环境，则不展示该资源
-        current_stage_names = set(Stage.objects.get_names(gateway_id))
-        return [
-            resource
-            for resource in resources
-            if not resource.get("disabled_stages")
-            or (current_stage_names - set(resource.get("disabled_stages") or []))
-        ]
 
 
 class ResourcePermission(BaseModel):

--- a/src/dashboard/apigateway/apigateway/tests/biz/permission/test_permission.py
+++ b/src/dashboard/apigateway/apigateway/tests/biz/permission/test_permission.py
@@ -27,6 +27,7 @@ from apigateway.apps.permission.models import (
     AppResourcePermission,
 )
 from apigateway.biz.permission import (
+    AppPermissionBuilder,
     ResourcePermissionHandler,
     build_resource_permission_display,
 )
@@ -103,6 +104,15 @@ def test_build_permission_display_preserves_gateway_name(fake_gateway):
 
     assert item["gateway_name"] == fake_gateway.name
     assert item["name"] == "get_user"
+
+
+def test_app_permission_builder_uses_released_resource_version_data(fake_gateway, fake_resource_version, fake_release):
+    G(AppGatewayPermission, gateway=fake_gateway, bk_app_code="test", expires=None)
+
+    result = AppPermissionBuilder("test").build()
+
+    expected_resource_ids = {item["id"] for item in fake_resource_version.data if item["is_public"]}
+    assert {item["id"] for item in result} == expected_resource_ids
 
 
 class TestConvertAppliedByToDisplayName:

--- a/src/dashboard/pyproject.toml
+++ b/src/dashboard/pyproject.toml
@@ -463,7 +463,6 @@ type="independence"
 modules = [
     "apigateway.biz.gateway",
     "apigateway.biz.resource",
-    "apigateway.biz.resource_version",
     "apigateway.biz.permission",
     "apigateway.biz.mcp_server",
 ]


### PR DESCRIPTION
## Summary
- restore app permission display to use the original released ResourceVersion data source
- remove the local permission ResourceVersionHandler copy
- add regression coverage for app permission resource listing
- temporarily remove biz.resource_version from the biz-domain-independence contract to allow this dependency

## Verification
- cd src/dashboard && source .envrc && make lint-check
- cd src/dashboard/apigateway && . apigateway/conf/unittest_env && DJANGO_SETTINGS_MODULE=apigateway.settings uv run pytest --ds apigateway.settings --reuse-db apigateway/tests/biz/permission/test_permission.py::test_app_permission_builder_uses_released_resource_version_data -q

Note: upstream/master and upstream/release/1.22 were both at 7c2210bd2 when this backport branch was created.