### PR TITLE
fix(dashboard): allow stag programmable stage name

### DIFF
--- a/src/dashboard/apigateway/apigateway/biz/constants.py
+++ b/src/dashboard/apigateway/apigateway/biz/constants.py
@@ -33,6 +33,6 @@ SEMVER_PATTERN = re.compile(
 
 MAX_BACKEND_TIMEOUT_IN_SECOND = settings.MAX_BACKEND_TIMEOUT_IN_SECOND
 
-PROGRAMMABLE_GATEWAY_ALLOWED_STAGE_NAMES = frozenset({"stage", "prod"})
+PROGRAMMABLE_GATEWAY_ALLOWED_STAGE_NAMES = frozenset({"stag", "prod"})
 
 PROGRAMMABLE_GATEWAY_VERSION_PATTERN = re.compile(r"^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)\+(stag|prod)$")

--- a/src/dashboard/apigateway/apigateway/biz/validators.py
+++ b/src/dashboard/apigateway/apigateway/biz/validators.py
@@ -172,7 +172,7 @@ class ProgrammableGatewayVersionValidator(GetGatewayFromContextMixin):
 
 
 class ProgrammableGatewayStageNameValidator(GetGatewayFromContextMixin):
-    """可编程网关环境名称校验：环境名称只能为 stage 或 prod"""
+    """可编程网关环境名称校验：环境名称只能为 stag 或 prod"""
 
     requires_context = True
 
@@ -184,7 +184,7 @@ class ProgrammableGatewayStageNameValidator(GetGatewayFromContextMixin):
         name = attrs.get("name", "")
         if name and name not in PROGRAMMABLE_GATEWAY_ALLOWED_STAGE_NAMES:
             raise serializers.ValidationError(
-                _("可编程网关环境名称只能为 stage 或 prod，当前名称：{name}").format(name=name)
+                _("可编程网关环境名称只能为 stag 或 prod，当前名称：{name}").format(name=name)
             )
 
 

--- a/src/dashboard/apigateway/apigateway/tests/biz/test_validators.py
+++ b/src/dashboard/apigateway/apigateway/tests/biz/test_validators.py
@@ -1087,13 +1087,13 @@ class TestProgrammableGatewayStageNameValidator:
     @pytest.mark.parametrize(
         "name, will_error",
         [
-            ("stage", False),
+            ("stage", True),
             ("prod", False),
             ("dev", True),
             ("test", True),
             ("staging", True),
             ("production", True),
-            ("stag", True),
+            ("stag", False),
         ],
     )
     def test_validate_programmable_gateway(self, fake_gateway, name, will_error):


### PR DESCRIPTION
## Summary
- Allow programmable gateway stage name validation to accept `stag` instead of `stage`.
- Align the validator message and focused test expectations with the existing `stag` version suffix/default stage behavior.

## Verification
- `uv run bash -lc 'cd apigateway && set -a && . apigateway/conf/unittest_env && set +a && python -m pytest --nomigrations --ds apigateway.settings -q --tb=short apigateway/tests/biz/test_validators.py::TestProgrammableGatewayStageNameValidator::test_validate_programmable_gateway'` — 7 passed\n- `uv run make edition-ee && uv run make lint-check` — passed\n- `uv run make test` — 3018 passed\n- `git diff --check -- src/dashboard/apigateway/apigateway/biz/constants.py src/dashboard/apigateway/apigateway/biz/validators.py src/dashboard/apigateway/apigateway/tests/biz/test_validators.py` — passed