### PR TITLE
feat: return updater in app permission list

### DIFF
--- a/src/dashboard/apigateway/apigateway/apis/v2/sync/views.py
+++ b/src/dashboard/apigateway/apigateway/apis/v2/sync/views.py
@@ -413,7 +413,7 @@ class GatewayAppPermissionGrantApi(generics.CreateAPIView):
         )
         permission_model = PermissionDimensionManager.get_permission_model(data["grant_dimension"])
 
-        username = request.user.username or settings.GATEWAY_DEFAULT_CREATOR
+        username = settings.GATEWAY_DEFAULT_CREATOR
 
         permission_model.objects.save_permissions(
             gateway=request.gateway,

--- a/src/dashboard/apigateway/apigateway/apis/v2/sync/views.py
+++ b/src/dashboard/apigateway/apigateway/apis/v2/sync/views.py
@@ -412,12 +412,16 @@ class GatewayAppPermissionGrantApi(generics.CreateAPIView):
             )
         )
         permission_model = PermissionDimensionManager.get_permission_model(data["grant_dimension"])
+
+        username = request.user.username or settings.GATEWAY_DEFAULT_CREATOR
+
         permission_model.objects.save_permissions(
             gateway=request.gateway,
             resource_ids=resource_ids,
             bk_app_code=data["target_app_code"],
             expire_days=data.get("expire_days"),
             grant_type=GrantTypeEnum.INITIALIZE.value,
+            handled_by=username,
         )
 
         return OKJsonResponse(status=status.HTTP_201_CREATED)

--- a/src/dashboard/apigateway/apigateway/apis/web/permission/serializers.py
+++ b/src/dashboard/apigateway/apigateway/apis/web/permission/serializers.py
@@ -67,7 +67,7 @@ class AppPermissionOutputSLZ(serializers.Serializer):
         choices=GrantTypeEnum.get_choices(), default=GrantTypeEnum.INITIALIZE.value, help_text="授权类型"
     )
     renewable = serializers.SerializerMethodField(help_text="是否可续期")
-    updater = serializers.CharField(help_text="操作人", required=False, allow_blank=True)
+    handled_by = serializers.CharField(help_text="操作人", required=False, allow_blank=True)
 
     class Meta:
         ref_name = "apigateway.apis.web.permission.serializers.AppPermissionOutputSLZ"

--- a/src/dashboard/apigateway/apigateway/apis/web/permission/serializers.py
+++ b/src/dashboard/apigateway/apigateway/apis/web/permission/serializers.py
@@ -67,6 +67,7 @@ class AppPermissionOutputSLZ(serializers.Serializer):
         choices=GrantTypeEnum.get_choices(), default=GrantTypeEnum.INITIALIZE.value, help_text="授权类型"
     )
     renewable = serializers.SerializerMethodField(help_text="是否可续期")
+    updater = serializers.CharField(help_text="操作人", required=False, allow_blank=True)
 
     class Meta:
         ref_name = "apigateway.apis.web.permission.serializers.AppPermissionOutputSLZ"

--- a/src/dashboard/apigateway/apigateway/apis/web/permission/views.py
+++ b/src/dashboard/apigateway/apigateway/apis/web/permission/views.py
@@ -113,7 +113,7 @@ class AppPermissionQuerySetMixin(AppGatewayPermissionQuerySetMixin, AppResourceP
                 "expires": perm.expires,
                 "grant_dimension": GrantDimensionEnum.API.value,
                 "id": perm.id,
-                "updater": perm.handled_by,
+                "handled_by": perm.handled_by,
             }
             for perm in gateway_queryset
         ]
@@ -125,7 +125,7 @@ class AppPermissionQuerySetMixin(AppGatewayPermissionQuerySetMixin, AppResourceP
                 "expires": perm.expires,
                 "grant_dimension": GrantDimensionEnum.RESOURCE.value,
                 "id": perm.id,
-                "updater": perm.handled_by,
+                "handled_by": perm.handled_by,
             }
             for perm in resource_queryset
         ]

--- a/src/dashboard/apigateway/apigateway/apis/web/permission/views.py
+++ b/src/dashboard/apigateway/apigateway/apis/web/permission/views.py
@@ -113,6 +113,7 @@ class AppPermissionQuerySetMixin(AppGatewayPermissionQuerySetMixin, AppResourceP
                 "expires": perm.expires,
                 "grant_dimension": GrantDimensionEnum.API.value,
                 "id": perm.id,
+                "updater": perm.handled_by,
             }
             for perm in gateway_queryset
         ]
@@ -124,6 +125,7 @@ class AppPermissionQuerySetMixin(AppGatewayPermissionQuerySetMixin, AppResourceP
                 "expires": perm.expires,
                 "grant_dimension": GrantDimensionEnum.RESOURCE.value,
                 "id": perm.id,
+                "updater": perm.handled_by,
             }
             for perm in resource_queryset
         ]
@@ -396,6 +398,7 @@ class AppResourcePermissionCreateApi(generics.CreateAPIView):
             bk_app_code=data["bk_app_code"],
             expire_days=data["expire_days"],
             grant_type=GrantTypeEnum.INITIALIZE.value,
+            handled_by=request.user.username,
         )
 
         # 查询授权后的资源权限
@@ -511,6 +514,7 @@ class AppGatewayPermissionCreateApi(generics.CreateAPIView):
             bk_app_code=data["bk_app_code"],
             expire_days=data["expire_days"],
             grant_type=GrantTypeEnum.INITIALIZE.value,
+            handled_by=request.user.username,
         )
 
         Auditor.record_permission_op_success(

--- a/src/dashboard/apigateway/apigateway/apps/permission/managers.py
+++ b/src/dashboard/apigateway/apigateway/apps/permission/managers.py
@@ -42,6 +42,7 @@ class AppGatewayPermissionManager(models.Manager):
         bk_app_code=None,
         grant_type=GrantTypeEnum.INITIALIZE.value,
         expire_days=None,
+        handled_by="",
     ):
         obj, _ = self.update_or_create(
             gateway=gateway,
@@ -49,6 +50,7 @@ class AppGatewayPermissionManager(models.Manager):
             defaults={
                 "expires": calculate_expires(expire_days),
                 "grant_type": grant_type,
+                "handled_by": handled_by,
             },
         )
         return obj
@@ -110,7 +112,7 @@ class AppResourcePermissionManager(models.Manager):
             grant_type=grant_type,
         )
 
-    def save_permissions(self, gateway, resource_ids, bk_app_code, grant_type, expire_days=None):
+    def save_permissions(self, gateway, resource_ids, bk_app_code, grant_type, expire_days=None, handled_by=""):
         expires = calculate_expires(expire_days)
 
         # 此处不再重复校验 resource_id 属于网关
@@ -124,6 +126,7 @@ class AppResourcePermissionManager(models.Manager):
                 defaults={
                     "expires": expires,
                     "grant_type": grant_type,
+                    "handled_by": handled_by,
                     "created_time": now_datetime(),
                     "updated_time": now_datetime(),
                 },

--- a/src/dashboard/apigateway/apigateway/apps/permission/migrations/0013_add_permission_handled_by.py
+++ b/src/dashboard/apigateway/apigateway/apps/permission/migrations/0013_add_permission_handled_by.py
@@ -1,0 +1,39 @@
+#
+# TencentBlueKing is pleased to support the open source community by making
+# 蓝鲸智云 - API 网关(BlueKing - APIGateway) available.
+# Copyright (C) Tencent. All rights reserved.
+# Licensed under the MIT License (the "License"); you may not use this file except
+# in compliance with the License. You may obtain a copy of the License at
+#
+#     http://opensource.org/licenses/MIT
+#
+# Unless required by applicable law or agreed to in writing, software distributed under
+# the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+# either express or implied. See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# We undertake not to change the open source license (MIT license) applicable
+# to the current version of the project delivered to anyone in the future.
+#
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("permission", "0012_app_gateway_permission_grant_type"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="appapipermission",
+            name="handled_by",
+            field=models.CharField(blank=True, default="", max_length=32),
+        ),
+        migrations.AddField(
+            model_name="appresourcepermission",
+            name="handled_by",
+            field=models.CharField(blank=True, default="", max_length=32),
+        ),
+    ]

--- a/src/dashboard/apigateway/apigateway/apps/permission/models.py
+++ b/src/dashboard/apigateway/apigateway/apps/permission/models.py
@@ -60,6 +60,7 @@ class AppGatewayPermission(TimestampedModelMixin):
         default=GrantTypeEnum.INITIALIZE.value,
         db_index=True,
     )
+    handled_by = models.CharField(max_length=32, blank=True, default="")
 
     objects: ClassVar[managers.AppGatewayPermissionManager] = managers.AppGatewayPermissionManager()
 
@@ -108,6 +109,7 @@ class AppResourcePermission(TimestampedModelMixin):
         default=generate_expire_time, blank=True, null=True, help_text=_("默认过期时间为180天")
     )
     grant_type = models.CharField(max_length=16, choices=GrantTypeEnum.get_choices(), db_index=True)
+    handled_by = models.CharField(max_length=32, blank=True, default="")
 
     objects: ClassVar[managers.AppResourcePermissionManager] = managers.AppResourcePermissionManager()
 

--- a/src/dashboard/apigateway/apigateway/biz/permission/manager.py
+++ b/src/dashboard/apigateway/apigateway/biz/permission/manager.py
@@ -276,6 +276,7 @@ class GatewayPermissionDimensionManager(PermissionDimensionManager):
                 bk_app_code=apply.bk_app_code,
                 grant_type=GrantTypeEnum.APPLY.value,
                 expire_days=apply.expire_days,
+                handled_by=handled_by,
             )
 
         self._handle_apply_status(apply, status)
@@ -378,6 +379,7 @@ class ResourcePermissionDimensionManager(PermissionDimensionManager):
                 bk_app_code=apply.bk_app_code,
                 grant_type=GrantTypeEnum.APPLY.value,
                 expire_days=apply.expire_days,
+                handled_by=handled_by,
             )
 
         # 更新应用访问资源权限申请状态

--- a/src/dashboard/apigateway/apigateway/tests/apis/web/permission/test_serializers.py
+++ b/src/dashboard/apigateway/apigateway/tests/apis/web/permission/test_serializers.py
@@ -124,6 +124,7 @@ class TestAppPermissionOutputSLZ(TestCase):
                 "grant_type": "apply",
                 "renewable": False,
                 "id": app_api_permission.id,
+                "updater": "",
             },
             {
                 "bk_app_code": "test",
@@ -136,6 +137,7 @@ class TestAppPermissionOutputSLZ(TestCase):
                 "grant_type": "apply",
                 "renewable": True,
                 "id": app_resource_permission.id,
+                "updater": "",
             },
         ]
 

--- a/src/dashboard/apigateway/apigateway/tests/apis/web/permission/test_serializers.py
+++ b/src/dashboard/apigateway/apigateway/tests/apis/web/permission/test_serializers.py
@@ -124,7 +124,7 @@ class TestAppPermissionOutputSLZ(TestCase):
                 "grant_type": "apply",
                 "renewable": False,
                 "id": app_api_permission.id,
-                "updater": "",
+                "handled_by": "",
             },
             {
                 "bk_app_code": "test",
@@ -137,7 +137,7 @@ class TestAppPermissionOutputSLZ(TestCase):
                 "grant_type": "apply",
                 "renewable": True,
                 "id": app_resource_permission.id,
-                "updater": "",
+                "handled_by": "",
             },
         ]
 

--- a/src/dashboard/apigateway/apigateway/tests/apis/web/permission/test_views.py
+++ b/src/dashboard/apigateway/apigateway/tests/apis/web/permission/test_views.py
@@ -87,7 +87,7 @@ class TestAppPermissionViewSet:
                 "expected": {
                     "count": 1,
                     "status_code": 200,
-                    "updater": "admin",
+                    "handled_by": "admin",
                 },
             },
             {
@@ -114,8 +114,8 @@ class TestAppPermissionViewSet:
             assert response.status_code == test["expected"]["status_code"], result
             if response.status_code == 200:
                 assert result["data"]["count"] == test["expected"]["count"]
-                if "updater" in test["expected"]:
-                    assert result["data"]["results"][0]["updater"] == test["expected"]["updater"]
+                if "handled_by" in test["expected"]:
+                    assert result["data"]["results"][0]["handled_by"] == test["expected"]["handled_by"]
 
 
 class TestAppPermissionRenewViewSet(TestCase):

--- a/src/dashboard/apigateway/apigateway/tests/apis/web/permission/test_views.py
+++ b/src/dashboard/apigateway/apigateway/tests/apis/web/permission/test_views.py
@@ -56,6 +56,7 @@ class TestAppPermissionViewSet:
             models.AppGatewayPermission,
             gateway=fake_gateway,
             bk_app_code="test",
+            handled_by="admin",
         )
 
         data = [
@@ -77,6 +78,16 @@ class TestAppPermissionViewSet:
                 "expected": {
                     "count": 1,
                     "status_code": 200,
+                },
+            },
+            {
+                "params": {
+                    "grant_dimension": "api",
+                },
+                "expected": {
+                    "count": 1,
+                    "status_code": 200,
+                    "updater": "admin",
                 },
             },
             {
@@ -103,6 +114,8 @@ class TestAppPermissionViewSet:
             assert response.status_code == test["expected"]["status_code"], result
             if response.status_code == 200:
                 assert result["data"]["count"] == test["expected"]["count"]
+                if "updater" in test["expected"]:
+                    assert result["data"]["results"][0]["updater"] == test["expected"]["updater"]
 
 
 class TestAppPermissionRenewViewSet(TestCase):
@@ -187,6 +200,11 @@ class TestAppResourcePermissionViewSet:
             )
             result = response.json()
             assert response.status_code == 201, result
+            permission = test["expected"]["permission_model"].objects.get(
+                gateway=fake_gateway,
+                bk_app_code=test["params"]["bk_app_code"],
+            )
+            assert permission.handled_by == "admin"
 
 
 class TestAppGatewayPermissionViewSet:
@@ -233,6 +251,11 @@ class TestAppGatewayPermissionViewSet:
             )
             result = response.json()
             assert response.status_code == 201, result
+            permission = test["expected"]["permission_model"].objects.get(
+                gateway=fake_gateway,
+                bk_app_code=test["params"]["bk_app_code"],
+            )
+            assert permission.handled_by == "admin"
 
 
 class TestAppResourcePermissionBatchViewSet(TestCase):

--- a/src/dashboard/apigateway/apigateway/tests/apps/permission/test_managers.py
+++ b/src/dashboard/apigateway/apigateway/tests/apps/permission/test_managers.py
@@ -52,9 +52,11 @@ class TestAppAPIPermissionManager:
             bk_app_code="test",
             grant_type=GrantTypeEnum.APPLY.value,
             expire_days=180,
+            handled_by="admin",
         )
 
         assert permission.grant_type == GrantTypeEnum.APPLY.value
+        assert permission.handled_by == "admin"
 
     def test_renew_by_ids(self):
         perm_1 = G(
@@ -241,12 +243,14 @@ class TestAppResourcePermissionManager:
                 "bk_app_code": "test",
                 "grant_type": "apply",
                 "expire_days": 180,
+                "handled_by": "admin",
             },
             {
                 "resource_ids": [resource_2.id],
                 "bk_app_code": "test",
                 "grant_type": "apply",
                 "expire_days": 180,
+                "handled_by": "admin",
             },
         ]
         for test in data:
@@ -255,6 +259,7 @@ class TestAppResourcePermissionManager:
                 gateway=self.gateway, resource_id=test["resource_ids"][0], bk_app_code=test["bk_app_code"]
             )
             assert permission.grant_type == test["grant_type"]
+            assert permission.handled_by == test["handled_by"]
             assert 180 * 24 * 3600 - 10 < (permission.expires - now_datetime()).total_seconds() < 180 * 24 * 3600
 
 

--- a/src/dashboard/apigateway/apigateway/tests/biz/permission/test_manager.py
+++ b/src/dashboard/apigateway/apigateway/tests/biz/permission/test_manager.py
@@ -89,6 +89,7 @@ class TestGatewayPermissionDimensionManager:
         assert record.id
         permission = AppGatewayPermission.objects.get(gateway=fake_gateway, bk_app_code=apply.bk_app_code)
         assert permission.grant_type == GrantTypeEnum.APPLY.value
+        assert permission.handled_by == "admin"
         assert AppPermissionApplyStatus.objects.filter(gateway=fake_gateway).count() == 0
 
     def test_handle_permission_apply_rejected(self, fake_gateway):
@@ -241,7 +242,9 @@ class TestResourcePermissionDimensionManager:
             part_resource_ids=None,
         )
         assert record.id
-        assert AppResourcePermission.objects.filter(gateway=fake_gateway, bk_app_code=apply.bk_app_code).count() == 2
+        permissions = AppResourcePermission.objects.filter(gateway=fake_gateway, bk_app_code=apply.bk_app_code)
+        assert permissions.count() == 2
+        assert {permission.handled_by for permission in permissions} == {"admin"}
         assert (
             AppPermissionApplyStatus.objects.filter(gateway=fake_gateway, bk_app_code=apply.bk_app_code).count() == 0
         )


### PR DESCRIPTION
- 为网关应用权限列表接口补充返回 updater 字段，用于展示权限操作人。主动授权和审批通过场景都会将当前操作人写入权限记录，并通过 app-permissions/?grant_dimension=api 等列表接口返回，同时补充了迁移和相关测试覆盖。