### PR TITLE
fix(dashboard): update ITSM permission ticket title

### DIFF
--- a/src/dashboard/apigateway/apigateway/service/bk_itsm.py
+++ b/src/dashboard/apigateway/apigateway/service/bk_itsm.py
@@ -203,8 +203,8 @@ class ItsmPermissionApplyHelper:
     ) -> str:
         """根据授权维度构建工单标题"""
         if grant_dimension == FormattedGrantDimensionEnum.MCP_SERVER.value:
-            return f"MCP Server 权限申请【{bk_app_code}】【{gateway_name}】【{apply_resources}】"
-        return f"网关权限申请【{gateway_name}】【{bk_app_code}】"
+            return f"应用 [{bk_app_code}] 申请蓝鲸 MCP [{apply_resources}] 权限"
+        return f"应用 [{bk_app_code}] 申请蓝鲸 API 网关 [{gateway_name}] 权限"
 
     def _build_apply_resources_display(
         self,

--- a/src/dashboard/apigateway/apigateway/tests/service/test_bk_itsm.py
+++ b/src/dashboard/apigateway/apigateway/tests/service/test_bk_itsm.py
@@ -271,13 +271,13 @@ class TestItsmPermissionApplyHelper:
         title = ItsmPermissionApplyHelper._build_ticket_title(
             FormattedGrantDimensionEnum.GATEWAY.value, "demo-gateway", "bk-test", "demo-gateway"
         )
-        assert title == "网关权限申请【demo-gateway】【bk-test】"
+        assert title == "应用 [bk-test] 申请蓝鲸 API 网关 [demo-gateway] 权限"
 
     def test_build_ticket_title_for_mcp_server(self):
         title = ItsmPermissionApplyHelper._build_ticket_title(
             FormattedGrantDimensionEnum.MCP_SERVER.value, "demo-gateway", "bk-test", "mcp-a"
         )
-        assert title == "MCP Server 权限申请【bk-test】【demo-gateway】【mcp-a】"
+        assert title == "应用 [bk-test] 申请蓝鲸 MCP [mcp-a] 权限"
 
     def test_build_apply_resources_display_for_gateway(self):
         helper = ItsmPermissionApplyHelper()


### PR DESCRIPTION
## Summary
- update ITSM permission ticket titles for API gateway and MCP permission applications
- update the direct title helper unit tests to match the new copy

## Verification
- `uv run bash -lc 'cd apigateway && set -a && . apigateway/conf/unittest_env && set +a && python -m pytest --nomigrations --ds apigateway.settings -q --tb=short apigateway/tests/service/test_bk_itsm.py::TestItsmPermissionApplyHelper::test_build_ticket_title_for_gateway apigateway/tests/service/test_bk_itsm.py::TestItsmPermissionApplyHelper::test_build_ticket_title_for_mcp_server'` -> 2 passed\n- `uv run make edition-ee && uv run make lint-check` -> passed\n- `uv run make edition-ee && uv run make test` -> 2980 passed\n- `git diff --check HEAD~1..HEAD` -> passed