### PR TITLE
fix(home): 网关名称超长时省略号显示并 hover 显示 tooltip

### DIFF
--- a/src/dashboard-front/src/views/home/Index.vue
+++ b/src/dashboard-front/src/views/home/Index.vue
@@ -188,7 +188,7 @@
               class="table-item"
             >
               <div
-                class="flex-1 flex items-center of2"
+                class="flex-1 flex items-center of2 overflow-hidden"
               >
                 <div
                   :class="item.status ? '' : 'deact'"
@@ -208,6 +208,13 @@
                   {{ item.name[0].toUpperCase() }}
                 </div>
                 <span
+                  :ref="(el: any) => setNameRef(el, item.id)"
+                  v-bk-tooltips="{
+                    content: item.name,
+                    theme: 'light',
+                    placement: 'top',
+                    disabled: !overflowMap[item.id]
+                  }"
                   :class="item.status ? '' : 'deact-name'"
                   class="name"
                   @click.stop="() => handleGoPage('StageManagement', item)"
@@ -480,6 +487,25 @@ const visibleTagCountMap = reactive<Record<number, number>>({});
 const DEFAULT_VISIBLE = 3; // 初始默认
 const MAX_VISIBLE_TAGS = 6; // 最大显示数量上限
 
+// 名称溢出检测
+const nameRefs = new Map<number, HTMLElement>();
+const overflowMap = reactive<Record<number, boolean>>({});
+
+const setNameRef = (el: any, id: number) => {
+  const node = el instanceof HTMLElement ? el : (el?.$el instanceof HTMLElement ? el.$el : null);
+  if (!node) {
+    nameRefs.delete(id);
+    return;
+  }
+  nameRefs.set(id, node);
+};
+
+const checkOverflow = () => {
+  nameRefs.forEach((el, id) => {
+    overflowMap[id] = el.scrollWidth > el.clientWidth;
+  });
+};
+
 // 防抖定时器
 let filterTimer: number | null = null;
 
@@ -595,6 +621,7 @@ const shouldShowGuide = computed(() => {
 watch(gatewaysList, () => {
   nextTick(() => {
     calculateVisibleTags();
+    checkOverflow();
   });
 }, { deep: true });
 
@@ -1050,10 +1077,14 @@ onBeforeUnmount(() => {
         }
 
         .name {
+          min-width: 0;
           margin-right: 10px;
           font-weight: 700;
           color: #313238;
           cursor: pointer;
+          overflow: hidden;
+          text-overflow: ellipsis;
+          white-space: nowrap;
 
           &:hover {
             color: #3a84ff;


### PR DESCRIPTION
- 网关名称超长时截断为省略号，避免挤出后续列布局

- BkTag 紧跟名称后面显示

- 仅文本溢出时 hover 才显示完整名称 tooltip

### Description

<!-- 关联相关issue Please include a summary of the change and which issue is fixed. -->
<!-- 给出必要的上下文以及review需要的必要信息 Please also include relevant motivation and context. -->

Fixes # (issue)

### Checklist

- [ ] 填写 PR 描述及相关 issue (write PR description and related issue)
- [ ] 代码风格检查通过 (code style check passed)
- [ ] PR 中包含单元测试 (include unit test)
- [ ] 单元测试通过 (unit test passed)
- [ ] 本地开发联调环境验证通过 (local development environment verification passed)
