### PR TITLE
fix(dashboard): preload release event detail relations

### DIFF
--- a/src/dashboard/apigateway/apigateway/apis/web/release/views.py
+++ b/src/dashboard/apigateway/apigateway/apis/web/release/views.py
@@ -336,7 +336,11 @@ class RelishHistoryEventsRetrieveAPI(generics.RetrieveAPIView):
     lookup_url_kwarg = "history_id"
 
     def get_queryset(self):
-        return ReleaseHistory.objects.filter(gateway=self.request.gateway).select_related("data_plane")
+        return ReleaseHistory.objects.filter(gateway=self.request.gateway).select_related(
+            "stage",
+            "resource_version",
+            "data_plane",
+        )
 
     def retrieve(self, request, *args, **kwargs):
         release_history = self.get_object()

--- a/src/dashboard/apigateway/apigateway/tests/apis/web/release/test_views.py
+++ b/src/dashboard/apigateway/apigateway/tests/apis/web/release/test_views.py
@@ -273,3 +273,35 @@ class TestReleaseHistoryEventsRetrieveAPI:
         result = resp.json()
         assert resp.status_code == 200
         assert len(result["data"]) >= 1
+
+    def test_retrieve_prefetches_stage_and_resource_version(
+        self, request_view, django_assert_num_queries, fake_gateway
+    ):
+        stage = G(Stage, gateway=fake_gateway)
+        resource_version = G(ResourceVersion, gateway=fake_gateway, version="1.0.0")
+        history = G(
+            ReleaseHistory,
+            gateway=fake_gateway,
+            stage=stage,
+            resource_version=resource_version,
+            created_time=dummy_time.time,
+        )
+        G(
+            PublishEvent,
+            publish=history,
+            name=PublishEventNameTypeEnum.VALIDATE_CONFIGURATION.value,
+            status=PublishEventStatusTypeEnum.FAILURE.value,
+            created_time=dummy_time.time + datetime.timedelta(seconds=10),
+        )
+
+        with django_assert_num_queries(4):
+            resp = request_view(
+                method="GET",
+                view_name="gateway.release_histories.events",
+                path_params={"gateway_id": fake_gateway.id, "history_id": history.id},
+            )
+            result = resp.json()
+
+        assert resp.status_code == 200
+        assert result["data"]["stage"] == {"id": stage.id, "name": stage.name}
+        assert result["data"]["resource_version_display"] == resource_version.object_display


### PR DESCRIPTION
Summary
- Preload stage and resource_version when retrieving release history event details.
- Add a query-count regression test for the release history events endpoint.

Verification
- uv run pytest --ds apigateway.settings --reuse-db apigateway/tests/apis/web/release/test_views.py::TestReleaseHistoryEventsRetrieveAPI -q
- make lint-check
- make test
