### PR TITLE
feat(gateway): check PaaS repo authorization before app creation

### DIFF
--- a/src/dashboard/apigateway/apigateway/apis/web/gateway/serializers.py
+++ b/src/dashboard/apigateway/apigateway/apis/web/gateway/serializers.py
@@ -479,3 +479,13 @@ class GatewayCheckNameAvailableOutputSLZ(serializers.Serializer):
 
     class Meta:
         ref_name = "apigateway.apis.web.gateway.serializers.GatewayCheckNameAvailableOutputSLZ"
+
+
+class GatewayRepoAuthorizationOutputSLZ(serializers.Serializer):
+    authorized = serializers.BooleanField(read_only=True, help_text="用户是否已授权代码仓库")
+    message = serializers.CharField(allow_blank=True, read_only=True, help_text="未授权提示信息")
+    address = serializers.CharField(allow_blank=True, read_only=True, help_text="仓库授权链接")
+    auth_docs = serializers.CharField(allow_blank=True, read_only=True, help_text="仓库授权文档链接")
+
+    class Meta:
+        ref_name = "apigateway.apis.web.gateway.serializers.GatewayRepoAuthorizationOutputSLZ"

--- a/src/dashboard/apigateway/apigateway/apis/web/gateway/urls.py
+++ b/src/dashboard/apigateway/apigateway/apis/web/gateway/urls.py
@@ -22,6 +22,7 @@ from . import views
 urlpatterns = [
     path("", views.GatewayListCreateApi.as_view(), name="gateways.list_create"),
     path("check-name-available/", views.GatewayCheckNameAvailableApi.as_view(), name="gateways.check_name_available"),
+    path("repo-authorization/", views.GatewayRepoAuthorizationApi.as_view(), name="gateways.repo_authorization"),
     path(
         # 使用 gateway_id，复用 GatewayPermission 的权限校验
         "<int:gateway_id>/",

--- a/src/dashboard/apigateway/apigateway/apis/web/gateway/views.py
+++ b/src/dashboard/apigateway/apigateway/apis/web/gateway/views.py
@@ -43,7 +43,7 @@ from apigateway.common.tenant.constants import (
 from apigateway.common.tenant.request import get_user_tenant_id
 from apigateway.common.tenant.user_credentials import get_user_credentials_from_request
 from apigateway.components.bkauth import list_all_apps_of_tenant, list_available_apps_for_tenant
-from apigateway.components.bkpaas import create_paas_app, update_app_maintainers
+from apigateway.components.bkpaas import create_paas_app, get_paas_repo_authorization, update_app_maintainers
 from apigateway.components.bkuser import list_tenants
 from apigateway.controller.publisher.publish import trigger_gateway_publish
 from apigateway.core.constants import (
@@ -67,6 +67,7 @@ from .serializers import (
     GatewayListInputSLZ,
     GatewayListOutputSLZ,
     GatewayReleasingStatusOutputSLZ,
+    GatewayRepoAuthorizationOutputSLZ,
     GatewayRetrieveOutputSLZ,
     GatewayTenantAppListOutputSLZ,
     GatewayUpdateInputSLZ,
@@ -187,12 +188,21 @@ class GatewayListCreateApi(generics.ListCreateAPIView):
                 ):
                     raise error_codes.INVALID_ARGUMENT.format(_("Git 信息无效。"), replace=True)
 
+            user_credentials = get_user_credentials_from_request(request)
+            if not git_info:
+                repo_authorization = get_paas_repo_authorization(user_credentials=user_credentials)
+                if not repo_authorization["authorized"]:
+                    raise error_codes.NO_PERMISSION.format(
+                        repo_authorization["message"] or _("用户未关联仓库授权。"),
+                        replace=True,
+                    ).set_data(repo_authorization)
+
             app_code = slz.validated_data["name"]
             ok = create_paas_app(
                 app_code=app_code,
                 language=language,
                 git_info=git_info,
-                user_credentials=get_user_credentials_from_request(request),
+                user_credentials=user_credentials,
             )
             if not ok:
                 raise error_codes.INTERNAL.format(_("创建蓝鲸应用失败。"), replace=True)
@@ -200,7 +210,7 @@ class GatewayListCreateApi(generics.ListCreateAPIView):
             update_app_maintainers(
                 app_code,
                 slz.validated_data["maintainers"],
-                user_credentials=get_user_credentials_from_request(request),
+                user_credentials=user_credentials,
             )
 
             # set the related app code, while the programmable gateway is created before the app syncing gateway
@@ -559,4 +569,21 @@ class GatewayCheckNameAvailableApi(generics.RetrieveAPIView):
             is_available = False
 
         slz = self.get_serializer({"is_available": is_available})
+        return OKJsonResponse(data=slz.data)
+
+
+@method_decorator(
+    name="get",
+    decorator=swagger_auto_schema(
+        operation_description="检查用户是否已授权代码仓库",
+        responses={status.HTTP_200_OK: GatewayRepoAuthorizationOutputSLZ()},
+        tags=["WebAPI.Gateway"],
+    ),
+)
+class GatewayRepoAuthorizationApi(generics.RetrieveAPIView):
+    serializer_class = GatewayRepoAuthorizationOutputSLZ
+
+    def retrieve(self, request, *args, **kwargs):
+        repo_authorization = get_paas_repo_authorization(user_credentials=get_user_credentials_from_request(request))
+        slz = self.get_serializer(repo_authorization)
         return OKJsonResponse(data=slz.data)

--- a/src/dashboard/apigateway/apigateway/components/bkpaas.py
+++ b/src/dashboard/apigateway/apigateway/components/bkpaas.py
@@ -158,6 +158,52 @@ def get_app_maintainers(bk_app_code: str) -> List[str]:
     return []
 
 
+def get_paas_repo_authorization(
+    source_control_type: str = "tc_git",
+    user_credentials: Optional[UserCredentials] = None,
+) -> Dict[str, Any]:
+    """检查用户是否已授权 PaaS 代码仓库"""
+    url = url_join(get_paas3_url_prefix(), f"/api/sourcectl/{source_control_type}/repos/")
+    data: Dict[str, Any] = {}
+    ok, resp_data = http_get(
+        url,
+        data,
+        headers=gen_gateway_headers(user_credentials),
+        timeout=REQ_PAAS_API_TIMEOUT,
+        allow_status_codes={403},
+    )
+    if not ok:
+        logger.error(
+            "%s api failed! %s %s, data: %s, request_id: %s, error: %s",
+            "paasv3",
+            "http_get",
+            url,
+            data,
+            local.request_id,
+            resp_data["error"],
+        )
+        raise error_codes.REMOTE_REQUEST_ERROR.format(
+            f"request paasv3 fail! "
+            f"Request=[http_get {urlparse(url).path} request_id={local.request_id}]"
+            f"error={resp_data['error']}"
+        )
+
+    if "results" in resp_data:
+        return {
+            "authorized": True,
+            "message": "",
+            "address": "",
+            "auth_docs": "",
+        }
+
+    return {
+        "authorized": False,
+        "message": resp_data.get("message", ""),
+        "address": resp_data.get("address", ""),
+        "auth_docs": resp_data.get("auth_docs", ""),
+    }
+
+
 def create_paas_app(
     app_code: str,
     language: str,

--- a/src/dashboard/apigateway/apigateway/components/bkpaas.py
+++ b/src/dashboard/apigateway/apigateway/components/bkpaas.py
@@ -170,9 +170,17 @@ def get_paas_repo_authorization(
         data,
         headers=gen_gateway_headers(user_credentials),
         timeout=REQ_PAAS_API_TIMEOUT,
-        allow_status_codes={403},
     )
     if not ok:
+        if resp_data.get("status_code") == 403:
+            response_data = resp_data.get("response_data", {})
+            return {
+                "authorized": False,
+                "message": response_data.get("message", ""),
+                "address": response_data.get("address", ""),
+                "auth_docs": response_data.get("auth_docs", ""),
+            }
+
         logger.error(
             "%s api failed! %s %s, data: %s, request_id: %s, error: %s",
             "paasv3",
@@ -188,19 +196,11 @@ def get_paas_repo_authorization(
             f"error={resp_data['error']}"
         )
 
-    if "results" in resp_data:
-        return {
-            "authorized": True,
-            "message": "",
-            "address": "",
-            "auth_docs": "",
-        }
-
     return {
-        "authorized": False,
-        "message": resp_data.get("message", ""),
-        "address": resp_data.get("address", ""),
-        "auth_docs": resp_data.get("auth_docs", ""),
+        "authorized": True,
+        "message": "",
+        "address": "",
+        "auth_docs": "",
     }
 
 

--- a/src/dashboard/apigateway/apigateway/components/http.py
+++ b/src/dashboard/apigateway/apigateway/components/http.py
@@ -55,6 +55,13 @@ session.mount("https://", adapter)
 session.mount("http://", adapter)
 
 
+def _get_json_response(resp):
+    try:
+        return resp.json() if resp.content else {}
+    except ValueError:
+        return {}
+
+
 def _http_request(
     method,
     url,
@@ -65,7 +72,6 @@ def _http_request(
     cert=None,
     cookies=None,
     request_session=None,
-    allow_status_codes=None,
     **kwargs,
 ):
     if request_session is None:
@@ -73,7 +79,6 @@ def _http_request(
 
     headers = _enrich_header(headers)
     request_id = headers.get("X-Request-Id")
-    allow_status_codes = allow_status_codes or set()
 
     logger.debug(
         (
@@ -169,7 +174,7 @@ def _http_request(
                 latency,
             )
 
-        if resp.status_code > 299 and resp.status_code not in allow_status_codes:
+        if resp.status_code > 299:
             content = resp.content[:256] if resp.content else ""
             logger.error(
                 "http request fail! %s %s, data: %s, request_id: %s, response.status_code: %s, response.body: %s",
@@ -185,7 +190,9 @@ def _http_request(
                 "error": (
                     f"status_code is {resp.status_code}, not 2xx! "
                     f"{method} {urlparse(url).path}, request_id={request_id}, resp.body={content}"
-                )
+                ),
+                "status_code": resp.status_code,
+                "response_data": _get_json_response(resp),
             }
 
         logger.debug(

--- a/src/dashboard/apigateway/apigateway/components/http.py
+++ b/src/dashboard/apigateway/apigateway/components/http.py
@@ -65,6 +65,7 @@ def _http_request(
     cert=None,
     cookies=None,
     request_session=None,
+    allow_status_codes=None,
     **kwargs,
 ):
     if request_session is None:
@@ -72,6 +73,7 @@ def _http_request(
 
     headers = _enrich_header(headers)
     request_id = headers.get("X-Request-Id")
+    allow_status_codes = allow_status_codes or set()
 
     logger.debug(
         (
@@ -167,7 +169,7 @@ def _http_request(
                 latency,
             )
 
-        if resp.status_code > 299:
+        if resp.status_code > 299 and resp.status_code not in allow_status_codes:
             content = resp.content[:256] if resp.content else ""
             logger.error(
                 "http request fail! %s %s, data: %s, request_id: %s, response.status_code: %s, response.body: %s",

--- a/src/dashboard/apigateway/apigateway/tests/apis/web/gateway/test_views.py
+++ b/src/dashboard/apigateway/apigateway/tests/apis/web/gateway/test_views.py
@@ -15,7 +15,7 @@
 # We undertake not to change the open source license (MIT license) applicable
 # to the current version of the project delivered to anyone in the future.
 #
-from unittest.mock import patch
+from unittest.mock import ANY, patch
 
 import pytest
 
@@ -71,6 +71,105 @@ class TestGatewayListCreateApi:
         assert auth_config["allow_delete_sensitive_params"] is False
 
         assert GatewayDataPlaneBinding.objects.filter(gateway=gateway, data_plane=default_data_plane).exists()
+
+    def test_create_programmable_gateway_without_repo_authorization(
+        self,
+        request_view,
+        faker,
+        mocker,
+    ):
+        name = f"pgw-{faker.pyint(min_value=10000, max_value=99999)}"
+        data = {
+            "name": name,
+            "description": faker.pystr(),
+            "maintainers": ["admin"],
+            "is_public": False,
+            "tenant_mode": "single",
+            "tenant_id": "default",
+            "kind": GatewayKindEnum.PROGRAMMABLE.value,
+            "extra_info": {"language": "python"},
+        }
+        mocker.patch("apigateway.apis.web.gateway.views.settings.EDITION", "te")
+        mocker.patch("apigateway.apis.web.gateway.validators.is_app_code_occupied", return_value=False)
+        mock_create_paas_app = mocker.patch("apigateway.apis.web.gateway.views.create_paas_app")
+        mocker.patch(
+            "apigateway.apis.web.gateway.views.get_paas_repo_authorization",
+            return_value={
+                "authorized": False,
+                "message": "用户未关联 oauth 授权",
+                "address": "https://git.example.com/oauth/authorize",
+                "auth_docs": "http://docs.example.com/tc_git_oauth",
+            },
+        )
+
+        resp = request_view(
+            method="POST",
+            view_name="gateways.list_create",
+            data=data,
+        )
+        result = resp.json()
+
+        assert resp.status_code == 403
+        assert result["error"]["message"] == "用户未关联 oauth 授权"
+        assert result["error"]["data"]["address"] == "https://git.example.com/oauth/authorize"
+        assert not Gateway.objects.filter(name=name).exists()
+        mock_create_paas_app.assert_not_called()
+
+    def test_create_programmable_gateway_with_repo_authorization(
+        self,
+        request_view,
+        faker,
+        mocker,
+        default_data_plane,
+    ):
+        name = f"pgw-{faker.pyint(min_value=10000, max_value=99999)}"
+        data = {
+            "name": name,
+            "description": faker.pystr(),
+            "maintainers": ["admin"],
+            "is_public": False,
+            "tenant_mode": "single",
+            "tenant_id": "default",
+            "kind": GatewayKindEnum.PROGRAMMABLE.value,
+            "extra_info": {
+                "language": "python",
+                "repository": f"https://git.example.com/bkapps/{name}.git",
+            },
+        }
+        mocker.patch("apigateway.apis.web.gateway.views.settings.EDITION", "te")
+        mocker.patch("apigateway.apis.web.gateway.validators.is_app_code_occupied", return_value=False)
+        mock_repo_authorization = mocker.patch(
+            "apigateway.apis.web.gateway.views.get_paas_repo_authorization",
+            return_value={
+                "authorized": True,
+                "message": "",
+                "address": "",
+                "auth_docs": "",
+            },
+        )
+        mock_create_paas_app = mocker.patch("apigateway.apis.web.gateway.views.create_paas_app", return_value=True)
+        mock_update_app_maintainers = mocker.patch("apigateway.apis.web.gateway.views.update_app_maintainers")
+
+        resp = request_view(
+            method="POST",
+            view_name="gateways.list_create",
+            data=data,
+        )
+        result = resp.json()
+
+        assert resp.status_code == 201
+        gateway = Gateway.objects.get(name=name)
+        assert result["data"]["id"] == gateway.id
+        assert gateway.kind == GatewayKindEnum.PROGRAMMABLE.value
+        assert GatewayDataPlaneBinding.objects.filter(gateway=gateway, data_plane=default_data_plane).exists()
+        mock_repo_authorization.assert_called_once_with(user_credentials=ANY)
+        mock_create_paas_app.assert_called_once_with(
+            app_code=name,
+            language="python",
+            git_info=None,
+            user_credentials=ANY,
+        )
+        mock_update_app_maintainers.assert_called_once_with(name, ["admin"], user_credentials=ANY)
 
     @pytest.mark.parametrize(
         "data, expected_status_code, expected_error",
@@ -269,3 +368,30 @@ class TestGatewayCheckNameAvailableApi:
 
         assert resp.status_code == 200
         assert result["data"]["is_available"] is False
+
+
+class TestGatewayRepoAuthorizationApi:
+    def test_retrieve(self, request_view, mocker):
+        mocker.patch(
+            "apigateway.apis.web.gateway.views.get_paas_repo_authorization",
+            return_value={
+                "authorized": False,
+                "message": "用户未关联 oauth 授权",
+                "address": "https://git.example.com/oauth/authorize",
+                "auth_docs": "http://docs.example.com/tc_git_oauth",
+            },
+        )
+
+        resp = request_view(
+            method="GET",
+            view_name="gateways.repo_authorization",
+        )
+        result = resp.json()
+
+        assert resp.status_code == 200
+        assert result["data"] == {
+            "authorized": False,
+            "message": "用户未关联 oauth 授权",
+            "address": "https://git.example.com/oauth/authorize",
+            "auth_docs": "http://docs.example.com/tc_git_oauth",
+        }

--- a/src/dashboard/apigateway/apigateway/tests/components/test_bkpaas.py
+++ b/src/dashboard/apigateway/apigateway/tests/components/test_bkpaas.py
@@ -1,0 +1,91 @@
+#
+# TencentBlueKing is pleased to support the open source community by making
+# 蓝鲸智云 - API 网关(BlueKing - APIGateway) available.
+# Copyright (C) Tencent. All rights reserved.
+# Licensed under the MIT License (the "License"); you may not use this file except
+# in compliance with the License. You may obtain a copy of the License at
+#
+#     http://opensource.org/licenses/MIT
+#
+# Unless required by applicable law or agreed to in writing, software distributed under
+# the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+# either express or implied. See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# We undertake not to change the open source license (MIT license) applicable
+# to the current version of the project delivered to anyone in the future.
+#
+
+import pytest
+
+from apigateway.common.error_codes import error_codes
+from apigateway.common.tenant.user_credentials import UserCredentials
+from apigateway.components.bkpaas import REQ_PAAS_API_TIMEOUT, get_paas_repo_authorization
+
+
+def test_get_paas_repo_authorization__authorized(mocker):
+    user_credentials = UserCredentials(credentials="bk-token", tenant_id="default")
+    mocker.patch("apigateway.components.bkpaas.get_paas3_url_prefix", return_value="https://paas.example.com/prod")
+    mock_gen_gateway_headers = mocker.patch(
+        "apigateway.components.bkpaas.gen_gateway_headers",
+        return_value={"X-Bkapi-Authorization": "authorization"},
+    )
+    mock_http_get = mocker.patch(
+        "apigateway.components.bkpaas.http_get",
+        return_value=(True, {"results": [{"fullname": "bkapps/demo"}]}),
+    )
+
+    result = get_paas_repo_authorization(user_credentials=user_credentials)
+
+    assert result == {
+        "authorized": True,
+        "message": "",
+        "address": "",
+        "auth_docs": "",
+    }
+    mock_gen_gateway_headers.assert_called_once_with(user_credentials)
+    mock_http_get.assert_called_once_with(
+        "https://paas.example.com/prod/api/sourcectl/tc_git/repos/",
+        {},
+        headers={"X-Bkapi-Authorization": "authorization"},
+        timeout=REQ_PAAS_API_TIMEOUT,
+        allow_status_codes={403},
+    )
+
+
+def test_get_paas_repo_authorization__unauthorized(mocker):
+    mocker.patch("apigateway.components.bkpaas.get_paas3_url_prefix", return_value="https://paas.example.com/prod")
+    mocker.patch(
+        "apigateway.components.bkpaas.gen_gateway_headers", return_value={"X-Bkapi-Authorization": "authorization"}
+    )
+    mocker.patch(
+        "apigateway.components.bkpaas.http_get",
+        return_value=(
+            True,
+            {
+                "message": "用户未关联 oauth 授权",
+                "address": "https://git.example.com/oauth/authorize",
+                "auth_docs": "http://docs.example.com/tc_git_oauth",
+            },
+        ),
+    )
+
+    result = get_paas_repo_authorization()
+
+    assert result == {
+        "authorized": False,
+        "message": "用户未关联 oauth 授权",
+        "address": "https://git.example.com/oauth/authorize",
+        "auth_docs": "http://docs.example.com/tc_git_oauth",
+    }
+
+
+def test_get_paas_repo_authorization__failed(mocker):
+    mocker.patch("apigateway.components.bkpaas.get_paas3_url_prefix", return_value="https://paas.example.com/prod")
+    mocker.patch(
+        "apigateway.components.bkpaas.gen_gateway_headers", return_value={"X-Bkapi-Authorization": "authorization"}
+    )
+    mocker.patch("apigateway.components.bkpaas.http_get", return_value=(False, {"error": "request failed"}))
+
+    with pytest.raises(error_codes.REMOTE_REQUEST_ERROR.__class__):
+        get_paas_repo_authorization()

--- a/src/dashboard/apigateway/apigateway/tests/components/test_bkpaas.py
+++ b/src/dashboard/apigateway/apigateway/tests/components/test_bkpaas.py
@@ -49,7 +49,6 @@ def test_get_paas_repo_authorization__authorized(mocker):
         {},
         headers={"X-Bkapi-Authorization": "authorization"},
         timeout=REQ_PAAS_API_TIMEOUT,
-        allow_status_codes={403},
     )
 
 
@@ -61,11 +60,15 @@ def test_get_paas_repo_authorization__unauthorized(mocker):
     mocker.patch(
         "apigateway.components.bkpaas.http_get",
         return_value=(
-            True,
+            False,
             {
-                "message": "用户未关联 oauth 授权",
-                "address": "https://git.example.com/oauth/authorize",
-                "auth_docs": "http://docs.example.com/tc_git_oauth",
+                "error": "status_code is 403, not 2xx!",
+                "status_code": 403,
+                "response_data": {
+                    "message": "用户未关联 oauth 授权",
+                    "address": "https://git.example.com/oauth/authorize",
+                    "auth_docs": "http://docs.example.com/tc_git_oauth",
+                },
             },
         ),
     )

--- a/src/dashboard/apigateway/apigateway/tests/components/test_http.py
+++ b/src/dashboard/apigateway/apigateway/tests/components/test_http.py
@@ -48,6 +48,25 @@ def test_http_request_get(mock_session):
     assert response == {"key": "value"}
 
 
+def test_http_request_allowed_status_code(mock_session):
+    mock_response = requests.Response()
+    mock_response.status_code = 403
+    mock_response._content = b'{"message": "forbidden", "address": "http://example.com/auth"}'
+    mock_session.get.return_value = mock_response
+
+    success, response = _http_request(
+        method="GET",
+        url="http://example.com",
+        headers={"X-Request-Id": "test-request-id"},
+        data={"param": "value"},
+        timeout=5,
+        allow_status_codes={403},
+    )
+
+    assert success is True
+    assert response == {"message": "forbidden", "address": "http://example.com/auth"}
+
+
 def test_http_request_post(mock_session):
     mock_response = requests.Response()
     mock_response.status_code = 200

--- a/src/dashboard/apigateway/apigateway/tests/components/test_http.py
+++ b/src/dashboard/apigateway/apigateway/tests/components/test_http.py
@@ -48,7 +48,7 @@ def test_http_request_get(mock_session):
     assert response == {"key": "value"}
 
 
-def test_http_request_allowed_status_code(mock_session):
+def test_http_request_error_with_status_code_and_json_response(mock_session):
     mock_response = requests.Response()
     mock_response.status_code = 403
     mock_response._content = b'{"message": "forbidden", "address": "http://example.com/auth"}'
@@ -60,11 +60,30 @@ def test_http_request_allowed_status_code(mock_session):
         headers={"X-Request-Id": "test-request-id"},
         data={"param": "value"},
         timeout=5,
-        allow_status_codes={403},
     )
 
-    assert success is True
-    assert response == {"message": "forbidden", "address": "http://example.com/auth"}
+    assert success is False
+    assert response["status_code"] == 403
+    assert response["response_data"] == {"message": "forbidden", "address": "http://example.com/auth"}
+
+
+def test_http_request_error_with_html_response(mock_session):
+    mock_response = requests.Response()
+    mock_response.status_code = 403
+    mock_response._content = b"<html>forbidden</html>"
+    mock_session.get.return_value = mock_response
+
+    success, response = _http_request(
+        method="GET",
+        url="http://example.com",
+        headers={"X-Request-Id": "test-request-id"},
+        data={"param": "value"},
+        timeout=5,
+    )
+
+    assert success is False
+    assert response["status_code"] == 403
+    assert response["response_data"] == {}
 
 
 def test_http_request_post(mock_session):


### PR DESCRIPTION
## Summary

- Check PaaS `tc_git` repository authorization before creating programmable gateways.
- Return authorization links when OAuth authorization is missing.
- Add standalone repository authorization status API.
- Add focused component, HTTP, and gateway view tests.

## Tests

```bash
cd src/dashboard/apigateway
set -a; . apigateway/conf/unittest_env; set +a
../.venv/bin/python -m pytest --nomigrations --ds apigateway.settings -q --tb=short \
  apigateway/tests/components/test_bkpaas.py \
  apigateway/tests/components/test_http.py \
  apigateway/tests/apis/web/gateway/test_views.py::TestGatewayListCreateApi::test_create_programmable_gateway_without_repo_authorization \
  apigateway/tests/apis/web/gateway/test_views.py::TestGatewayListCreateApi::test_create_programmable_gateway_with_repo_authorization \
  apigateway/tests/apis/web/gateway/test_views.py::TestGatewayRepoAuthorizationApi::test_retrieve
```

```bash
cd src/dashboard
.venv/bin/ruff check --config=pyproject.toml --force-exclude <changed files>
.venv/bin/ruff format --check --config=pyproject.toml --force-exclude <changed files>
```
