### PR TITLE
fix(mcp): preserve OpenAPI request body schemas

### DIFF
--- a/src/mcp-proxy/pkg/infra/logging/desensitize.go
+++ b/src/mcp-proxy/pkg/infra/logging/desensitize.go
@@ -20,7 +20,7 @@
 package logging
 
 import (
-	"fmt"
+	"strconv"
 	"strings"
 
 	"github.com/tidwall/gjson"
@@ -71,7 +71,7 @@ func (r *Desensitize) Write(entry zapcore.Entry, fields []zapcore.Field) error {
 				for index, value := range result.Array() {
 					fileValue := value.String()
 					maskValue := getSensitiveFieldMaskValue(fileValue)
-					indexJsonPath := strings.ReplaceAll(jsonPath, "#", fmt.Sprintf("%d", index))
+					indexJsonPath := strings.ReplaceAll(jsonPath, "#", strconv.Itoa(index))
 					fields[i].String, _ = sjson.Set(fields[i].String, indexJsonPath, maskValue)
 				}
 			}

--- a/src/mcp-proxy/pkg/infra/proxy/converter.go
+++ b/src/mcp-proxy/pkg/infra/proxy/converter.go
@@ -31,20 +31,38 @@ const bodyParamDefaultDescription = "HTTP request body in JSON format, " +
 
 func openapiSchemaRefToJSONSchema(schemaRef *openapi3.SchemaRef) jsonschema.Schema {
 	var jsonSchema jsonschema.Schema
-	if schemaRef == nil {
+	schemaJSON, err := marshalOpenAPISchemaRefJSON(schemaRef)
+	if err != nil || len(schemaJSON) == 0 {
 		return jsonSchema
 	}
 
-	schemaJSON, err := schemaRef.MarshalJSON()
-	if err != nil {
-		return jsonSchema
-	}
 	schemaJSON = normalizeOpenAPIJSONSchema(schemaJSON)
 	if err := json.Unmarshal(schemaJSON, &jsonSchema); err != nil {
-		var rawSchema map[string]any
-		if err := json.Unmarshal(schemaJSON, &rawSchema); err == nil {
-			jsonSchema.ExtraProperties = rawSchema
-		}
+		return fallbackOpenAPIJSONSchema(schemaJSON)
+	}
+	return jsonSchema
+}
+
+func marshalOpenAPISchemaRefJSON(schemaRef *openapi3.SchemaRef) ([]byte, error) {
+	if schemaRef == nil {
+		return nil, nil
+	}
+	if schemaRef.Value != nil {
+		return schemaRef.Value.MarshalJSON()
+	}
+	return schemaRef.MarshalJSON()
+}
+
+func fallbackOpenAPIJSONSchema(schemaJSON []byte) jsonschema.Schema {
+	var rawSchema map[string]any
+	if err := json.Unmarshal(schemaJSON, &rawSchema); err != nil {
+		return jsonschema.Schema{}
+	}
+
+	jsonSchema := jsonschema.Schema{ExtraProperties: rawSchema}
+	if description, ok := rawSchema["description"].(string); ok && description != "" {
+		jsonSchema.Description = &description
+		delete(rawSchema, "description")
 	}
 	return jsonSchema
 }
@@ -90,11 +108,8 @@ func normalizeOpenAPIJSONSchemaObject(schema map[string]any) {
 
 	for _, key := range []string{
 		"items", "additionalProperties", "additionalItems", "contains", "propertyNames", "if", "then", "else", "not",
+		"allOf", "anyOf", "oneOf",
 	} {
-		normalizeOpenAPIJSONSchemaValue(schema[key])
-	}
-
-	for _, key := range []string{"allOf", "anyOf", "oneOf"} {
 		normalizeOpenAPIJSONSchemaValue(schema[key])
 	}
 
@@ -126,11 +141,7 @@ func normalizeOpenAPIExclusiveBound(schema map[string]any, exclusiveKey, boundKe
 }
 
 func jsonSchemaDescriptionIsEmpty(schema *jsonschema.Schema) bool {
-	if schema.Description != nil && *schema.Description != "" {
-		return false
-	}
-	description, ok := schema.ExtraProperties["description"].(string)
-	return !ok || description == ""
+	return schema.Description == nil || *schema.Description == ""
 }
 
 // OpenapiToMcpToolConfig ...
@@ -211,9 +222,6 @@ func OpenapiToMcpToolConfig(
 								jsonSchema.ExtraProperties = map[string]any{}
 							}
 							jsonSchema.ExtraProperties["example"] = param.Value.Example
-						}
-						if param.Value.Required {
-							jsonSchema.Required = []string{param.Value.Name}
 						}
 						if param.Value.In == "header" {
 							headerParamSchema.WithPropertiesItem(

--- a/src/mcp-proxy/pkg/infra/proxy/converter.go
+++ b/src/mcp-proxy/pkg/infra/proxy/converter.go
@@ -26,6 +26,113 @@ import (
 	jsonschema "github.com/swaggest/jsonschema-go"
 )
 
+const bodyParamDefaultDescription = "HTTP request body in JSON format, " +
+	"containing the main data payload for the API request."
+
+func openapiSchemaRefToJSONSchema(schemaRef *openapi3.SchemaRef) jsonschema.Schema {
+	var jsonSchema jsonschema.Schema
+	if schemaRef == nil {
+		return jsonSchema
+	}
+
+	schemaJSON, err := schemaRef.MarshalJSON()
+	if err != nil {
+		return jsonSchema
+	}
+	schemaJSON = normalizeOpenAPIJSONSchema(schemaJSON)
+	if err := json.Unmarshal(schemaJSON, &jsonSchema); err != nil {
+		var rawSchema map[string]any
+		if err := json.Unmarshal(schemaJSON, &rawSchema); err == nil {
+			jsonSchema.ExtraProperties = rawSchema
+		}
+	}
+	return jsonSchema
+}
+
+func normalizeOpenAPIJSONSchema(schemaJSON []byte) []byte {
+	var schema any
+	if err := json.Unmarshal(schemaJSON, &schema); err != nil {
+		return schemaJSON
+	}
+	normalizeOpenAPIJSONSchemaValue(schema)
+
+	normalizedJSON, err := json.Marshal(schema)
+	if err != nil {
+		return schemaJSON
+	}
+	return normalizedJSON
+}
+
+func normalizeOpenAPIJSONSchemaValue(schema any) {
+	switch value := schema.(type) {
+	case map[string]any:
+		normalizeOpenAPIJSONSchemaObject(value)
+	case []any:
+		for _, item := range value {
+			normalizeOpenAPIJSONSchemaValue(item)
+		}
+	}
+}
+
+func normalizeOpenAPIJSONSchemaObject(schema map[string]any) {
+	normalizeOpenAPIExclusiveBound(schema, "exclusiveMinimum", "minimum")
+	normalizeOpenAPIExclusiveBound(schema, "exclusiveMaximum", "maximum")
+
+	for _, key := range []string{"properties", "patternProperties", "definitions", "$defs", "dependentSchemas"} {
+		childSchemas, ok := schema[key].(map[string]any)
+		if !ok {
+			continue
+		}
+		for _, childSchema := range childSchemas {
+			normalizeOpenAPIJSONSchemaValue(childSchema)
+		}
+	}
+
+	for _, key := range []string{
+		"items", "additionalProperties", "additionalItems", "contains", "propertyNames", "if", "then", "else", "not",
+	} {
+		normalizeOpenAPIJSONSchemaValue(schema[key])
+	}
+
+	for _, key := range []string{"allOf", "anyOf", "oneOf"} {
+		normalizeOpenAPIJSONSchemaValue(schema[key])
+	}
+
+	dependencies, ok := schema["dependencies"].(map[string]any)
+	if !ok {
+		return
+	}
+	for _, dependency := range dependencies {
+		normalizeOpenAPIJSONSchemaValue(dependency)
+	}
+}
+
+func normalizeOpenAPIExclusiveBound(schema map[string]any, exclusiveKey, boundKey string) {
+	exclusive, ok := schema[exclusiveKey].(bool)
+	if !ok {
+		return
+	}
+	if !exclusive {
+		delete(schema, exclusiveKey)
+		return
+	}
+
+	bound, ok := schema[boundKey]
+	if !ok {
+		delete(schema, exclusiveKey)
+		return
+	}
+	schema[exclusiveKey] = bound
+}
+
+func jsonSchemaDescriptionIsEmpty(schema *jsonschema.Schema) bool {
+	if schema.Description != nil && *schema.Description != "" {
+		return false
+	}
+	description, ok := schema.ExtraProperties["description"].(string)
+	return !ok || description == ""
+}
+
 // OpenapiToMcpToolConfig ...
 // nolint:gocyclo
 // This function takes an OpenAPI specification and a map of operation IDs and returns a slice of ToolConfig structs.
@@ -95,15 +202,19 @@ func OpenapiToMcpToolConfig(
 				}
 				for _, param := range operation.Parameters {
 					if param.Value.Schema != nil {
-						schema := param.Value.Schema.Value
-						schema.Description = param.Value.Description
-						schema.Example = param.Value.Example
-						if param.Value.Required {
-							schema.Required = []string{param.Value.Name}
+						jsonSchema := openapiSchemaRefToJSONSchema(param.Value.Schema)
+						if param.Value.Description != "" {
+							jsonSchema.Description = &param.Value.Description
 						}
-						marshalJSON, _ := schema.MarshalJSON()
-						var jsonSchema jsonschema.Schema
-						_ = jsonSchema.UnmarshalJSON(marshalJSON)
+						if param.Value.Example != nil {
+							if jsonSchema.ExtraProperties == nil {
+								jsonSchema.ExtraProperties = map[string]any{}
+							}
+							jsonSchema.ExtraProperties["example"] = param.Value.Example
+						}
+						if param.Value.Required {
+							jsonSchema.Required = []string{param.Value.Name}
+						}
 						if param.Value.In == "header" {
 							headerParamSchema.WithPropertiesItem(
 								param.Value.Name,
@@ -181,18 +292,17 @@ func OpenapiToMcpToolConfig(
 			if operation.RequestBody != nil && operation.RequestBody.Value != nil {
 				if content, ok := operation.RequestBody.Value.Content["application/json"]; ok &&
 					content != nil {
-					schema := content.Schema
-					marshalJSON, _ := schema.MarshalJSON()
-					var jsonSchema jsonschema.Schema
-					_ = json.Unmarshal(marshalJSON, &jsonSchema)
-					// Add description if not already set
-					if jsonSchema.Description == nil || *jsonSchema.Description == "" {
-						bodyParamDesc := "HTTP request body in JSON format, containing the main data payload for the API request."
+					jsonSchema := openapiSchemaRefToJSONSchema(content.Schema)
+					if jsonSchemaDescriptionIsEmpty(&jsonSchema) {
+						bodyParamDesc := bodyParamDefaultDescription
 						jsonSchema.Description = &bodyParamDesc
 					}
 					paramSchema.WithPropertiesItem("body_param", jsonschema.SchemaOrBool{
 						TypeObject: &jsonSchema,
 					})
+					if operation.RequestBody.Value.Required {
+						paramSchema.Required = append(paramSchema.Required, "body_param")
+					}
 				}
 			}
 

--- a/src/mcp-proxy/pkg/infra/proxy/converter_test.go
+++ b/src/mcp-proxy/pkg/infra/proxy/converter_test.go
@@ -26,6 +26,15 @@ import (
 	. "github.com/onsi/gomega"
 )
 
+func buildInputSchemaForTest(tool *ToolConfig) map[string]any {
+	schemaBytes, err := tool.ParamSchema.JSONSchemaBytes()
+	Expect(err).NotTo(HaveOccurred())
+
+	var inputSchema map[string]any
+	Expect(json.Unmarshal(schemaBytes, &inputSchema)).To(Succeed())
+	return inputSchema
+}
+
 var _ = Describe("Converter", func() {
 	Describe("OpenapiToMcpToolConfig", func() {
 		It("should return empty slice for empty paths", func() {
@@ -191,6 +200,12 @@ var _ = Describe("Converter", func() {
 			Expect(result).To(HaveLen(1))
 			Expect(result[0].ParamSchema.Properties).To(HaveKey("query_param"))
 			Expect(result[0].ParamSchema.Required).To(ContainElement("query_param"))
+
+			inputSchema := buildInputSchemaForTest(result[0])
+			queryParam := inputSchema["properties"].(map[string]any)["query_param"].(map[string]any)
+			limit := queryParam["properties"].(map[string]any)["limit"].(map[string]any)
+			Expect(queryParam["required"]).To(ContainElement("limit"))
+			Expect(limit).NotTo(HaveKey("required"))
 		})
 
 		It("should handle path parameters", func() {
@@ -405,6 +420,159 @@ var _ = Describe("Converter", func() {
 			Expect(raiseBudget).To(HaveKeyWithValue("type", "number"))
 			Expect(raiseBudget).To(HaveKeyWithValue("minimum", float64(0)))
 			Expect(raiseBudget).To(HaveKeyWithValue("exclusiveMinimum", float64(0)))
+		})
+
+		It("should preserve request body schema with OpenAPI exclusive maximum", func() {
+			maximum := float64(100)
+			spec := &openapi3.T{
+				OpenAPI: "3.0.0",
+				Info:    &openapi3.Info{Title: "Test API", Version: "1.0.0"},
+				Servers: []*openapi3.Server{{URL: "https://api.example.com/v1"}},
+				Paths:   &openapi3.Paths{},
+			}
+
+			pathItem := &openapi3.PathItem{
+				Post: &openapi3.Operation{
+					OperationID: "updateDiscount",
+					Summary:     "Update discount",
+					RequestBody: &openapi3.RequestBodyRef{
+						Value: &openapi3.RequestBody{
+							Content: openapi3.Content{
+								"application/json": &openapi3.MediaType{
+									Schema: &openapi3.SchemaRef{
+										Value: &openapi3.Schema{
+											Type: &openapi3.Types{"object"},
+											Properties: openapi3.Schemas{
+												"discount": &openapi3.SchemaRef{
+													Value: &openapi3.Schema{
+														Type: &openapi3.Types{
+															"number",
+														},
+														Max:          &maximum,
+														ExclusiveMax: true,
+													},
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+					Responses: &openapi3.Responses{},
+				},
+			}
+			spec.Paths.Set("/discounts", pathItem)
+
+			result := OpenapiToMcpToolConfig(spec, nil, nil)
+			Expect(result).To(HaveLen(1))
+
+			inputSchema := buildInputSchemaForTest(result[0])
+			bodyParam := inputSchema["properties"].(map[string]any)["body_param"].(map[string]any)
+			discount := bodyParam["properties"].(map[string]any)["discount"].(map[string]any)
+			Expect(discount).To(HaveKeyWithValue("maximum", float64(100)))
+			Expect(discount).To(HaveKeyWithValue("exclusiveMaximum", float64(100)))
+		})
+
+		It("should use resolved schema ref value instead of dangling ref", func() {
+			spec := &openapi3.T{
+				OpenAPI: "3.0.0",
+				Info:    &openapi3.Info{Title: "Test API", Version: "1.0.0"},
+				Servers: []*openapi3.Server{{URL: "https://api.example.com/v1"}},
+				Paths:   &openapi3.Paths{},
+			}
+
+			pathItem := &openapi3.PathItem{
+				Post: &openapi3.Operation{
+					OperationID: "createUser",
+					Summary:     "Create user",
+					RequestBody: &openapi3.RequestBodyRef{
+						Value: &openapi3.RequestBody{
+							Content: openapi3.Content{
+								"application/json": &openapi3.MediaType{
+									Schema: &openapi3.SchemaRef{
+										Ref: "#/components/schemas/CreateUserRequest",
+										Value: &openapi3.Schema{
+											Type: &openapi3.Types{
+												"object",
+											},
+											Required: []string{"name"},
+											Properties: openapi3.Schemas{
+												"name": &openapi3.SchemaRef{
+													Value: &openapi3.Schema{
+														Type: &openapi3.Types{
+															"string",
+														},
+													},
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+					Responses: &openapi3.Responses{},
+				},
+			}
+			spec.Paths.Set("/users", pathItem)
+
+			result := OpenapiToMcpToolConfig(spec, nil, nil)
+			Expect(result).To(HaveLen(1))
+
+			inputSchema := buildInputSchemaForTest(result[0])
+			bodyParam := inputSchema["properties"].(map[string]any)["body_param"].(map[string]any)
+			Expect(bodyParam).NotTo(HaveKey("$ref"))
+			Expect(bodyParam).To(HaveKeyWithValue("type", "object"))
+			Expect(bodyParam["required"]).To(ContainElement("name"))
+			Expect(bodyParam["properties"].(map[string]any)).To(HaveKey("name"))
+		})
+
+		It("should use resolved parameter schema ref value", func() {
+			minimum := float64(1)
+			spec := &openapi3.T{
+				OpenAPI: "3.0.0",
+				Info:    &openapi3.Info{Title: "Test API", Version: "1.0.0"},
+				Servers: []*openapi3.Server{{URL: "https://api.example.com/v1"}},
+				Paths:   &openapi3.Paths{},
+			}
+
+			pathItem := &openapi3.PathItem{
+				Get: &openapi3.Operation{
+					OperationID: "getUsers",
+					Summary:     "Get users",
+					Parameters: openapi3.Parameters{
+						&openapi3.ParameterRef{
+							Value: &openapi3.Parameter{
+								Name:     "limit",
+								In:       "query",
+								Required: true,
+								Schema: &openapi3.SchemaRef{
+									Ref: "#/components/schemas/Limit",
+									Value: &openapi3.Schema{
+										Type: &openapi3.Types{"integer"},
+										Min:  &minimum,
+									},
+								},
+							},
+						},
+					},
+					Responses: &openapi3.Responses{},
+				},
+			}
+			spec.Paths.Set("/users", pathItem)
+
+			result := OpenapiToMcpToolConfig(spec, nil, nil)
+			Expect(result).To(HaveLen(1))
+
+			inputSchema := buildInputSchemaForTest(result[0])
+			queryParam := inputSchema["properties"].(map[string]any)["query_param"].(map[string]any)
+			limit := queryParam["properties"].(map[string]any)["limit"].(map[string]any)
+			Expect(limit).NotTo(HaveKey("$ref"))
+			Expect(limit).To(HaveKeyWithValue("type", "integer"))
+			Expect(limit).To(HaveKeyWithValue("minimum", float64(1)))
+			Expect(limit).NotTo(HaveKey("required"))
+			Expect(queryParam["required"]).To(ContainElement("limit"))
 		})
 
 		It("should handle multiple operations in one path", func() {

--- a/src/mcp-proxy/pkg/infra/proxy/converter_test.go
+++ b/src/mcp-proxy/pkg/infra/proxy/converter_test.go
@@ -19,6 +19,8 @@
 package proxy
 
 import (
+	"encoding/json"
+
 	"github.com/getkin/kin-openapi/openapi3"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -281,6 +283,7 @@ var _ = Describe("Converter", func() {
 					Summary:     "Create a new user",
 					RequestBody: &openapi3.RequestBodyRef{
 						Value: &openapi3.RequestBody{
+							Required: true,
 							Content: openapi3.Content{
 								"application/json": &openapi3.MediaType{
 									Schema: &openapi3.SchemaRef{
@@ -322,6 +325,86 @@ var _ = Describe("Converter", func() {
 			Expect(result[0].Name).To(Equal("createUser"))
 			Expect(result[0].Method).To(Equal("POST"))
 			Expect(result[0].ParamSchema.Properties).To(HaveKey("body_param"))
+
+			schemaBytes, err := result[0].ParamSchema.JSONSchemaBytes()
+			Expect(err).NotTo(HaveOccurred())
+			var inputSchema map[string]any
+			Expect(json.Unmarshal(schemaBytes, &inputSchema)).To(Succeed())
+			Expect(inputSchema["required"]).To(ContainElement("body_param"))
+
+			properties := inputSchema["properties"].(map[string]any)
+			bodyParam := properties["body_param"].(map[string]any)
+			Expect(bodyParam).To(HaveKeyWithValue("type", "object"))
+			Expect(bodyParam["required"]).To(ConsistOf("name", "email"))
+			Expect(bodyParam["properties"].(map[string]any)).To(HaveKey("name"))
+			Expect(bodyParam["properties"].(map[string]any)).To(HaveKey("email"))
+		})
+
+		It("should preserve request body schema with OpenAPI exclusive minimum", func() {
+			minimum := float64(0)
+			spec := &openapi3.T{
+				OpenAPI: "3.0.0",
+				Info:    &openapi3.Info{Title: "Test API", Version: "1.0.0"},
+				Servers: []*openapi3.Server{{URL: "https://api.example.com/v1"}},
+				Paths:   &openapi3.Paths{},
+			}
+
+			pathItem := &openapi3.PathItem{
+				Post: &openapi3.Operation{
+					OperationID: "updateBudget",
+					Summary:     "Update budget",
+					RequestBody: &openapi3.RequestBodyRef{
+						Value: &openapi3.RequestBody{
+							Required: true,
+							Content: openapi3.Content{
+								"application/json": &openapi3.MediaType{
+									Schema: &openapi3.SchemaRef{
+										Value: &openapi3.Schema{
+											Type: &openapi3.Types{
+												"object",
+											},
+											Required: []string{
+												"raise_budget",
+											},
+											Properties: openapi3.Schemas{
+												"raise_budget": &openapi3.SchemaRef{
+													Value: &openapi3.Schema{
+														Type: &openapi3.Types{
+															"number",
+														},
+														Min:          &minimum,
+														ExclusiveMin: true,
+														Description:  "起量预算（单位元，必须大于 0）。",
+													},
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+					Responses: &openapi3.Responses{},
+				},
+			}
+			spec.Paths.Set("/budgets", pathItem)
+
+			result := OpenapiToMcpToolConfig(spec, nil, nil)
+			Expect(result).To(HaveLen(1))
+
+			schemaBytes, err := result[0].ParamSchema.JSONSchemaBytes()
+			Expect(err).NotTo(HaveOccurred())
+			var inputSchema map[string]any
+			Expect(json.Unmarshal(schemaBytes, &inputSchema)).To(Succeed())
+
+			bodyParam := inputSchema["properties"].(map[string]any)["body_param"].(map[string]any)
+			Expect(bodyParam).To(HaveKeyWithValue("type", "object"))
+			Expect(bodyParam["required"]).To(ContainElement("raise_budget"))
+
+			raiseBudget := bodyParam["properties"].(map[string]any)["raise_budget"].(map[string]any)
+			Expect(raiseBudget).To(HaveKeyWithValue("type", "number"))
+			Expect(raiseBudget).To(HaveKeyWithValue("minimum", float64(0)))
+			Expect(raiseBudget).To(HaveKeyWithValue("exclusiveMinimum", float64(0)))
 		})
 
 		It("should handle multiple operations in one path", func() {

--- a/src/mcp-proxy/tests/integration/init.sql
+++ b/src/mcp-proxy/tests/integration/init.sql
@@ -386,7 +386,7 @@ VALUES (2, 1, 2, '{
                     "format": "double",
                     "minimum": 0,
                     "exclusiveMinimum": true,
-                    "description": "Bid amount must be greater than 0."
+                    "description": "Schema conversion test field only; bid amount must be greater than 0."
                   }
                 }
               }

--- a/src/mcp-proxy/tests/integration/init.sql
+++ b/src/mcp-proxy/tests/integration/init.sql
@@ -371,6 +371,7 @@ VALUES (2, 1, 2, '{
           }
         ],
         "requestBody": {
+          "required": true,
           "content": {
             "application/json": {
               "schema": {
@@ -379,6 +380,13 @@ VALUES (2, 1, 2, '{
                   "fields": {
                     "type": "array",
                     "items": {"type": "string"}
+                  },
+                  "bid_amount": {
+                    "type": "number",
+                    "format": "double",
+                    "minimum": 0,
+                    "exclusiveMinimum": true,
+                    "description": "Bid amount must be greater than 0."
                   }
                 }
               }

--- a/src/mcp-proxy/tests/integration/streamable_http_test.go
+++ b/src/mcp-proxy/tests/integration/streamable_http_test.go
@@ -1086,6 +1086,66 @@ var _ = Describe("Streamable HTTP Protocol", func() {
 		})
 	})
 
+	Describe("OpenAPI Schema Conversion", func() {
+		It("should preserve request body schema with OpenAPI exclusive minimum", func() {
+			mcpURL := fmt.Sprintf("%s/%s/mcp", client.BaseURL, "test-path-param-server")
+
+			httpClient := &http.Client{
+				Timeout: 30 * time.Second,
+				Transport: &jwtRoundTripper{
+					token: jwtToken,
+					base:  http.DefaultTransport,
+				},
+			}
+
+			transport := &mcp.StreamableClientTransport{
+				Endpoint:   mcpURL,
+				HTTPClient: httpClient,
+			}
+
+			mcpClient := mcp.NewClient(&mcp.Implementation{
+				Name:    "test-client",
+				Version: "1.0.0",
+			}, nil)
+
+			session, err := mcpClient.Connect(ctx, transport, nil)
+			Expect(err).NotTo(HaveOccurred())
+			defer session.Close()
+
+			result, err := session.ListTools(ctx, nil)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result).NotTo(BeNil())
+
+			var listBizHostsTool *mcp.Tool
+			for _, tool := range result.Tools {
+				if tool.Name == "list_biz_hosts" {
+					listBizHostsTool = tool
+					break
+				}
+			}
+			Expect(listBizHostsTool).NotTo(BeNil())
+
+			inputSchema, ok := listBizHostsTool.InputSchema.(map[string]any)
+			Expect(ok).To(BeTrue())
+			Expect(inputSchema["required"]).To(ContainElement("body_param"))
+
+			properties, ok := inputSchema["properties"].(map[string]any)
+			Expect(ok).To(BeTrue())
+			bodyParam, ok := properties["body_param"].(map[string]any)
+			Expect(ok).To(BeTrue())
+			Expect(bodyParam).To(HaveKeyWithValue("type", "object"))
+
+			bodyProperties, ok := bodyParam["properties"].(map[string]any)
+			Expect(ok).To(BeTrue())
+			Expect(bodyProperties).To(HaveKey("fields"))
+			bidAmount, ok := bodyProperties["bid_amount"].(map[string]any)
+			Expect(ok).To(BeTrue())
+			Expect(bidAmount).To(HaveKeyWithValue("type", "number"))
+			Expect(bidAmount).To(HaveKeyWithValue("minimum", float64(0)))
+			Expect(bidAmount).To(HaveKeyWithValue("exclusiveMinimum", float64(0)))
+		})
+	})
+
 	Describe("Large Integer Path/Query Params", func() {
 		It("should preserve large integer path and query params without scientific notation", func() {
 			mcpURL := fmt.Sprintf("%s/%s/mcp", client.BaseURL, "test-path-param-server")
@@ -1117,7 +1177,9 @@ var _ = Describe("Streamable HTTP Protocol", func() {
 				Arguments: map[string]any{
 					"path_param":  map[string]any{"bk_biz_id": 2005000002},
 					"query_param": map[string]any{"limit": 20},
-					"body_param":  map[string]any{"fields": []string{"bk_host_id", "bk_host_innerip"}},
+					"body_param": map[string]any{
+						"fields": []string{"bk_host_id", "bk_host_innerip"},
+					},
 				},
 			})
 			Expect(err).NotTo(HaveOccurred())


### PR DESCRIPTION
## Summary
- Normalize OpenAPI 3.0 boolean exclusiveMinimum/exclusiveMaximum before converting request body schemas to MCP tool input schemas.
- Preserve raw schemas as a fallback and mark body_param required when requestBody.required is true.
- Add unit coverage and integration test fixture coverage for tools/list schema preservation.

## Tests
- `go test -mod=mod ./pkg/infra/proxy ./pkg/infra/logging ./tests/integration`
- pre-commit hooks: fmt, lint, license, sensitive info checks

Target branch: `upstream/master`
