### PR TITLE
fix: handle empty app code in app request alerts

### DIFF
--- a/src/dashboard/apigateway/apigateway/service/alert_flow/handlers/app_request.py
+++ b/src/dashboard/apigateway/apigateway/service/alert_flow/handlers/app_request.py
@@ -36,7 +36,7 @@ class AppRequestDimension(BaseModel):
     api_id: int
     resource_id: int
     stage: str
-    app_code: str
+    app_code: Optional[str] = None
 
 
 # NOTE: 这里是蓝鲸应用请求网关报错，告警给蓝鲸应用负责人，被动，无法配置/忽略

--- a/src/dashboard/apigateway/apigateway/tests/service/alert_flow/handlers/test_app_request.py
+++ b/src/dashboard/apigateway/apigateway/tests/service/alert_flow/handlers/test_app_request.py
@@ -49,6 +49,29 @@ class TestAppRequestAppCodeRequiredFilter:
                 },
                 True,
             ),
+            (
+                {
+                    "alarm_record_id": 1,
+                    "event_dimensions": {
+                        "api_id": 2,
+                        "resource_id": 3,
+                        "stage": "prod",
+                        "app_code": None,
+                    },
+                },
+                True,
+            ),
+            (
+                {
+                    "alarm_record_id": 1,
+                    "event_dimensions": {
+                        "api_id": 2,
+                        "resource_id": 3,
+                        "stage": "prod",
+                    },
+                },
+                True,
+            ),
         ],
     )
     def test_do(self, mocker, event, expected_none):


### PR DESCRIPTION
- 修复应用请求告警事件中 app_code 为空或缺失时，Pydantic 校验失败导致 Celery 任务异常的问题。调整告警维度模型允许 app_code 为空，使其继续走已有的空 app_code 过滤逻辑，并补充对应测试用例。