### PR TITLE
fix(dashboard): run pre-commit hooks in dashboard cwd

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,13 +6,13 @@ repos:
         name: ruff-formatter
         language: system
         types: [python]
-        entry: bash -c 'uv run --project src/dashboard --locked ruff format --config=src/dashboard/pyproject.toml --force-exclude "$@"' --
+        entry: bash -c 'cd src/dashboard && uv run --locked ruff format --config=pyproject.toml --force-exclude "${@#src/dashboard/}"' --
         files: src/dashboard/
       - id: ruff
         name: ruff
         language: system
         types: [python]
-        entry: bash -c 'uv run --project src/dashboard --locked ruff check --config=src/dashboard/pyproject.toml --force-exclude --fix "$@"' --
+        entry: bash -c 'cd src/dashboard && uv run --locked ruff check --config=pyproject.toml --force-exclude --fix "${@#src/dashboard/}"' --
         files: src/dashboard/
       - id: mypy
         name: mypy


### PR DESCRIPTION
## Summary

- Run dashboard `ruff format` and `ruff check --fix` pre-commit hooks from `src/dashboard`.
- Convert pre-commit's root-relative `src/dashboard/...` filenames to dashboard-relative paths before passing them to Ruff.
- Keep dashboard-local lint as the source of truth for import grouping.

## Verification

- `git diff --check`
- `pre-commit run format --files <two temporary dashboard python files>` -> passed
- `pre-commit run ruff --files <two temporary dashboard python files>` -> passed and rewrote imports to dashboard-local ordering
- `cd src/dashboard && uv run --locked ruff check --config=pyproject.toml --force-exclude <temporary dashboard-relative files>` -> `All checks passed!`
- `cd src/dashboard && make edition-ee && make lint-check` -> passed

No runtime tests were run because this only changes pre-commit hook CWD/path handling.
