### PR TITLE
fix(mcp-proxy): skip request body without schema

### DIFF
--- a/src/mcp-proxy/pkg/infra/proxy/converter.go
+++ b/src/mcp-proxy/pkg/infra/proxy/converter.go
@@ -180,7 +180,7 @@ func OpenapiToMcpToolConfig(
 
 			if operation.RequestBody != nil && operation.RequestBody.Value != nil {
 				if content, ok := operation.RequestBody.Value.Content["application/json"]; ok &&
-					content != nil {
+					content != nil && content.Schema != nil {
 					schema := content.Schema
 					marshalJSON, _ := schema.MarshalJSON()
 					var jsonSchema jsonschema.Schema

--- a/src/mcp-proxy/pkg/infra/proxy/converter_test.go
+++ b/src/mcp-proxy/pkg/infra/proxy/converter_test.go
@@ -267,6 +267,38 @@ var _ = Describe("Converter", func() {
 			Expect(result[0].ParamSchema.Required).To(ContainElement("header_param"))
 		})
 
+		It("should skip JSON request body without schema", func() {
+			spec := &openapi3.T{
+				OpenAPI: "3.0.0",
+				Info:    &openapi3.Info{Title: "Test API", Version: "1.0.0"},
+				Servers: []*openapi3.Server{{URL: "https://api.example.com/v1"}},
+				Paths:   &openapi3.Paths{},
+			}
+
+			pathItem := &openapi3.PathItem{
+				Post: &openapi3.Operation{
+					OperationID: "createUser",
+					Summary:     "Create a new user",
+					RequestBody: &openapi3.RequestBodyRef{
+						Value: &openapi3.RequestBody{
+							Content: openapi3.Content{
+								"application/json": &openapi3.MediaType{},
+							},
+						},
+					},
+					Responses: &openapi3.Responses{},
+				},
+			}
+			spec.Paths.Set("/users", pathItem)
+
+			var result []*ToolConfig
+			Expect(func() {
+				result = OpenapiToMcpToolConfig(spec, nil, nil)
+			}).NotTo(Panic())
+			Expect(result).To(HaveLen(1))
+			Expect(result[0].ParamSchema.Properties).NotTo(HaveKey("body_param"))
+		})
+
 		It("should handle request body with JSON content", func() {
 			spec := &openapi3.T{
 				OpenAPI: "3.0.0",


### PR DESCRIPTION
## Summary
- Skip JSON request body conversion when the OpenAPI media type has no schema.
- Add a regression test for application/json request bodies without schema to avoid converter panic during MCP server reload.

## Verification
- `./bin/ginkgo -r -mod=vendor --focus "skip JSON request body without schema" ./pkg/infra/proxy/...` — failed before fix with nil pointer panic.
- `./bin/ginkgo -r -mod=vendor --focus "skip JSON request body without schema|request body with JSON content" ./pkg/infra/proxy/...` — passed, 2 specs.
- `./bin/ginkgo -r -mod=vendor ./pkg/infra/proxy/...` — passed, 140 specs.
- `make lint` — passed; note the configured lint command applies auto-fixes, and an unrelated formatter change was reverted before commit.
- `make test` — passed, 14 suites; integration specs were skipped by the unit-test target as usual.