### PR TITLE
fix(mcp-proxy): disable pprof by default

### DIFF
--- a/src/mcp-proxy/AGENTS.md
+++ b/src/mcp-proxy/AGENTS.md
@@ -214,8 +214,8 @@ Streamable HTTP is stateless and uses the same handler for user and application 
 - `BK_API_URL_TMPL` overrides `mcpServer.bkApiUrlTmpl`.
 - `PROMETHEUS_METRIC_NAME_PREFIX` overrides `metric.namePrefix`, default `bk_apigateway_`. Keep metric names
   compatible with dashboard PromQL in `src/dashboard/apigateway/apigateway/service/prometheus/`.
-- `PPROF_USERNAME` and `PPROF_PASSWORD` override pprof credentials. Defaults exist in code, but production
-  config should set real credentials.
+- `PPROF_USERNAME` and `PPROF_PASSWORD` override pprof credentials. Empty username or password disables
+  pprof; set both values through config or env vars to enable it.
 - `BKAI_DEV_TRACE_ENABLE`, `BKAI_DEV_TRACE_ENDPOINT`, `BKAI_DEV_TRACE_SERVICE_NAME`, and
   `BKAI_DEV_TRACE_TOKEN` override the `bkAIDevTrace` config section.
 - `mcpServer.logTruncate` sizes are string lengths, not byte counts.

--- a/src/mcp-proxy/config.yaml.tpl
+++ b/src/mcp-proxy/config.yaml.tpl
@@ -117,5 +117,5 @@ bkAIDevTrace:
 
 ## config for pprof
 pprof:
-  username: "bk-apigateway"  # 环境变量 PPROF_USERNAME 优先
-  password: "xxxxx"  # 环境变量 PPROF_PASSWORD 优先，生产环境请使用强密码
+  username: ""  # 环境变量 PPROF_USERNAME 优先；为空时禁用 pprof
+  password: ""  # 环境变量 PPROF_PASSWORD 优先；为空时禁用 pprof

--- a/src/mcp-proxy/pkg/config/config.go
+++ b/src/mcp-proxy/pkg/config/config.go
@@ -452,14 +452,8 @@ func applyPProfDefaults(cfg *Config) {
 	if env := os.Getenv("PPROF_USERNAME"); env != "" {
 		cfg.PProf.Username = env
 	}
-	if cfg.PProf.Username == "" {
-		cfg.PProf.Username = "bk-mcp" // 默认用户名
-	}
 	if env := os.Getenv("PPROF_PASSWORD"); env != "" {
 		cfg.PProf.Password = env
-	}
-	if cfg.PProf.Password == "" {
-		cfg.PProf.Password = "DebugModel@bk" // 默认密码，生产环境应该修改
 	}
 }
 

--- a/src/mcp-proxy/pkg/config/config_test.go
+++ b/src/mcp-proxy/pkg/config/config_test.go
@@ -667,6 +667,54 @@ var _ = Describe("Config", func() {
 			Expect(cfg.McpServer.LogTruncate.APILogErrorResponseSize).To(Equal(4096))
 		})
 
+		It("should leave pprof credentials empty when config and env are empty", func() {
+			v := viper.New()
+			v.Set("databases", []map[string]any{
+				{
+					"id": "default", "host": "localhost", "port": 3306,
+					"user": "root", "password": "password", "name": "testdb",
+				},
+			})
+
+			DeferCleanup(func() {
+				_ = os.Unsetenv("PPROF_USERNAME")
+				_ = os.Unsetenv("PPROF_PASSWORD")
+			})
+			Expect(os.Unsetenv("PPROF_USERNAME")).To(Succeed())
+			Expect(os.Unsetenv("PPROF_PASSWORD")).To(Succeed())
+
+			cfg, err := config.Load(v)
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(cfg.PProf.Username).To(BeEmpty())
+			Expect(cfg.PProf.Password).To(BeEmpty())
+		})
+
+		It("should override pprof config file values with env vars", func() {
+			v := viper.New()
+			v.Set("databases", []map[string]any{
+				{
+					"id": "default", "host": "localhost", "port": 3306,
+					"user": "root", "password": "password", "name": "testdb",
+				},
+			})
+			v.Set("pprof.username", "config-user")
+			v.Set("pprof.password", "config-password")
+
+			Expect(os.Setenv("PPROF_USERNAME", "env-user")).To(Succeed())
+			Expect(os.Setenv("PPROF_PASSWORD", "env-password")).To(Succeed())
+			DeferCleanup(func() {
+				_ = os.Unsetenv("PPROF_USERNAME")
+				_ = os.Unsetenv("PPROF_PASSWORD")
+			})
+
+			cfg, err := config.Load(v)
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(cfg.PProf.Username).To(Equal("env-user"))
+			Expect(cfg.PProf.Password).To(Equal("env-password"))
+		})
+
 		It("should set MaxConcurrentPrefetch default", func() {
 			v := viper.New()
 			v.Set("databases", []map[string]any{


### PR DESCRIPTION
## Summary
- remove hard-coded default pprof username/password from mcp-proxy config loading
- make the pprof template credentials empty so pprof stays disabled unless both credentials are configured
- add config tests for empty credentials and env override behavior

## Verification
- `go test ./pkg/config` failed before the production change on the new empty-credential regression test
- `go test ./pkg/config` passed
- `git diff --check` passed
- `make init` passed
- `make dep` passed
- `make lint` passed
- `make test` passed