### PR TITLE
chore(dashboard): upgrade bk-esb gateway definition spec

### DIFF
--- a/src/dashboard/apigateway/apigateway/data/apigw-definitions/bk-esb-definition.yaml
+++ b/src/dashboard/apigateway/apigateway/data/apigw-definitions/bk-esb-definition.yaml
@@ -1,3 +1,5 @@
+spec_version: 2
+
 release:
   comment: "蓝鲸 ESB 编码组件数据同步"
 
@@ -8,15 +10,17 @@ apigateway:
   maintainers:
     - "admin"
 
-stage:
-  name: "prod"
-  vars: {}
-  proxy_http:
-    timeout: 600
-    upstreams:
-      loadbalance: "roundrobin"
-      hosts:
-        - host: "{{ environ.BK_COMPONENT_API_INNER_URL }}"
+stages:
+  - name: "prod"
+    vars: {}
+    backends:
+      - name: "default"
+        config:
+          timeout: 600
+          loadbalance: "roundrobin"
+          hosts:
+            - host: "{{ environ.BK_COMPONENT_API_INNER_URL }}"
+              weight: 100
 
 grant_permissions:
   - bk_app_code: bk_apigateway


### PR DESCRIPTION
## Summary
- Upgrade `bk-esb-definition.yaml` to `spec_version: 2`.
- Convert the legacy single `stage.proxy_http` config to `stages[].backends[]`, matching the current definition shape used by `bk-apigateway-definition.yaml` and the upstream sync-apigateway spec.

## Verification
- `uv run python -c 'from pathlib import Path; import yaml; p=Path("apigateway/apigateway/data/apigw-definitions/bk-esb-definition.yaml"); data=yaml.safe_load(p.read_text()); assert data["spec_version"] == 2; assert "stage" not in data; stage=data["stages"][0]; assert stage["name"] == "prod"; backend=stage["backends"][0]; assert backend["name"] == "default"; assert backend["config"]["timeout"] == 600; assert backend["config"]["hosts"][0]["weight"] == 100; print("bk-esb definition spec_version=2 backend shape ok")'`
- `make check-openapi` (exit 0; existing report has 42 warnings and 0 errors)
- `git diff --check`
