### PR TITLE
fix(resource): return validation error for recursive openapi refs

### DIFF
--- a/src/dashboard/apigateway/apigateway/biz/openapi/openapi.py
+++ b/src/dashboard/apigateway/apigateway/biz/openapi/openapi.py
@@ -23,6 +23,7 @@ from openapi_spec_validator.validation.exceptions import UnresolvableParameterEr
 from openapi_spec_validator.versions import OPENAPIV2, get_spec_version
 from openapi_spec_validator.versions.exceptions import OpenAPIVersionNotFound
 from prance import ResolvingParser
+from prance.util.url import ResolutionError
 
 from apigateway.apps.support.constants import OpenAPIFormatEnum
 from apigateway.core.models import Gateway
@@ -119,7 +120,10 @@ class OpenAPIImportManager:
 
         # 进行逻辑校验
 
-        self.parse()
+        try:
+            self.parse()
+        except ResolutionError as err:
+            return [SchemaValidateErr(str(err), "$", [])]
 
         validator = ResourceImportValidator(
             gateway=self.gateway,

--- a/src/dashboard/apigateway/apigateway/tests/biz/resource/importer/test_openapi.py
+++ b/src/dashboard/apigateway/apigateway/tests/biz/resource/importer/test_openapi.py
@@ -906,6 +906,56 @@ paths:
         assert resources[0]["is_public"] is False
         assert resources[0]["auth_config"]["auth_verified_required"] is False
 
+    def test_validate_returns_schema_err_for_recursive_ref(self):
+        data = {
+            "swagger": "2.0",
+            "basePath": "/",
+            "info": {"version": "0.1", "title": "Test"},
+            "schemes": ["http"],
+            "paths": {
+                "/tree/": {
+                    "get": {
+                        "operationId": "get_tree",
+                        "description": "test recursive ref",
+                        "tags": [],
+                        "responses": {
+                            "200": {
+                                "description": "success",
+                                "schema": {"$ref": "#/definitions/v3TopoNodeInfo"},
+                            },
+                        },
+                        "x-bk-apigateway-resource": {
+                            "isPublic": True,
+                            "backend": {
+                                "type": "HTTP",
+                                "path": "/tree/",
+                                "method": "get",
+                                "timeout": 30,
+                            },
+                        },
+                    }
+                }
+            },
+            "definitions": {
+                "v3TopoNodeInfo": {
+                    "type": "object",
+                    "properties": {
+                        "children": {
+                            "type": "array",
+                            "items": {"$ref": "#/definitions/v3TopoNodeInfo"},
+                        }
+                    },
+                }
+            },
+        }
+        manager = self._make_manager(data)
+
+        validate_err_list = manager.validate()
+
+        assert len(validate_err_list) == 1
+        assert "Recursion reached limit" in validate_err_list[0].message
+        assert "#/definitions/v3TopoNodeInfo" in validate_err_list[0].message
+
 
 class TestOpenAPIExporter:
     def test_get_swagger_by_paths(self):


### PR DESCRIPTION
## Summary

- Catch `prance.util.url.ResolutionError` during OpenAPI import validation and convert it to `SchemaValidateErr`
- Add regression coverage for recursive internal `$ref` definitions such as `#/definitions/v3TopoNodeInfo`

## Why

Resource import check should return validation failure details to users for invalid OpenAPI content. Recursive internal `$ref` definitions previously escaped the validation flow as a 500 response when prance hit its recursion limit.

## Verification

- `cd src/dashboard/apigateway && set -a && . apigateway/conf/unittest_env && set +a && ../.venv/bin/python -m pytest --nomigrations --ds apigateway.settings -q --tb=short apigateway/tests/biz/resource/importer/test_openapi.py::TestOpenAPIImportManagerParse apigateway/tests/biz/resource/importer/test_openapi.py::TestOpenAPIImportManagerValidateRefs` passed, 20 tests
- `PATH="$PWD/.venv/bin:$PATH" make lint` passed in `src/dashboard`
- `PATH="$PWD/.venv/bin:$PATH" make test` passed in `src/dashboard`, 3001 tests
