### PR TITLE
feat: support sorting MCPServer app permissions by effective time

### DIFF
--- a/src/dashboard/apigateway/apigateway/apis/web/mcp_server/serializers.py
+++ b/src/dashboard/apigateway/apigateway/apis/web/mcp_server/serializers.py
@@ -939,6 +939,16 @@ class GatewayMCPServerAppPermissionListInputSLZ(serializers.Serializer):
         default="",
         help_text="授权类型",
     )
+    order_by = serializers.ChoiceField(
+        choices=[
+            ("effective_time", "按生效时间排序"),
+            ("-effective_time", "按生效时间倒序"),
+        ],
+        required=False,
+        allow_blank=True,
+        default="",
+        help_text="排序方式",
+    )
 
     class Meta:
         ref_name = "apigateway.apis.web.mcp_server.serializers.GatewayMCPServerAppPermissionListInputSLZ"

--- a/src/dashboard/apigateway/apigateway/apis/web/mcp_server/views.py
+++ b/src/dashboard/apigateway/apigateway/apis/web/mcp_server/views.py
@@ -21,7 +21,8 @@ import csv
 from io import StringIO
 
 from django.db import transaction
-from django.db.models import Q
+from django.db.models import Case, DateTimeField, F, OuterRef, Q, Subquery, When
+from django.db.models.functions import Coalesce
 from django.utils.decorators import method_decorator
 from django.utils.translation import gettext as _
 from drf_yasg.utils import swagger_auto_schema
@@ -1106,6 +1107,35 @@ def _filter_gateway_app_permissions(queryset, data):
     return queryset
 
 
+def _order_gateway_app_permissions(queryset, order_by):
+    """网关级 MCPServer 应用权限排序"""
+    if order_by not in ["effective_time", "-effective_time"]:
+        return queryset.order_by("mcp_server__name", "bk_app_code")
+
+    approved_apply_handled_time = MCPServerAppPermissionApply.objects.filter(
+        mcp_server_id=OuterRef("mcp_server_id"),
+        bk_app_code=OuterRef("bk_app_code"),
+        status=MCPServerAppPermissionApplyStatusEnum.APPROVED.value,
+        is_deleted=False,
+    ).order_by("-handled_time", "-id")
+
+    queryset = queryset.annotate(
+        _effective_time=Case(
+            When(
+                grant_type=MCPServerAppPermissionGrantTypeEnum.APPLY.value,
+                then=Coalesce(
+                    Subquery(approved_apply_handled_time.values("handled_time")[:1]),
+                    F("created_time"),
+                ),
+            ),
+            default=F("created_time"),
+            output_field=DateTimeField(),
+        )
+    )
+    order_field = "_effective_time" if order_by == "effective_time" else "-_effective_time"
+    return queryset.order_by(order_field, "mcp_server__name", "bk_app_code")
+
+
 @method_decorator(
     name="get",
     decorator=swagger_auto_schema(
@@ -1125,7 +1155,7 @@ class GatewayMCPServerAppPermissionListApi(generics.ListAPIView):
         )
 
         queryset = _filter_gateway_app_permissions(queryset, slz.validated_data)
-        queryset = queryset.order_by("mcp_server__name", "bk_app_code")
+        queryset = _order_gateway_app_permissions(queryset, slz.validated_data.get("order_by"))
         page = self.paginate_queryset(queryset)
 
         slz = GatewayMCPServerAppPermissionListOutputSLZ(

--- a/src/dashboard/apigateway/apigateway/tests/apis/web/mcp_server/test_views.py
+++ b/src/dashboard/apigateway/apigateway/tests/apis/web/mcp_server/test_views.py
@@ -3392,6 +3392,59 @@ class TestGatewayMCPServerAppPermissionListApi:
         result = resp.json()
         assert result["data"]["count"] == 2
 
+    def test_list_order_by_effective_time(self, request_view, fake_gateway, fake_mcp_server):
+        base_time = now_datetime()
+        grant_permission = G(
+            MCPServerAppPermission,
+            mcp_server=fake_mcp_server,
+            bk_app_code="grant-app",
+            grant_type=MCPServerAppPermissionGrantTypeEnum.GRANT.value,
+        )
+        apply_permission = G(
+            MCPServerAppPermission,
+            mcp_server=fake_mcp_server,
+            bk_app_code="apply-app",
+            grant_type=MCPServerAppPermissionGrantTypeEnum.APPLY.value,
+        )
+        MCPServerAppPermission.objects.filter(id=grant_permission.id).update(
+            created_time=base_time - datetime.timedelta(days=2)
+        )
+        MCPServerAppPermission.objects.filter(id=apply_permission.id).update(
+            created_time=base_time - datetime.timedelta(days=3)
+        )
+        G(
+            MCPServerAppPermissionApply,
+            mcp_server=fake_mcp_server,
+            bk_app_code="apply-app",
+            applied_by="admin",
+            applied_time=base_time - datetime.timedelta(days=4),
+            handled_by="admin",
+            handled_time=base_time - datetime.timedelta(days=1),
+            status=MCPServerAppPermissionApplyStatusEnum.APPROVED.value,
+        )
+
+        resp = request_view(
+            method="GET",
+            view_name="mcp_server.gateway_app_permission.list",
+            path_params={"gateway_id": fake_gateway.id},
+            gateway=fake_gateway,
+            data={"order_by": "effective_time"},
+        )
+        assert resp.status_code == 200
+        result = resp.json()
+        assert [item["bk_app_code"] for item in result["data"]["results"]] == ["grant-app", "apply-app"]
+
+        resp = request_view(
+            method="GET",
+            view_name="mcp_server.gateway_app_permission.list",
+            path_params={"gateway_id": fake_gateway.id},
+            gateway=fake_gateway,
+            data={"order_by": "-effective_time"},
+        )
+        assert resp.status_code == 200
+        result = resp.json()
+        assert [item["bk_app_code"] for item in result["data"]["results"]] == ["apply-app", "grant-app"]
+
     def test_list_filter_by_mcp_server_id(self, request_view, fake_gateway, fake_mcp_server, fake_stage, faker):
         another_mcp = G(
             MCPServer,


### PR DESCRIPTION
## Summary
- Add `order_by` support for `effective_time` and `-effective_time` in `GatewayMCPServerAppPermissionListApi`.
- Sort application-based permissions by approved apply record `handled_time`, falling back to permission `created_time`.
- Keep the original default sorting when effective time sorting is not requested.
- Add tests for ascending and descending effective time sorting.

## Test
- `apigateway/tests/apis/web/mcp_server/test_views.py::TestGatewayMCPServerAppPermissionListApi` passed.
