### PR TITLE
fix: handle empty app code in app request alerts for release/1.22

### DIFF
--- a/src/dashboard/apigateway/apigateway/service/alert_flow/handlers/app_request.py
+++ b/src/dashboard/apigateway/apigateway/service/alert_flow/handlers/app_request.py
@@ -36,7 +36,7 @@ class AppRequestDimension(BaseModel):
     api_id: int
     resource_id: int
     stage: str
-    app_code: str
+    app_code: Optional[str] = None
 
 
 # NOTE: 这里是蓝鲸应用请求网关报错，告警给蓝鲸应用负责人，被动，无法配置/忽略

--- a/src/dashboard/apigateway/apigateway/tests/service/alert_flow/handlers/test_app_request.py
+++ b/src/dashboard/apigateway/apigateway/tests/service/alert_flow/handlers/test_app_request.py
@@ -49,6 +49,29 @@ class TestAppRequestAppCodeRequiredFilter:
                 },
                 True,
             ),
+            (
+                {
+                    "alarm_record_id": 1,
+                    "event_dimensions": {
+                        "api_id": 2,
+                        "resource_id": 3,
+                        "stage": "prod",
+                        "app_code": None,
+                    },
+                },
+                True,
+            ),
+            (
+                {
+                    "alarm_record_id": 1,
+                    "event_dimensions": {
+                        "api_id": 2,
+                        "resource_id": 3,
+                        "stage": "prod",
+                    },
+                },
+                True,
+            ),
         ],
     )
     def test_do(self, mocker, event, expected_none):


### PR DESCRIPTION
### Description

Backport #2852 to release/1.22.

Source PR: https://github.com/TencentBlueKing/blueking-apigateway/pull/2852

Cherry-picked commits:
- da0822bd6 fix: handle empty app code in app request alerts

Fixes: N/A (release backport)

### Verification

- `uv run bash -lc 'cd apigateway && set -a && . apigateway/conf/unittest_env && set +a && python -m pytest --nomigrations --ds apigateway.settings -q --tb=short apigateway/tests/service/alert_flow/handlers/test_app_request.py'` (10 passed)
- `uv run make edition-ee && uv run make lint-check` (passed: ruff, mypy, import-linter 6 contracts kept)

### Checklist

- [x] 填写 PR 描述及相关 issue (write PR description and related issue)
- [x] 代码风格检查通过 (code style check passed)
- [x] PR 中包含单元测试 (include unit test)
- [x] 单元测试通过 (unit test passed)
- [ ] 本地开发联调环境验证通过 (local development environment verification passed)