### PR TITLE
fix(mcp-proxy): serialize query arrays as repeated params for release/1.22

### DIFF
--- a/src/mcp-proxy/pkg/infra/proxy/proxy.go
+++ b/src/mcp-proxy/pkg/infra/proxy/proxy.go
@@ -626,9 +626,9 @@ func setHandlerRequestParams(
 		}
 	}
 	if handlerRequest.QueryParam != nil {
-		for k, value := range handlerRequest.QueryParam {
-			if err := req.SetQueryParam(k, value); err != nil {
-				auditLog.Error("set query param err", zap.String(k, value), zap.Error(err))
+		for k, values := range handlerRequest.QueryParam {
+			if err := req.SetQueryParam(k, values...); err != nil {
+				auditLog.Error("set query param err", zap.Strings(k, values), zap.Error(err))
 				return err
 			}
 		}
@@ -917,7 +917,7 @@ func genToolHandler(toolApiConfig *ToolConfig, serverName string, rawResponseEna
 			auditStatus        = "success"
 			auditUpstreamReqID string
 			auditHeaderInfo    map[string]string
-			auditQueryParam    StringParamMap
+			auditQueryParam    QueryParam
 			auditPathParam     StringParamMap
 			auditBodyParam     any
 		)

--- a/src/mcp-proxy/pkg/infra/proxy/proxy_test.go
+++ b/src/mcp-proxy/pkg/infra/proxy/proxy_test.go
@@ -24,11 +24,13 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"strings"
 	"sync"
 	"time"
 
 	"github.com/gin-gonic/gin"
+	"github.com/go-openapi/runtime"
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -1046,12 +1048,63 @@ var _ = Describe("MCPProxy", func() {
 		})
 	})
 
+	Describe("setHandlerRequestParams", func() {
+		It("should set array query values as repeated query params", func() {
+			req := newRecordingClientRequest()
+			handlerRequest := &HandlerRequest{
+				QueryParam: QueryParam{
+					"related": {"fields", "storages"},
+				},
+			}
+
+			err := setHandlerRequestParams(req, handlerRequest, map[string]string{}, zap.NewNop())
+			Expect(err).NotTo(HaveOccurred())
+			Expect(req.GetQueryParams()["related"]).To(Equal([]string{"fields", "storages"}))
+			Expect(req.GetQueryParams().Encode()).To(Equal("related=fields&related=storages"))
+			Expect(req.GetQueryParams().Encode()).NotTo(ContainSubstring("%5Bfields+storages%5D"))
+		})
+
+		It("should keep scalar query values unchanged", func() {
+			req := newRecordingClientRequest()
+			handlerRequest := &HandlerRequest{
+				QueryParam: QueryParam{
+					"extra": {"true"},
+					"ratio": {"1.25"},
+				},
+			}
+
+			err := setHandlerRequestParams(req, handlerRequest, map[string]string{}, zap.NewNop())
+			Expect(err).NotTo(HaveOccurred())
+			Expect(req.GetQueryParams()["extra"]).To(Equal([]string{"true"}))
+			Expect(req.GetQueryParams()["ratio"]).To(Equal([]string{"1.25"}))
+		})
+
+		It("should keep header and path params scalar", func() {
+			req := newRecordingClientRequest()
+			headerInfo := map[string]string{}
+			handlerRequest := &HandlerRequest{
+				HeaderParam: StringParamMap{"X-Trace-ID": "2005000002"},
+				PathParam:   StringParamMap{"bk_biz_id": "2005000002"},
+			}
+
+			err := setHandlerRequestParams(req, handlerRequest, headerInfo, zap.NewNop())
+			Expect(err).NotTo(HaveOccurred())
+			Expect(req.GetHeaderParams().Values("X-Trace-ID")).To(Equal([]string{"2005000002"}))
+			Expect(req.pathParams["bk_biz_id"]).To(Equal("2005000002"))
+			Expect(headerInfo["X-Trace-ID"]).To(Equal("2005000002"))
+		})
+	})
+
 	Describe("decodeHandlerRequest with UseNumber", func() {
 		It("should preserve numbers for all request parameter groups", func() {
 			arguments := map[string]any{
 				"header_param": map[string]any{"X-Trace-ID": 2005000002},
-				"query_param":  map[string]any{"bk_biz_id": 2005000002, "ratio": 1.25},
-				"path_param":   map[string]any{"bk_biz_id": 2005000002},
+				"query_param": map[string]any{
+					"bk_biz_id": 2005000002,
+					"ratio":     1.25,
+					"ids":       []any{2005000002, json.Number("9007199254740992")},
+				},
+				"path_param": map[string]any{"bk_biz_id": 2005000002},
 				"body_param": map[string]any{
 					"bk_biz_id": 2005000002,
 					"nested":    map[string]any{"id": 2005000003},
@@ -1068,8 +1121,9 @@ var _ = Describe("MCPProxy", func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			Expect(handlerRequest.HeaderParam["X-Trace-ID"]).To(Equal("2005000002"))
-			Expect(handlerRequest.QueryParam["bk_biz_id"]).To(Equal("2005000002"))
-			Expect(handlerRequest.QueryParam["ratio"]).To(Equal("1.25"))
+			Expect(handlerRequest.QueryParam["bk_biz_id"]).To(Equal([]string{"2005000002"}))
+			Expect(handlerRequest.QueryParam["ratio"]).To(Equal([]string{"1.25"}))
+			Expect(handlerRequest.QueryParam["ids"]).To(Equal([]string{"2005000002", "9007199254740992"}))
 			Expect(handlerRequest.PathParam["bk_biz_id"]).To(Equal("2005000002"))
 
 			body := handlerRequest.BodyParam.(map[string]any)
@@ -1078,3 +1132,85 @@ var _ = Describe("MCPProxy", func() {
 		})
 	})
 })
+
+type recordingClientRequest struct {
+	headers    http.Header
+	query      url.Values
+	pathParams map[string]string
+	bodyParam  any
+	timeout    time.Duration
+}
+
+func newRecordingClientRequest() *recordingClientRequest {
+	return &recordingClientRequest{
+		headers:    http.Header{},
+		query:      url.Values{},
+		pathParams: map[string]string{},
+	}
+}
+
+var _ runtime.ClientRequest = (*recordingClientRequest)(nil)
+
+func (r *recordingClientRequest) SetHeaderParam(name string, values ...string) error {
+	r.headers.Del(name)
+	for _, value := range values {
+		r.headers.Add(name, value)
+	}
+	return nil
+}
+
+func (r *recordingClientRequest) GetHeaderParams() http.Header {
+	return r.headers.Clone()
+}
+
+func (r *recordingClientRequest) SetQueryParam(name string, values ...string) error {
+	r.query[name] = values
+	return nil
+}
+
+func (r *recordingClientRequest) SetFormParam(string, ...string) error {
+	return nil
+}
+
+func (r *recordingClientRequest) SetPathParam(name, value string) error {
+	r.pathParams[name] = value
+	return nil
+}
+
+func (r *recordingClientRequest) GetQueryParams() url.Values {
+	return r.query
+}
+
+func (r *recordingClientRequest) SetFileParam(string, ...runtime.NamedReadCloser) error {
+	return nil
+}
+
+func (r *recordingClientRequest) SetBodyParam(body any) error {
+	r.bodyParam = body
+	return nil
+}
+
+func (r *recordingClientRequest) SetTimeout(timeout time.Duration) error {
+	r.timeout = timeout
+	return nil
+}
+
+func (r *recordingClientRequest) GetMethod() string {
+	return ""
+}
+
+func (r *recordingClientRequest) GetPath() string {
+	return ""
+}
+
+func (r *recordingClientRequest) GetBody() []byte {
+	return nil
+}
+
+func (r *recordingClientRequest) GetBodyParam() any {
+	return r.bodyParam
+}
+
+func (r *recordingClientRequest) GetFileParam() map[string][]runtime.NamedReadCloser {
+	return nil
+}

--- a/src/mcp-proxy/pkg/infra/proxy/types.go
+++ b/src/mcp-proxy/pkg/infra/proxy/types.go
@@ -71,10 +71,48 @@ func (m *StringParamMap) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+// QueryParam stores HTTP query parameters as multiple string values per key.
+type QueryParam map[string][]string
+
+// UnmarshalJSON decodes JSON query values into strings, preserving numeric precision and arrays.
+func (m *QueryParam) UnmarshalJSON(data []byte) error {
+	if string(data) == "null" {
+		*m = nil
+		return nil
+	}
+
+	var values map[string]any
+	decoder := json.NewDecoder(bytes.NewReader(data))
+	decoder.UseNumber()
+	if err := decoder.Decode(&values); err != nil {
+		return err
+	}
+
+	result := make(QueryParam, len(values))
+	for key, value := range values {
+		if items, ok := value.([]any); ok {
+			if len(items) == 0 {
+				continue
+			}
+
+			queryValues := make([]string, 0, len(items))
+			for _, item := range items {
+				queryValues = append(queryValues, stringifyRequestParamValue(item))
+			}
+			result[key] = queryValues
+			continue
+		}
+
+		result[key] = []string{stringifyRequestParamValue(value)}
+	}
+	*m = result
+	return nil
+}
+
 // HandlerRequest ...
 type HandlerRequest struct {
 	HeaderParam StringParamMap `json:"header_param,omitempty"`
-	QueryParam  StringParamMap `json:"query_param,omitempty"`
+	QueryParam  QueryParam     `json:"query_param,omitempty"`
 	PathParam   StringParamMap `json:"path_param,omitempty"`
 	BodyParam   any            `json:"body_param,omitempty"`
 }

--- a/src/mcp-proxy/pkg/infra/proxy/types_test.go
+++ b/src/mcp-proxy/pkg/infra/proxy/types_test.go
@@ -33,7 +33,7 @@ var _ = Describe("Types", func() {
 			It("should marshal and unmarshal correctly", func() {
 				request := proxy.HandlerRequest{
 					HeaderParam: proxy.StringParamMap{"Content-Type": "application/json"},
-					QueryParam:  proxy.StringParamMap{"limit": "10", "offset": "0"},
+					QueryParam:  proxy.QueryParam{"limit": {"10"}, "offset": {"0"}},
 					PathParam:   proxy.StringParamMap{"id": "123"},
 					BodyParam:   map[string]any{"name": "test"},
 				}
@@ -46,7 +46,7 @@ var _ = Describe("Types", func() {
 				err = json.Unmarshal(data, &result)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(result.HeaderParam["Content-Type"]).To(Equal("application/json"))
-				Expect(result.QueryParam["limit"]).To(Equal("10"))
+				Expect(result.QueryParam["limit"]).To(Equal([]string{"10"}))
 				Expect(result.PathParam["id"]).To(Equal("123"))
 				Expect(result.BodyParam.(map[string]any)["name"]).To(Equal("test"))
 			})
@@ -60,7 +60,7 @@ var _ = Describe("Types", func() {
 
 			It("should handle partial fields", func() {
 				request := proxy.HandlerRequest{
-					QueryParam: proxy.StringParamMap{"search": "test"},
+					QueryParam: proxy.QueryParam{"search": {"test"}},
 				}
 
 				data, err := json.Marshal(request)
@@ -102,7 +102,7 @@ var _ = Describe("Types", func() {
 			It("should unmarshal from JSON string", func() {
 				jsonStr := `{
 					"header_param": {"Authorization": "Bearer token"},
-					"query_param": {"page": 1},
+					"query_param": {"page": ["1"]},
 					"path_param": {"userId": "abc123"},
 					"body_param": {"data": "test"}
 				}`
@@ -112,9 +112,63 @@ var _ = Describe("Types", func() {
 				Expect(err).NotTo(HaveOccurred())
 
 				Expect(request.HeaderParam["Authorization"]).To(Equal("Bearer token"))
-				Expect(request.QueryParam["page"]).To(Equal("1"))
+				Expect(request.QueryParam["page"]).To(Equal([]string{"1"}))
 				Expect(request.PathParam["userId"]).To(Equal("abc123"))
 				Expect(request.BodyParam.(map[string]any)["data"]).To(Equal("test"))
+			})
+		})
+	})
+
+	Describe("QueryParam", func() {
+		Describe("UnmarshalJSON", func() {
+			It("should decode array values as multiple query values", func() {
+				jsonStr := `{"related": ["fields", "storages"]}`
+				var m proxy.QueryParam
+				err := json.Unmarshal([]byte(jsonStr), &m)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(m["related"]).To(Equal([]string{"fields", "storages"}))
+			})
+
+			It("should decode single-item arrays as one query value", func() {
+				jsonStr := `{"related": ["fields"]}`
+				var m proxy.QueryParam
+				err := json.Unmarshal([]byte(jsonStr), &m)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(m["related"]).To(Equal([]string{"fields"}))
+			})
+
+			It("should skip empty arrays instead of stringifying them", func() {
+				jsonStr := `{"related": []}`
+				var m proxy.QueryParam
+				err := json.Unmarshal([]byte(jsonStr), &m)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(m).NotTo(HaveKey("related"))
+			})
+
+			It("should decode scalar values using existing string conversion semantics", func() {
+				jsonStr := `{"extra": true, "ratio": 1.25, "bk_biz_id": 2005000002}`
+				var m proxy.QueryParam
+				err := json.Unmarshal([]byte(jsonStr), &m)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(m["extra"]).To(Equal([]string{"true"}))
+				Expect(m["ratio"]).To(Equal([]string{"1.25"}))
+				Expect(m["bk_biz_id"]).To(Equal([]string{"2005000002"}))
+			})
+
+			It("should preserve large integers in arrays without scientific notation", func() {
+				jsonStr := `{"ids": [2005000002, 9007199254740992]}`
+				var m proxy.QueryParam
+				err := json.Unmarshal([]byte(jsonStr), &m)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(m["ids"]).To(Equal([]string{"2005000002", "9007199254740992"}))
+			})
+
+			It("should handle null input", func() {
+				jsonStr := `null`
+				var m proxy.QueryParam
+				err := json.Unmarshal([]byte(jsonStr), &m)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(m).To(BeNil())
 			})
 		})
 	})


### PR DESCRIPTION
## Summary
- Backport #2896 to release/1.22
- Add query-specific multi-value request params for MCP proxy calls
- Serialize query array values as repeated query entries instead of stringified slices
- Preserve scalar header/path behavior and JSON number string preservation

## Cherry-picked commits
- a7de1dcb661ad6412cae989706c08297516444fe fix(mcp-proxy): serialize query arrays as repeated params

## Verification
- go test ./pkg/infra/proxy
