### PR TITLE
fix(mcp-proxy): isolate MCP reload panics

### DIFF
--- a/src/mcp-proxy/pkg/infra/proxy/converter.go
+++ b/src/mcp-proxy/pkg/infra/proxy/converter.go
@@ -54,6 +54,7 @@ func marshalOpenAPISchemaRefJSON(schemaRef *openapi3.SchemaRef) ([]byte, error) 
 }
 
 func openapiSchemaRefHasSchema(schemaRef *openapi3.SchemaRef) bool {
+	// LoadFromData resolves valid refs and rejects dangling refs before reload conversion.
 	return schemaRef != nil && (schemaRef.Value != nil || schemaRef.Ref != "")
 }
 

--- a/src/mcp-proxy/pkg/infra/proxy/converter.go
+++ b/src/mcp-proxy/pkg/infra/proxy/converter.go
@@ -44,13 +44,17 @@ func openapiSchemaRefToJSONSchema(schemaRef *openapi3.SchemaRef) jsonschema.Sche
 }
 
 func marshalOpenAPISchemaRefJSON(schemaRef *openapi3.SchemaRef) ([]byte, error) {
-	if schemaRef == nil {
+	if !openapiSchemaRefHasSchema(schemaRef) {
 		return nil, nil
 	}
 	if schemaRef.Value != nil {
 		return schemaRef.Value.MarshalJSON()
 	}
 	return schemaRef.MarshalJSON()
+}
+
+func openapiSchemaRefHasSchema(schemaRef *openapi3.SchemaRef) bool {
+	return schemaRef != nil && (schemaRef.Value != nil || schemaRef.Ref != "")
 }
 
 func fallbackOpenAPIJSONSchema(schemaJSON []byte) jsonschema.Schema {
@@ -212,57 +216,60 @@ func OpenapiToMcpToolConfig(
 					Type: j.WithSimpleTypes(jsonschema.Object),
 				}
 				for _, param := range operation.Parameters {
-					if param.Value.Schema != nil {
-						jsonSchema := openapiSchemaRefToJSONSchema(param.Value.Schema)
-						if param.Value.Description != "" {
-							jsonSchema.Description = &param.Value.Description
+					if param == nil || param.Value == nil ||
+						!openapiSchemaRefHasSchema(param.Value.Schema) {
+						continue
+					}
+					parameter := param.Value
+					jsonSchema := openapiSchemaRefToJSONSchema(parameter.Schema)
+					if parameter.Description != "" {
+						jsonSchema.Description = &parameter.Description
+					}
+					if parameter.Example != nil {
+						if jsonSchema.ExtraProperties == nil {
+							jsonSchema.ExtraProperties = map[string]any{}
 						}
-						if param.Value.Example != nil {
-							if jsonSchema.ExtraProperties == nil {
-								jsonSchema.ExtraProperties = map[string]any{}
-							}
-							jsonSchema.ExtraProperties["example"] = param.Value.Example
-						}
-						if param.Value.In == "header" {
-							headerParamSchema.WithPropertiesItem(
-								param.Value.Name,
-								jsonschema.SchemaOrBool{
-									TypeObject: &jsonSchema,
-								},
-							)
-							if param.Value.Required {
-								headerParamSchema.Required = append(
-									headerParamSchema.Required,
-									param.Value.Name,
-								)
-							}
-						}
-						if param.Value.In == "query" {
-							queryParamSchema.WithPropertiesItem(
-								param.Value.Name,
-								jsonschema.SchemaOrBool{
-									TypeObject: &jsonSchema,
-								},
-							)
-							if param.Value.Required {
-								queryParamSchema.Required = append(
-									queryParamSchema.Required,
-									param.Value.Name,
-								)
-							}
-						}
-						if param.Value.In == "path" {
-							pathParamSchema.Required = append(
-								pathParamSchema.Required,
-								param.Value.Name,
-							)
-							pathParamSchema.WithPropertiesItem(
-								param.Value.Name,
-								jsonschema.SchemaOrBool{
-									TypeObject: &jsonSchema,
-								},
+						jsonSchema.ExtraProperties["example"] = parameter.Example
+					}
+					if parameter.In == "header" {
+						headerParamSchema.WithPropertiesItem(
+							parameter.Name,
+							jsonschema.SchemaOrBool{
+								TypeObject: &jsonSchema,
+							},
+						)
+						if parameter.Required {
+							headerParamSchema.Required = append(
+								headerParamSchema.Required,
+								parameter.Name,
 							)
 						}
+					}
+					if parameter.In == "query" {
+						queryParamSchema.WithPropertiesItem(
+							parameter.Name,
+							jsonschema.SchemaOrBool{
+								TypeObject: &jsonSchema,
+							},
+						)
+						if parameter.Required {
+							queryParamSchema.Required = append(
+								queryParamSchema.Required,
+								parameter.Name,
+							)
+						}
+					}
+					if parameter.In == "path" {
+						pathParamSchema.Required = append(
+							pathParamSchema.Required,
+							parameter.Name,
+						)
+						pathParamSchema.WithPropertiesItem(
+							parameter.Name,
+							jsonschema.SchemaOrBool{
+								TypeObject: &jsonSchema,
+							},
+						)
 					}
 				}
 				if len(headerParamSchema.Properties) > 0 {
@@ -299,7 +306,7 @@ func OpenapiToMcpToolConfig(
 
 			if operation.RequestBody != nil && operation.RequestBody.Value != nil {
 				if content, ok := operation.RequestBody.Value.Content["application/json"]; ok &&
-					content != nil && content.Schema != nil {
+					content != nil && openapiSchemaRefHasSchema(content.Schema) {
 					jsonSchema := openapiSchemaRefToJSONSchema(content.Schema)
 					if jsonSchemaDescriptionIsEmpty(&jsonSchema) {
 						bodyParamDesc := bodyParamDefaultDescription

--- a/src/mcp-proxy/pkg/infra/proxy/converter_test.go
+++ b/src/mcp-proxy/pkg/infra/proxy/converter_test.go
@@ -284,6 +284,48 @@ var _ = Describe("Converter", func() {
 			Expect(result[0].ParamSchema.Required).To(ContainElement("header_param"))
 		})
 
+		It("should skip invalid parameters without panicking", func() {
+			spec := &openapi3.T{
+				OpenAPI: "3.0.0",
+				Info:    &openapi3.Info{Title: "Test API", Version: "1.0.0"},
+				Servers: []*openapi3.Server{{URL: "https://api.example.com/v1"}},
+				Paths:   &openapi3.Paths{},
+			}
+
+			pathItem := &openapi3.PathItem{
+				Get: &openapi3.Operation{
+					OperationID: "getUsers",
+					Summary:     "Get users",
+					Parameters: openapi3.Parameters{
+						nil,
+						&openapi3.ParameterRef{},
+						&openapi3.ParameterRef{
+							Value: &openapi3.Parameter{
+								Name: "limit",
+								In:   "query",
+							},
+						},
+						&openapi3.ParameterRef{
+							Value: &openapi3.Parameter{
+								Name:   "offset",
+								In:     "query",
+								Schema: &openapi3.SchemaRef{},
+							},
+						},
+					},
+					Responses: &openapi3.Responses{},
+				},
+			}
+			spec.Paths.Set("/users", pathItem)
+
+			var result []*ToolConfig
+			Expect(func() {
+				result = OpenapiToMcpToolConfig(spec, nil, nil)
+			}).NotTo(Panic())
+			Expect(result).To(HaveLen(1))
+			Expect(result[0].ParamSchema.Properties).NotTo(HaveKey("query_param"))
+		})
+
 		It("should skip JSON request body without schema", func() {
 			spec := &openapi3.T{
 				OpenAPI: "3.0.0",

--- a/src/mcp-proxy/pkg/mcp/export_test.go
+++ b/src/mcp-proxy/pkg/mcp/export_test.go
@@ -123,6 +123,15 @@ func GetServerLoadResultError(result *serverLoadResult) error {
 	return result.err
 }
 
+// BuildReloadPanicReportForTest exposes buildReloadPanicReport for testing.
+func BuildReloadPanicReportForTest(
+	phase string,
+	serverName string,
+	panicErr any,
+) (string, map[string]string, map[string]any, error) {
+	return buildReloadPanicReport(phase, serverName, panicErr)
+}
+
 // PrefetchServerConfigsForTest exposes prefetchServerConfigs for benchmark testing.
 func PrefetchServerConfigsForTest(
 	ctx context.Context,

--- a/src/mcp-proxy/pkg/mcp/export_test.go
+++ b/src/mcp-proxy/pkg/mcp/export_test.go
@@ -21,6 +21,7 @@ package mcp
 import (
 	"context"
 
+	"github.com/getkin/kin-openapi/openapi3"
 	sdkmcp "github.com/modelcontextprotocol/go-sdk/mcp"
 
 	"mcp_proxy/pkg/entity/model"
@@ -104,9 +105,22 @@ func NewConfig(resourceVersion int) *Config {
 	}
 }
 
+// NewConfigWithOpenAPISpec creates a Config with OpenAPI data for testing.
+func NewConfigWithOpenAPISpec(resourceVersion int, openapiFileData *openapi3.T) *Config {
+	return &Config{
+		resourceVersion: resourceVersion,
+		openapiFileData: openapiFileData,
+	}
+}
+
 // GetLoadStatsValues returns stats values for testing.
 func GetLoadStatsValues(stats *loadStats) (added, updated, skipped, errorCount int) {
 	return stats.addedCount, stats.updatedCount, stats.skippedCount, stats.errorCount
+}
+
+// GetServerLoadResultError returns the load result error for testing.
+func GetServerLoadResultError(result *serverLoadResult) error {
+	return result.err
 }
 
 // PrefetchServerConfigsForTest exposes prefetchServerConfigs for benchmark testing.

--- a/src/mcp-proxy/pkg/mcp/mcp.go
+++ b/src/mcp-proxy/pkg/mcp/mcp.go
@@ -307,6 +307,15 @@ func applyServerChanges(
 	stats := &loadStats{}
 
 	for _, result := range results {
+		if result == nil || result.server == nil {
+			err := fmt.Errorf("missing server")
+			if result != nil && result.err != nil {
+				err = result.err
+			}
+			logging.GetLogger().Errorf("mcp server[<nil>] load failed: %v", err)
+			stats.errorCount++
+			continue
+		}
 		svr := result.server
 		activeMcpServer[svr.Name] = struct{}{}
 		applyServerChange(ctx, mcpProxy, result, stats)
@@ -324,7 +333,11 @@ func applyServerChange(
 	svr := result.server
 	defer func() {
 		if panicErr := recover(); panicErr != nil {
-			logging.GetLogger().Errorf("mcp server[%s] apply failed with panic: %v", svr.Name, panicErr)
+			serverName := "<nil>"
+			if svr != nil {
+				serverName = svr.Name
+			}
+			logging.GetLogger().Errorf("mcp server[%s] apply failed with panic: %v", serverName, panicErr)
 			stats.errorCount++
 		}
 	}()

--- a/src/mcp-proxy/pkg/mcp/mcp.go
+++ b/src/mcp-proxy/pkg/mcp/mcp.go
@@ -22,6 +22,7 @@ package mcp
 import (
 	"context"
 	"fmt"
+	"runtime/debug"
 	"strings"
 	"sync"
 	"time"
@@ -36,6 +37,7 @@ import (
 	"mcp_proxy/pkg/infra/bkaidevtrace"
 	"mcp_proxy/pkg/infra/logging"
 	"mcp_proxy/pkg/infra/proxy"
+	"mcp_proxy/pkg/infra/sentry"
 	"mcp_proxy/pkg/util"
 )
 
@@ -203,13 +205,46 @@ func prefetchServerConfigs(
 
 func recoverPrefetchPanic(result *serverLoadResult) {
 	if panicErr := recover(); panicErr != nil {
-		result.err = fmt.Errorf("prefetch panic: %v", panicErr)
 		serverName := "<nil>"
-		if result.server != nil {
+		if result != nil && result.server != nil {
 			serverName = result.server.Name
 		}
-		logging.GetLogger().Errorf("mcp server[%s] prefetch failed with panic: %v", serverName, panicErr)
+		err := reportReloadPanic("prefetch", serverName, panicErr)
+		if result != nil {
+			result.err = err
+		}
 	}
+}
+
+func buildReloadPanicReport(
+	phase string,
+	serverName string,
+	panicErr any,
+) (string, map[string]string, map[string]any, error) {
+	stack := string(debug.Stack())
+	err := fmt.Errorf("%s panic: %v", phase, panicErr)
+	tags := map[string]string{
+		"mcp_server_name": serverName,
+		"phase":           phase,
+	}
+	extra := map[string]any{
+		"panic":      fmt.Sprint(panicErr),
+		"stacktrace": stack,
+	}
+	return stack, tags, extra, err
+}
+
+func reportReloadPanic(phase, serverName string, panicErr any) error {
+	stack, tags, extra, err := buildReloadPanicReport(phase, serverName, panicErr)
+	logging.GetLogger().Errorf(
+		"mcp server[%s] %s failed with panic: %v\nstacktrace:\n%s",
+		serverName,
+		phase,
+		panicErr,
+		stack,
+	)
+	sentry.ReportToSentry("mcp server reload panic", tags, extra)
+	return err
 }
 
 // prefetchSingleServer 预取单个 server 的 release 和 openapi spec
@@ -337,7 +372,7 @@ func applyServerChange(
 			if svr != nil {
 				serverName = svr.Name
 			}
-			logging.GetLogger().Errorf("mcp server[%s] apply failed with panic: %v", serverName, panicErr)
+			_ = reportReloadPanic("apply", serverName, panicErr)
 			stats.errorCount++
 		}
 	}()

--- a/src/mcp-proxy/pkg/mcp/mcp.go
+++ b/src/mcp-proxy/pkg/mcp/mcp.go
@@ -410,7 +410,12 @@ func applyServerChange(
 	}
 
 	// 如果mcp server已经存在，更新mcp server
-	if updateMCPServer(ctx, mcpProxy, svr, result.conf) {
+	updated, updateErr := updateMCPServer(ctx, mcpProxy, svr, result.conf)
+	if updateErr != nil {
+		stats.errorCount++
+		return
+	}
+	if updated {
 		stats.updatedCount++
 	} else {
 		stats.skippedCount++
@@ -469,20 +474,11 @@ func updateMCPServer(
 	mcpProxy *proxy.MCPProxy,
 	svr *model.MCPServer,
 	conf *Config,
-) bool {
+) (bool, error) {
 	mcpServer := mcpProxy.GetMCPServer(svr.Name)
 	if mcpServer == nil {
 		logging.GetLogger().Warnf("mcp server[%s] does not exist, skip tool cleanup", svr.Name)
-		return false
-	}
-
-	toolNames := svr.GetToolNames()
-	var toolUpdated bool
-	for _, tool := range mcpServer.GetTools() {
-		if !arrutil.Contains(toolNames, tool) {
-			mcpServer.RemoveTool(tool)
-			toolUpdated = true
-		}
+		return false, fmt.Errorf("mcp server[%s] does not exist", svr.Name)
 	}
 
 	var resourceVersionUpdated bool
@@ -494,9 +490,18 @@ func updateMCPServer(
 		)
 		if err != nil {
 			logging.GetLogger().Errorf("update mcp server[%s] from openapi spec error: %v", svr.Name, err)
-			return false
+			return false, err
 		}
 		resourceVersionUpdated = true
+	}
+
+	toolNames := svr.GetToolNames()
+	var toolUpdated bool
+	for _, tool := range mcpServer.GetTools() {
+		if !arrutil.Contains(toolNames, tool) {
+			mcpServer.RemoveTool(tool)
+			toolUpdated = true
+		}
 	}
 
 	// 更新 Prompts（每次都检查更新）
@@ -507,9 +512,9 @@ func updateMCPServer(
 		logging.GetLogger().Infof(
 			"updated prompts:%d, tools_changed:%v, resource_version_changed:%v for mcp server[%s]",
 			len(prompts), toolUpdated, resourceVersionUpdated, svr.Name)
-		return true
+		return true, nil
 	}
-	return false
+	return false, nil
 }
 
 // cleanupStaleMCPServers 删除已经不存在的 mcp server，返回删除数量

--- a/src/mcp-proxy/pkg/mcp/mcp.go
+++ b/src/mcp-proxy/pkg/mcp/mcp.go
@@ -191,6 +191,7 @@ func prefetchServerConfigs(
 		idx, s := i, svr
 		util.GoroutineWithRecovery(ctx, func() {
 			defer wg.Done()
+			defer recoverPrefetchPanic(results[idx])
 			sem <- struct{}{}        // acquire
 			defer func() { <-sem }() // release
 			prefetchSingleServer(ctx, mcpProxy, results[idx], s)
@@ -198,6 +199,17 @@ func prefetchServerConfigs(
 	}
 	wg.Wait()
 	return results
+}
+
+func recoverPrefetchPanic(result *serverLoadResult) {
+	if panicErr := recover(); panicErr != nil {
+		result.err = fmt.Errorf("prefetch panic: %v", panicErr)
+		serverName := "<nil>"
+		if result.server != nil {
+			serverName = result.server.Name
+		}
+		logging.GetLogger().Errorf("mcp server[%s] prefetch failed with panic: %v", serverName, panicErr)
+	}
 }
 
 // prefetchSingleServer 预取单个 server 的 release 和 openapi spec
@@ -297,48 +309,64 @@ func applyServerChanges(
 	for _, result := range results {
 		svr := result.server
 		activeMcpServer[svr.Name] = struct{}{}
-
-		if result.err != nil {
-			logging.GetLogger().Errorf("mcp server[%s] load failed: %v", svr.Name, result.err)
-			stats.errorCount++
-			continue
-		}
-
-		// 处理协议类型变化（需要在主线程中执行 delete）
-		if mcpProxy.IsMCPServerExist(svr.Name) {
-			existingServer := mcpProxy.GetMCPServer(svr.Name)
-			if existingServer.GetProtocolType() != svr.GetProtocolType() {
-				mcpProxy.DeleteMCPServer(svr.Name)
-			}
-		}
-
-		// 如果不需要重新加载 openapi spec（版本未变化）
-		if result.skipped {
-			prompts := loadMCPServerPrompts(ctx, svr.ID)
-			mcpProxy.UpdateMCPServerPrompts(svr.Name, prompts)
-			stats.skippedCount++
-			continue
-		}
-
-		// 如果mcp server不存在，添加mcp server
-		if !mcpProxy.IsMCPServerExist(svr.Name) && result.conf != nil {
-			if addMCPServer(ctx, mcpProxy, svr, result.conf) {
-				stats.addedCount++
-			} else {
-				stats.errorCount++
-			}
-			continue
-		}
-
-		// 如果mcp server已经存在，更新mcp server
-		if updateMCPServer(ctx, mcpProxy, svr, result.conf) {
-			stats.updatedCount++
-		} else {
-			stats.skippedCount++
-		}
+		applyServerChange(ctx, mcpProxy, result, stats)
 	}
 
 	return stats, activeMcpServer
+}
+
+func applyServerChange(
+	ctx context.Context,
+	mcpProxy *proxy.MCPProxy,
+	result *serverLoadResult,
+	stats *loadStats,
+) {
+	svr := result.server
+	defer func() {
+		if panicErr := recover(); panicErr != nil {
+			logging.GetLogger().Errorf("mcp server[%s] apply failed with panic: %v", svr.Name, panicErr)
+			stats.errorCount++
+		}
+	}()
+
+	if result.err != nil {
+		logging.GetLogger().Errorf("mcp server[%s] load failed: %v", svr.Name, result.err)
+		stats.errorCount++
+		return
+	}
+
+	// 处理协议类型变化（需要在主线程中执行 delete）
+	if mcpProxy.IsMCPServerExist(svr.Name) {
+		existingServer := mcpProxy.GetMCPServer(svr.Name)
+		if existingServer.GetProtocolType() != svr.GetProtocolType() {
+			mcpProxy.DeleteMCPServer(svr.Name)
+		}
+	}
+
+	// 如果不需要重新加载 openapi spec（版本未变化）
+	if result.skipped {
+		prompts := loadMCPServerPrompts(ctx, svr.ID)
+		mcpProxy.UpdateMCPServerPrompts(svr.Name, prompts)
+		stats.skippedCount++
+		return
+	}
+
+	// 如果mcp server不存在，添加mcp server
+	if !mcpProxy.IsMCPServerExist(svr.Name) && result.conf != nil {
+		if addMCPServer(ctx, mcpProxy, svr, result.conf) {
+			stats.addedCount++
+		} else {
+			stats.errorCount++
+		}
+		return
+	}
+
+	// 如果mcp server已经存在，更新mcp server
+	if updateMCPServer(ctx, mcpProxy, svr, result.conf) {
+		stats.updatedCount++
+	} else {
+		stats.skippedCount++
+	}
 }
 
 // addMCPServer 添加新的 mcp server，返回是否成功

--- a/src/mcp-proxy/pkg/mcp/mcp_load_test.go
+++ b/src/mcp-proxy/pkg/mcp/mcp_load_test.go
@@ -462,6 +462,106 @@ var _ = Describe("MCP Load Functions", func() {
 			Expect(mcpProxy.IsMCPServerExist("good-server")).To(BeTrue())
 		})
 
+		It("should keep existing tools when an update panics before applying the new spec", func() {
+			initialSpec := &openapi3.T{
+				OpenAPI: "3.0.0",
+				Info:    &openapi3.Info{Title: "Initial API", Version: "1.0.0"},
+				Servers: []*openapi3.Server{{URL: "https://initial.example.com"}},
+				Paths:   &openapi3.Paths{},
+			}
+			initialSpec.Paths.Set("/keep", &openapi3.PathItem{
+				Get: &openapi3.Operation{
+					OperationID: "keepTool",
+					Responses:   &openapi3.Responses{},
+				},
+			})
+			initialSpec.Paths.Set("/remove", &openapi3.PathItem{
+				Get: &openapi3.Operation{
+					OperationID: "removeTool",
+					Responses:   &openapi3.Responses{},
+				},
+			})
+			err := mcpProxy.AddMCPServerFromOpenAPISpec(
+				"bad-server",
+				1,
+				initialSpec,
+				[]string{"keepTool", "removeTool"},
+				nil,
+				constant.MCPServerProtocolTypeSSE,
+				false,
+			)
+			Expect(err).NotTo(HaveOccurred())
+
+			badSpec := &openapi3.T{
+				OpenAPI: "3.0.0",
+				Info:    &openapi3.Info{Title: "Bad API", Version: "1.0.0"},
+				Paths:   &openapi3.Paths{},
+			}
+			badSpec.Paths.Set("/keep", &openapi3.PathItem{
+				Get: &openapi3.Operation{
+					OperationID: "keepTool",
+					Responses:   &openapi3.Responses{},
+				},
+			})
+			results := []*mcppkg.ServerLoadResult{
+				mcppkg.NewServerLoadResult(
+					&model.MCPServer{
+						ID:            1,
+						Name:          "bad-server",
+						ResourceNames: model.ArrayString{"keepTool"},
+						ProtocolType:  constant.MCPServerProtocolTypeSSE,
+					},
+					nil,
+					mcppkg.NewConfigWithOpenAPISpec(2, badSpec),
+					nil,
+					false,
+					false,
+					true,
+				),
+			}
+
+			var stats *mcppkg.LoadStats
+			Expect(func() {
+				stats, _ = mcppkg.ApplyServerChangesForTest(ctx, mcpProxy, results)
+			}).NotTo(Panic())
+
+			_, updated, skipped, errCount := mcppkg.GetLoadStatsValues(stats)
+			Expect(updated).To(Equal(0))
+			Expect(skipped).To(Equal(0))
+			Expect(errCount).To(Equal(1))
+			Expect(
+				mcpProxy.GetMCPServer("bad-server").GetTools(),
+			).To(
+				ContainElements("keepTool", "removeTool"),
+			)
+		})
+
+		It("should count update failures as errors", func() {
+			results := []*mcppkg.ServerLoadResult{
+				mcppkg.NewServerLoadResult(
+					&model.MCPServer{
+						ID:           1,
+						Name:         "missing-server",
+						ProtocolType: constant.MCPServerProtocolTypeSSE,
+					},
+					nil,
+					nil,
+					nil,
+					false,
+					false,
+					true,
+				),
+			}
+
+			stats, _ := mcppkg.ApplyServerChangesForTest(ctx, mcpProxy, results)
+
+			added, updated, skipped, errCount := mcppkg.GetLoadStatsValues(stats)
+			Expect(added).To(Equal(0))
+			Expect(updated).To(Equal(0))
+			Expect(skipped).To(Equal(0))
+			Expect(errCount).To(Equal(1))
+		})
+
 		It("should isolate panic from one server and continue applying later servers", func() {
 			previousPromptCache := cacheimpls.GetMCPServerPromptCache()
 			retrieveFunc := func(ctx context.Context, key cache.Key) (any, error) {

--- a/src/mcp-proxy/pkg/mcp/mcp_load_test.go
+++ b/src/mcp-proxy/pkg/mcp/mcp_load_test.go
@@ -21,11 +21,17 @@ package mcp_test
 import (
 	"context"
 	"errors"
+	"time"
 
+	"github.com/TencentBlueKing/gopkg/cache"
+	"github.com/TencentBlueKing/gopkg/cache/memory"
 	"github.com/getkin/kin-openapi/openapi3"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	"gorm.io/gorm"
 
+	"mcp_proxy/pkg/cacheimpls"
+	"mcp_proxy/pkg/config"
 	"mcp_proxy/pkg/constant"
 	"mcp_proxy/pkg/entity/model"
 	"mcp_proxy/pkg/infra/proxy"
@@ -286,6 +292,21 @@ var _ = Describe("MCP Load Functions", func() {
 		})
 	})
 
+	Describe("prefetchServerConfigs", func() {
+		It("should record panic as a server load error", func() {
+			previousMaxConcurrentPrefetch := config.G.McpServer.MaxConcurrentPrefetch
+			config.G.McpServer.MaxConcurrentPrefetch = 1
+			DeferCleanup(func() {
+				config.G.McpServer.MaxConcurrentPrefetch = previousMaxConcurrentPrefetch
+			})
+
+			results := mcppkg.PrefetchServerConfigsForTest(ctx, mcpProxy, []*model.MCPServer{nil})
+
+			Expect(results).To(HaveLen(1))
+			Expect(mcppkg.GetServerLoadResultError(results[0])).To(HaveOccurred())
+		})
+	})
+
 	Describe("applyServerChanges", func() {
 		It("should count errors for failed results", func() {
 			r := mcppkg.NewServerLoadResult(
@@ -356,6 +377,90 @@ var _ = Describe("MCP Load Functions", func() {
 			_, _, _, errCount := mcppkg.GetLoadStatsValues(stats)
 
 			Expect(errCount).To(Equal(3))
+		})
+
+		It("should isolate panic from one server and continue applying later servers", func() {
+			previousPromptCache := cacheimpls.GetMCPServerPromptCache()
+			retrieveFunc := func(ctx context.Context, key cache.Key) (any, error) {
+				return nil, gorm.ErrRecordNotFound
+			}
+			cacheimpls.SetMCPServerPromptCache(
+				memory.NewCache("mockPromptCache", retrieveFunc, time.Minute, nil),
+			)
+			DeferCleanup(func() {
+				cacheimpls.SetMCPServerPromptCache(previousPromptCache)
+			})
+
+			badSpec := &openapi3.T{
+				OpenAPI: "3.0.0",
+				Info:    &openapi3.Info{Title: "Bad API", Version: "1.0.0"},
+				Paths:   &openapi3.Paths{},
+			}
+			badSpec.Paths.Set("/bad", &openapi3.PathItem{
+				Get: &openapi3.Operation{
+					OperationID: "badTool",
+					Responses:   &openapi3.Responses{},
+				},
+			})
+
+			goodSpec := &openapi3.T{
+				OpenAPI: "3.0.0",
+				Info:    &openapi3.Info{Title: "Good API", Version: "1.0.0"},
+				Servers: []*openapi3.Server{{URL: "https://good.example.com"}},
+				Paths:   &openapi3.Paths{},
+			}
+			goodSpec.Paths.Set("/good", &openapi3.PathItem{
+				Get: &openapi3.Operation{
+					OperationID: "goodTool",
+					Responses:   &openapi3.Responses{},
+				},
+			})
+
+			results := []*mcppkg.ServerLoadResult{
+				mcppkg.NewServerLoadResult(
+					&model.MCPServer{
+						ID:            1,
+						Name:          "bad-server",
+						ResourceNames: model.ArrayString{"badTool"},
+						ProtocolType:  constant.MCPServerProtocolTypeSSE,
+					},
+					nil,
+					mcppkg.NewConfigWithOpenAPISpec(1, badSpec),
+					nil,
+					false,
+					true,
+					true,
+				),
+				mcppkg.NewServerLoadResult(
+					&model.MCPServer{
+						ID:            2,
+						Name:          "good-server",
+						ResourceNames: model.ArrayString{"goodTool"},
+						ProtocolType:  constant.MCPServerProtocolTypeSSE,
+					},
+					nil,
+					mcppkg.NewConfigWithOpenAPISpec(1, goodSpec),
+					nil,
+					false,
+					true,
+					true,
+				),
+			}
+
+			var stats *mcppkg.LoadStats
+			var activeServers map[string]struct{}
+			Expect(func() {
+				stats, activeServers = mcppkg.ApplyServerChangesForTest(ctx, mcpProxy, results)
+			}).NotTo(Panic())
+
+			added, updated, skipped, errCount := mcppkg.GetLoadStatsValues(stats)
+			Expect(added).To(Equal(1))
+			Expect(updated).To(Equal(0))
+			Expect(skipped).To(Equal(0))
+			Expect(errCount).To(Equal(1))
+			Expect(activeServers).To(HaveKey("bad-server"))
+			Expect(activeServers).To(HaveKey("good-server"))
+			Expect(mcpProxy.IsMCPServerExist("good-server")).To(BeTrue())
 		})
 	})
 

--- a/src/mcp-proxy/pkg/mcp/mcp_load_test.go
+++ b/src/mcp-proxy/pkg/mcp/mcp_load_test.go
@@ -379,6 +379,72 @@ var _ = Describe("MCP Load Functions", func() {
 			Expect(errCount).To(Equal(3))
 		})
 
+		It("should count nil-server apply results as errors and continue later servers", func() {
+			previousPromptCache := cacheimpls.GetMCPServerPromptCache()
+			retrieveFunc := func(ctx context.Context, key cache.Key) (any, error) {
+				return nil, gorm.ErrRecordNotFound
+			}
+			cacheimpls.SetMCPServerPromptCache(
+				memory.NewCache("mockPromptCache", retrieveFunc, time.Minute, nil),
+			)
+			DeferCleanup(func() {
+				cacheimpls.SetMCPServerPromptCache(previousPromptCache)
+			})
+
+			goodSpec := &openapi3.T{
+				OpenAPI: "3.0.0",
+				Info:    &openapi3.Info{Title: "Good API", Version: "1.0.0"},
+				Servers: []*openapi3.Server{{URL: "https://good.example.com"}},
+				Paths:   &openapi3.Paths{},
+			}
+			goodSpec.Paths.Set("/good", &openapi3.PathItem{
+				Get: &openapi3.Operation{
+					OperationID: "goodTool",
+					Responses:   &openapi3.Responses{},
+				},
+			})
+
+			results := []*mcppkg.ServerLoadResult{
+				mcppkg.NewServerLoadResult(
+					nil,
+					nil,
+					nil,
+					errors.New("prefetch panic"),
+					false,
+					false,
+					false,
+				),
+				mcppkg.NewServerLoadResult(
+					&model.MCPServer{
+						ID:            2,
+						Name:          "good-server",
+						ResourceNames: model.ArrayString{"goodTool"},
+						ProtocolType:  constant.MCPServerProtocolTypeSSE,
+					},
+					nil,
+					mcppkg.NewConfigWithOpenAPISpec(1, goodSpec),
+					nil,
+					false,
+					true,
+					true,
+				),
+			}
+
+			var stats *mcppkg.LoadStats
+			var activeServers map[string]struct{}
+			Expect(func() {
+				stats, activeServers = mcppkg.ApplyServerChangesForTest(ctx, mcpProxy, results)
+			}).NotTo(Panic())
+
+			added, updated, skipped, errCount := mcppkg.GetLoadStatsValues(stats)
+			Expect(added).To(Equal(1))
+			Expect(updated).To(Equal(0))
+			Expect(skipped).To(Equal(0))
+			Expect(errCount).To(Equal(1))
+			Expect(activeServers).To(HaveKey("good-server"))
+			Expect(mcpProxy.IsMCPServerExist("good-server")).To(BeTrue())
+		})
+
 		It("should isolate panic from one server and continue applying later servers", func() {
 			previousPromptCache := cacheimpls.GetMCPServerPromptCache()
 			retrieveFunc := func(ctx context.Context, key cache.Key) (any, error) {

--- a/src/mcp-proxy/pkg/mcp/mcp_load_test.go
+++ b/src/mcp-proxy/pkg/mcp/mcp_load_test.go
@@ -188,6 +188,23 @@ var _ = Describe("MCP Load Functions", func() {
 		})
 	})
 
+	Describe("reload panic reporting", func() {
+		It("should include stack and sentry context", func() {
+			stack, tags, extra, err := mcppkg.BuildReloadPanicReportForTest(
+				"prefetch",
+				"bad-server",
+				"boom",
+			)
+
+			Expect(err).To(MatchError(ContainSubstring("prefetch panic: boom")))
+			Expect(stack).To(ContainSubstring("goroutine"))
+			Expect(tags).To(HaveKeyWithValue("mcp_server_name", "bad-server"))
+			Expect(tags).To(HaveKeyWithValue("phase", "prefetch"))
+			Expect(extra).To(HaveKeyWithValue("panic", "boom"))
+			Expect(extra).To(HaveKeyWithValue("stacktrace", stack))
+		})
+	})
+
 	Describe("cleanupAllMCPServers", func() {
 		It("should remove all MCP servers from proxy", func() {
 			// Add two servers


### PR DESCRIPTION
## Summary
- Skip malformed OpenAPI parameters whose parameter ref, parameter value, or schema ref is missing, while preserving resolved schemas and `$ref` schemas.
- Add per-server panic isolation in MCP reload apply so one bad server does not abort later server processing.
- Record prefetch goroutine panics on the matching server load result so reload error counts stay accurate.

## Verification
- `go test -mod=mod ./pkg/infra/proxy ./pkg/mcp`: passed
- `go test -mod=vendor ./pkg/mcp`: passed after pre-commit formatting
- `make dep`: passed
- `make init`: passed
- `make lint`: passed, 0 issues
- `make test`: passed, Ginkgo ran 14 suites

## Review
- Used small-step-refactoring constraints: tests first, key reload change in its own commit.
- Ran refactor audit call-site scans for changed/new symbols; no dead or proxy-only production leftovers found.
- Ran code-review-and-quality pass; no blocking findings.
