### PR TITLE
fix(monitor): handle string status in alarm subtype for release/1.22

### DIFF
--- a/src/dashboard/apigateway/apigateway/service/alert_flow/helpers.py
+++ b/src/dashboard/apigateway/apigateway/service/alert_flow/helpers.py
@@ -71,8 +71,14 @@ class MonitorEvent:
     def alarm_subtype(self) -> str:
         code_name = self.event_dimensions.get("code_name", "")
 
+        status = self.event_dimensions.get("status", -1)
+        try:
+            status_code = int(status)
+        except (TypeError, ValueError):
+            status_code = -1
+
         # in apisix, upstream 500 has no code_name, so we need to convert it to status_code_5xx here
-        if code_name == "" and self.event_dimensions.get("status", -1) >= 500:
+        if code_name == "" and status_code >= 500:
             code_name = "REQUEST_RESOURCE_5xx"
 
         return ERROR_CODE_NAME_TO_ALARM_SUBTYPE.get(code_name, "")

--- a/src/dashboard/apigateway/apigateway/tests/service/alert_flow/test_helpers.py
+++ b/src/dashboard/apigateway/apigateway/tests/service/alert_flow/test_helpers.py
@@ -66,6 +66,13 @@ class TestMonitorEvent:
         )
         assert event.alarm_subtype == "bad_gateway"
 
+    def test_alarm_subtype_with_string_status(self):
+        event = MonitorEvent(
+            alarm_type=AlarmTypeEnum.RESOURCE_BACKEND,
+            raw={"event": {"dimensions": {"status": "500"}}},
+        )
+        assert event.alarm_subtype == "status_code_5xx"
+
     def test_update_extend_fields(self):
         event = MonitorEvent(alarm_type=AlarmTypeEnum.APP_REQUEST, raw={})
         event.update_extend_fields({"color": "green"})


### PR DESCRIPTION
### Description

Backport #2857 to release/1.22.

Source PR: https://github.com/TencentBlueKing/blueking-apigateway/pull/2857

Cherry-picked commits:
- 13e7a856d fix(monitor): handle string status in alarm subtype

Fixes: N/A (release backport)

### Verification

- `uv run bash -lc 'cd apigateway && set -a && . apigateway/conf/unittest_env && set +a && python -m pytest --nomigrations --ds apigateway.settings -q --tb=short apigateway/tests/service/alert_flow/test_helpers.py'` (10 passed)
- `uv run make edition-ee && uv run make lint-check` (passed: ruff, mypy, import-linter 6 contracts kept)

### Checklist

- [x] 填写 PR 描述及相关 issue (write PR description and related issue)
- [x] 代码风格检查通过 (code style check passed)
- [x] PR 中包含单元测试 (include unit test)
- [x] 单元测试通过 (unit test passed)
- [ ] 本地开发联调环境验证通过 (local development environment verification passed)