### PR TITLE
fix: audit permission approval and renewal handlers

### DIFF
--- a/src/dashboard/apigateway/apigateway/apis/web/permission/views.py
+++ b/src/dashboard/apigateway/apigateway/apis/web/permission/views.py
@@ -211,6 +211,7 @@ class AppPermissionRenewApi(generics.CreateAPIView):
                     gateway=request.gateway,
                     ids=resource_dimension_ids,
                     expire_days=expire_days,
+                    handled_by=request.user.username,
                 )
             )
             Auditor.record_permission_op_success(
@@ -230,6 +231,7 @@ class AppPermissionRenewApi(generics.CreateAPIView):
                     gateway=request.gateway,
                     ids=gateway_dimension_ids,
                     expire_days=expire_days,
+                    handled_by=request.user.username,
                 )
             )
             Auditor.record_permission_op_success(
@@ -442,8 +444,21 @@ class AppResourcePermissionRenewApi(generics.CreateAPIView):
 
         data = slz.validated_data
 
-        AppResourcePermission.objects.renew_by_ids(
-            gateway=request.gateway, ids=data["ids"], expires=data["expire_days"]
+        data_before, data_after, bk_app_codes = ResourcePermissionHandler.renew_resource_permissions_by_ids(
+            gateway=request.gateway,
+            ids=data["ids"],
+            expire_days=data["expire_days"],
+            handled_by=request.user.username,
+        )
+        Auditor.record_permission_op_success(
+            op_type=OpTypeEnum.MODIFY,
+            username=request.user.username,
+            gateway_id=request.gateway.id,
+            instance_id=";".join([str(i) for i in data["ids"]]),
+            instance_name=";".join(bk_app_codes),
+            data_before=[get_model_dict(perm) for perm in data_before],
+            data_after=[get_model_dict(perm) for perm in data_after],
+            comment="资源权限续期",
         )
 
         return OKJsonResponse(status=status.HTTP_201_CREATED)
@@ -551,8 +566,21 @@ class AppGatewayPermissionRenewApi(generics.CreateAPIView):
 
         data = slz.validated_data
 
-        AppGatewayPermission.objects.renew_by_ids(
-            gateway=request.gateway, ids=data["ids"], expires=data["expire_days"]
+        data_before, data_after, bk_app_codes = ResourcePermissionHandler.renew_gateway_permissions_by_ids(
+            gateway=request.gateway,
+            ids=data["ids"],
+            expire_days=data["expire_days"],
+            handled_by=request.user.username,
+        )
+        Auditor.record_permission_op_success(
+            op_type=OpTypeEnum.MODIFY,
+            username=request.user.username,
+            gateway_id=request.gateway.id,
+            instance_id=";".join([str(i) for i in data["ids"]]),
+            instance_name=";".join(bk_app_codes),
+            data_before=[get_model_dict(perm) for perm in data_before],
+            data_after=[get_model_dict(perm) for perm in data_after],
+            comment="网关权限续期",
         )
 
         return OKJsonResponse(status=status.HTTP_201_CREATED)
@@ -740,6 +768,16 @@ class AppPermissionApplyApprovalApi(AppPermissionApplyQuerySetMixin, generics.Cr
                 comment=data["comment"],
                 handled_by=request.user.username,
                 part_resource_ids=part_resource_ids.get(f"{apply.id}"),
+            )
+            Auditor.record_permission_op_success(
+                op_type=OpTypeEnum.MODIFY,
+                username=request.user.username,
+                gateway_id=request.gateway.id,
+                instance_id=record.id,
+                instance_name=record.bk_app_code,
+                data_before={},
+                data_after=get_model_dict(record),
+                comment="权限申请审批",
             )
 
             try:

--- a/src/dashboard/apigateway/apigateway/apps/permission/managers.py
+++ b/src/dashboard/apigateway/apigateway/apps/permission/managers.py
@@ -55,26 +55,36 @@ class AppGatewayPermissionManager(models.Manager):
         )
         return obj
 
-    def renew_by_ids(self, gateway, ids, expires=DEFAULT_PERMISSION_EXPIRE_DAYS):
+    def renew_by_ids(self, gateway, ids, expires=DEFAULT_PERMISSION_EXPIRE_DAYS, handled_by=""):
         queryset = self.filter(gateway=gateway, id__in=ids)
         for obj in queryset:
             obj.expires = calculate_renew_time(obj.expires, expires)
             obj.updated_time = now_datetime()
+            if handled_by:
+                obj.handled_by = handled_by
 
-        self.bulk_update(queryset, ["expires", "updated_time"])
+        update_fields = ["expires", "updated_time"]
+        if handled_by:
+            update_fields.append("handled_by")
+        self.bulk_update(queryset, update_fields)
 
 
 class AppResourcePermissionManager(models.Manager):
     def filter_public_permission_by_app(self, bk_app_code: str):
         return self.filter(bk_app_code=bk_app_code, gateway__is_public=True)
 
-    def renew_by_ids(self, gateway, ids, expires=DEFAULT_PERMISSION_EXPIRE_DAYS):
+    def renew_by_ids(self, gateway, ids, expires=DEFAULT_PERMISSION_EXPIRE_DAYS, handled_by=""):
         queryset = self.filter(gateway=gateway, id__in=ids)
         for obj in queryset:
             obj.expires = calculate_renew_time(obj.expires, expires)
             obj.updated_time = now_datetime()
+            if handled_by:
+                obj.handled_by = handled_by
 
-        self.bulk_update(queryset, ["expires", "updated_time"])
+        update_fields = ["expires", "updated_time"]
+        if handled_by:
+            update_fields.append("handled_by")
+        self.bulk_update(queryset, update_fields)
 
     def renew_by_resource_ids(
         self,

--- a/src/dashboard/apigateway/apigateway/biz/permission/permission.py
+++ b/src/dashboard/apigateway/apigateway/biz/permission/permission.py
@@ -126,7 +126,7 @@ class ResourcePermissionHandler:
             )
 
     @staticmethod
-    def renew_resource_permissions_by_ids(gateway: Gateway, ids: List[int], expire_days: int):
+    def renew_resource_permissions_by_ids(gateway: Gateway, ids: List[int], expire_days: int, handled_by: str = ""):
         if not ids:
             return [], [], []
 
@@ -140,6 +140,7 @@ class ResourcePermissionHandler:
             gateway=gateway,
             ids=ids,
             expires=expire_days,
+            handled_by=handled_by,
         )
         data_after = list(
             AppResourcePermission.objects.filter(
@@ -152,7 +153,7 @@ class ResourcePermissionHandler:
         return data_before, data_after, bk_app_codes
 
     @staticmethod
-    def renew_gateway_permissions_by_ids(gateway: Gateway, ids: List[int], expire_days: int):
+    def renew_gateway_permissions_by_ids(gateway: Gateway, ids: List[int], expire_days: int, handled_by: str = ""):
         if not ids:
             return [], [], []
 
@@ -166,6 +167,7 @@ class ResourcePermissionHandler:
             gateway=gateway,
             ids=ids,
             expires=expire_days,
+            handled_by=handled_by,
         )
         data_after = list(
             AppGatewayPermission.objects.filter(

--- a/src/dashboard/apigateway/apigateway/tests/apis/web/permission/test_views.py
+++ b/src/dashboard/apigateway/apigateway/tests/apis/web/permission/test_views.py
@@ -17,13 +17,13 @@
 # to the current version of the project delivered to anyone in the future.
 #
 import json
-from unittest import mock
 
 import pytest
 from django.test import TestCase
 from django_dynamic_fixture import G
 
 from apigateway.apis.web.permission import views
+from apigateway.apps.audit.models import AuditEventLog
 from apigateway.apps.permission import models
 from apigateway.core.models import Resource
 from apigateway.tests.utils.testing import APIRequestFactory, create_gateway, dummy_time, get_response_json
@@ -133,6 +133,7 @@ class TestAppPermissionRenewViewSet(TestCase):
             bk_app_code="test",
             resource_id=resource.id,
             grant_type="initialize",
+            handled_by="old-admin",
         )
 
         data = [
@@ -158,6 +159,12 @@ class TestAppPermissionRenewViewSet(TestCase):
 
             resource_p1_obj = models.AppResourcePermission.objects.get(id=resource_p1.id)
             assert resource_p1_obj.grant_type == "initialize"
+            assert resource_p1_obj.handled_by == "admin"
+
+            audit_log = AuditEventLog.objects.get(op_object_id=str(resource_p1.id), comment="批量续期资源")
+            assert audit_log.username == "admin"
+            assert json.loads(audit_log.data_before)[0]["handled_by"] == "old-admin"
+            assert json.loads(audit_log.data_after)[0]["handled_by"] == "admin"
 
 
 class TestAppResourcePermissionViewSet:
@@ -273,6 +280,7 @@ class TestAppResourcePermissionBatchViewSet(TestCase):
             bk_app_code="test",
             resource_id=resource.id,
             grant_type="apply",
+            handled_by="old-admin",
         )
 
         data = [
@@ -304,6 +312,12 @@ class TestAppResourcePermissionBatchViewSet(TestCase):
                 < (perm_record.expires - now_datetime()).total_seconds()
                 < (180 + 180) * 24 * 3600
             )
+            self.assertEqual(perm_record.handled_by, "admin")
+
+            audit_log = AuditEventLog.objects.get(op_object_id=str(perm_2.id), comment="资源权限续期")
+            self.assertEqual(audit_log.username, "admin")
+            self.assertEqual(json.loads(audit_log.data_before)[0]["handled_by"], "old-admin")
+            self.assertEqual(json.loads(audit_log.data_after)[0]["handled_by"], "admin")
 
     def test_destroy(self):
         resource = G(Resource, gateway=self.gateway)
@@ -349,12 +363,11 @@ class TestAppGatewayPermissionBatchViewSet(TestCase):
         cls.gateway = create_gateway()
 
     def test_renew(self):
-        resource = G(Resource, gateway=self.gateway)
-
         perm_1 = G(
             models.AppGatewayPermission,
             gateway=self.gateway,
             bk_app_code="test",
+            handled_by="old-admin",
         )
 
         data = [
@@ -387,10 +400,14 @@ class TestAppGatewayPermissionBatchViewSet(TestCase):
                 < (perm_record.expires - now_datetime()).total_seconds()
                 < (180 + 180) * 24 * 3600
             )
+            self.assertEqual(perm_record.handled_by, "admin")
+
+            audit_log = AuditEventLog.objects.get(op_object_id=str(perm_1.id), comment="网关权限续期")
+            self.assertEqual(audit_log.username, "admin")
+            self.assertEqual(json.loads(audit_log.data_before)[0]["handled_by"], "old-admin")
+            self.assertEqual(json.loads(audit_log.data_after)[0]["handled_by"], "admin")
 
     def test_destroy(self):
-        resource = G(Resource, gateway=self.gateway)
-
         perm_1 = G(
             models.AppGatewayPermission,
             gateway=self.gateway,
@@ -468,13 +485,27 @@ class TestAppPermissionApplyViewSet:
 
 class TestAppPermissionApplyBatchViewSet:
     def test_post(self, mocker, fake_gateway, request_factory):
+        record_1 = G(
+            models.AppPermissionRecord,
+            gateway=fake_gateway,
+            bk_app_code="test-api",
+            status="approved",
+            handled_by="admin",
+        )
+        record_2 = G(
+            models.AppPermissionRecord,
+            gateway=fake_gateway,
+            bk_app_code="test-resource",
+            status="rejected",
+            handled_by="admin",
+        )
         mocker.patch(
             "apigateway.biz.permission.GatewayPermissionDimensionManager.handle_permission_apply",
-            return_value=mock.MagicMock(id=1),
+            return_value=record_1,
         )
         mocker.patch(
             "apigateway.biz.permission.ResourcePermissionDimensionManager.handle_permission_apply",
-            return_value=mock.MagicMock(id=1),
+            return_value=record_2,
         )
         mocker.patch(
             "apigateway.apis.web.permission.views.send_mail_for_perm_handle",
@@ -527,6 +558,11 @@ class TestAppPermissionApplyBatchViewSet:
             assert response.status_code == 201
 
         assert models.AppPermissionApply.objects.filter(gateway=fake_gateway).count() == 0
+        assert AuditEventLog.objects.filter(comment="权限申请审批").count() == 2
+        audit_log = AuditEventLog.objects.get(op_object_id=str(record_1.id), comment="权限申请审批")
+        assert audit_log.username == "admin"
+        assert json.loads(audit_log.data_after)["handled_by"] == "admin"
+        assert json.loads(audit_log.data_after)["bk_app_code"] == "test-api"
 
 
 class TestAppPermissionRecordViewSet(TestCase):

--- a/src/dashboard/apigateway/apigateway/tests/apps/permission/test_managers.py
+++ b/src/dashboard/apigateway/apigateway/tests/apps/permission/test_managers.py
@@ -81,6 +81,7 @@ class TestAppAPIPermissionManager:
         models.AppGatewayPermission.objects.renew_by_ids(
             self.gateway,
             ids=[perm_1.id, perm_2.id, perm_3.id],
+            handled_by="admin",
         )
         perm_1 = models.AppGatewayPermission.objects.get(id=perm_1.id)
         perm_2 = models.AppGatewayPermission.objects.get(id=perm_2.id)
@@ -88,6 +89,7 @@ class TestAppAPIPermissionManager:
         assert to_datetime_from_now(days=179) < perm_1.expires < to_datetime_from_now(days=181)
         assert to_datetime_from_now(days=170 + 179) < perm_2.expires < to_datetime_from_now(days=170 + 181)
         assert to_datetime_from_now(days=720 + 179) < perm_3.expires < to_datetime_from_now(days=720 + 181)
+        assert {perm_1.handled_by, perm_2.handled_by, perm_3.handled_by} == {"admin"}
 
 
 class TestAppResourcePermissionManager:
@@ -131,6 +133,7 @@ class TestAppResourcePermissionManager:
         models.AppResourcePermission.objects.renew_by_ids(
             self.gateway,
             ids=[perm_1.id, perm_2.id, perm_3.id],
+            handled_by="admin",
         )
         perm_1 = models.AppResourcePermission.objects.get(id=perm_1.id)
         perm_2 = models.AppResourcePermission.objects.get(id=perm_2.id)
@@ -138,6 +141,7 @@ class TestAppResourcePermissionManager:
         assert to_datetime_from_now(days=179) < perm_1.expires < to_datetime_from_now(181)
         assert to_datetime_from_now(days=70 + 179) < perm_2.expires < to_datetime_from_now(70 + 181)
         assert to_datetime_from_now(days=720 + 179) < perm_3.expires < to_datetime_from_now(720 + 181)
+        assert {perm_1.handled_by, perm_2.handled_by, perm_3.handled_by} == {"admin"}
 
     def test_renew_by_resource_ids(self):
         perm_1 = G(


### PR DESCRIPTION
- 本次调整补齐应用权限处理人的溯源能力：权限续期时会刷新 handled_by 为当前操作人，并在资源/网关权限续期、权限申请审批场景记录审计日志。审计日志中保留操作人及变更前后数据，便于追踪权限是谁审批、授权或续期的。