### PR TITLE
feat(mcp_server): return updater in MCP permission lists

### DIFF
--- a/src/dashboard/apigateway/apigateway/apis/web/mcp_server/serializers.py
+++ b/src/dashboard/apigateway/apigateway/apis/web/mcp_server/serializers.py
@@ -692,12 +692,16 @@ class MCPServerAppPermissionListOutputSLZ(serializers.Serializer):
     id = serializers.IntegerField(read_only=True)
     bk_app_code = serializers.CharField(required=True, help_text="蓝鲸应用 ID")
     expires = serializers.DateTimeField(help_text="过期时间")
+    updater = serializers.SerializerMethodField(help_text="操作人")
     grant_type = serializers.ChoiceField(
         choices=MCPServerAppPermissionGrantTypeEnum.get_choices(), help_text="授权类型"
     )
 
     class Meta:
         ref_name = "apigateway.apis.web.mcp_server.serializers.MCPServerAppPermissionListOutputSLZ"
+
+    def get_updater(self, obj):
+        return obj.updated_by or obj.created_by or ""
 
 
 class MCPServerAppPermissionCreateInputSLZ(serializers.Serializer):
@@ -963,6 +967,7 @@ class GatewayMCPServerAppPermissionListOutputSLZ(serializers.Serializer):
     applied_by = serializers.SerializerMethodField(help_text="申请人")
     effective_time = serializers.SerializerMethodField(help_text="生效时间")
     handled_by = serializers.SerializerMethodField(help_text="审批人/授权人")
+    updater = serializers.SerializerMethodField(help_text="操作人")
     grant_type = serializers.ChoiceField(
         read_only=True, choices=MCPServerAppPermissionGrantTypeEnum.get_choices(), help_text="授权类型"
     )
@@ -997,6 +1002,12 @@ class GatewayMCPServerAppPermissionListOutputSLZ(serializers.Serializer):
         if apply_record:
             return apply_record.handled_by
         return obj.created_by or obj.updated_by or ""
+
+    def get_updater(self, obj):
+        apply_record = self._get_apply_record(obj)
+        if apply_record:
+            return apply_record.handled_by
+        return obj.updated_by or obj.created_by or ""
 
     def get_grant_type_display(self, obj):
         return _(MCPServerAppPermissionGrantTypeEnum.get_choice_label(obj.grant_type))

--- a/src/dashboard/apigateway/apigateway/tests/apis/web/mcp_server/test_serializers.py
+++ b/src/dashboard/apigateway/apigateway/tests/apis/web/mcp_server/test_serializers.py
@@ -27,6 +27,7 @@ from apigateway.apis.web.mcp_server.serializers import (
     GatewayMCPServerAppPermissionExportInputSLZ,
     GatewayMCPServerAppPermissionListInputSLZ,
     GatewayMCPServerAppPermissionListOutputSLZ,
+    MCPServerAppPermissionListOutputSLZ,
     MCPServerCategoryOutputSLZ,
     MCPServerCreateInputSLZ,
     MCPServerListInputSLZ,
@@ -616,6 +617,7 @@ class TestGatewayMCPServerAppPermissionListOutputSLZ:
         assert data["grant_type"] == MCPServerAppPermissionGrantTypeEnum.APPLY.value
         # APPLY 类型应该通过审批单获取 handled_by
         assert data["handled_by"] == "admin"
+        assert data["updater"] == "admin"
 
     def test_output_apply_type_without_record(self, fake_gateway, fake_stage):
         """测试申请授权类型（无关联审批记录）的序列化输出，应回退到 permission 字段"""
@@ -658,6 +660,31 @@ class TestGatewayMCPServerAppPermissionListOutputSLZ:
         slz = GatewayMCPServerAppPermissionListOutputSLZ(permission, context={})
         data = slz.data
         assert data["handled_by"] == "grant_user"
+        assert data["updater"] == "grant_user"
+
+
+class TestMCPServerAppPermissionListOutputSLZ:
+    """测试单个 MCPServer 应用权限列表输出序列化器"""
+
+    def test_output_updater(self, fake_gateway, fake_stage):
+        mcp_server = G(
+            MCPServer,
+            gateway=fake_gateway,
+            stage=fake_stage,
+            name="test-mcp",
+        )
+        permission = G(
+            MCPServerAppPermission,
+            mcp_server=mcp_server,
+            bk_app_code="test-app",
+            grant_type=MCPServerAppPermissionGrantTypeEnum.GRANT.value,
+            created_by="creator_user",
+            updated_by="operator_user",
+        )
+
+        slz = MCPServerAppPermissionListOutputSLZ(permission)
+
+        assert slz.data["updater"] == "operator_user"
 
 
 class TestGatewayMCPServerAppPermissionExportInputSLZ:

--- a/src/dashboard/apigateway/apigateway/tests/apis/web/mcp_server/test_views.py
+++ b/src/dashboard/apigateway/apigateway/tests/apis/web/mcp_server/test_views.py
@@ -1187,6 +1187,7 @@ class TestMCPServerAppPermissionListCreateApi:
             mcp_server=fake_mcp_server,
             bk_app_code="test-app",
             grant_type=MCPServerAppPermissionGrantTypeEnum.GRANT.value,
+            updated_by="operator",
         )
 
         resp = request_view(
@@ -1199,6 +1200,7 @@ class TestMCPServerAppPermissionListCreateApi:
 
         assert resp.status_code == 200
         assert result["data"]["count"] == 1
+        assert result["data"]["results"][0]["updater"] == "operator"
 
     def test_list_with_filter(self, request_view, fake_gateway, fake_mcp_server):
         G(
@@ -3383,6 +3385,7 @@ class TestGatewayMCPServerAppPermissionListApi:
             mcp_server=fake_mcp_server,
             bk_app_code="app1",
             grant_type=MCPServerAppPermissionGrantTypeEnum.GRANT.value,
+            updated_by="operator",
         )
         G(
             MCPServerAppPermission,
@@ -3400,6 +3403,7 @@ class TestGatewayMCPServerAppPermissionListApi:
         assert resp.status_code == 200
         result = resp.json()
         assert result["data"]["count"] == 2
+        assert result["data"]["results"][0]["updater"] == "operator"
 
     def test_list_order_by_effective_time(self, request_view, fake_gateway, fake_mcp_server):
         base_time = now_datetime()


### PR DESCRIPTION
- 为 MCP Server 应用权限列表接口补充返回 updater 字段，用于前端展示权限的操作人信息。updater 统一表示当前权限记录最近一次生效操作的操作人，包括主动授权和审批通过等场景，并补充了 serializer 和接口层测试覆盖。