### PR TITLE
fix: include global MCP servers in tenant marketplace filters

### DIFF
--- a/src/dashboard/apigateway/apigateway/apis/web/mcp_marketplace/views.py
+++ b/src/dashboard/apigateway/apigateway/apis/web/mcp_marketplace/views.py
@@ -34,7 +34,7 @@ from apigateway.biz.gateway.type import GatewayTypeHandler
 from apigateway.biz.mcp_server import MCPServerHandler
 from apigateway.common.django.translation import get_current_language_code
 from apigateway.common.error_codes import error_codes
-from apigateway.common.tenant.constants import TENANT_ID_OPERATION, TenantModeEnum
+from apigateway.common.tenant.constants import TenantModeEnum
 from apigateway.common.tenant.query import gateway_mcp_server_filter_by_user_tenant_id
 from apigateway.common.tenant.request import get_user_tenant_id
 from apigateway.common.tenant.validators import check_user_can_access_gateway
@@ -375,18 +375,10 @@ class MCPMarketplaceCategoryListApi(generics.ListAPIView):
                 )
         # 如果有租户过滤，使用和 MCPMarketplaceServerListApi 一样的筛选逻辑
         if user_tenant_id:
-            # 运营租户可以看到 全租户网关 + 自己租户网关的 MCP Server
-            if user_tenant_id == TENANT_ID_OPERATION:
-                mcp_server_filter &= Q(mcp_servers__gateway__tenant_mode=TenantModeEnum.GLOBAL.value) | Q(
-                    mcp_servers__gateway__tenant_mode=TenantModeEnum.SINGLE.value,
-                    mcp_servers__gateway__tenant_id=user_tenant_id,
-                )
-            else:
-                # 其他租户只能看到本租户网关的 MCP Server
-                mcp_server_filter &= Q(
-                    mcp_servers__gateway__tenant_mode=TenantModeEnum.SINGLE.value,
-                    mcp_servers__gateway__tenant_id=user_tenant_id,
-                )
+            mcp_server_filter &= Q(mcp_servers__gateway__tenant_mode=TenantModeEnum.GLOBAL.value) | Q(
+                mcp_servers__gateway__tenant_mode=TenantModeEnum.SINGLE.value,
+                mcp_servers__gateway__tenant_id=user_tenant_id,
+            )
 
         # 使用 annotate 一次性统计每个分类的 MCPServer 数量，避免 N+1 查询
         queryset = (

--- a/src/dashboard/apigateway/apigateway/common/tenant/query.py
+++ b/src/dashboard/apigateway/apigateway/common/tenant/query.py
@@ -61,7 +61,7 @@ def gateway_filter_by_app_tenant_id(queryset: QuerySet, app_tenant_id: str) -> Q
 
 
 def gateway_mcp_server_filter_by_user_tenant_id(queryset: QuerySet, user_tenant_id: str) -> QuerySet:
-    """网关管理员维度查看网关 MCP Server 列表，运营租户能看到全租户网关 + 本租户网关的 MCP Server，其他租户只能看到本租户网关的 MCP Server
+    """网关管理员维度查看网关 MCP Server 列表，能看到全租户网关 + 本租户网关的 MCP Server
 
     Args:
         queryset (QuerySet): mcp_server queryset
@@ -70,11 +70,7 @@ def gateway_mcp_server_filter_by_user_tenant_id(queryset: QuerySet, user_tenant_
     Returns:
         QuerySet: filtered queryset
     """
-    # 运营租户可以看到 全租户网关 + 自己租户网关
-    if user_tenant_id == TENANT_ID_OPERATION:
-        return queryset.filter(
-            Q(gateway__tenant_mode=TenantModeEnum.GLOBAL.value)
-            | Q(gateway__tenant_mode=TenantModeEnum.SINGLE.value, gateway__tenant_id=user_tenant_id)
-        )
-    # only list the gateways under the tenant
-    return queryset.filter(gateway__tenant_mode=TenantModeEnum.SINGLE.value, gateway__tenant_id=user_tenant_id)
+    return queryset.filter(
+        Q(gateway__tenant_mode=TenantModeEnum.GLOBAL.value)
+        | Q(gateway__tenant_mode=TenantModeEnum.SINGLE.value, gateway__tenant_id=user_tenant_id)
+    )

--- a/src/dashboard/apigateway/apigateway/tests/apis/web/mcp_marketplace/test_views.py
+++ b/src/dashboard/apigateway/apigateway/tests/apis/web/mcp_marketplace/test_views.py
@@ -28,7 +28,9 @@ from apigateway.apps.mcp_server.constants import (
     MCPServerStatusEnum,
 )
 from apigateway.apps.mcp_server.models import MCPServer, MCPServerCategory, MCPServerExtend
+from apigateway.common.tenant.constants import TenantModeEnum
 from apigateway.core.constants import GatewayStatusEnum, StageStatusEnum
+from apigateway.core.models import Gateway, Stage
 
 pytestmark = pytest.mark.django_db
 
@@ -761,6 +763,77 @@ class TestMCPMarketplaceCategoryListApi:
         assert result["data"][1]["display_name"] == "运维工具"
         assert result["data"][1]["sort_order"] == 3
         assert result["data"][1]["mcp_server_count"] == 0  # 新增统计字段
+
+    def test_list_categories_includes_global_and_own_tenant_mcp_servers(
+        self,
+        settings,
+        request_view,
+        fake_categories,
+        fake_public_mcp_server,
+    ):
+        """测试非运营租户分类统计包含全租户网关和本租户网关的 MCPServer"""
+        settings.ENABLE_MULTI_TENANT_MODE = True
+        user_tenant_id = "tenant_123"
+
+        request_user = type(
+            "User",
+            (),
+            {
+                "tenant_id": user_tenant_id,
+                "is_active": True,
+                "is_authenticated": True,
+            },
+        )()
+
+        fake_public_mcp_server.gateway.tenant_mode = TenantModeEnum.GLOBAL.value
+        fake_public_mcp_server.gateway.tenant_id = "system"
+        fake_public_mcp_server.gateway.save()
+        fake_public_mcp_server.categories.add(fake_categories["official"])
+
+        own_gateway = G(
+            Gateway,
+            status=GatewayStatusEnum.ACTIVE.value,
+            is_public=True,
+            tenant_mode=TenantModeEnum.SINGLE.value,
+            tenant_id=user_tenant_id,
+        )
+        own_stage = G(Stage, gateway=own_gateway, status=StageStatusEnum.ACTIVE.value)
+        own_tenant_server = G(
+            MCPServer,
+            gateway=own_gateway,
+            stage=own_stage,
+            status=MCPServerStatusEnum.ACTIVE.value,
+            is_public=True,
+        )
+        own_tenant_server.categories.add(fake_categories["official"])
+
+        other_gateway = G(
+            Gateway,
+            status=GatewayStatusEnum.ACTIVE.value,
+            is_public=True,
+            tenant_mode=TenantModeEnum.SINGLE.value,
+            tenant_id="other_tenant",
+        )
+        other_stage = G(Stage, gateway=other_gateway, status=StageStatusEnum.ACTIVE.value)
+        other_tenant_server = G(
+            MCPServer,
+            gateway=other_gateway,
+            stage=other_stage,
+            status=MCPServerStatusEnum.ACTIVE.value,
+            is_public=True,
+        )
+        other_tenant_server.categories.add(fake_categories["official"])
+
+        resp = request_view(
+            method="GET",
+            view_name="mcp_marketplace.category.list",
+            user=request_user,
+        )
+        result = resp.json()
+
+        assert resp.status_code == 200
+        official_category = next(cat for cat in result["data"] if cat["name"] == OFFICIAL_MCP_CATEGORY_NAME)
+        assert official_category["mcp_server_count"] == 2
 
     def test_list_categories_with_mcp_server_count(self, request_view, fake_categories, fake_public_mcp_server):
         """测试分类列表接口返回正确的 MCPServer 统计数据"""

--- a/src/dashboard/apigateway/apigateway/tests/common/tenant/test_query.py
+++ b/src/dashboard/apigateway/apigateway/tests/common/tenant/test_query.py
@@ -21,7 +21,11 @@ from django.db.models import Q
 from django.test import TestCase
 
 from apigateway.common.tenant.constants import TENANT_ID_OPERATION, TenantModeEnum
-from apigateway.common.tenant.query import gateway_filter_by_app_tenant_id, gateway_filter_by_user_tenant_id
+from apigateway.common.tenant.query import (
+    gateway_filter_by_app_tenant_id,
+    gateway_filter_by_user_tenant_id,
+    gateway_mcp_server_filter_by_user_tenant_id,
+)
 
 
 @pytest.mark.django_db
@@ -42,6 +46,30 @@ class TestGatewayFilterByUserTenantId(TestCase):
         user_tenant_id = "tenant_123"
         filtered_queryset = gateway_filter_by_user_tenant_id(self.queryset, user_tenant_id)
         expected_filter = {"tenant_mode": TenantModeEnum.SINGLE.value, "tenant_id": user_tenant_id}
+        assert filtered_queryset.filter_condition == expected_filter
+
+
+@pytest.mark.django_db
+class TestGatewayMCPServerFilterByUserTenantId(TestCase):
+    def setUp(self):
+        self.queryset = MockQuerySet()
+
+    def test_filter_by_operation_tenant(self):
+        user_tenant_id = TENANT_ID_OPERATION
+        filtered_queryset = gateway_mcp_server_filter_by_user_tenant_id(self.queryset, user_tenant_id)
+        expected_filter = Q(gateway__tenant_mode=TenantModeEnum.GLOBAL.value) | Q(
+            gateway__tenant_mode=TenantModeEnum.SINGLE.value,
+            gateway__tenant_id=user_tenant_id,
+        )
+        assert filtered_queryset.filter_condition == expected_filter
+
+    def test_filter_by_single_tenant(self):
+        user_tenant_id = "tenant_123"
+        filtered_queryset = gateway_mcp_server_filter_by_user_tenant_id(self.queryset, user_tenant_id)
+        expected_filter = Q(gateway__tenant_mode=TenantModeEnum.GLOBAL.value) | Q(
+            gateway__tenant_mode=TenantModeEnum.SINGLE.value,
+            gateway__tenant_id=user_tenant_id,
+        )
         assert filtered_queryset.filter_condition == expected_filter
 
 


### PR DESCRIPTION
## Summary
- allow MCP marketplace tenant filters to include global gateway MCP servers for all tenants
- update marketplace category count filtering to match the list endpoint behavior
- add focused tenant filter and marketplace category count regression tests

## Verification
- uv run bash -lc 'set -a && . apigateway/conf/unittest_env && set +a && python3 -m pytest --nomigrations --ds apigateway.settings -q --tb=short apigateway/tests/common/tenant/test_query.py::TestGatewayMCPServerFilterByUserTenantId apigateway/tests/apis/web/mcp_marketplace/test_views.py::TestMCPMarketplaceCategoryListApi::test_list_categories_includes_global_and_own_tenant_mcp_servers'\n- uv run ruff check apigateway/apigateway/common/tenant/query.py apigateway/apigateway/apis/web/mcp_marketplace/views.py apigateway/apigateway/tests/common/tenant/test_query.py apigateway/apigateway/tests/apis/web/mcp_marketplace/test_views.py\n- pre-commit hooks on commit: ruff-formatter, ruff, mypy, import-linter, sensitive info checks