### PR TITLE
fix(dashboard): handle parallel release sync worker failures

### DIFF
--- a/src/dashboard/apigateway/apigateway/controller/management/commands/sync_releases_to_gateway_parallel.py
+++ b/src/dashboard/apigateway/apigateway/controller/management/commands/sync_releases_to_gateway_parallel.py
@@ -37,7 +37,15 @@ def sync_gateway(gateway):
     connection.close()
 
     print(f"syncing release for gateway {gateway.name} ...")
-    ok = publish.trigger_gateway_publish(PublishSourceEnum.CLI_SYNC, author="cli", gateway_id=gateway.id, is_sync=True)
+    try:
+        ok = publish.trigger_gateway_publish(
+            PublishSourceEnum.CLI_SYNC, author="cli", gateway_id=gateway.id, is_sync=True
+        )
+    except Exception:
+        logger.exception("syncing release for gateway %s failed with exception", gateway.name)
+        print(f"[ERROR] syncing release for gateway {gateway.name} failed")
+        return gateway.name
+
     if not ok:
         print(f"[ERROR] syncing release for gateway {gateway.name} failed")
         return gateway.name

--- a/src/dashboard/apigateway/apigateway/tests/controller/management/commands/test_sync_releases_to_gateway_parallel.py
+++ b/src/dashboard/apigateway/apigateway/tests/controller/management/commands/test_sync_releases_to_gateway_parallel.py
@@ -1,0 +1,28 @@
+from unittest import mock
+
+import pytest
+from ddf import G
+
+from apigateway.controller.management.commands.sync_releases_to_gateway_parallel import sync_gateway
+from apigateway.core.models import Gateway
+
+pytestmark = pytest.mark.django_db
+
+
+class TestSyncGateway:
+    @mock.patch("apigateway.controller.management.commands.sync_releases_to_gateway_parallel.logger")
+    @mock.patch(
+        "apigateway.controller.management.commands.sync_releases_to_gateway_parallel.publish.trigger_gateway_publish"
+    )
+    @mock.patch("django.db.connection.close")
+    def test_returns_gateway_name_when_publish_raises(self, mock_close, mock_trigger_gateway_publish, mock_logger):
+        gateway = G(Gateway, name="test-gateway")
+        mock_trigger_gateway_publish.side_effect = RuntimeError("boom")
+
+        result = sync_gateway(gateway)
+
+        assert result == gateway.name
+        mock_close.assert_called_once()
+        mock_logger.exception.assert_called_once_with(
+            "syncing release for gateway %s failed with exception", gateway.name
+        )


### PR DESCRIPTION
## Summary
Fix the parallel release sync management command so worker exceptions do not crash the whole process with a multiprocessing serialization error.

## What changed
- catch exceptions inside the sync worker and return the gateway name as a normal failure result
- log the worker traceback from the worker process so the real failure remains visible
- add a regression test for the worker helper when publish raises

## Validation
- `cd src/dashboard/apigateway && export PYTHONDONTWRITEBYTECODE=1 && . apigateway/conf/unittest_env && pytest --ds apigateway.settings --reuse-db apigateway/tests/controller/management/commands/test_sync_releases_to_gateway_parallel.py`