### PR TITLE
feat(plugin): add uri-blocker resource plugin support

### DIFF
--- a/src/dashboard/apigateway/apigateway/apps/plugin/constants.py
+++ b/src/dashboard/apigateway/apigateway/apps/plugin/constants.py
@@ -50,6 +50,8 @@ class PluginTypeCodeEnum(StructuredEnum):
     BK_OAUTH2_VERIFY = EnumField("bk-oauth2-verify", label=_("OAuth2 验证"))
     BK_OAUTH2_AUDIENCE_VALIDATE = EnumField("bk-oauth2-audience-validate", label=_("OAuth2 受众验证"))
 
+    URI_BLOCKER = EnumField("uri-blocker", label=_("URI 阻断"))
+
 
 class PluginTypeScopeEnum(StructuredEnum):
     STAGE = EnumField(ScopeTypeEnum.STAGE.value, label=_("环境"))

--- a/src/dashboard/apigateway/apigateway/fixtures/plugins.yaml
+++ b/src/dashboard/apigateway/apigateway/fixtures/plugins.yaml
@@ -4325,3 +4325,200 @@
                 X-API-Version: v2
               weight: 2
             - weight: 5
+
+- model: schema.schema
+  fields:
+    created_time: 2026-06-10 00:00:00.000000+00:00
+    updated_time: 2026-06-10 00:00:00.000000+00:00
+    name: uri-blocker
+    type: plugin
+    version: '0'
+    _schema: |-
+      {
+        "$comment": "this is a mark for our injected plugin schema",
+        "type": "object",
+        "properties": {
+          "block_rules": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "minLength": 1,
+              "maxLength": 4096
+            },
+            "uniqueItems": true
+          },
+          "case_insensitive": {
+            "type": "boolean",
+            "default": false
+          },
+          "rejected_code": {
+            "type": "integer",
+            "minimum": 200,
+            "default": 403
+          },
+          "rejected_msg": {
+            "type": "string",
+            "minLength": 1
+          }
+        },
+        "required": ["block_rules"]
+      }
+    description: '-'
+    example: '-'
+- model: plugin.plugintype
+  fields:
+    code: uri-blocker
+    name: URI 阻断
+    name_en: URI Blocker
+    description: "通过 URI 正则规则阻断请求，可用于提前拦截爬虫、安全扫描等请求。"
+    description_en: Block requests by URI regex rules. It can be used to block crawlers and security scan requests at the gateway layer.
+    is_public: true
+    scope: resource
+    priority: 2900
+    _tags: "安全,Security"
+    schema:
+    - uri-blocker
+    - plugin
+    - '0'
+- model: plugin.pluginform
+  fields:
+    language: ''
+    type:
+    - uri-blocker
+    notes: 通过 URI 正则规则阻断请求，可用于提前拦截爬虫、安全扫描等请求。
+    example: |-
+      作用：拦截访问 wp-admin、PHP 文件、root.exe 等疑似爬虫或安全扫描请求。
+
+      block_rules:
+        - ".*wp-admin.*"
+        - ".*\\.php$"
+        - ".*root\\.exe.*"
+      case_insensitive: true
+      rejected_code: 403
+      rejected_msg: "access is not allowed"
+    style: dynamic
+    default_value: ''
+    config: |-
+      {
+        "schema": {
+          "type": "object",
+          "properties": {
+            "block_rules": {
+              "title": "URI 阻断规则",
+              "description": "用于匹配请求 URI 的正则规则，命中任意规则时请求将被拒绝。",
+              "type": "array",
+              "items": {
+                "type": "string",
+                "minLength": 1,
+                "maxLength": 4096,
+                "ui:rules": [
+                  "required"
+                ]
+              },
+              "minItems": 1,
+              "uniqueItems": true,
+              "ui:component": {
+                "name": "bfArray"
+              }
+            },
+            "case_insensitive": {
+              "title": "忽略大小写",
+              "description": "匹配请求 URI 时是否忽略大小写。",
+              "type": "boolean",
+              "default": false
+            },
+            "rejected_code": {
+              "title": "拒绝状态码",
+              "description": "请求 URI 命中阻断规则时返回的 HTTP 状态码。",
+              "type": "integer",
+              "minimum": 200,
+              "default": 403
+            },
+            "rejected_msg": {
+              "title": "拒绝信息",
+              "description": "请求 URI 命中阻断规则时返回的响应内容。",
+              "type": "string",
+              "minLength": 1,
+              "ui:component": {
+                "type": "textarea",
+                "rows": 4
+              }
+            }
+          },
+          "required": ["block_rules"]
+        },
+        "layout": [],
+        "formData": {},
+        "rules": {}
+      }
+- model: plugin.pluginform
+  fields:
+    language: 'en'
+    type:
+    - uri-blocker
+    notes: Block requests by URI regex rules. It can be used to block crawlers and security scan requests at the gateway layer.
+    example: |-
+      Purpose: Block suspicious crawler or security scan requests for wp-admin, PHP files, root.exe, and similar paths.
+
+      block_rules:
+        - ".*wp-admin.*"
+        - ".*\\.php$"
+        - ".*root\\.exe.*"
+      case_insensitive: true
+      rejected_code: 403
+      rejected_msg: "access is not allowed"
+    style: dynamic
+    default_value: ''
+    config: |-
+      {
+        "schema": {
+          "type": "object",
+          "properties": {
+            "block_rules": {
+              "title": "URI block rules",
+              "description": "Regex rules used to match request URIs. Requests are rejected when any rule matches.",
+              "type": "array",
+              "items": {
+                "type": "string",
+                "minLength": 1,
+                "maxLength": 4096,
+                "ui:rules": [
+                  "required"
+                ]
+              },
+              "minItems": 1,
+              "uniqueItems": true,
+              "ui:component": {
+                "name": "bfArray"
+              }
+            },
+            "case_insensitive": {
+              "title": "Case insensitive",
+              "description": "Whether to ignore case when matching request URIs.",
+              "type": "boolean",
+              "default": false
+            },
+            "rejected_code": {
+              "title": "Rejected status code",
+              "description": "HTTP status code returned when the request URI matches a block rule.",
+              "type": "integer",
+              "minimum": 200,
+              "default": 403
+            },
+            "rejected_msg": {
+              "title": "Rejected message",
+              "description": "Response body returned when the request URI matches a block rule.",
+              "type": "string",
+              "minLength": 1,
+              "ui:component": {
+                "type": "textarea",
+                "rows": 4
+              }
+            }
+          },
+          "required": ["block_rules"]
+        },
+        "layout": [],
+        "formData": {},
+        "rules": {}
+      }

--- a/src/dashboard/apigateway/apigateway/service/alert_flow/handlers/app_request.py
+++ b/src/dashboard/apigateway/apigateway/service/alert_flow/handlers/app_request.py
@@ -36,7 +36,7 @@ class AppRequestDimension(BaseModel):
     api_id: int
     resource_id: int
     stage: str
-    app_code: str
+    app_code: Optional[str] = None
 
 
 # NOTE: 这里是蓝鲸应用请求网关报错，告警给蓝鲸应用负责人，被动，无法配置/忽略

--- a/src/dashboard/apigateway/apigateway/service/plugin/__init__.py
+++ b/src/dashboard/apigateway/apigateway/service/plugin/__init__.py
@@ -30,6 +30,7 @@ from .checker import (
     RedirectChecker,
     RequestValidationChecker,
     ResponseRewriteChecker,
+    UriBlockerChecker,
     check_vars,
 )
 from .convertor import (
@@ -88,6 +89,7 @@ __all__ = [
     "RequestValidationConvertor",
     "ResponseRewriteChecker",
     "ResponseRewriteConvertor",
+    "UriBlockerChecker",
     # functions
     "check_vars",
     "format_fault_injection_config",

--- a/src/dashboard/apigateway/apigateway/service/plugin/checker.py
+++ b/src/dashboard/apigateway/apigateway/service/plugin/checker.py
@@ -191,6 +191,36 @@ class RequestValidationChecker(BaseChecker):
             self._validate_json_schema("header_schema", header_schema)
 
 
+class UriBlockerChecker(BaseChecker):
+    def check(self, payload: str):
+        loaded_data = yaml_loads(payload)
+        if not loaded_data:
+            raise ValueError("YAML cannot be empty")
+
+        block_rules = loaded_data.get("block_rules")
+        if not block_rules:
+            raise ValueError("block_rules cannot be empty")
+
+        if not isinstance(block_rules, list):
+            raise TypeError("block_rules should be list")
+
+        for index, rule in enumerate(block_rules):
+            if not isinstance(rule, str):
+                raise TypeError(f"block_rules[{index}] should be string")
+
+            if not rule:
+                raise ValueError(f"block_rules[{index}] cannot be empty")
+
+            try:
+                re.compile(rule)
+            except re.error as err:
+                raise ValueError(f"block_rules[{index}] is not a valid regex: {err}")
+
+        duplicate_rules = [rule for rule, count in Counter(block_rules).items() if count >= 2]
+        if duplicate_rules:
+            raise ValueError(_("block_rules has duplicate elements：{}").format(", ".join(duplicate_rules)))
+
+
 class FaultInjectionChecker(BaseChecker):
     def check(self, payload: str):
         loaded_data = yaml_loads(payload)
@@ -443,6 +473,7 @@ class PluginConfigYamlChecker:
         PluginTypeCodeEnum.BK_HEADER_REWRITE.value: HeaderRewriteChecker(),
         PluginTypeCodeEnum.BK_IP_RESTRICTION.value: BkIPRestrictionChecker(),
         PluginTypeCodeEnum.REQUEST_VALIDATION.value: RequestValidationChecker(),
+        PluginTypeCodeEnum.URI_BLOCKER.value: UriBlockerChecker(),
         PluginTypeCodeEnum.FAULT_INJECTION.value: FaultInjectionChecker(),
         PluginTypeCodeEnum.RESPONSE_REWRITE.value: ResponseRewriteChecker(),
         PluginTypeCodeEnum.REDIRECT.value: RedirectChecker(),

--- a/src/dashboard/apigateway/apigateway/tests/service/alert_flow/handlers/test_app_request.py
+++ b/src/dashboard/apigateway/apigateway/tests/service/alert_flow/handlers/test_app_request.py
@@ -49,6 +49,29 @@ class TestAppRequestAppCodeRequiredFilter:
                 },
                 True,
             ),
+            (
+                {
+                    "alarm_record_id": 1,
+                    "event_dimensions": {
+                        "api_id": 2,
+                        "resource_id": 3,
+                        "stage": "prod",
+                        "app_code": None,
+                    },
+                },
+                True,
+            ),
+            (
+                {
+                    "alarm_record_id": 1,
+                    "event_dimensions": {
+                        "api_id": 2,
+                        "resource_id": 3,
+                        "stage": "prod",
+                    },
+                },
+                True,
+            ),
         ],
     )
     def test_do(self, mocker, event, expected_none):

--- a/src/dashboard/apigateway/apigateway/tests/service/plugin/test_checkers.py
+++ b/src/dashboard/apigateway/apigateway/tests/service/plugin/test_checkers.py
@@ -34,6 +34,7 @@ from apigateway.service.plugin import (
     RedirectChecker,
     RequestValidationChecker,
     ResponseRewriteChecker,
+    UriBlockerChecker,
 )
 from apigateway.utils.yaml import yaml_dumps
 
@@ -279,6 +280,12 @@ class TestPluginConfigYamlChecker:
                     "allow_credential": True,
                 },
             ),
+            (
+                "uri-blocker",
+                {
+                    "block_rules": ["["],
+                },
+            ),
         ],
     )
     def test_check__error(self, type_code, data):
@@ -412,6 +419,54 @@ class TestRequestValidationChecker:
     )
     def test_check(self, data, ctx):
         checker = RequestValidationChecker()
+        with ctx:
+            checker.check(yaml_dumps(data))
+
+
+class TestUriBlockerChecker:
+    @pytest.mark.parametrize(
+        "data, ctx",
+        [
+            (
+                {
+                    "block_rules": [
+                        ".*wp-admin.*",
+                        ".*\\.php$",
+                    ],
+                    "case_insensitive": True,
+                    "rejected_code": 403,
+                    "rejected_msg": "access is not allowed",
+                },
+                does_not_raise(),
+            ),
+            (
+                {
+                    "block_rules": [],
+                },
+                pytest.raises(ValueError),
+            ),
+            (
+                {
+                    "block_rules": ["["],
+                },
+                pytest.raises(ValueError),
+            ),
+            (
+                {
+                    "block_rules": ["foo", "foo"],
+                },
+                pytest.raises(ValueError),
+            ),
+            (
+                {
+                    "block_rules": ["foo", 1],
+                },
+                pytest.raises(TypeError),
+            ),
+        ],
+    )
+    def test_check(self, data, ctx):
+        checker = UriBlockerChecker()
         with ctx:
             checker.check(yaml_dumps(data))
 


### PR DESCRIPTION
- 本次新增 APISIX `uri-blocker` 插件的后端支持，用于在资源维度按 URI 正则规则拦截请求，可用于提前阻断爬虫、安全扫描等异常访问。主要包括插件类型注册、插件配置 schema/form fixture、配置合法性校验，以及对应 checker 单测补充。