### PR TITLE
Fix permission cleanup and tenant filtering

### DIFF
--- a/src/dashboard/apigateway/apigateway/apis/web/mcp_server/views.py
+++ b/src/dashboard/apigateway/apigateway/apis/web/mcp_server/views.py
@@ -340,6 +340,12 @@ class MCPServerRetrieveUpdateDestroyApi(generics.RetrieveUpdateDestroyAPIView):
         # 删除 prompts
         MCPServerHandler.delete_prompts(instance.id)
 
+        # Delete resource permission records created by sync_permissions
+        MCPServerHandler.cleanup_all_resource_permissions(
+            gateway_id=self.request.gateway.id,
+            mcp_server_id=instance.id,
+        )
+
         instance.delete()
 
         Auditor.record_mcp_server_op_success(

--- a/src/dashboard/apigateway/apigateway/apis/web/personal_workbench/views.py
+++ b/src/dashboard/apigateway/apigateway/apis/web/personal_workbench/views.py
@@ -28,8 +28,10 @@ from apigateway.biz.mcp_server import MCPServerPermissionHandler
 from apigateway.biz.permission import ResourcePermissionHandler
 from apigateway.biz.personal_workbench import WorkbenchPermissionHandler
 from apigateway.common.tenant.query import (
-    gateway_filter_by_user_tenant_id,
+    gateway_filter_by_app_tenant_id,
+    gateway_filter_by_maintainer_tenant_id,
     gateway_mcp_server_filter_by_user_tenant_id,
+    gateway_related_filter_by_maintainer_tenant_id,
     gateway_related_filter_by_user_tenant_id,
     mcp_server_related_filter_by_user_tenant_id,
 )
@@ -154,14 +156,14 @@ class WorkbenchGatewayFilterOptionListApi(WorkbenchPermissionMixin, generics.Lis
                 AppPermissionApply.objects.filter(applied_by=username).values_list("gateway_id", flat=True).distinct()
             )
             queryset = Gateway.objects.filter(id__in=gateway_ids).order_by("name")
-            return gateway_filter_by_user_tenant_id(queryset, tenant_id)
+            return gateway_filter_by_app_tenant_id(queryset, tenant_id)
 
         if filter_type == WorkbenchFilterTypeEnum.HANDLED.value:
             # 我的已办：从用户处理过的记录中提取去重的网关；ITSM 回调无实际审批人，按当前用户维护的网关补充
             queryset = WorkbenchPermissionHandler.get_handled_gateway_permission_record_queryset(username, tenant_id)
             gateway_ids = queryset.values_list("gateway_id", flat=True).distinct()
             queryset = Gateway.objects.filter(id__in=gateway_ids).order_by("name")
-            return gateway_filter_by_user_tenant_id(queryset, tenant_id)
+            return gateway_filter_by_maintainer_tenant_id(queryset, tenant_id)
 
         # pending（默认）：从当前用户待审批的 API 网关权限申请中提取去重的网关
         gateway_ids = (
@@ -218,7 +220,7 @@ class WorkbenchMCPServerFilterOptionListApi(WorkbenchPermissionMixin, generics.L
                 .distinct()
             )
             queryset = MCPServer.objects.select_related("gateway").filter(id__in=mcp_server_ids).order_by("name")
-            return gateway_mcp_server_filter_by_user_tenant_id(queryset, tenant_id)
+            return gateway_related_filter_by_maintainer_tenant_id(queryset, tenant_id)
 
         # pending（默认）：从当前用户待审批的 MCP Server 权限申请中提取去重的 MCP Server
         mcp_server_ids = (
@@ -265,7 +267,7 @@ class WorkbenchMCPGatewayFilterOptionListApi(WorkbenchPermissionMixin, generics.
                 .distinct()
             )
             queryset = Gateway.objects.filter(id__in=gateway_ids).order_by("name")
-            return gateway_filter_by_user_tenant_id(queryset, tenant_id)
+            return gateway_filter_by_app_tenant_id(queryset, tenant_id)
 
         if filter_type == WorkbenchFilterTypeEnum.HANDLED.value:
             # 我的已办：从用户处理过的 MCP 记录中提取去重的网关；ITSM 回调无实际审批人，按当前用户维护的网关补充
@@ -275,7 +277,7 @@ class WorkbenchMCPGatewayFilterOptionListApi(WorkbenchPermissionMixin, generics.
                 .distinct()
             )
             queryset = Gateway.objects.filter(id__in=gateway_ids).order_by("name")
-            return gateway_filter_by_user_tenant_id(queryset, tenant_id)
+            return gateway_filter_by_maintainer_tenant_id(queryset, tenant_id)
 
         # pending（默认）：从当前用户待审批的 MCP Server 权限申请中提取去重的网关
         gateway_ids = (

--- a/src/dashboard/apigateway/apigateway/biz/gateway/gateway.py
+++ b/src/dashboard/apigateway/apigateway/biz/gateway/gateway.py
@@ -34,7 +34,7 @@ from apigateway.apps.support.models import ReleasedResourceDoc
 from apigateway.biz.release import ReleaseHandler
 from apigateway.biz.stage import StageHandler
 from apigateway.common.constants import CallSourceTypeEnum
-from apigateway.common.tenant.query import gateway_filter_by_user_tenant_id
+from apigateway.common.tenant.query import gateway_filter_by_maintainer_tenant_id
 from apigateway.core.constants import (
     ContextScopeTypeEnum,
     GatewayOperationSourceEnum,
@@ -89,7 +89,7 @@ class GatewayHandler:
         """获取用户有权限的网关列表"""
         queryset = Gateway.objects.filter(_maintainers__contains=username)
         if tenant_id:
-            queryset = gateway_filter_by_user_tenant_id(queryset, tenant_id)
+            queryset = gateway_filter_by_maintainer_tenant_id(queryset, tenant_id)
 
         # 使用 _maintainers 过滤的数据并不准确，需要根据其中人员列表二次过滤
         return [gateway for gateway in queryset if gateway.has_permission(username)]

--- a/src/dashboard/apigateway/apigateway/biz/mcp_server/mcp_server.py
+++ b/src/dashboard/apigateway/apigateway/biz/mcp_server/mcp_server.py
@@ -255,7 +255,7 @@ class MCPServerHandler:
         return f"v_mcp_{mcp_server_id}_{app_code}"
 
     @staticmethod
-    def _cleanup_all_resource_permissions(gateway_id: int, mcp_server_id: int):
+    def cleanup_all_resource_permissions(gateway_id: int, mcp_server_id: int):
         """清理 mcp_server 的所有权限
         特征：bk_app_code 以 v_mcp_{mcp_server_id}_ 开头
         只有虚拟 app_code 能带下划线
@@ -308,7 +308,7 @@ class MCPServerHandler:
         if not app_codes:
             logger.debug("no app_codes, cleanup the permissions of the mcp_server %d", mcp_server_id)
             # if no app_codes, cleanup the permissions of the mcp_server
-            MCPServerHandler._cleanup_all_resource_permissions(
+            MCPServerHandler.cleanup_all_resource_permissions(
                 gateway_id=mcp_server.gateway_id,
                 mcp_server_id=mcp_server_id,
             )

--- a/src/dashboard/apigateway/apigateway/biz/mcp_server/permission.py
+++ b/src/dashboard/apigateway/apigateway/biz/mcp_server/permission.py
@@ -30,7 +30,7 @@ from apigateway.apps.mcp_server.constants import (
 from apigateway.apps.mcp_server.models import MCPServer, MCPServerAppPermissionApply
 from apigateway.apps.permission.constants import FormattedGrantDimensionEnum
 from apigateway.common.error_codes import error_codes
-from apigateway.common.tenant.query import gateway_filter_by_user_tenant_id
+from apigateway.common.tenant.query import gateway_filter_by_maintainer_tenant_id
 from apigateway.core.constants import GatewayStatusEnum, StageStatusEnum
 from apigateway.core.models import Gateway
 from apigateway.service.bk_itsm import ItsmPermissionApplyHelper
@@ -45,7 +45,7 @@ class MCPServerPermissionHandler:
         """获取指定用户作为网关管理员待审批的 MCP Server 权限申请列表"""
         queryset = Gateway.objects.filter(_maintainers__contains=username)
         if tenant_id:
-            queryset = gateway_filter_by_user_tenant_id(queryset, tenant_id)
+            queryset = gateway_filter_by_maintainer_tenant_id(queryset, tenant_id)
 
         gateway_ids = [gateway.id for gateway in queryset if gateway.has_permission(username)]
         return MCPServerAppPermissionApply.objects.filter(

--- a/src/dashboard/apigateway/apigateway/biz/permission/permission.py
+++ b/src/dashboard/apigateway/apigateway/biz/permission/permission.py
@@ -35,7 +35,7 @@ from apigateway.common.tenant.constants import (
     TENANT_ID_OPERATION,
     TenantModeEnum,
 )
-from apigateway.common.tenant.query import gateway_filter_by_user_tenant_id
+from apigateway.common.tenant.query import gateway_filter_by_maintainer_tenant_id
 from apigateway.components.bkauth import get_app_tenant_info_cached
 from apigateway.components.bkuser import query_display_names_cached
 from apigateway.core.models import Gateway, Resource
@@ -47,7 +47,7 @@ class ResourcePermissionHandler:
         """获取指定用户作为网关管理员待审批的 API 网关权限申请列表"""
         queryset = Gateway.objects.filter(_maintainers__contains=username)
         if tenant_id:
-            queryset = gateway_filter_by_user_tenant_id(queryset, tenant_id)
+            queryset = gateway_filter_by_maintainer_tenant_id(queryset, tenant_id)
 
         gateway_ids = [gateway.id for gateway in queryset if gateway.has_permission(username)]
         return AppPermissionApply.objects.filter(

--- a/src/dashboard/apigateway/apigateway/biz/personal_workbench/permission.py
+++ b/src/dashboard/apigateway/apigateway/biz/personal_workbench/permission.py
@@ -26,8 +26,8 @@ from apigateway.apps.permission.models import AppPermissionRecord
 from apigateway.biz.bk_itsm import ITSM_PERMISSION_APPROVAL_HANDLER
 from apigateway.biz.gateway import GatewayHandler
 from apigateway.common.tenant.query import (
-    gateway_related_filter_by_user_tenant_id,
-    mcp_server_related_filter_by_user_tenant_id,
+    gateway_related_filter_by_maintainer_tenant_id,
+    mcp_server_related_filter_by_maintainer_tenant_id,
 )
 
 
@@ -45,7 +45,7 @@ class WorkbenchPermissionHandler:
                 gateway_id__in=cls._get_user_gateway_ids(username, tenant_id),
             )
         ).exclude(status=ApplyStatusEnum.PENDING.value)
-        return gateway_related_filter_by_user_tenant_id(queryset, tenant_id)
+        return gateway_related_filter_by_maintainer_tenant_id(queryset, tenant_id)
 
     @classmethod
     def get_handled_mcp_permission_apply_queryset(cls, username: str, tenant_id: str) -> QuerySet:
@@ -57,4 +57,4 @@ class WorkbenchPermissionHandler:
             ),
             is_deleted=False,
         ).exclude(status=MCPServerAppPermissionApplyStatusEnum.PENDING.value)
-        return mcp_server_related_filter_by_user_tenant_id(queryset, tenant_id)
+        return mcp_server_related_filter_by_maintainer_tenant_id(queryset, tenant_id)

--- a/src/dashboard/apigateway/apigateway/common/tenant/query.py
+++ b/src/dashboard/apigateway/apigateway/common/tenant/query.py
@@ -24,7 +24,7 @@ from .constants import (
 )
 
 
-def gateway_filter_by_user_tenant_id(queryset: QuerySet, user_tenant_id: str) -> QuerySet:
+def gateway_filter_by_maintainer_tenant_id(queryset: QuerySet, user_tenant_id: str) -> QuerySet:
     """网关管理员维度查看网关列表，运营租户能看到全租户网关 + 本租户网关，其他租户只能看到本租户网关
 
     Args:
@@ -60,8 +60,8 @@ def gateway_filter_by_app_tenant_id(queryset: QuerySet, app_tenant_id: str) -> Q
     )
 
 
-def gateway_related_filter_by_user_tenant_id(queryset: QuerySet, user_tenant_id: str) -> QuerySet:
-    """按用户租户 ID 过滤通过 gateway 外键关联的 QuerySet（如 AppPermissionApply、AppPermissionRecord）
+def gateway_related_filter_by_maintainer_tenant_id(queryset: QuerySet, user_tenant_id: str) -> QuerySet:
+    """按维护者租户 ID 过滤通过 gateway 外键关联的 QuerySet（如 AppPermissionApply、AppPermissionRecord）
 
     Args:
         queryset (QuerySet): 含 gateway 外键的 queryset
@@ -78,8 +78,24 @@ def gateway_related_filter_by_user_tenant_id(queryset: QuerySet, user_tenant_id:
     return queryset.filter(gateway__tenant_mode=TenantModeEnum.SINGLE.value, gateway__tenant_id=user_tenant_id)
 
 
-def mcp_server_related_filter_by_user_tenant_id(queryset: QuerySet, user_tenant_id: str) -> QuerySet:
-    """按用户租户 ID 过滤通过 mcp_server__gateway 外键关联的 QuerySet（如 MCPServerAppPermissionApply）
+def gateway_related_filter_by_user_tenant_id(queryset: QuerySet, user_tenant_id: str) -> QuerySet:
+    """按用户租户 ID 过滤通过 gateway 外键关联的 QuerySet（如 AppPermissionApply、AppPermissionRecord）
+
+    Args:
+        queryset (QuerySet): 含 gateway 外键的 queryset
+        user_tenant_id (str): user tenant id
+
+    Returns:
+        QuerySet: filtered queryset
+    """
+    return queryset.filter(
+        Q(gateway__tenant_mode=TenantModeEnum.GLOBAL.value)
+        | Q(gateway__tenant_mode=TenantModeEnum.SINGLE.value, gateway__tenant_id=user_tenant_id)
+    )
+
+
+def mcp_server_related_filter_by_maintainer_tenant_id(queryset: QuerySet, user_tenant_id: str) -> QuerySet:
+    """按维护者租户 ID 过滤通过 mcp_server__gateway 外键关联的 QuerySet（如 MCPServerAppPermissionApply）
 
     Args:
         queryset (QuerySet): 含 mcp_server__gateway 外键路径的 queryset
@@ -102,10 +118,29 @@ def mcp_server_related_filter_by_user_tenant_id(queryset: QuerySet, user_tenant_
     )
 
 
+def mcp_server_related_filter_by_user_tenant_id(queryset: QuerySet, user_tenant_id: str) -> QuerySet:
+    """按用户租户 ID 过滤通过 mcp_server__gateway 外键关联的 QuerySet（如 MCPServerAppPermissionApply）
+
+    Args:
+        queryset (QuerySet): 含 mcp_server__gateway 外键路径的 queryset
+        user_tenant_id (str): user tenant id
+
+    Returns:
+        QuerySet: filtered queryset
+    """
+    return queryset.filter(
+        Q(mcp_server__gateway__tenant_mode=TenantModeEnum.GLOBAL.value)
+        | Q(
+            mcp_server__gateway__tenant_mode=TenantModeEnum.SINGLE.value,
+            mcp_server__gateway__tenant_id=user_tenant_id,
+        )
+    )
+
+
 def gateway_mcp_server_filter_by_user_tenant_id(queryset: QuerySet, user_tenant_id: str) -> QuerySet:
     """按用户租户 ID 过滤 MCPServer QuerySet（通过 gateway 关联）
 
-    运营租户能看到全租户网关 + 本租户网关的 MCP Server，其他租户只能看到本租户网关的 MCP Server。
+    用户能看到全租户网关 + 本租户网关的 MCP Server。
 
     Args:
         queryset (QuerySet): mcp_server queryset
@@ -114,9 +149,7 @@ def gateway_mcp_server_filter_by_user_tenant_id(queryset: QuerySet, user_tenant_
     Returns:
         QuerySet: filtered queryset
     """
-    if user_tenant_id == TENANT_ID_OPERATION:
-        return queryset.filter(
-            Q(gateway__tenant_mode=TenantModeEnum.GLOBAL.value)
-            | Q(gateway__tenant_mode=TenantModeEnum.SINGLE.value, gateway__tenant_id=user_tenant_id)
-        )
-    return queryset.filter(gateway__tenant_mode=TenantModeEnum.SINGLE.value, gateway__tenant_id=user_tenant_id)
+    return queryset.filter(
+        Q(gateway__tenant_mode=TenantModeEnum.GLOBAL.value)
+        | Q(gateway__tenant_mode=TenantModeEnum.SINGLE.value, gateway__tenant_id=user_tenant_id)
+    )

--- a/src/dashboard/apigateway/apigateway/conf/celery_conf.py
+++ b/src/dashboard/apigateway/apigateway/conf/celery_conf.py
@@ -75,6 +75,10 @@ CELERY_BEAT_SCHEDULE = {
         "task": "apigateway.controller.tasks.clean_task.delete_old_stats_records",
         "schedule": crontab(day_of_week="*", hour=1, minute=25),
     },
+    "apigateway.controller.tasks.clean_task.delete_old_app_resource_permission_records": {
+        "task": "apigateway.controller.tasks.clean_task.delete_old_app_resource_permission_records",
+        "schedule": crontab(day_of_week="*", hour=1, minute=30),
+    },
     "apigateway.apps.mcp_server.tasks.sync_mcp_server_prompts": {
         "task": "apigateway.apps.mcp_server.tasks.sync_mcp_server_prompts",
         "schedule": crontab(minute="*/10"),

--- a/src/dashboard/apigateway/apigateway/controller/tasks/__init__.py
+++ b/src/dashboard/apigateway/apigateway/controller/tasks/__init__.py
@@ -18,6 +18,7 @@
 from apigateway.controller.tasks.clean_task import (
     delete_legacy_resource_version,
     delete_old_alarm_records,
+    delete_old_app_resource_permission_records,
     delete_old_debug_history,
     delete_old_publish_events,
     delete_old_resource_doc_version_records,
@@ -41,6 +42,7 @@ __all__ = [
     "delete_old_publish_events",
     "delete_old_debug_history",
     "delete_old_alarm_records",
+    "delete_old_app_resource_permission_records",
     "delete_legacy_resource_version",
     "delete_old_stats_records",
 ]

--- a/src/dashboard/apigateway/apigateway/controller/tasks/clean_task.py
+++ b/src/dashboard/apigateway/apigateway/controller/tasks/clean_task.py
@@ -27,6 +27,7 @@ from django.utils import timezone
 from apigateway.apps.api_debug.models import APIDebugHistory
 from apigateway.apps.metrics.models import StatisticsAppRequestByDay, StatisticsGatewayRequestByDay
 from apigateway.apps.monitor.models import AlarmRecord
+from apigateway.apps.permission.models import AppResourcePermission
 from apigateway.apps.support.models import ReleasedResourceDoc, ResourceDocVersion
 from apigateway.core.constants import ResourceVersionSchemaEnum
 from apigateway.core.models import PublishEvent, Release, ReleasedResource, ResourceVersion
@@ -111,6 +112,47 @@ def delete_old_alarm_records():
     count, _ = AlarmRecord.objects.filter(id__in=ids_to_delete).delete()
 
     logger.info("deleted %s alarm records older than %s", count, delete_end_time)
+
+
+@shared_task(ignore_result=True)
+def delete_old_app_resource_permission_records():
+    """Clean expired app resource permission records."""
+    logger.info("begin clean app resource permission old records")
+
+    now = timezone.now()
+
+    # 1. delete the test_app expired records
+    default_test_app_delete_end_time = now - timedelta(days=30) - relativedelta(days=1)
+    default_test_app_permission_ids_to_delete = list(
+        AppResourcePermission.objects.filter(
+            bk_app_code=settings.DEFAULT_TEST_APP["bk_app_code"],
+            expires__lt=default_test_app_delete_end_time,
+        )
+        .order_by("id")
+        .values_list("id", flat=True)[:2000]
+    )
+
+    count, _ = AppResourcePermission.objects.filter(id__in=default_test_app_permission_ids_to_delete).delete()
+    logger.info(
+        "deleted %s default test app resource permission records older than %s",
+        count,
+        default_test_app_delete_end_time,
+    )
+
+    # 2. delete the expired 3 years before records
+    all_app_delete_end_time = now - relativedelta(years=3) - relativedelta(days=1)
+    app_resource_permission_ids_to_delete = list(
+        AppResourcePermission.objects.filter(expires__lt=all_app_delete_end_time)
+        .order_by("id")
+        .values_list("id", flat=True)[:2000]
+    )
+
+    count, _ = AppResourcePermission.objects.filter(id__in=app_resource_permission_ids_to_delete).delete()
+    logger.info(
+        "deleted %s app resource permission records older than %s",
+        count,
+        all_app_delete_end_time,
+    )
 
 
 @shared_task(ignore_result=True)

--- a/src/dashboard/apigateway/apigateway/tests/apis/web/mcp_server/test_views.py
+++ b/src/dashboard/apigateway/apigateway/tests/apis/web/mcp_server/test_views.py
@@ -753,7 +753,12 @@ class TestMCPServerRetrieveUpdateDestroyApi:
 
         assert resp.status_code == 400
 
-    def test_destroy_inactive_success(self, request_view, fake_gateway, fake_mcp_server_inactive):
+    def test_destroy_inactive_success(self, mocker, request_view, fake_gateway, fake_mcp_server_inactive):
+        mock_cleanup_all_resource_permissions = mocker.patch(
+            "apigateway.biz.mcp_server.MCPServerHandler.cleanup_all_resource_permissions",
+            return_value=None,
+        )
+
         resp = request_view(
             method="DELETE",
             view_name="mcp_server.retrieve_update_destroy",
@@ -763,6 +768,10 @@ class TestMCPServerRetrieveUpdateDestroyApi:
 
         assert resp.status_code == 204
         assert not MCPServer.objects.filter(id=fake_mcp_server_inactive.id).exists()
+        mock_cleanup_all_resource_permissions.assert_called_once_with(
+            gateway_id=fake_gateway.id,
+            mcp_server_id=fake_mcp_server_inactive.id,
+        )
 
 
 class TestMCPServerUpdateStatusApi:

--- a/src/dashboard/apigateway/apigateway/tests/biz/mcp_server/test_mcp_server.py
+++ b/src/dashboard/apigateway/apigateway/tests/biz/mcp_server/test_mcp_server.py
@@ -57,12 +57,31 @@ class TestMCPServerHandler:
         assert MCPServerHandler._virtual_app_code(1, "test") == "v_mcp_1_test"
 
     def test_cleanup_all_resource_permissions(self, fake_gateway):
-        G(AppResourcePermission, gateway_id=fake_gateway.id, bk_app_code="v_mcp_1_test")
+        AppResourcePermission.objects.create(
+            gateway=fake_gateway,
+            bk_app_code="v_mcp_1_test",
+            resource_id=1,
+            grant_type=GrantTypeEnum.SYNC.value,
+            expires=NeverExpiresTime.time,
+        )
+        AppResourcePermission.objects.create(
+            gateway=fake_gateway,
+            bk_app_code="v_mcp_2_test",
+            resource_id=1,
+            grant_type=GrantTypeEnum.SYNC.value,
+            expires=NeverExpiresTime.time,
+        )
 
-        MCPServerHandler._cleanup_all_resource_permissions(fake_gateway.id, 1)
+        MCPServerHandler.cleanup_all_resource_permissions(gateway_id=fake_gateway.id, mcp_server_id=1)
 
-        records = AppResourcePermission.objects.filter(gateway_id=fake_gateway.id, bk_app_code="v_mcp_1_test").all()
-        assert len(records) == 0
+        assert not AppResourcePermission.objects.filter(
+            gateway_id=fake_gateway.id,
+            bk_app_code="v_mcp_1_test",
+        ).exists()
+        assert AppResourcePermission.objects.filter(
+            gateway_id=fake_gateway.id,
+            bk_app_code="v_mcp_2_test",
+        ).exists()
 
     def test_disable_servers(self, fake_gateway, fake_stage):
         server1 = G(MCPServer, gateway=fake_gateway, stage=fake_stage, status=MCPServerStatusEnum.ACTIVE.value)
@@ -95,7 +114,7 @@ class TestMCPServerHandler:
         G(AppResourcePermission, gateway=fake_gateway, bk_app_code=f"v_mcp_{mcp_server.id}_test1", resource_id=1)
         G(AppResourcePermission, gateway=fake_gateway, bk_app_code=f"v_mcp_{mcp_server.id}_test2", resource_id=2)
 
-        with patch.object(MCPServerHandler, "_cleanup_all_resource_permissions") as mock_cleanup:
+        with patch.object(MCPServerHandler, "cleanup_all_resource_permissions") as mock_cleanup:
             MCPServerHandler.sync_permissions(mcp_server.id)
 
             # Should call cleanup with correct parameters
@@ -111,7 +130,7 @@ class TestMCPServerHandler:
         # Create app permission
         G(MCPServerAppPermission, mcp_server=mcp_server, bk_app_code="test_app")
 
-        with patch.object(MCPServerHandler, "_cleanup_all_resource_permissions") as mock_cleanup:
+        with patch.object(MCPServerHandler, "cleanup_all_resource_permissions") as mock_cleanup:
             MCPServerHandler.sync_permissions(mcp_server.id)
 
             # Should not call cleanup since we return early

--- a/src/dashboard/apigateway/apigateway/tests/biz/mcp_server/test_permission.py
+++ b/src/dashboard/apigateway/apigateway/tests/biz/mcp_server/test_permission.py
@@ -42,7 +42,7 @@ class TestMCPServerPermissionHandler:
         G(AppResourcePermission, gateway=fake_gateway, bk_app_code=f"v_mcp_{mcp_server.id}_test1", resource_id=1)
         G(AppResourcePermission, gateway=fake_gateway, bk_app_code=f"v_mcp_{mcp_server.id}_test2", resource_id=2)
 
-        with patch.object(MCPServerHandler, "_cleanup_all_resource_permissions") as mock_cleanup:
+        with patch.object(MCPServerHandler, "cleanup_all_resource_permissions") as mock_cleanup:
             MCPServerHandler.sync_permissions(mcp_server.id)
 
             # Should call cleanup with correct parameters
@@ -58,7 +58,7 @@ class TestMCPServerPermissionHandler:
         # Create app permission
         G(MCPServerAppPermission, mcp_server=mcp_server, bk_app_code="test_app")
 
-        with patch.object(MCPServerHandler, "_cleanup_all_resource_permissions") as mock_cleanup:
+        with patch.object(MCPServerHandler, "cleanup_all_resource_permissions") as mock_cleanup:
             MCPServerHandler.sync_permissions(mcp_server.id)
 
             # Should not call cleanup since we return early

--- a/src/dashboard/apigateway/apigateway/tests/common/tenant/test_query.py
+++ b/src/dashboard/apigateway/apigateway/tests/common/tenant/test_query.py
@@ -23,22 +23,24 @@ from django.test import TestCase
 from apigateway.common.tenant.constants import TENANT_ID_OPERATION, TenantModeEnum
 from apigateway.common.tenant.query import (
     gateway_filter_by_app_tenant_id,
-    gateway_filter_by_user_tenant_id,
+    gateway_filter_by_maintainer_tenant_id,
     gateway_mcp_server_filter_by_user_tenant_id,
+    gateway_related_filter_by_maintainer_tenant_id,
     gateway_related_filter_by_user_tenant_id,
+    mcp_server_related_filter_by_maintainer_tenant_id,
     mcp_server_related_filter_by_user_tenant_id,
 )
 
 
 @pytest.mark.django_db
-class TestGatewayFilterByUserTenantId(TestCase):
+class TestGatewayFilterByMaintainerTenantId(TestCase):
     def setUp(self):
         # Setup initial data for the tests
         self.queryset = MockQuerySet()
 
     def test_filter_by_operation_tenant(self):
         user_tenant_id = TENANT_ID_OPERATION
-        filtered_queryset = gateway_filter_by_user_tenant_id(self.queryset, user_tenant_id)
+        filtered_queryset = gateway_filter_by_maintainer_tenant_id(self.queryset, user_tenant_id)
         expected_filter = Q(tenant_mode=TenantModeEnum.GLOBAL.value) | Q(
             tenant_mode=TenantModeEnum.SINGLE.value, tenant_id=user_tenant_id
         )
@@ -46,8 +48,32 @@ class TestGatewayFilterByUserTenantId(TestCase):
 
     def test_filter_by_single_tenant(self):
         user_tenant_id = "tenant_123"
-        filtered_queryset = gateway_filter_by_user_tenant_id(self.queryset, user_tenant_id)
+        filtered_queryset = gateway_filter_by_maintainer_tenant_id(self.queryset, user_tenant_id)
         expected_filter = {"tenant_mode": TenantModeEnum.SINGLE.value, "tenant_id": user_tenant_id}
+        assert filtered_queryset.filter_condition == expected_filter
+
+
+@pytest.mark.django_db
+class TestGatewayRelatedFilterByMaintainerTenantId(TestCase):
+    def setUp(self):
+        self.queryset = MockQuerySet()
+
+    def test_filter_by_operation_tenant(self):
+        user_tenant_id = TENANT_ID_OPERATION
+        filtered_queryset = gateway_related_filter_by_maintainer_tenant_id(self.queryset, user_tenant_id)
+        expected_filter = Q(gateway__tenant_mode=TenantModeEnum.GLOBAL.value) | Q(
+            gateway__tenant_mode=TenantModeEnum.SINGLE.value,
+            gateway__tenant_id=user_tenant_id,
+        )
+        assert filtered_queryset.filter_condition == expected_filter
+
+    def test_filter_by_single_tenant(self):
+        user_tenant_id = "tenant_123"
+        filtered_queryset = gateway_related_filter_by_maintainer_tenant_id(self.queryset, user_tenant_id)
+        expected_filter = {
+            "gateway__tenant_mode": TenantModeEnum.SINGLE.value,
+            "gateway__tenant_id": user_tenant_id,
+        }
         assert filtered_queryset.filter_condition == expected_filter
 
 
@@ -68,9 +94,33 @@ class TestGatewayRelatedFilterByUserTenantId(TestCase):
     def test_filter_by_single_tenant(self):
         user_tenant_id = "tenant_123"
         filtered_queryset = gateway_related_filter_by_user_tenant_id(self.queryset, user_tenant_id)
+        expected_filter = Q(gateway__tenant_mode=TenantModeEnum.GLOBAL.value) | Q(
+            gateway__tenant_mode=TenantModeEnum.SINGLE.value,
+            gateway__tenant_id=user_tenant_id,
+        )
+        assert filtered_queryset.filter_condition == expected_filter
+
+
+@pytest.mark.django_db
+class TestMCPServerRelatedFilterByMaintainerTenantId(TestCase):
+    def setUp(self):
+        self.queryset = MockQuerySet()
+
+    def test_filter_by_operation_tenant(self):
+        user_tenant_id = TENANT_ID_OPERATION
+        filtered_queryset = mcp_server_related_filter_by_maintainer_tenant_id(self.queryset, user_tenant_id)
+        expected_filter = Q(mcp_server__gateway__tenant_mode=TenantModeEnum.GLOBAL.value) | Q(
+            mcp_server__gateway__tenant_mode=TenantModeEnum.SINGLE.value,
+            mcp_server__gateway__tenant_id=user_tenant_id,
+        )
+        assert filtered_queryset.filter_condition == expected_filter
+
+    def test_filter_by_single_tenant(self):
+        user_tenant_id = "tenant_123"
+        filtered_queryset = mcp_server_related_filter_by_maintainer_tenant_id(self.queryset, user_tenant_id)
         expected_filter = {
-            "gateway__tenant_mode": TenantModeEnum.SINGLE.value,
-            "gateway__tenant_id": user_tenant_id,
+            "mcp_server__gateway__tenant_mode": TenantModeEnum.SINGLE.value,
+            "mcp_server__gateway__tenant_id": user_tenant_id,
         }
         assert filtered_queryset.filter_condition == expected_filter
 
@@ -92,10 +142,10 @@ class TestMCPServerRelatedFilterByUserTenantId(TestCase):
     def test_filter_by_single_tenant(self):
         user_tenant_id = "tenant_123"
         filtered_queryset = mcp_server_related_filter_by_user_tenant_id(self.queryset, user_tenant_id)
-        expected_filter = {
-            "mcp_server__gateway__tenant_mode": TenantModeEnum.SINGLE.value,
-            "mcp_server__gateway__tenant_id": user_tenant_id,
-        }
+        expected_filter = Q(mcp_server__gateway__tenant_mode=TenantModeEnum.GLOBAL.value) | Q(
+            mcp_server__gateway__tenant_mode=TenantModeEnum.SINGLE.value,
+            mcp_server__gateway__tenant_id=user_tenant_id,
+        )
         assert filtered_queryset.filter_condition == expected_filter
 
 
@@ -116,10 +166,10 @@ class TestGatewayMCPServerFilterByUserTenantId(TestCase):
     def test_filter_by_single_tenant(self):
         user_tenant_id = "tenant_123"
         filtered_queryset = gateway_mcp_server_filter_by_user_tenant_id(self.queryset, user_tenant_id)
-        expected_filter = {
-            "gateway__tenant_mode": TenantModeEnum.SINGLE.value,
-            "gateway__tenant_id": user_tenant_id,
-        }
+        expected_filter = Q(gateway__tenant_mode=TenantModeEnum.GLOBAL.value) | Q(
+            gateway__tenant_mode=TenantModeEnum.SINGLE.value,
+            gateway__tenant_id=user_tenant_id,
+        )
         assert filtered_queryset.filter_condition == expected_filter
 
 

--- a/src/dashboard/apigateway/apigateway/tests/controller/tasks/test_clean_task.py
+++ b/src/dashboard/apigateway/apigateway/tests/controller/tasks/test_clean_task.py
@@ -1,0 +1,83 @@
+#
+# TencentBlueKing is pleased to support the open source community by making
+# 蓝鲸智云 - API 网关 (BlueKing - APIGateway) available.
+# Copyright (C) Tencent. All rights reserved.
+# Licensed under the MIT License (the "License"); you may not use this file except
+# in compliance with the License. You may obtain a copy of the License at
+#
+#     http://opensource.org/licenses/MIT
+#
+# Unless required by applicable law or agreed to in writing, software distributed under
+# the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+# either express or implied. See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# We undertake not to change the open source license (MIT license) applicable
+# to the current version of the project delivered to anyone in the future.
+#
+
+import pytest
+from ddf import G
+from django.test import override_settings
+
+from apigateway.apps.permission.models import AppResourcePermission
+from apigateway.controller.tasks.clean_task import delete_old_app_resource_permission_records
+from apigateway.utils.time import to_datetime_from_now
+
+pytestmark = pytest.mark.django_db
+
+
+class TestDeleteOldAppResourcePermissionRecords:
+    @override_settings(DEFAULT_TEST_APP={"bk_app_code": "default-test-app"})
+    def test_delete_expired_records(self, fake_gateway):
+        default_test_app_old_permission = G(
+            AppResourcePermission,
+            gateway=fake_gateway,
+            bk_app_code="default-test-app",
+            resource_id=1,
+            expires=to_datetime_from_now(days=-31),
+        )
+        default_test_app_recent_permission = G(
+            AppResourcePermission,
+            gateway=fake_gateway,
+            bk_app_code="default-test-app",
+            resource_id=2,
+            expires=to_datetime_from_now(days=-29),
+        )
+        other_app_old_permission = G(
+            AppResourcePermission,
+            gateway=fake_gateway,
+            bk_app_code="other-app",
+            resource_id=3,
+            expires=to_datetime_from_now(days=-(365 * 4)),
+        )
+        other_app_recent_permission = G(
+            AppResourcePermission,
+            gateway=fake_gateway,
+            bk_app_code="other-app",
+            resource_id=4,
+            expires=to_datetime_from_now(days=-31),
+        )
+        not_expired_permission = G(
+            AppResourcePermission,
+            gateway=fake_gateway,
+            bk_app_code="default-test-app",
+            resource_id=5,
+            expires=to_datetime_from_now(days=1),
+        )
+        permanent_permission = G(
+            AppResourcePermission,
+            gateway=fake_gateway,
+            bk_app_code="default-test-app",
+            resource_id=6,
+            expires=None,
+        )
+
+        delete_old_app_resource_permission_records()
+
+        assert not AppResourcePermission.objects.filter(id=default_test_app_old_permission.id).exists()
+        assert not AppResourcePermission.objects.filter(id=other_app_old_permission.id).exists()
+        assert AppResourcePermission.objects.filter(id=default_test_app_recent_permission.id).exists()
+        assert AppResourcePermission.objects.filter(id=other_app_recent_permission.id).exists()
+        assert AppResourcePermission.objects.filter(id=not_expired_permission.id).exists()
+        assert AppResourcePermission.objects.filter(id=permanent_permission.id).exists()


### PR DESCRIPTION
## Summary
- Clean up app and MCP server permission data when related resources are deleted.
- Add a scheduled cleanup task for stale controller-side permission artifacts.
- Split tenant query helpers by maintainer vs user/app visibility and update personal workbench filters accordingly.

## Test plan
- `source .envrc && make lint-check`
- `source .envrc && make test`


Made with [Cursor](https://cursor.com)