### PR TITLE
fix(mcp-proxy): use json.RawMessage for BodyParam to preserve number precision

### DIFF
--- a/src/mcp-proxy/pkg/entity/model/mcp_test.go
+++ b/src/mcp-proxy/pkg/entity/model/mcp_test.go
@@ -277,7 +277,8 @@ var _ = Describe("MCP Models", func() {
 		})
 
 		Describe("Value", func() {
-			DescribeTable("serializes arrays correctly",
+			DescribeTable(
+				"serializes arrays correctly",
 				func(arr model.ArrayString, expected string) {
 					result, err := arr.Value()
 					Expect(err).NotTo(HaveOccurred())
@@ -285,7 +286,11 @@ var _ = Describe("MCP Models", func() {
 				},
 				Entry("empty array", model.ArrayString{}, ""),
 				Entry("single item", model.ArrayString{"item1"}, "item1"),
-				Entry("multiple items", model.ArrayString{"item1", "item2", "item3"}, "item1;item2;item3"),
+				Entry(
+					"multiple items",
+					model.ArrayString{"item1", "item2", "item3"},
+					"item1;item2;item3",
+				),
 				Entry("contains empty item", model.ArrayString{"item1", "", "item3"}, "item1;;item3"),
 			)
 		})

--- a/src/mcp-proxy/pkg/infra/proxy/proxy.go
+++ b/src/mcp-proxy/pkg/infra/proxy/proxy.go
@@ -641,7 +641,7 @@ func setHandlerRequestParams(
 			}
 		}
 	}
-	if len(handlerRequest.BodyParam) > 0 {
+	if len(handlerRequest.BodyParam) > 0 && string(handlerRequest.BodyParam) != "null" {
 		if err := req.SetBodyParam(handlerRequest.BodyParam); err != nil {
 			auditLog.Error(
 				"set body param err",

--- a/src/mcp-proxy/pkg/infra/proxy/proxy.go
+++ b/src/mcp-proxy/pkg/infra/proxy/proxy.go
@@ -643,7 +643,11 @@ func setHandlerRequestParams(
 	}
 	if len(handlerRequest.BodyParam) > 0 {
 		if err := req.SetBodyParam(handlerRequest.BodyParam); err != nil {
-			auditLog.Error("set body param err", zap.Any("body", handlerRequest.BodyParam), zap.Error(err))
+			auditLog.Error(
+				"set body param err",
+				zap.ByteString("body", handlerRequest.BodyParam),
+				zap.Error(err),
+			)
 			return err
 		}
 	}

--- a/src/mcp-proxy/pkg/infra/proxy/proxy.go
+++ b/src/mcp-proxy/pkg/infra/proxy/proxy.go
@@ -641,7 +641,7 @@ func setHandlerRequestParams(
 			}
 		}
 	}
-	if handlerRequest.BodyParam != nil {
+	if len(handlerRequest.BodyParam) > 0 {
 		if err := req.SetBodyParam(handlerRequest.BodyParam); err != nil {
 			auditLog.Error("set body param err", zap.Any("body", handlerRequest.BodyParam), zap.Error(err))
 			return err
@@ -919,7 +919,7 @@ func genToolHandler(toolApiConfig *ToolConfig, serverName string, rawResponseEna
 			auditHeaderInfo    map[string]string
 			auditQueryParam    QueryParam
 			auditPathParam     StringParamMap
-			auditBodyParam     any
+			auditBodyParam     json.RawMessage
 		)
 
 		// 在函数返回时记录完整的 audit log，包含 response, latency 等字段

--- a/src/mcp-proxy/pkg/infra/proxy/proxy_test.go
+++ b/src/mcp-proxy/pkg/infra/proxy/proxy_test.go
@@ -1126,9 +1126,27 @@ var _ = Describe("MCPProxy", func() {
 			Expect(handlerRequest.QueryParam["ids"]).To(Equal([]string{"2005000002", "9007199254740992"}))
 			Expect(handlerRequest.PathParam["bk_biz_id"]).To(Equal("2005000002"))
 
-			body := handlerRequest.BodyParam.(map[string]any)
-			Expect(body["bk_biz_id"]).To(Equal(json.Number("2005000002")))
-			Expect(body["nested"].(map[string]any)["id"]).To(Equal(json.Number("2005000003")))
+			// BodyParam is now json.RawMessage, preserving original JSON bytes
+			Expect(string(handlerRequest.BodyParam)).To(ContainSubstring("2005000002"))
+			Expect(string(handlerRequest.BodyParam)).To(ContainSubstring("2005000003"))
+		})
+
+		It("should preserve large integers in body param without precision loss", func() {
+			// This is the exact scenario that causes precision loss with float64:
+			// 7643696123382648115 exceeds float64 precision (2^53)
+			arguments := json.RawMessage(`{
+				"body_param": {"video_kol_item_list": [7643696123382648115], "unique_id": 1750035600002}
+			}`)
+
+			var handlerRequest HandlerRequest
+			decoder := json.NewDecoder(bytes.NewReader(arguments))
+			decoder.UseNumber()
+			err := decoder.Decode(&handlerRequest)
+			Expect(err).NotTo(HaveOccurred())
+
+			// json.RawMessage preserves the exact original bytes
+			Expect(string(handlerRequest.BodyParam)).To(ContainSubstring("7643696123382648115"))
+			Expect(string(handlerRequest.BodyParam)).To(ContainSubstring("1750035600002"))
 		})
 	})
 })

--- a/src/mcp-proxy/pkg/infra/proxy/proxy_test.go
+++ b/src/mcp-proxy/pkg/infra/proxy/proxy_test.go
@@ -1148,6 +1148,27 @@ var _ = Describe("MCPProxy", func() {
 			Expect(string(handlerRequest.BodyParam)).To(ContainSubstring("7643696123382648115"))
 			Expect(string(handlerRequest.BodyParam)).To(ContainSubstring("1750035600002"))
 		})
+
+		It("should treat explicit null body_param as empty (no body forwarded)", func() {
+			arguments := json.RawMessage(`{
+				"body_param": null
+			}`)
+
+			var handlerRequest HandlerRequest
+			decoder := json.NewDecoder(bytes.NewReader(arguments))
+			decoder.UseNumber()
+			err := decoder.Decode(&handlerRequest)
+			Expect(err).NotTo(HaveOccurred())
+
+			// json.RawMessage decodes JSON null as the literal bytes "null"
+			// but setHandlerRequestParams should skip it (preserve old behavior)
+			Expect(string(handlerRequest.BodyParam)).To(Equal("null"))
+			Expect(
+				len(handlerRequest.BodyParam) > 0 && string(handlerRequest.BodyParam) != "null",
+			).To(
+				BeFalse(),
+			)
+		})
 	})
 })
 

--- a/src/mcp-proxy/pkg/infra/proxy/types.go
+++ b/src/mcp-proxy/pkg/infra/proxy/types.go
@@ -111,8 +111,8 @@ func (m *QueryParam) UnmarshalJSON(data []byte) error {
 
 // HandlerRequest ...
 type HandlerRequest struct {
-	HeaderParam StringParamMap `json:"header_param,omitempty"`
-	QueryParam  QueryParam     `json:"query_param,omitempty"`
-	PathParam   StringParamMap `json:"path_param,omitempty"`
-	BodyParam   any            `json:"body_param,omitempty"`
+	HeaderParam StringParamMap  `json:"header_param,omitempty"`
+	QueryParam  QueryParam      `json:"query_param,omitempty"`
+	PathParam   StringParamMap  `json:"path_param,omitempty"`
+	BodyParam   json.RawMessage `json:"body_param,omitempty"`
 }

--- a/src/mcp-proxy/pkg/infra/proxy/types_test.go
+++ b/src/mcp-proxy/pkg/infra/proxy/types_test.go
@@ -35,7 +35,7 @@ var _ = Describe("Types", func() {
 					HeaderParam: proxy.StringParamMap{"Content-Type": "application/json"},
 					QueryParam:  proxy.QueryParam{"limit": {"10"}, "offset": {"0"}},
 					PathParam:   proxy.StringParamMap{"id": "123"},
-					BodyParam:   map[string]any{"name": "test"},
+					BodyParam:   json.RawMessage(`{"name":"test"}`),
 				}
 
 				data, err := json.Marshal(request)
@@ -48,7 +48,10 @@ var _ = Describe("Types", func() {
 				Expect(result.HeaderParam["Content-Type"]).To(Equal("application/json"))
 				Expect(result.QueryParam["limit"]).To(Equal([]string{"10"}))
 				Expect(result.PathParam["id"]).To(Equal("123"))
-				Expect(result.BodyParam.(map[string]any)["name"]).To(Equal("test"))
+
+				var body map[string]any
+				Expect(json.Unmarshal(result.BodyParam, &body)).To(Succeed())
+				Expect(body["name"]).To(Equal("test"))
 			})
 
 			It("should handle empty fields", func() {
@@ -77,13 +80,9 @@ var _ = Describe("Types", func() {
 
 			It("should handle complex body param", func() {
 				request := proxy.HandlerRequest{
-					BodyParam: map[string]any{
-						"user": map[string]any{
-							"name":  "John",
-							"email": "john@example.com",
-							"roles": []string{"admin", "user"},
-						},
-					},
+					BodyParam: json.RawMessage(
+						`{"user":{"name":"John","email":"john@example.com","roles":["admin","user"]}}`,
+					),
 				}
 
 				data, err := json.Marshal(request)
@@ -93,10 +92,25 @@ var _ = Describe("Types", func() {
 				err = json.Unmarshal(data, &result)
 				Expect(err).NotTo(HaveOccurred())
 
-				body := result.BodyParam.(map[string]any)
+				var body map[string]any
+				Expect(json.Unmarshal(result.BodyParam, &body)).To(Succeed())
 				user := body["user"].(map[string]any)
 				Expect(user["name"]).To(Equal("John"))
 				Expect(user["email"]).To(Equal("john@example.com"))
+			})
+
+			It("should preserve large integer precision in body param", func() {
+				jsonStr := `{
+					"body_param": {"video_kol_item_list": [7643696123382648115], "unique_id": 1750035600002}
+				}`
+
+				var request proxy.HandlerRequest
+				err := json.Unmarshal([]byte(jsonStr), &request)
+				Expect(err).NotTo(HaveOccurred())
+
+				// BodyParam is json.RawMessage, so it preserves the original bytes exactly
+				Expect(string(request.BodyParam)).To(ContainSubstring("7643696123382648115"))
+				Expect(string(request.BodyParam)).To(ContainSubstring("1750035600002"))
 			})
 
 			It("should unmarshal from JSON string", func() {
@@ -114,7 +128,10 @@ var _ = Describe("Types", func() {
 				Expect(request.HeaderParam["Authorization"]).To(Equal("Bearer token"))
 				Expect(request.QueryParam["page"]).To(Equal([]string{"1"}))
 				Expect(request.PathParam["userId"]).To(Equal("abc123"))
-				Expect(request.BodyParam.(map[string]any)["data"]).To(Equal("test"))
+
+				var body map[string]any
+				Expect(json.Unmarshal(request.BodyParam, &body)).To(Succeed())
+				Expect(body["data"]).To(Equal("test"))
 			})
 		})
 	})

--- a/src/mcp-proxy/pkg/infra/proxy/types_test.go
+++ b/src/mcp-proxy/pkg/infra/proxy/types_test.go
@@ -115,11 +115,11 @@ var _ = Describe("Types", func() {
 
 			It("should unmarshal from JSON string", func() {
 				jsonStr := `{
-					"header_param": {"Authorization": "Bearer token"},
-					"query_param": {"page": ["1"]},
-					"path_param": {"userId": "abc123"},
-					"body_param": {"data": "test"}
-				}`
+				"header_param": {"Authorization": "Bearer token"},
+				"query_param": {"page": ["1"]},
+				"path_param": {"userId": "abc123"},
+				"body_param": {"data": "test"}
+			}`
 
 				var request proxy.HandlerRequest
 				err := json.Unmarshal([]byte(jsonStr), &request)
@@ -132,6 +132,28 @@ var _ = Describe("Types", func() {
 				var body map[string]any
 				Expect(json.Unmarshal(request.BodyParam, &body)).To(Succeed())
 				Expect(body["data"]).To(Equal("test"))
+			})
+
+			It("should handle explicit null body_param", func() {
+				jsonStr := `{"body_param": null}`
+
+				var request proxy.HandlerRequest
+				err := json.Unmarshal([]byte(jsonStr), &request)
+				Expect(err).NotTo(HaveOccurred())
+
+				// json.RawMessage stores "null" literal bytes for JSON null
+				Expect(string(request.BodyParam)).To(Equal("null"))
+			})
+
+			It("should handle missing body_param as nil", func() {
+				jsonStr := `{"query_param": {"page": ["1"]}}`
+
+				var request proxy.HandlerRequest
+				err := json.Unmarshal([]byte(jsonStr), &request)
+				Expect(err).NotTo(HaveOccurred())
+
+				// omitempty + missing field = nil RawMessage
+				Expect(request.BodyParam).To(BeNil())
 			})
 		})
 	})

--- a/src/mcp-proxy/tests/integration/sse_test.go
+++ b/src/mcp-proxy/tests/integration/sse_test.go
@@ -994,6 +994,111 @@ var _ = Describe("SSE Protocol", func() {
 			}
 		})
 	})
+
+	Describe("SSE Large Integer Body Param Precision", func() {
+		It("should preserve large integers in body_param without precision loss via SSE", func() {
+			sseURL := fmt.Sprintf("%s/%s/sse", client.BaseURL, "test-sse-server")
+
+			httpClient := &http.Client{
+				Timeout: 30 * time.Second,
+				Transport: &jwtRoundTripper{
+					token: jwtToken,
+					base:  http.DefaultTransport,
+				},
+			}
+
+			transport := &mcp.SSEClientTransport{
+				Endpoint:   sseURL,
+				HTTPClient: httpClient,
+			}
+
+			mcpClient := mcp.NewClient(&mcp.Implementation{
+				Name:    "test-client",
+				Version: "1.0.0",
+			}, nil)
+
+			session, err := mcpClient.Connect(ctx, transport, nil)
+			Expect(err).NotTo(HaveOccurred())
+			defer session.Close()
+
+			// Call echo tool with large integers that exceed float64 precision (>2^53)
+			result, err := session.CallTool(ctx, &mcp.CallToolParams{
+				Name: "echo",
+				Arguments: map[string]any{
+					"body_param": map[string]any{
+						"video_kol_item_list": []any{7643696123382648115},
+						"unique_id":           1750035600002,
+						"message":             "precision test via SSE",
+					},
+				},
+			})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result).NotTo(BeNil())
+			Expect(result.Content).NotTo(BeEmpty())
+
+			// go-httpbin /anything echoes back the JSON body in the "json" field
+			textContent, ok := result.Content[0].(*mcp.TextContent)
+			Expect(ok).To(BeTrue())
+			// The response should contain the exact large integer, not truncated/rounded
+			Expect(textContent.Text).To(ContainSubstring("7643696123382648115"))
+			Expect(textContent.Text).To(ContainSubstring("1750035600002"))
+			// Ensure no scientific notation
+			Expect(textContent.Text).NotTo(ContainSubstring("7.643"))
+			Expect(textContent.Text).NotTo(ContainSubstring("1.750"))
+		})
+
+		It("should preserve nested large integers in body_param via SSE", func() {
+			sseURL := fmt.Sprintf("%s/%s/sse", client.BaseURL, "test-sse-server")
+
+			httpClient := &http.Client{
+				Timeout: 30 * time.Second,
+				Transport: &jwtRoundTripper{
+					token: jwtToken,
+					base:  http.DefaultTransport,
+				},
+			}
+
+			transport := &mcp.SSEClientTransport{
+				Endpoint:   sseURL,
+				HTTPClient: httpClient,
+			}
+
+			mcpClient := mcp.NewClient(&mcp.Implementation{
+				Name:    "test-client",
+				Version: "1.0.0",
+			}, nil)
+
+			session, err := mcpClient.Connect(ctx, transport, nil)
+			Expect(err).NotTo(HaveOccurred())
+			defer session.Close()
+
+			// Test with nested structures containing large integers
+			result, err := session.CallTool(ctx, &mcp.CallToolParams{
+				Name: "echo",
+				Arguments: map[string]any{
+					"body_param": map[string]any{
+						"message": "nested precision test via SSE",
+						"data": map[string]any{
+							"order_id":   9007199254740993,
+							"account_id": 9223372036854775807,
+							"items":      []any{1234567890123456789, 9876543210987654321},
+						},
+					},
+				},
+			})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result).NotTo(BeNil())
+			Expect(result.Content).NotTo(BeEmpty())
+
+			textContent, ok := result.Content[0].(*mcp.TextContent)
+			Expect(ok).To(BeTrue())
+			// Verify all large integers are preserved
+			Expect(textContent.Text).To(ContainSubstring("9007199254740993"))
+			Expect(textContent.Text).To(ContainSubstring("9223372036854775807"))
+			Expect(textContent.Text).To(ContainSubstring("1234567890123456789"))
+			Expect(textContent.Text).To(ContainSubstring("9876543210987654321"))
+		})
+	})
 })
 
 // jwtRoundTripper 是一个自定义的 http.RoundTripper，用于在每个请求中添加 JWT 认证头

--- a/src/mcp-proxy/tests/integration/sse_test.go
+++ b/src/mcp-proxy/tests/integration/sse_test.go
@@ -1081,7 +1081,7 @@ var _ = Describe("SSE Protocol", func() {
 						"data": map[string]any{
 							"order_id":   9007199254740993,
 							"account_id": 9223372036854775807,
-							"items":      []any{1234567890123456789, 9876543210987654321},
+							"items":      []any{1234567890123456789, 8876543210987654321},
 						},
 					},
 				},
@@ -1096,7 +1096,7 @@ var _ = Describe("SSE Protocol", func() {
 			Expect(textContent.Text).To(ContainSubstring("9007199254740993"))
 			Expect(textContent.Text).To(ContainSubstring("9223372036854775807"))
 			Expect(textContent.Text).To(ContainSubstring("1234567890123456789"))
-			Expect(textContent.Text).To(ContainSubstring("9876543210987654321"))
+			Expect(textContent.Text).To(ContainSubstring("8876543210987654321"))
 		})
 	})
 })

--- a/src/mcp-proxy/tests/integration/streamable_http_test.go
+++ b/src/mcp-proxy/tests/integration/streamable_http_test.go
@@ -1195,4 +1195,112 @@ var _ = Describe("Streamable HTTP Protocol", func() {
 			Expect(textContent.Text).To(ContainSubstring("limit=20"))
 		})
 	})
+
+	Describe("Large Integer Body Param Precision", func() {
+		It("should preserve large integers in body_param without precision loss", func() {
+			mcpURL := fmt.Sprintf("%s/%s/mcp", client.BaseURL, "test-http-server")
+
+			httpClient := &http.Client{
+				Timeout: 30 * time.Second,
+				Transport: &jwtRoundTripper{
+					token: jwtToken,
+					base:  http.DefaultTransport,
+				},
+			}
+
+			transport := &mcp.StreamableClientTransport{
+				Endpoint:   mcpURL,
+				HTTPClient: httpClient,
+			}
+
+			mcpClient := mcp.NewClient(&mcp.Implementation{
+				Name:    "test-client",
+				Version: "1.0.0",
+			}, nil)
+
+			session, err := mcpClient.Connect(ctx, transport, nil)
+			Expect(err).NotTo(HaveOccurred())
+			defer session.Close()
+
+			// Call echo tool with large integers that exceed float64 precision (>2^53)
+			// 7643696123382648115 is a typical large int64 value that loses precision
+			// if parsed through float64 intermediary
+			result, err := session.CallTool(ctx, &mcp.CallToolParams{
+				Name: "echo",
+				Arguments: map[string]any{
+					"body_param": map[string]any{
+						"video_kol_item_list": []any{7643696123382648115},
+						"unique_id":           1750035600002,
+						"message":             "precision test",
+					},
+				},
+			})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result).NotTo(BeNil())
+			Expect(result.Content).NotTo(BeEmpty())
+
+			// go-httpbin /anything echoes back the JSON body in the "json" field
+			// Verify the large integer is preserved exactly
+			textContent, ok := result.Content[0].(*mcp.TextContent)
+			Expect(ok).To(BeTrue())
+			// The response should contain the exact large integer, not a truncated/rounded version
+			Expect(textContent.Text).To(ContainSubstring("7643696123382648115"))
+			Expect(textContent.Text).To(ContainSubstring("1750035600002"))
+			// Ensure no scientific notation is present for these numbers
+			Expect(textContent.Text).NotTo(ContainSubstring("7.643"))
+			Expect(textContent.Text).NotTo(ContainSubstring("1.750"))
+		})
+
+		It("should preserve nested large integers in body_param", func() {
+			mcpURL := fmt.Sprintf("%s/%s/mcp", client.BaseURL, "test-http-server")
+
+			httpClient := &http.Client{
+				Timeout: 30 * time.Second,
+				Transport: &jwtRoundTripper{
+					token: jwtToken,
+					base:  http.DefaultTransport,
+				},
+			}
+
+			transport := &mcp.StreamableClientTransport{
+				Endpoint:   mcpURL,
+				HTTPClient: httpClient,
+			}
+
+			mcpClient := mcp.NewClient(&mcp.Implementation{
+				Name:    "test-client",
+				Version: "1.0.0",
+			}, nil)
+
+			session, err := mcpClient.Connect(ctx, transport, nil)
+			Expect(err).NotTo(HaveOccurred())
+			defer session.Close()
+
+			// Test with nested structures containing large integers
+			result, err := session.CallTool(ctx, &mcp.CallToolParams{
+				Name: "echo",
+				Arguments: map[string]any{
+					"body_param": map[string]any{
+						"message": "nested precision test",
+						"data": map[string]any{
+							"order_id":   9007199254740993,
+							"account_id": 9223372036854775807,
+							"items":      []any{1234567890123456789, 9876543210987654321},
+						},
+					},
+				},
+			})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result).NotTo(BeNil())
+			Expect(result.Content).NotTo(BeEmpty())
+
+			textContent, ok := result.Content[0].(*mcp.TextContent)
+			Expect(ok).To(BeTrue())
+			// Verify all large integers are preserved
+			Expect(textContent.Text).To(ContainSubstring("9007199254740993"))
+			Expect(textContent.Text).To(ContainSubstring("9223372036854775807"))
+			Expect(textContent.Text).To(ContainSubstring("1234567890123456789"))
+			Expect(textContent.Text).To(ContainSubstring("9876543210987654321"))
+		})
+	})
 })

--- a/src/mcp-proxy/tests/integration/streamable_http_test.go
+++ b/src/mcp-proxy/tests/integration/streamable_http_test.go
@@ -1285,7 +1285,7 @@ var _ = Describe("Streamable HTTP Protocol", func() {
 						"data": map[string]any{
 							"order_id":   9007199254740993,
 							"account_id": 9223372036854775807,
-							"items":      []any{1234567890123456789, 9876543210987654321},
+							"items":      []any{1234567890123456789, 8876543210987654321},
 						},
 					},
 				},
@@ -1300,7 +1300,7 @@ var _ = Describe("Streamable HTTP Protocol", func() {
 			Expect(textContent.Text).To(ContainSubstring("9007199254740993"))
 			Expect(textContent.Text).To(ContainSubstring("9223372036854775807"))
 			Expect(textContent.Text).To(ContainSubstring("1234567890123456789"))
-			Expect(textContent.Text).To(ContainSubstring("9876543210987654321"))
+			Expect(textContent.Text).To(ContainSubstring("8876543210987654321"))
 		})
 	})
 })


### PR DESCRIPTION
## Description

Fix large integer precision loss in MCP tool call body parameters. When forwarding tool call requests to upstream APIs, integers exceeding float64 precision range (>2^53, e.g. `7643696123382648115`) were being silently corrupted during the JSON decode/re-encode cycle.

## Root Cause

`HandlerRequest.BodyParam` was typed as `any`. Even with `decoder.UseNumber()`, the intermediate representation could lose precision in certain edge cases during the marshal/unmarshal pipeline between the MCP SDK and the upstream HTTP request builder.

## Fix

Change `BodyParam` from `any` to `json.RawMessage`, which preserves the original JSON bytes exactly as received from the MCP client. This eliminates any possibility of numeric precision loss in the body payload, as the raw bytes are forwarded directly without intermediate parsing.

## Changes

- `pkg/infra/proxy/types.go`: `BodyParam` field type `any` → `json.RawMessage`
- `pkg/infra/proxy/proxy.go`: Use `len()` check for `json.RawMessage`; update audit log type
- `pkg/infra/proxy/types_test.go`: Update tests, add large integer precision test
- `pkg/infra/proxy/proxy_test.go`: Update decode tests for raw bytes preservation

## Test Results

```
Ran 140 of 140 Specs in 0.010 seconds
SUCCESS! -- 140 Passed | 0 Failed | 0 Pending | 0 Skipped
```

All 13 test suites (pkg/...) pass. Lint: 0 issues.