### PR TITLE
fix(mcp-proxy): skip request body without schema

### DIFF
--- a/src/mcp-proxy/pkg/infra/proxy/converter.go
+++ b/src/mcp-proxy/pkg/infra/proxy/converter.go
@@ -299,7 +299,7 @@ func OpenapiToMcpToolConfig(
 
 			if operation.RequestBody != nil && operation.RequestBody.Value != nil {
 				if content, ok := operation.RequestBody.Value.Content["application/json"]; ok &&
-					content != nil {
+					content != nil && content.Schema != nil {
 					jsonSchema := openapiSchemaRefToJSONSchema(content.Schema)
 					if jsonSchemaDescriptionIsEmpty(&jsonSchema) {
 						bodyParamDesc := bodyParamDefaultDescription

--- a/src/mcp-proxy/pkg/infra/proxy/converter_test.go
+++ b/src/mcp-proxy/pkg/infra/proxy/converter_test.go
@@ -284,6 +284,38 @@ var _ = Describe("Converter", func() {
 			Expect(result[0].ParamSchema.Required).To(ContainElement("header_param"))
 		})
 
+		It("should skip JSON request body without schema", func() {
+			spec := &openapi3.T{
+				OpenAPI: "3.0.0",
+				Info:    &openapi3.Info{Title: "Test API", Version: "1.0.0"},
+				Servers: []*openapi3.Server{{URL: "https://api.example.com/v1"}},
+				Paths:   &openapi3.Paths{},
+			}
+
+			pathItem := &openapi3.PathItem{
+				Post: &openapi3.Operation{
+					OperationID: "createUser",
+					Summary:     "Create a new user",
+					RequestBody: &openapi3.RequestBodyRef{
+						Value: &openapi3.RequestBody{
+							Content: openapi3.Content{
+								"application/json": &openapi3.MediaType{},
+							},
+						},
+					},
+					Responses: &openapi3.Responses{},
+				},
+			}
+			spec.Paths.Set("/users", pathItem)
+
+			var result []*ToolConfig
+			Expect(func() {
+				result = OpenapiToMcpToolConfig(spec, nil, nil)
+			}).NotTo(Panic())
+			Expect(result).To(HaveLen(1))
+			Expect(result[0].ParamSchema.Properties).NotTo(HaveKey("body_param"))
+		})
+
 		It("should handle request body with JSON content", func() {
 			spec := &openapi3.T{
 				OpenAPI: "3.0.0",


### PR DESCRIPTION
## Summary
- forward-port #2956 to master
- source PR: https://github.com/TencentBlueKing/blueking-apigateway/pull/2956

## Cherry-picked commits
- faada5d9d9562226580c313137f7b30c97807948 fix(mcp-proxy): skip request body without schema

## Verification
- `./bin/ginkgo -r -mod=vendor --focus "skip JSON request body without schema|request body with JSON content" ./pkg/infra/proxy/...` — passed, 2 specs
- `./bin/ginkgo -r -mod=vendor ./pkg/infra/proxy/...` — passed, 191 specs

Note: the cherry-pick had a narrow conflict in `converter.go` because master already refactored schema conversion helpers. The resolution keeps the master helper and only adds the `content.Schema != nil` guard.