### PR TITLE
Fix workbench tenant permission filters

### DIFF
--- a/src/dashboard/apigateway/apigateway/apis/web/mcp_marketplace/views.py
+++ b/src/dashboard/apigateway/apigateway/apis/web/mcp_marketplace/views.py
@@ -30,7 +30,7 @@ from apigateway.apps.mcp_server.constants import (
 from apigateway.apps.mcp_server.models import MCPServer, MCPServerCategory
 from apigateway.biz.mcp_server import MCPServerHandler
 from apigateway.common.error_codes import error_codes
-from apigateway.common.tenant.constants import TENANT_ID_OPERATION, TenantModeEnum
+from apigateway.common.tenant.constants import TenantModeEnum
 from apigateway.common.tenant.query import gateway_mcp_server_filter_by_user_tenant_id
 from apigateway.common.tenant.request import get_user_tenant_id
 from apigateway.common.tenant.validators import check_user_can_access_gateway
@@ -266,20 +266,11 @@ class MCPMarketplaceCategoryListApi(generics.ListAPIView):
                 mcp_server_filter &= Q(
                     mcp_servers__categories__name__in=categories, mcp_servers__categories__is_active=True
                 )
-        # 如果有租户过滤，使用和 MCPMarketplaceServerListApi 一样的筛选逻辑
         if user_tenant_id:
-            # 运营租户可以看到 全租户网关 + 自己租户网关的 MCP Server
-            if user_tenant_id == TENANT_ID_OPERATION:
-                mcp_server_filter &= Q(mcp_servers__gateway__tenant_mode=TenantModeEnum.GLOBAL.value) | Q(
-                    mcp_servers__gateway__tenant_mode=TenantModeEnum.SINGLE.value,
-                    mcp_servers__gateway__tenant_id=user_tenant_id,
-                )
-            else:
-                # 其他租户只能看到本租户网关的 MCP Server
-                mcp_server_filter &= Q(
-                    mcp_servers__gateway__tenant_mode=TenantModeEnum.SINGLE.value,
-                    mcp_servers__gateway__tenant_id=user_tenant_id,
-                )
+            mcp_server_filter &= Q(mcp_servers__gateway__tenant_mode=TenantModeEnum.GLOBAL.value) | Q(
+                mcp_servers__gateway__tenant_mode=TenantModeEnum.SINGLE.value,
+                mcp_servers__gateway__tenant_id=user_tenant_id,
+            )
 
         # 使用 annotate 一次性统计每个分类的 MCPServer 数量，避免 N+1 查询
         queryset = (

--- a/src/dashboard/apigateway/apigateway/apis/web/personal_workbench/views.py
+++ b/src/dashboard/apigateway/apigateway/apis/web/personal_workbench/views.py
@@ -28,8 +28,10 @@ from apigateway.biz.mcp_server import MCPServerPermissionHandler
 from apigateway.biz.permission import ResourcePermissionHandler
 from apigateway.biz.personal_workbench import WorkbenchPermissionHandler
 from apigateway.common.tenant.query import (
-    gateway_filter_by_user_tenant_id,
+    gateway_filter_by_app_tenant_id,
+    gateway_filter_by_maintainer_tenant_id,
     gateway_mcp_server_filter_by_user_tenant_id,
+    gateway_related_filter_by_maintainer_tenant_id,
     gateway_related_filter_by_user_tenant_id,
     mcp_server_related_filter_by_user_tenant_id,
 )
@@ -154,14 +156,14 @@ class WorkbenchGatewayFilterOptionListApi(WorkbenchPermissionMixin, generics.Lis
                 AppPermissionApply.objects.filter(applied_by=username).values_list("gateway_id", flat=True).distinct()
             )
             queryset = Gateway.objects.filter(id__in=gateway_ids).order_by("name")
-            return gateway_filter_by_user_tenant_id(queryset, tenant_id)
+            return gateway_filter_by_app_tenant_id(queryset, tenant_id)
 
         if filter_type == WorkbenchFilterTypeEnum.HANDLED.value:
             # 我的已办：从用户处理过的记录中提取去重的网关；ITSM 回调无实际审批人，按当前用户维护的网关补充
             queryset = WorkbenchPermissionHandler.get_handled_gateway_permission_record_queryset(username, tenant_id)
             gateway_ids = queryset.values_list("gateway_id", flat=True).distinct()
             queryset = Gateway.objects.filter(id__in=gateway_ids).order_by("name")
-            return gateway_filter_by_user_tenant_id(queryset, tenant_id)
+            return gateway_filter_by_maintainer_tenant_id(queryset, tenant_id)
 
         # pending（默认）：从当前用户待审批的 API 网关权限申请中提取去重的网关
         gateway_ids = (
@@ -218,7 +220,7 @@ class WorkbenchMCPServerFilterOptionListApi(WorkbenchPermissionMixin, generics.L
                 .distinct()
             )
             queryset = MCPServer.objects.select_related("gateway").filter(id__in=mcp_server_ids).order_by("name")
-            return gateway_mcp_server_filter_by_user_tenant_id(queryset, tenant_id)
+            return gateway_related_filter_by_maintainer_tenant_id(queryset, tenant_id)
 
         # pending（默认）：从当前用户待审批的 MCP Server 权限申请中提取去重的 MCP Server
         mcp_server_ids = (
@@ -265,7 +267,7 @@ class WorkbenchMCPGatewayFilterOptionListApi(WorkbenchPermissionMixin, generics.
                 .distinct()
             )
             queryset = Gateway.objects.filter(id__in=gateway_ids).order_by("name")
-            return gateway_filter_by_user_tenant_id(queryset, tenant_id)
+            return gateway_filter_by_app_tenant_id(queryset, tenant_id)
 
         if filter_type == WorkbenchFilterTypeEnum.HANDLED.value:
             # 我的已办：从用户处理过的 MCP 记录中提取去重的网关；ITSM 回调无实际审批人，按当前用户维护的网关补充
@@ -275,7 +277,7 @@ class WorkbenchMCPGatewayFilterOptionListApi(WorkbenchPermissionMixin, generics.
                 .distinct()
             )
             queryset = Gateway.objects.filter(id__in=gateway_ids).order_by("name")
-            return gateway_filter_by_user_tenant_id(queryset, tenant_id)
+            return gateway_filter_by_maintainer_tenant_id(queryset, tenant_id)
 
         # pending（默认）：从当前用户待审批的 MCP Server 权限申请中提取去重的网关
         gateway_ids = (

--- a/src/dashboard/apigateway/apigateway/apis/web/personal_workbench/views.py
+++ b/src/dashboard/apigateway/apigateway/apis/web/personal_workbench/views.py
@@ -213,7 +213,7 @@ class WorkbenchMCPServerFilterOptionListApi(WorkbenchPermissionMixin, generics.L
             return gateway_mcp_server_filter_by_user_tenant_id(queryset, tenant_id)
 
         if filter_type == WorkbenchFilterTypeEnum.HANDLED.value:
-            # 我的已办：从用户处理过的记录中提取去重的 MCP Server；ITSM 回调无实际审批人，按当前用户维护的网关补充
+            # 我的已办：从管理员处理过的记录中提取去重的 MCP Server；ITSM 回调无实际审批人，按当前用户维护的网关补充
             mcp_server_ids = (
                 WorkbenchPermissionHandler.get_handled_mcp_permission_apply_queryset(username, tenant_id)
                 .values_list("mcp_server_id", flat=True)

--- a/src/dashboard/apigateway/apigateway/biz/gateway/gateway.py
+++ b/src/dashboard/apigateway/apigateway/biz/gateway/gateway.py
@@ -34,7 +34,7 @@ from apigateway.apps.support.models import ReleasedResourceDoc
 from apigateway.biz.release import ReleaseHandler
 from apigateway.biz.stage import StageHandler
 from apigateway.common.constants import CallSourceTypeEnum
-from apigateway.common.tenant.query import gateway_filter_by_user_tenant_id
+from apigateway.common.tenant.query import gateway_filter_by_maintainer_tenant_id
 from apigateway.core.constants import (
     ContextScopeTypeEnum,
     GatewayOperationSourceEnum,
@@ -89,7 +89,7 @@ class GatewayHandler:
         """获取用户有权限的网关列表"""
         queryset = Gateway.objects.filter(_maintainers__contains=username)
         if tenant_id:
-            queryset = gateway_filter_by_user_tenant_id(queryset, tenant_id)
+            queryset = gateway_filter_by_maintainer_tenant_id(queryset, tenant_id)
 
         # 使用 _maintainers 过滤的数据并不准确，需要根据其中人员列表二次过滤
         return [gateway for gateway in queryset if gateway.has_permission(username)]

--- a/src/dashboard/apigateway/apigateway/biz/mcp_server/permission.py
+++ b/src/dashboard/apigateway/apigateway/biz/mcp_server/permission.py
@@ -30,7 +30,7 @@ from apigateway.apps.mcp_server.constants import (
 from apigateway.apps.mcp_server.models import MCPServer, MCPServerAppPermissionApply
 from apigateway.apps.permission.constants import FormattedGrantDimensionEnum
 from apigateway.common.error_codes import error_codes
-from apigateway.common.tenant.query import gateway_filter_by_user_tenant_id
+from apigateway.common.tenant.query import gateway_filter_by_maintainer_tenant_id
 from apigateway.core.constants import GatewayStatusEnum, StageStatusEnum
 from apigateway.core.models import Gateway
 from apigateway.service.bk_itsm import ItsmPermissionApplyHelper
@@ -45,7 +45,7 @@ class MCPServerPermissionHandler:
         """获取指定用户作为网关管理员待审批的 MCP Server 权限申请列表"""
         queryset = Gateway.objects.filter(_maintainers__contains=username)
         if tenant_id:
-            queryset = gateway_filter_by_user_tenant_id(queryset, tenant_id)
+            queryset = gateway_filter_by_maintainer_tenant_id(queryset, tenant_id)
 
         gateway_ids = [gateway.id for gateway in queryset if gateway.has_permission(username)]
         return MCPServerAppPermissionApply.objects.filter(

--- a/src/dashboard/apigateway/apigateway/biz/permission/permission.py
+++ b/src/dashboard/apigateway/apigateway/biz/permission/permission.py
@@ -35,7 +35,7 @@ from apigateway.common.tenant.constants import (
     TENANT_ID_OPERATION,
     TenantModeEnum,
 )
-from apigateway.common.tenant.query import gateway_filter_by_user_tenant_id
+from apigateway.common.tenant.query import gateway_filter_by_maintainer_tenant_id
 from apigateway.components.bkauth import get_app_tenant_info_cached
 from apigateway.components.bkuser import query_display_names_cached
 from apigateway.core.models import Gateway, Resource
@@ -47,7 +47,7 @@ class ResourcePermissionHandler:
         """获取指定用户作为网关管理员待审批的 API 网关权限申请列表"""
         queryset = Gateway.objects.filter(_maintainers__contains=username)
         if tenant_id:
-            queryset = gateway_filter_by_user_tenant_id(queryset, tenant_id)
+            queryset = gateway_filter_by_maintainer_tenant_id(queryset, tenant_id)
 
         gateway_ids = [gateway.id for gateway in queryset if gateway.has_permission(username)]
         return AppPermissionApply.objects.filter(

--- a/src/dashboard/apigateway/apigateway/biz/personal_workbench/permission.py
+++ b/src/dashboard/apigateway/apigateway/biz/personal_workbench/permission.py
@@ -26,8 +26,8 @@ from apigateway.apps.permission.models import AppPermissionRecord
 from apigateway.biz.bk_itsm import ITSM_PERMISSION_APPROVAL_HANDLER
 from apigateway.biz.gateway import GatewayHandler
 from apigateway.common.tenant.query import (
-    gateway_related_filter_by_user_tenant_id,
-    mcp_server_related_filter_by_user_tenant_id,
+    gateway_related_filter_by_maintainer_tenant_id,
+    mcp_server_related_filter_by_maintainer_tenant_id,
 )
 
 
@@ -45,7 +45,7 @@ class WorkbenchPermissionHandler:
                 gateway_id__in=cls._get_user_gateway_ids(username, tenant_id),
             )
         ).exclude(status=ApplyStatusEnum.PENDING.value)
-        return gateway_related_filter_by_user_tenant_id(queryset, tenant_id)
+        return gateway_related_filter_by_maintainer_tenant_id(queryset, tenant_id)
 
     @classmethod
     def get_handled_mcp_permission_apply_queryset(cls, username: str, tenant_id: str) -> QuerySet:
@@ -57,4 +57,4 @@ class WorkbenchPermissionHandler:
             ),
             is_deleted=False,
         ).exclude(status=MCPServerAppPermissionApplyStatusEnum.PENDING.value)
-        return mcp_server_related_filter_by_user_tenant_id(queryset, tenant_id)
+        return mcp_server_related_filter_by_maintainer_tenant_id(queryset, tenant_id)

--- a/src/dashboard/apigateway/apigateway/common/tenant/query.py
+++ b/src/dashboard/apigateway/apigateway/common/tenant/query.py
@@ -24,7 +24,7 @@ from .constants import (
 )
 
 
-def gateway_filter_by_user_tenant_id(queryset: QuerySet, user_tenant_id: str) -> QuerySet:
+def gateway_filter_by_maintainer_tenant_id(queryset: QuerySet, user_tenant_id: str) -> QuerySet:
     """网关管理员维度查看网关列表，运营租户能看到全租户网关 + 本租户网关，其他租户只能看到本租户网关
 
     Args:
@@ -60,8 +60,8 @@ def gateway_filter_by_app_tenant_id(queryset: QuerySet, app_tenant_id: str) -> Q
     )
 
 
-def gateway_related_filter_by_user_tenant_id(queryset: QuerySet, user_tenant_id: str) -> QuerySet:
-    """按用户租户 ID 过滤通过 gateway 外键关联的 QuerySet（如 AppPermissionApply、AppPermissionRecord）
+def gateway_related_filter_by_maintainer_tenant_id(queryset: QuerySet, user_tenant_id: str) -> QuerySet:
+    """按维护者租户 ID 过滤通过 gateway 外键关联的 QuerySet（如 AppPermissionApply、AppPermissionRecord）
 
     Args:
         queryset (QuerySet): 含 gateway 外键的 queryset
@@ -78,8 +78,24 @@ def gateway_related_filter_by_user_tenant_id(queryset: QuerySet, user_tenant_id:
     return queryset.filter(gateway__tenant_mode=TenantModeEnum.SINGLE.value, gateway__tenant_id=user_tenant_id)
 
 
-def mcp_server_related_filter_by_user_tenant_id(queryset: QuerySet, user_tenant_id: str) -> QuerySet:
-    """按用户租户 ID 过滤通过 mcp_server__gateway 外键关联的 QuerySet（如 MCPServerAppPermissionApply）
+def gateway_related_filter_by_user_tenant_id(queryset: QuerySet, user_tenant_id: str) -> QuerySet:
+    """按用户租户 ID 过滤通过 gateway 外键关联的 QuerySet（如 AppPermissionApply、AppPermissionRecord）
+
+    Args:
+        queryset (QuerySet): 含 gateway 外键的 queryset
+        user_tenant_id (str): user tenant id
+
+    Returns:
+        QuerySet: filtered queryset
+    """
+    return queryset.filter(
+        Q(gateway__tenant_mode=TenantModeEnum.GLOBAL.value)
+        | Q(gateway__tenant_mode=TenantModeEnum.SINGLE.value, gateway__tenant_id=user_tenant_id)
+    )
+
+
+def mcp_server_related_filter_by_maintainer_tenant_id(queryset: QuerySet, user_tenant_id: str) -> QuerySet:
+    """按维护者租户 ID 过滤通过 mcp_server__gateway 外键关联的 QuerySet（如 MCPServerAppPermissionApply）
 
     Args:
         queryset (QuerySet): 含 mcp_server__gateway 外键路径的 queryset
@@ -102,10 +118,29 @@ def mcp_server_related_filter_by_user_tenant_id(queryset: QuerySet, user_tenant_
     )
 
 
+def mcp_server_related_filter_by_user_tenant_id(queryset: QuerySet, user_tenant_id: str) -> QuerySet:
+    """按用户租户 ID 过滤通过 mcp_server__gateway 外键关联的 QuerySet（如 MCPServerAppPermissionApply）
+
+    Args:
+        queryset (QuerySet): 含 mcp_server__gateway 外键路径的 queryset
+        user_tenant_id (str): user tenant id
+
+    Returns:
+        QuerySet: filtered queryset
+    """
+    return queryset.filter(
+        Q(mcp_server__gateway__tenant_mode=TenantModeEnum.GLOBAL.value)
+        | Q(
+            mcp_server__gateway__tenant_mode=TenantModeEnum.SINGLE.value,
+            mcp_server__gateway__tenant_id=user_tenant_id,
+        )
+    )
+
+
 def gateway_mcp_server_filter_by_user_tenant_id(queryset: QuerySet, user_tenant_id: str) -> QuerySet:
     """按用户租户 ID 过滤 MCPServer QuerySet（通过 gateway 关联）
 
-    运营租户能看到全租户网关 + 本租户网关的 MCP Server，其他租户只能看到本租户网关的 MCP Server。
+    用户能看到全租户网关 + 本租户网关的 MCP Server。
 
     Args:
         queryset (QuerySet): mcp_server queryset
@@ -114,9 +149,7 @@ def gateway_mcp_server_filter_by_user_tenant_id(queryset: QuerySet, user_tenant_
     Returns:
         QuerySet: filtered queryset
     """
-    if user_tenant_id == TENANT_ID_OPERATION:
-        return queryset.filter(
-            Q(gateway__tenant_mode=TenantModeEnum.GLOBAL.value)
-            | Q(gateway__tenant_mode=TenantModeEnum.SINGLE.value, gateway__tenant_id=user_tenant_id)
-        )
-    return queryset.filter(gateway__tenant_mode=TenantModeEnum.SINGLE.value, gateway__tenant_id=user_tenant_id)
+    return queryset.filter(
+        Q(gateway__tenant_mode=TenantModeEnum.GLOBAL.value)
+        | Q(gateway__tenant_mode=TenantModeEnum.SINGLE.value, gateway__tenant_id=user_tenant_id)
+    )

--- a/src/dashboard/apigateway/apigateway/tests/apis/web/mcp_marketplace/test_views.py
+++ b/src/dashboard/apigateway/apigateway/tests/apis/web/mcp_marketplace/test_views.py
@@ -28,7 +28,9 @@ from apigateway.apps.mcp_server.constants import (
     MCPServerStatusEnum,
 )
 from apigateway.apps.mcp_server.models import MCPServer, MCPServerCategory, MCPServerExtend
+from apigateway.common.tenant.constants import TenantModeEnum
 from apigateway.core.constants import GatewayStatusEnum, StageStatusEnum
+from apigateway.core.models import Gateway, Stage
 
 pytestmark = pytest.mark.django_db
 
@@ -790,6 +792,76 @@ class TestMCPMarketplaceCategoryListApi:
         )
         assert devops_category is not None
         assert devops_category["mcp_server_count"] == 0
+
+    def test_list_categories_count_includes_global_and_user_tenant_servers(
+        self, request_view, fake_categories, fake_public_mcp_server, faker
+    ):
+        """普通租户统计分类时，应包含全租户网关和本租户网关下的 MCPServer"""
+        fake_public_mcp_server.gateway.tenant_mode = TenantModeEnum.GLOBAL.value
+        fake_public_mcp_server.gateway.tenant_id = ""
+        fake_public_mcp_server.gateway.save()
+        fake_public_mcp_server.categories.add(fake_categories["devops"])
+
+        same_tenant_gateway = G(
+            Gateway,
+            name=faker.pystr()[:20],
+            _maintainers="admin",
+            status=GatewayStatusEnum.ACTIVE.value,
+            is_public=True,
+            tenant_mode=TenantModeEnum.SINGLE.value,
+            tenant_id="default",
+        )
+        same_tenant_stage = G(
+            Stage,
+            gateway=same_tenant_gateway,
+            status=StageStatusEnum.ACTIVE.value,
+            name=faker.pystr()[:20],
+        )
+        same_tenant_server = G(
+            MCPServer,
+            name=faker.pystr()[:20],
+            gateway=same_tenant_gateway,
+            stage=same_tenant_stage,
+            status=MCPServerStatusEnum.ACTIVE.value,
+            is_public=True,
+        )
+        same_tenant_server.categories.add(fake_categories["devops"])
+
+        other_tenant_gateway = G(
+            Gateway,
+            name=faker.pystr()[:20],
+            _maintainers="admin",
+            status=GatewayStatusEnum.ACTIVE.value,
+            is_public=True,
+            tenant_mode=TenantModeEnum.SINGLE.value,
+            tenant_id="other",
+        )
+        other_tenant_stage = G(
+            Stage,
+            gateway=other_tenant_gateway,
+            status=StageStatusEnum.ACTIVE.value,
+            name=faker.pystr()[:20],
+        )
+        other_tenant_server = G(
+            MCPServer,
+            name=faker.pystr()[:20],
+            gateway=other_tenant_gateway,
+            stage=other_tenant_stage,
+            status=MCPServerStatusEnum.ACTIVE.value,
+            is_public=True,
+        )
+        other_tenant_server.categories.add(fake_categories["devops"])
+
+        resp = request_view(
+            method="GET",
+            view_name="mcp_marketplace.category.list",
+        )
+        result = resp.json()
+
+        assert resp.status_code == 200
+        devops_category = next((cat for cat in result["data"] if cat["name"] == "DevOps"), None)
+        assert devops_category is not None
+        assert devops_category["mcp_server_count"] == 2
 
     def test_list_categories_empty(self, request_view):
         """测试没有分类时的情况"""

--- a/src/dashboard/apigateway/apigateway/tests/common/tenant/test_query.py
+++ b/src/dashboard/apigateway/apigateway/tests/common/tenant/test_query.py
@@ -23,22 +23,24 @@ from django.test import TestCase
 from apigateway.common.tenant.constants import TENANT_ID_OPERATION, TenantModeEnum
 from apigateway.common.tenant.query import (
     gateway_filter_by_app_tenant_id,
-    gateway_filter_by_user_tenant_id,
+    gateway_filter_by_maintainer_tenant_id,
     gateway_mcp_server_filter_by_user_tenant_id,
+    gateway_related_filter_by_maintainer_tenant_id,
     gateway_related_filter_by_user_tenant_id,
+    mcp_server_related_filter_by_maintainer_tenant_id,
     mcp_server_related_filter_by_user_tenant_id,
 )
 
 
 @pytest.mark.django_db
-class TestGatewayFilterByUserTenantId(TestCase):
+class TestGatewayFilterByMaintainerTenantId(TestCase):
     def setUp(self):
         # Setup initial data for the tests
         self.queryset = MockQuerySet()
 
     def test_filter_by_operation_tenant(self):
         user_tenant_id = TENANT_ID_OPERATION
-        filtered_queryset = gateway_filter_by_user_tenant_id(self.queryset, user_tenant_id)
+        filtered_queryset = gateway_filter_by_maintainer_tenant_id(self.queryset, user_tenant_id)
         expected_filter = Q(tenant_mode=TenantModeEnum.GLOBAL.value) | Q(
             tenant_mode=TenantModeEnum.SINGLE.value, tenant_id=user_tenant_id
         )
@@ -46,8 +48,32 @@ class TestGatewayFilterByUserTenantId(TestCase):
 
     def test_filter_by_single_tenant(self):
         user_tenant_id = "tenant_123"
-        filtered_queryset = gateway_filter_by_user_tenant_id(self.queryset, user_tenant_id)
+        filtered_queryset = gateway_filter_by_maintainer_tenant_id(self.queryset, user_tenant_id)
         expected_filter = {"tenant_mode": TenantModeEnum.SINGLE.value, "tenant_id": user_tenant_id}
+        assert filtered_queryset.filter_condition == expected_filter
+
+
+@pytest.mark.django_db
+class TestGatewayRelatedFilterByMaintainerTenantId(TestCase):
+    def setUp(self):
+        self.queryset = MockQuerySet()
+
+    def test_filter_by_operation_tenant(self):
+        user_tenant_id = TENANT_ID_OPERATION
+        filtered_queryset = gateway_related_filter_by_maintainer_tenant_id(self.queryset, user_tenant_id)
+        expected_filter = Q(gateway__tenant_mode=TenantModeEnum.GLOBAL.value) | Q(
+            gateway__tenant_mode=TenantModeEnum.SINGLE.value,
+            gateway__tenant_id=user_tenant_id,
+        )
+        assert filtered_queryset.filter_condition == expected_filter
+
+    def test_filter_by_single_tenant(self):
+        user_tenant_id = "tenant_123"
+        filtered_queryset = gateway_related_filter_by_maintainer_tenant_id(self.queryset, user_tenant_id)
+        expected_filter = {
+            "gateway__tenant_mode": TenantModeEnum.SINGLE.value,
+            "gateway__tenant_id": user_tenant_id,
+        }
         assert filtered_queryset.filter_condition == expected_filter
 
 
@@ -68,9 +94,33 @@ class TestGatewayRelatedFilterByUserTenantId(TestCase):
     def test_filter_by_single_tenant(self):
         user_tenant_id = "tenant_123"
         filtered_queryset = gateway_related_filter_by_user_tenant_id(self.queryset, user_tenant_id)
+        expected_filter = Q(gateway__tenant_mode=TenantModeEnum.GLOBAL.value) | Q(
+            gateway__tenant_mode=TenantModeEnum.SINGLE.value,
+            gateway__tenant_id=user_tenant_id,
+        )
+        assert filtered_queryset.filter_condition == expected_filter
+
+
+@pytest.mark.django_db
+class TestMCPServerRelatedFilterByMaintainerTenantId(TestCase):
+    def setUp(self):
+        self.queryset = MockQuerySet()
+
+    def test_filter_by_operation_tenant(self):
+        user_tenant_id = TENANT_ID_OPERATION
+        filtered_queryset = mcp_server_related_filter_by_maintainer_tenant_id(self.queryset, user_tenant_id)
+        expected_filter = Q(mcp_server__gateway__tenant_mode=TenantModeEnum.GLOBAL.value) | Q(
+            mcp_server__gateway__tenant_mode=TenantModeEnum.SINGLE.value,
+            mcp_server__gateway__tenant_id=user_tenant_id,
+        )
+        assert filtered_queryset.filter_condition == expected_filter
+
+    def test_filter_by_single_tenant(self):
+        user_tenant_id = "tenant_123"
+        filtered_queryset = mcp_server_related_filter_by_maintainer_tenant_id(self.queryset, user_tenant_id)
         expected_filter = {
-            "gateway__tenant_mode": TenantModeEnum.SINGLE.value,
-            "gateway__tenant_id": user_tenant_id,
+            "mcp_server__gateway__tenant_mode": TenantModeEnum.SINGLE.value,
+            "mcp_server__gateway__tenant_id": user_tenant_id,
         }
         assert filtered_queryset.filter_condition == expected_filter
 
@@ -92,10 +142,10 @@ class TestMCPServerRelatedFilterByUserTenantId(TestCase):
     def test_filter_by_single_tenant(self):
         user_tenant_id = "tenant_123"
         filtered_queryset = mcp_server_related_filter_by_user_tenant_id(self.queryset, user_tenant_id)
-        expected_filter = {
-            "mcp_server__gateway__tenant_mode": TenantModeEnum.SINGLE.value,
-            "mcp_server__gateway__tenant_id": user_tenant_id,
-        }
+        expected_filter = Q(mcp_server__gateway__tenant_mode=TenantModeEnum.GLOBAL.value) | Q(
+            mcp_server__gateway__tenant_mode=TenantModeEnum.SINGLE.value,
+            mcp_server__gateway__tenant_id=user_tenant_id,
+        )
         assert filtered_queryset.filter_condition == expected_filter
 
 
@@ -116,10 +166,10 @@ class TestGatewayMCPServerFilterByUserTenantId(TestCase):
     def test_filter_by_single_tenant(self):
         user_tenant_id = "tenant_123"
         filtered_queryset = gateway_mcp_server_filter_by_user_tenant_id(self.queryset, user_tenant_id)
-        expected_filter = {
-            "gateway__tenant_mode": TenantModeEnum.SINGLE.value,
-            "gateway__tenant_id": user_tenant_id,
-        }
+        expected_filter = Q(gateway__tenant_mode=TenantModeEnum.GLOBAL.value) | Q(
+            gateway__tenant_mode=TenantModeEnum.SINGLE.value,
+            gateway__tenant_id=user_tenant_id,
+        )
         assert filtered_queryset.filter_condition == expected_filter
 
 


### PR DESCRIPTION
修复点：
1. MCP 市场： 用户可以看到 全租户mcp server 和自己租户的mcp server 
2. 我的申请： 全租户的网关/MCP Server 申请单
3. 我的待办/已办： maintainer 级别的租户过滤


## Summary
- Split tenant query helpers by maintainer vs user/app visibility.
- Update personal workbench gateway and MCP permission filters to use the correct tenant visibility for applied and handled workflows.
- Add tenant query tests covering maintainer and user filter behavior separately.

## Test plan
- `source .envrc && make lint-check`
- `source .envrc && make test`

Replaces #2847, which was opened from a branch containing unrelated previously merged commits.

Made with [Cursor](https://cursor.com)