### PR TITLE
feat(dashboard): expose user personal center link

### DIFF
--- a/src/dashboard/apigateway/apigateway/conf/utils.py
+++ b/src/dashboard/apigateway/apigateway/conf/utils.py
@@ -264,6 +264,7 @@ def get_frontend_env_vars(
         "BK_LOGIN_URL": bk_login_url,
         "PAAS_DEVELOPER_CENTER_LINK": f"{bk_paas3_url}/developer-center",
         "PAAS_APP_CREATE_LINK": f"{bk_paas3_url}/developer-center/app/create",
+        "BK_USER_PERSONAL_CENTER_LINK": env.str("BK_USER_URL", default="") + "/personal-center",
         "BK_APISIX_URL": env.str("BK_APISIX_URL", default=""),
         "BK_APISIX_DOC_URL": env.str("BK_APISIX_DOC_URL", default=""),
         "BK_ANALYSIS_SCRIPT_SRC": env.str("BK_ANALYSIS_SCRIPT_SRC", default=""),

--- a/src/dashboard/apigateway/apigateway/tests/conf/test_utils.py
+++ b/src/dashboard/apigateway/apigateway/tests/conf/test_utils.py
@@ -22,7 +22,9 @@ from environ import Env
 from apigateway.conf.utils import get_frontend_env_vars
 
 
-def test_get_frontend_env_vars_includes_paas_developer_center_link():
+def test_get_frontend_env_vars_includes_paas_developer_center_link(monkeypatch):
+    monkeypatch.setenv("BK_USER_URL", "https://user.example.com")
+
     env_vars = get_frontend_env_vars(
         env=Env(),
         edition="ce",
@@ -43,3 +45,4 @@ def test_get_frontend_env_vars_includes_paas_developer_center_link():
 
     assert env_vars["PAAS_DEVELOPER_CENTER_LINK"] == "https://paas.example.com/developer-center"
     assert env_vars["PAAS_APP_CREATE_LINK"] == "https://paas.example.com/developer-center/app/create"
+    assert env_vars["BK_USER_PERSONAL_CENTER_LINK"] == "https://user.example.com/personal-center"


### PR DESCRIPTION
## Summary
- Expose `BK_USER_PERSONAL_CENTER_LINK` in dashboard frontend env vars.
- Add a focused assertion for the generated personal-center link.

## Verification
- `uv run bash -lc 'cd apigateway && set -a && . apigateway/conf/unittest_env && set +a && python -m pytest --nomigrations --ds apigateway.settings -q --tb=short apigateway/tests/conf/test_utils.py'` (1 passed)\n- `uv run make edition-ee && uv run make lint-check` (passed)\n- `uv run make edition-ee && uv run make test` (3018 passed)