### PR TITLE
fix(dashboard): add v2 sync public key endpoint

### DIFF
--- a/src/dashboard/apigateway/apigateway/apis/v2/sync/serializers.py
+++ b/src/dashboard/apigateway/apigateway/apis/v2/sync/serializers.py
@@ -179,6 +179,14 @@ class GatewaySyncOutputSLZ(serializers.Serializer):
         ref_name = "apigateway.apis.v2.sync.serializers.GatewaySyncOutputSLZ"
 
 
+class GatewayPublicKeyRetrieveOutputSLZ(serializers.Serializer):
+    issuer = serializers.CharField(read_only=True, help_text="颁发者")
+    public_key = serializers.CharField(read_only=True, help_text="公钥")
+
+    class Meta:
+        ref_name = "apigateway.apis.v2.sync.serializers.GatewayPublicKeyRetrieveOutputSLZ"
+
+
 class HostSLZ(serializers.Serializer):
     host = serializers.RegexField(
         DOMAIN_PATTERN,

--- a/src/dashboard/apigateway/apigateway/apis/v2/sync/urls.py
+++ b/src/dashboard/apigateway/apigateway/apis/v2/sync/urls.py
@@ -36,6 +36,12 @@ urlpatterns = [
             [
                 # POST /api/v2/sync/gateways/{gateway_name}/
                 path("", views.GatewaySyncApi.as_view(), name="openapi.v2.sync.gateway.sync"),
+                # GET /api/v2/sync/gateways/{gateway_name}/public_key/
+                path(
+                    "public_key/",
+                    views.GatewayPublicKeyRetrieveApi.as_view(),
+                    name="openapi.v2.sync.gateway.public_key.retrieve",
+                ),
                 path(
                     "stages/",
                     include(

--- a/src/dashboard/apigateway/apigateway/apis/v2/sync/views.py
+++ b/src/dashboard/apigateway/apigateway/apis/v2/sync/views.py
@@ -50,13 +50,14 @@ from apigateway.common.constants import CallSourceTypeEnum
 from apigateway.common.error_codes import error_codes
 from apigateway.components.bkauth import get_app_tenant_info
 from apigateway.core.constants import ReleaseHistoryStatusEnum, ReleaseStatusEnum
-from apigateway.core.models import Gateway, Release, Resource, ResourceVersion, Stage
+from apigateway.core.models import JWT, Gateway, Release, Resource, ResourceVersion, Stage
 from apigateway.utils.django import get_model_dict, get_object_or_None
 from apigateway.utils.responses import FailJsonResponse, OKJsonResponse
 
 from . import serializers
 from .serializers import (
     DocImportByArchiveInputSLZ,
+    GatewayPublicKeyRetrieveOutputSLZ,
     GatewayResourceVersionLatestRetrieveOutputSLZ,
     GatewaySyncOutputSLZ,
     ReleaseInputSLZ,
@@ -143,6 +144,28 @@ class GatewaySyncApi(generics.CreateAPIView):
         return OKJsonResponse(
             data=output_slz.data,
         )
+
+
+@method_decorator(
+    name="get",
+    decorator=swagger_auto_schema(
+        operation_description="获取网关公钥",
+        responses={status.HTTP_200_OK: GatewayPublicKeyRetrieveOutputSLZ()},
+        tags=["OpenAPI.V2.Sync"],
+    ),
+)
+class GatewayPublicKeyRetrieveApi(generics.RetrieveAPIView):
+    permission_classes = [OpenAPIV2GatewayRelatedAppPermission]
+
+    def get(self, request, gateway_name: str, *args, **kwargs):
+        jwt = JWT.objects.get(gateway=request.gateway)
+        output_slz = GatewayPublicKeyRetrieveOutputSLZ(
+            {
+                "issuer": getattr(settings, "JWT_ISSUER", ""),
+                "public_key": jwt.public_key,
+            }
+        )
+        return OKJsonResponse(data=output_slz.data)
 
 
 @method_decorator(

--- a/src/dashboard/apigateway/apigateway/tests/apis/v2/sync/test_views.py
+++ b/src/dashboard/apigateway/apigateway/tests/apis/v2/sync/test_views.py
@@ -29,6 +29,7 @@ from apigateway.apps.data_plane.models import DataPlane
 from apigateway.apps.mcp_server.models import MCPServer, MCPServerAppPermission, MCPServerCategory
 from apigateway.apps.permission.models import AppGatewayPermission, AppResourcePermission
 from apigateway.core.models import Backend, BackendConfig, GatewayRelatedApp, Resource, ResourceVersion, Stage
+from apigateway.service.gateway_jwt import GatewayJWTHandler
 from apigateway.service.resource_version import make_resource_schema_version
 
 
@@ -41,6 +42,25 @@ def disable_app_permission(mocker):
 
 
 class TestSyncApi:
+    def test_gateway_public_key_retrieve_from_dashboard_backend(
+        self, settings, request_view, fake_gateway, disable_app_permission
+    ):
+        settings.JWT_ISSUER = "foo"
+        jwt = GatewayJWTHandler.create_jwt(fake_gateway)
+
+        resp = request_view(
+            method="GET",
+            view_name="openapi.v2.sync.gateway.public_key.retrieve",
+            path_params={"gateway_name": fake_gateway.name},
+            gateway=fake_gateway,
+        )
+
+        assert resp.status_code == 200
+        assert resp.json()["data"] == {
+            "issuer": "foo",
+            "public_key": jwt.public_key,
+        }
+
     def test_gateway_related_apps_add_records_related_app_codes_before_and_after(
         self, mocker, request_view, fake_admin_user, fake_gateway, disable_app_permission
     ):


### PR DESCRIPTION
## Summary
- add the missing dashboard backend route for `GET /api/v2/sync/gateways/{gateway_name}/public_key/`
- return `issuer` and `public_key` from the gateway JWT record
- add a regression test covering the v2 sync public-key route used by post-migrate

## Verification
- `PATH="$PWD/.venv/bin:$PATH" bash -lc 'cd apigateway && . apigateway/conf/unittest_env && pytest apigateway/tests/apis/v2/sync/test_views.py::TestSyncApi::test_gateway_public_key_retrieve_from_dashboard_backend --ds apigateway.settings --reuse-db'`
- `PATH="$PWD/.venv/bin:$PATH" make check-openapi API=v2_sync_get_gateway_public_key_new`
- `PATH="$PWD/.venv/bin:$PATH" make lint`
- `PATH="$PWD/.venv/bin:$PATH" make test`
