### PR TITLE
fix(permission): validate released resource ids on apply

### DIFF
--- a/src/dashboard/apigateway/apigateway/apis/open/permission/views.py
+++ b/src/dashboard/apigateway/apigateway/apis/open/permission/views.py
@@ -24,8 +24,10 @@ from blue_krill.async_utils.django_utils import apply_async_on_commit
 from django.conf import settings
 from django.db import transaction
 from django.utils.decorators import method_decorator
+from django.utils.translation import gettext as _
 from drf_yasg.utils import swagger_auto_schema
 from rest_framework import status, viewsets
+from rest_framework.exceptions import ValidationError
 from rest_framework.views import APIView
 
 from apigateway.apis.open.permission.helpers import (
@@ -61,6 +63,15 @@ from . import serializers
 from .serializers import PaaSAppPermissionApplyV2InputSLZ
 
 logger = logging.getLogger(__name__)
+
+
+def _validate_resource_ids_in_released_resources(resource_ids: list[int], released_resources: list[dict]):
+    if not resource_ids:
+        return
+
+    released_resource_ids = {resource["id"] for resource in released_resources}
+    if set(resource_ids) - released_resource_ids:
+        raise ValidationError({"resource_ids": [_("指定的部分资源 ID 不属于当前网关已发布资源。")]})
 
 
 class ResourceViewSet(viewsets.ViewSet):
@@ -147,6 +158,11 @@ class BaseAppPermissionApplyAPIView(APIView, metaclass=ABCMeta):
                     f"app_code={app_code} is belongs to tenant {app_tenant_id}, should not apply the gateway of tenant {gateway_tenant_id}",
                     replace=True,
                 )
+
+        resource_ids = data.get("resource_ids") or []
+        if resource_ids:
+            released_resources = ResourceVersionHandler.get_released_public_resources(request.gateway.id)
+            _validate_resource_ids_in_released_resources(resource_ids, released_resources)
 
         manager = PermissionDimensionManager.get_manager(data["grant_dimension"])
         record = manager.create_apply_record(

--- a/src/dashboard/apigateway/apigateway/apis/v2/inner/views.py
+++ b/src/dashboard/apigateway/apigateway/apis/v2/inner/views.py
@@ -69,6 +69,15 @@ logger = logging.getLogger(__name__)
 # 注意：请使用 OpenAPIV2Permission / OpenAPIV2GatewayNamePermission, 有特殊情况请在类注释中说明
 
 
+def _validate_resource_ids_in_released_resources(resource_ids: list[int], released_resources: list[dict]):
+    if not resource_ids:
+        return
+
+    released_resource_ids = {resource["id"] for resource in released_resources}
+    if set(resource_ids) - released_resource_ids:
+        raise ValidationError({"resource_ids": [_("指定的部分资源 ID 不属于当前网关已发布资源。")]})
+
+
 @method_decorator(
     name="get",
     decorator=swagger_auto_schema(
@@ -291,6 +300,11 @@ class GatewayAppPermissionApplyCreateApi(generics.CreateAPIView):
                     f"app_code={app_code} is belongs to tenant {app_tenant_id}, should not apply the gateway of tenant {gateway_tenant_id}",
                     replace=True,
                 )
+
+        resource_ids = data.get("resource_ids") or []
+        if resource_ids:
+            released_resources = ResourceVersionHandler.get_released_public_resources(request.gateway.id)
+            _validate_resource_ids_in_released_resources(resource_ids, released_resources)
 
         manager = PermissionDimensionManager.get_manager(data["grant_dimension"])
         record = manager.create_apply_record(

--- a/src/dashboard/apigateway/apigateway/tests/apis/open/permission/test_views.py
+++ b/src/dashboard/apigateway/apigateway/tests/apis/open/permission/test_views.py
@@ -292,6 +292,43 @@ class TestAppPermissionRecordViewSet:
         assert result["data"]["id"] == record.id
 
 
+class TestPaaSAppPermissionApplyAPIView:
+    def test_create_rejects_resource_ids_not_in_released_resources(self, mocker, request_factory, fake_gateway):
+        mocker.patch(
+            "apigateway.apis.open.permission.serializers.BKAppCodeValidator.__call__",
+            return_value=None,
+        )
+        get_released_public_resources = mocker.patch(
+            "apigateway.apis.open.permission.views.ResourceVersionHandler.get_released_public_resources",
+            return_value=[
+                {
+                    "id": 1,
+                    "allow_apply_permission": True,
+                }
+            ],
+        )
+        get_manager = mocker.patch("apigateway.apis.open.permission.views.PermissionDimensionManager.get_manager")
+
+        request = request_factory.post(
+            "",
+            data={
+                "target_app_code": "test-app",
+                "resource_ids": [2],
+                "grant_dimension": "resource",
+            },
+        )
+        request.gateway = fake_gateway
+        request.app = mock.MagicMock(app_code="test")
+
+        response = views.PaaSAppPermissionApplyAPIView.as_view()(request, gateway_id=fake_gateway.id)
+        result = get_response_json(response)
+
+        assert response.status_code == 400
+        assert "resource_ids" in result["error"]["message"]
+        get_released_public_resources.assert_called_once_with(fake_gateway.id)
+        get_manager.assert_not_called()
+
+
 class TestAppPermissionGrantViewSet:
     def test_grant(self, mocker, request_factory, fake_gateway):
         mocker.patch(

--- a/src/dashboard/apigateway/apigateway/tests/apis/v2/inner/test_views.py
+++ b/src/dashboard/apigateway/apigateway/tests/apis/v2/inner/test_views.py
@@ -78,6 +78,49 @@ class TestGatewayRetrieveApi:
         assert result["data"]["name"] == fake_gateway.name
 
 
+class TestGatewayAppPermissionApplyCreateApi:
+    def test_create_rejects_resource_ids_from_other_gateway(
+        self,
+        request_to_view,
+        request_factory,
+        fake_gateway,
+        mocker,
+    ):
+        get_released_public_resources = mocker.patch(
+            "apigateway.apis.v2.inner.views.ResourceVersionHandler.get_released_public_resources",
+            return_value=[
+                {
+                    "id": 1,
+                    "allow_apply_permission": True,
+                }
+            ],
+        )
+        get_manager = mocker.patch("apigateway.apis.v2.inner.views.PermissionDimensionManager.get_manager")
+
+        request = request_factory.post(
+            "",
+            data={
+                "target_app_code": "test-app",
+                "resource_ids": [2],
+                "grant_dimension": "resource",
+            },
+        )
+        request.gateway = fake_gateway
+        request.app = mock.MagicMock(app_code="test")
+
+        response = request_to_view(
+            request,
+            view_name="openapi.v2.inner.gateway.permission.apply",
+            path_params={"gateway_name": fake_gateway.name},
+        )
+        result = get_response_json(response)
+
+        assert response.status_code == 400
+        assert "resource_ids" in result["error"]["message"]
+        get_released_public_resources.assert_called_once_with(fake_gateway.id)
+        get_manager.assert_not_called()
+
+
 class TestMCPServerPermissionListApi:
     def test_list_with_protocol_type(self, request_view, fake_gateway, fake_stage):
         """测试 MCP Server 权限列表包含协议类型数据"""


### PR DESCRIPTION
## Summary
- Validate PaaS permission apply `resource_ids` against the current gateway's released public resources before creating apply records.
- Apply the same guard to both v2 inner and legacy open PaaS permission apply entrypoints.
- Add regression tests proving invalid released-resource IDs are rejected before permission manager creation.

## Test plan
- `uv run bash -lc 'cd apigateway && set -a && . apigateway/conf/unittest_env && set +a && python3 -m pytest --nomigrations --ds apigateway.settings -q --tb=short apigateway/tests/apis/v2/inner/test_views.py::TestGatewayAppPermissionApplyCreateApi::test_create_rejects_resource_ids_from_other_gateway apigateway/tests/apis/open/permission/test_views.py::TestPaaSAppPermissionApplyAPIView::test_create_rejects_resource_ids_not_in_released_resources'`
- `uv run ruff check apigateway/apigateway/apis/v2/inner/views.py apigateway/apigateway/apis/open/permission/views.py apigateway/apigateway/tests/apis/v2/inner/test_views.py apigateway/apigateway/tests/apis/open/permission/test_views.py`
- pre-commit hooks during `git commit`


Made with [Cursor](https://cursor.com)