### PR TITLE
feat(dashboard): expose user personal center link

### DIFF
--- a/src/dashboard/apigateway/apigateway/conf/utils.py
+++ b/src/dashboard/apigateway/apigateway/conf/utils.py
@@ -259,6 +259,7 @@ def get_frontend_env_vars(
         "BK_DOCS_URL_PREFIX": bk_docs_url_prefix,
         "BK_USER_WEB_API_URL": bk_api_url_tmpl.format(api_name="bk-user-web") + "/prod",
         "BK_LOGIN_URL": bk_login_url,
+        "BK_USER_PERSONAL_CENTER_LINK": env.str("BK_USER_URL", default="") + "/personal-center",
         "BK_APISIX_URL": env.str("BK_APISIX_URL", default=""),
         "BK_APISIX_DOC_URL": env.str("BK_APISIX_DOC_URL", default=""),
         "BK_ANALYSIS_SCRIPT_SRC": env.str("BK_ANALYSIS_SCRIPT_SRC", default=""),

--- a/src/dashboard/apigateway/apigateway/tests/conf/test_conf_utils.py
+++ b/src/dashboard/apigateway/apigateway/tests/conf/test_conf_utils.py
@@ -1,0 +1,45 @@
+# -*- coding: utf-8 -*-
+#
+# TencentBlueKing is pleased to support the open source community by making
+# 蓝鲸智云 - API 网关(BlueKing - APIGateway) available.
+# Copyright (C) Tencent. All rights reserved.
+# Licensed under the MIT License (the "License"); you may not use this file except
+# in compliance with the License. You may obtain a copy of the License at
+#
+#     http://opensource.org/licenses/MIT
+#
+# Unless required by applicable law or agreed to in writing, software distributed under
+# the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+# either express or implied. See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# We undertake not to change the open source license (MIT license) applicable
+# to the current version of the project delivered to anyone in the future.
+#
+
+from environ import Env
+
+from apigateway.conf.utils import get_frontend_env_vars
+
+
+def test_get_frontend_env_vars_includes_user_personal_center_link(monkeypatch):
+    monkeypatch.setenv("BK_USER_URL", "https://user.example.com")
+
+    env_vars = get_frontend_env_vars(
+        env=Env(),
+        edition="ce",
+        bk_app_code="bk-apigateway",
+        default_test_app_code="demo-app",
+        bk_api_url_tmpl="https://bkapi.example.com/api/{api_name}",
+        bk_component_api_url="https://components.example.com",
+        dashboard_fe_url="https://dashboard-fe.example.com",
+        dashboard_url="https://dashboard.example.com",
+        csrf_cookie_name="csrftoken",
+        csrf_cookie_domain=".example.com",
+        bk_apigateway_version="1.22.0",
+        bk_docs_url_prefix="https://docs.example.com",
+        bk_login_url="https://login.example.com",
+        bk_sdk_languages=["python"],
+    )
+
+    assert env_vars["BK_USER_PERSONAL_CENTER_LINK"] == "https://user.example.com/personal-center"


### PR DESCRIPTION
## Summary
- Backport #2938 to release/1.22.
- Expose `BK_USER_PERSONAL_CENTER_LINK` in dashboard frontend env vars.
- Add a release-compatible focused test for the generated personal-center link.

## Backport Notes
- Cherry-picked from `b18017ed99155208c14d046b7b814201b72aa1d5`.
- Resolved release/1.22 differences by excluding master-only Paas link assertions and using a unique release test filename to avoid pytest `test_utils.py` import collision.

## Verification
- `uv run bash -lc 'cd apigateway && set -a && . apigateway/conf/unittest_env && set +a && python -m pytest --nomigrations --ds apigateway.settings -q --tb=short apigateway/tests/conf/test_conf_utils.py'` (1 passed)\n- `uv run make edition-ee && uv run make lint-check` (passed)\n- `uv run make edition-ee && uv run make test` (2986 passed)