### PR TITLE
fix(MCP): 校验 web MCPServer 归属网关 for release/1.22

### DIFF
--- a/src/dashboard/apigateway/apigateway/apis/v2/inner/views.py
+++ b/src/dashboard/apigateway/apigateway/apis/v2/inner/views.py
@@ -617,12 +617,9 @@ class MCPServerAppPermissionListApi(generics.ListAPIView):
 
         # 1. 查询 MCPServerAppPermission 表，获取所有有实际权限的 mcp_server（包括主动授权和申请通过）
         # unique_together = ("bk_app_code", "mcp_server") 保证不会重复
-        granted_permissions = (
-            MCPServerAppPermission.objects.filter(
-                bk_app_code=target_app_code,
-            )
-            .select_related("mcp_server", "mcp_server__gateway", "mcp_server__stage")
-        )
+        granted_permissions = MCPServerAppPermission.objects.filter(
+            bk_app_code=target_app_code,
+        ).select_related("mcp_server", "mcp_server__gateway", "mcp_server__stage")
 
         # 2. 查询申请通过的记录，用于获取 handled_by 信息
         approved_applies = MCPServerAppPermissionApply.objects.filter(

--- a/src/dashboard/apigateway/apigateway/apis/web/mcp_server/views.py
+++ b/src/dashboard/apigateway/apigateway/apis/web/mcp_server/views.py
@@ -22,6 +22,7 @@ from io import StringIO
 
 from django.db import transaction
 from django.db.models import Q
+from django.shortcuts import get_object_or_404
 from django.utils.decorators import method_decorator
 from django.utils.translation import gettext as _
 from drf_yasg.utils import swagger_auto_schema
@@ -229,6 +230,11 @@ class MCPServerListCreateApi(generics.ListCreateAPIView):
         return OKJsonResponse(status=status.HTTP_201_CREATED, data={"id": slz.instance.id})
 
 
+class MCPServerQuerySetMixin:
+    def get_queryset(self):
+        return super().get_queryset().filter(gateway=self.request.gateway)
+
+
 @method_decorator(
     name="get",
     decorator=swagger_auto_schema(
@@ -263,7 +269,7 @@ class MCPServerListCreateApi(generics.ListCreateAPIView):
         tags=["WebAPI.MCPServer"],
     ),
 )
-class MCPServerRetrieveUpdateDestroyApi(generics.RetrieveUpdateDestroyAPIView):
+class MCPServerRetrieveUpdateDestroyApi(MCPServerQuerySetMixin, generics.RetrieveUpdateDestroyAPIView):
     queryset = MCPServer.objects.select_related("stage").prefetch_related("categories")
     serializer_class = MCPServerRetrieveOutputSLZ
     lookup_url_kwarg = "mcp_server_id"
@@ -363,7 +369,7 @@ class MCPServerRetrieveUpdateDestroyApi(generics.RetrieveUpdateDestroyAPIView):
         tags=["WebAPI.MCPServer"],
     ),
 )
-class MCPServerUpdateStatusApi(generics.UpdateAPIView):
+class MCPServerUpdateStatusApi(MCPServerQuerySetMixin, generics.UpdateAPIView):
     queryset = MCPServer.objects.all()
     serializer_class = MCPServerUpdateStatusInputSLZ
     lookup_url_kwarg = "mcp_server_id"
@@ -397,7 +403,7 @@ class MCPServerUpdateStatusApi(generics.UpdateAPIView):
         tags=["WebAPI.MCPServer"],
     ),
 )
-class MCPServerToolsListApi(generics.ListAPIView):
+class MCPServerToolsListApi(MCPServerQuerySetMixin, generics.ListAPIView):
     queryset = MCPServer.objects.all()
     lookup_url_kwarg = "mcp_server_id"
 
@@ -427,7 +433,7 @@ class MCPServerToolsListApi(generics.ListAPIView):
         tags=["WebAPI.MCPServer"],
     ),
 )
-class MCPServerGuidelineRetrieveApi(generics.RetrieveAPIView):
+class MCPServerGuidelineRetrieveApi(MCPServerQuerySetMixin, generics.RetrieveAPIView):
     queryset = MCPServer.objects.all()
     serializer_class = MCPServerGuidelineOutputSLZ
     lookup_url_kwarg = "mcp_server_id"
@@ -460,7 +466,7 @@ class MCPServerGuidelineRetrieveApi(generics.RetrieveAPIView):
         tags=["WebAPI.MCPServer"],
     ),
 )
-class MCPServerConfigListApi(generics.RetrieveAPIView):
+class MCPServerConfigListApi(MCPServerQuerySetMixin, generics.RetrieveAPIView):
     """获取 MCPServer 配置列表，支持多种 AI 工具的配置"""
 
     queryset = MCPServer.objects.all()
@@ -486,7 +492,7 @@ class MCPServerConfigListApi(generics.RetrieveAPIView):
         tags=["WebAPI.MCPServer"],
     ),
 )
-class MCPServerToolDocRetrieveApi(generics.RetrieveAPIView):
+class MCPServerToolDocRetrieveApi(MCPServerQuerySetMixin, generics.RetrieveAPIView):
     queryset = MCPServer.objects.all()
     serializer_class = MCPServerToolDocOutputSLZ
     lookup_url_kwarg = "mcp_server_id"
@@ -539,7 +545,7 @@ class MCPServerToolDocRetrieveApi(generics.RetrieveAPIView):
         tags=["WebAPI.MCPServer"],
     ),
 )
-class MCPServerUserCustomDocApi(generics.RetrieveUpdateDestroyAPIView, generics.CreateAPIView):
+class MCPServerUserCustomDocApi(MCPServerQuerySetMixin, generics.RetrieveUpdateDestroyAPIView, generics.CreateAPIView):
     queryset = MCPServer.objects.all()
     lookup_url_kwarg = "mcp_server_id"
 
@@ -731,16 +737,17 @@ class MCPServerAppPermissionListCreateApi(MCPServerAppPermissionQuerySetMixin, g
         slz.is_valid(raise_exception=True)
 
         data = slz.validated_data
+        mcp_server = get_object_or_404(MCPServer, id=kwargs["mcp_server_id"], gateway=request.gateway)
 
         MCPServerAppPermission.objects.save_permission(
-            mcp_server_id=kwargs["mcp_server_id"],
+            mcp_server_id=mcp_server.id,
             bk_app_code=data["bk_app_code"],
             grant_type=MCPServerAppPermissionGrantTypeEnum.GRANT.value,
             expire_days=None,
             operator=request.user.username,
         )
 
-        MCPServerHandler.sync_permissions(kwargs["mcp_server_id"])
+        MCPServerHandler.sync_permissions(mcp_server.id)
 
         return OKJsonResponse(status=status.HTTP_201_CREATED)
 

--- a/src/dashboard/apigateway/apigateway/tests/apis/web/mcp_server/test_views.py
+++ b/src/dashboard/apigateway/apigateway/tests/apis/web/mcp_server/test_views.py
@@ -711,6 +711,18 @@ class TestMCPServerRetrieveUpdateDestroyApi:
         assert result["data"]["name"] == fake_mcp_server.name
         assert "updated_time" in result["data"]
 
+    def test_retrieve_from_other_gateway_returns_404(self, request_view, fake_gateway, fake_mcp_server):
+        other_gateway = create_gateway()
+
+        resp = request_view(
+            method="GET",
+            view_name="mcp_server.retrieve_update_destroy",
+            path_params={"gateway_id": other_gateway.id, "mcp_server_id": fake_mcp_server.id},
+            gateway=other_gateway,
+        )
+
+        assert resp.status_code == 404
+
     def test_update(self, mocker, request_view, fake_gateway, fake_mcp_server, faker):
         mocker.patch(
             "apigateway.biz.mcp_server.MCPServerHandler.get_valid_resource_names",
@@ -1240,6 +1252,37 @@ class TestMCPServerAppPermissionListCreateApi:
             mcp_server=fake_mcp_server,
             bk_app_code="new-app",
         ).exists()
+
+    def test_create_with_mcp_server_from_other_gateway_returns_404(self, mocker, request_view, fake_gateway, faker):
+        mock_sync_permissions = mocker.patch(
+            "apigateway.biz.mcp_server.MCPServerHandler.sync_permissions",
+            return_value=None,
+        )
+        other_gateway = create_gateway()
+        other_stage = G(Stage, gateway=other_gateway, status=1, name=faker.pystr(), description=faker.pystr())
+        other_mcp_server = G(
+            MCPServer,
+            name=faker.pystr()[:20],
+            gateway=other_gateway,
+            stage=other_stage,
+            status=MCPServerStatusEnum.ACTIVE.value,
+            _resource_names="resource1",
+        )
+
+        resp = request_view(
+            method="POST",
+            view_name="mcp_server.app-permission.list_create",
+            path_params={"gateway_id": fake_gateway.id, "mcp_server_id": other_mcp_server.id},
+            gateway=fake_gateway,
+            data={"bk_app_code": "new-app"},
+        )
+
+        assert resp.status_code == 404
+        assert not MCPServerAppPermission.objects.filter(
+            mcp_server=other_mcp_server,
+            bk_app_code="new-app",
+        ).exists()
+        mock_sync_permissions.assert_not_called()
 
 
 class TestMCPServerAppPermissionDestroyApi:


### PR DESCRIPTION
## Summary
- Backport #2862 to `release/1.22`.
- Source PR: https://github.com/TencentBlueKing/blueking-apigateway/pull/2862
- Resolved a release-branch import conflict in `apis/web/mcp_server/views.py`.
- Included one hook-required ruff formatting adjustment in `apis/v2/inner/views.py` from the release branch baseline.

## Cherry-picked commits
- 5a407c9f4b14de88cfa6908891f7429f999b06c8 fix(MCP): 校验 web MCPServer 归属网关

## Verification
- `uv run bash -lc 'cd apigateway && set -a && . apigateway/conf/unittest_env && set +a && python3 -m pytest --nomigrations --ds apigateway.settings -q --tb=short apigateway/tests/apis/web/mcp_server/test_views.py'` (114 passed)
- `uv run make lint` (passed)

Made with [Cursor](https://cursor.com)