### PR TITLE
fix(monitor): handle string status in alarm subtype

### DIFF
--- a/src/dashboard/apigateway/apigateway/service/alert_flow/handlers/app_request.py
+++ b/src/dashboard/apigateway/apigateway/service/alert_flow/handlers/app_request.py
@@ -36,7 +36,7 @@ class AppRequestDimension(BaseModel):
     api_id: int
     resource_id: int
     stage: str
-    app_code: str
+    app_code: Optional[str] = None
 
 
 # NOTE: 这里是蓝鲸应用请求网关报错，告警给蓝鲸应用负责人，被动，无法配置/忽略

--- a/src/dashboard/apigateway/apigateway/service/alert_flow/helpers.py
+++ b/src/dashboard/apigateway/apigateway/service/alert_flow/helpers.py
@@ -71,8 +71,14 @@ class MonitorEvent:
     def alarm_subtype(self) -> str:
         code_name = self.event_dimensions.get("code_name", "")
 
+        status = self.event_dimensions.get("status", -1)
+        try:
+            status_code = int(status)
+        except (TypeError, ValueError):
+            status_code = -1
+
         # in apisix, upstream 500 has no code_name, so we need to convert it to status_code_5xx here
-        if code_name == "" and self.event_dimensions.get("status", -1) >= 500:
+        if code_name == "" and status_code >= 500:
             code_name = "REQUEST_RESOURCE_5xx"
 
         return ERROR_CODE_NAME_TO_ALARM_SUBTYPE.get(code_name, "")

--- a/src/dashboard/apigateway/apigateway/tests/service/alert_flow/handlers/test_app_request.py
+++ b/src/dashboard/apigateway/apigateway/tests/service/alert_flow/handlers/test_app_request.py
@@ -49,6 +49,29 @@ class TestAppRequestAppCodeRequiredFilter:
                 },
                 True,
             ),
+            (
+                {
+                    "alarm_record_id": 1,
+                    "event_dimensions": {
+                        "api_id": 2,
+                        "resource_id": 3,
+                        "stage": "prod",
+                        "app_code": None,
+                    },
+                },
+                True,
+            ),
+            (
+                {
+                    "alarm_record_id": 1,
+                    "event_dimensions": {
+                        "api_id": 2,
+                        "resource_id": 3,
+                        "stage": "prod",
+                    },
+                },
+                True,
+            ),
         ],
     )
     def test_do(self, mocker, event, expected_none):

--- a/src/dashboard/apigateway/apigateway/tests/service/alert_flow/test_helpers.py
+++ b/src/dashboard/apigateway/apigateway/tests/service/alert_flow/test_helpers.py
@@ -66,6 +66,13 @@ class TestMonitorEvent:
         )
         assert event.alarm_subtype == "bad_gateway"
 
+    def test_alarm_subtype_with_string_status(self):
+        event = MonitorEvent(
+            alarm_type=AlarmTypeEnum.RESOURCE_BACKEND,
+            raw={"event": {"dimensions": {"status": "500"}}},
+        )
+        assert event.alarm_subtype == "status_code_5xx"
+
     def test_update_extend_fields(self):
         event = MonitorEvent(alarm_type=AlarmTypeEnum.APP_REQUEST, raw={})
         event.update_extend_fields({"color": "green"})


### PR DESCRIPTION
- 修复监控告警事件中 `status` 为字符串时，计算告警子类型触发类型比较异常的问题。现在会先将 `status` 转为整数，再判断是否属于后端 5xx 响应告警。