### PR TITLE
perf(docs-gateway): optimize gateway list URL template lookup

### DIFF
--- a/src/dashboard/apigateway/apigateway/apis/web/docs/gateway/gateway/serializers.py
+++ b/src/dashboard/apigateway/apigateway/apis/web/docs/gateway/gateway/serializers.py
@@ -56,6 +56,10 @@ class GatewayOutputSLZ(serializers.Serializer):
         ref_name = "apigateway.apis.web.docs.gateway.gateway.serializers.GatewayOutputSLZ"
 
     def get_api_url(self, obj):
+        gateway_id_to_bk_api_url_tmpl = self.context.get("gateway_id_to_bk_api_url_tmpl")
+        if gateway_id_to_bk_api_url_tmpl is not None:
+            return gateway_id_to_bk_api_url_tmpl[obj.id].format(api_name=obj.name)
+
         return GatewayHandler.get_gateway_domain(obj)
 
     def get_is_official(self, obj):

--- a/src/dashboard/apigateway/apigateway/apis/web/docs/gateway/gateway/serializers.py
+++ b/src/dashboard/apigateway/apigateway/apis/web/docs/gateway/gateway/serializers.py
@@ -18,7 +18,7 @@
 #
 from rest_framework import serializers
 
-from apigateway.biz.gateway import GatewayHandler, GatewayTypeHandler
+from apigateway.biz.gateway import GatewayTypeHandler
 from apigateway.common.i18n.field import SerializerTranslatedField
 from apigateway.core.constants import PLUGIN_GATEWAY_PREFIX
 
@@ -57,10 +57,7 @@ class GatewayOutputSLZ(serializers.Serializer):
 
     def get_api_url(self, obj):
         gateway_id_to_bk_api_url_tmpl = self.context.get("gateway_id_to_bk_api_url_tmpl")
-        if gateway_id_to_bk_api_url_tmpl is not None:
-            return gateway_id_to_bk_api_url_tmpl[obj.id].format(api_name=obj.name)
-
-        return GatewayHandler.get_gateway_domain(obj)
+        return gateway_id_to_bk_api_url_tmpl[obj.id].format(api_name=obj.name)
 
     def get_is_official(self, obj):
         return GatewayTypeHandler.is_official(self.context["gateway_auth_configs"][obj.id].gateway_type)

--- a/src/dashboard/apigateway/apigateway/apis/web/docs/gateway/gateway/views.py
+++ b/src/dashboard/apigateway/apigateway/apis/web/docs/gateway/gateway/views.py
@@ -71,8 +71,6 @@ class GatewayListApi(generics.ListAPIView):
         gateway_ids = [gateway["id"] for gateway in gateway_candidates]
         gateway_auth_configs = GatewayAuthContext().get_gateway_id_to_auth_config(gateway_ids)
 
-        # NOTE: 需将官方 SDK 放在前面，但官方标记 is_official 不在 Gateway 表中，因此需要获取数据后，再排序分页
-        # FIXME: 性能问题？
         sorted_candidates = sorted(
             gateway_candidates,
             key=lambda gateway: (
@@ -80,6 +78,8 @@ class GatewayListApi(generics.ListAPIView):
                 gateway["name"],
             ),
         )
+
+        # id__in 查询不能保证按 id 顺序返回结果，因此要做一层转换
         page = self.paginate_queryset(sorted_candidates)
         page_gateway_ids = [gateway["id"] for gateway in page]
         gateway_map = {gateway.id: gateway for gateway in queryset.filter(id__in=page_gateway_ids)}
@@ -114,6 +114,9 @@ class GatewayRetrieveApi(GatewayDocsPermissionMixin, generics.RetrieveAPIView):
             request.gateway,
             context={
                 "gateway_auth_configs": GatewayAuthContext().get_gateway_id_to_auth_config([request.gateway.id]),
+                "gateway_id_to_bk_api_url_tmpl": GatewayHandler.get_gateway_id_to_bk_api_url_tmpl(
+                    [request.gateway.id]
+                ),
                 "gateway_sdks": GatewaySDKHandler.get_sdks([request.gateway.id]),
             },
         )

--- a/src/dashboard/apigateway/apigateway/apis/web/docs/gateway/gateway/views.py
+++ b/src/dashboard/apigateway/apigateway/apis/web/docs/gateway/gateway/views.py
@@ -23,7 +23,7 @@ from drf_yasg.utils import swagger_auto_schema
 from rest_framework import generics, status
 
 from apigateway.apis.web.docs.gateway.mixins import GatewayDocsPermissionMixin
-from apigateway.biz.gateway import GatewayHandler
+from apigateway.biz.gateway import GatewayHandler, GatewayTypeHandler
 from apigateway.biz.sdk import GatewaySDKHandler
 from apigateway.common.tenant.query import gateway_filter_by_app_tenant_id
 from apigateway.common.tenant.request import get_user_tenant_id
@@ -67,24 +67,36 @@ class GatewayListApi(generics.ListAPIView):
         if not show_plugin_gateway:
             queryset = queryset.exclude(name__startswith=PLUGIN_GATEWAY_PREFIX)
 
-        gateways = list(queryset)
+        gateway_candidates = list(queryset.values("id", "name"))
+        gateway_ids = [gateway["id"] for gateway in gateway_candidates]
+        gateway_auth_configs = GatewayAuthContext().get_gateway_id_to_auth_config(gateway_ids)
 
-        gateway_ids = [gateway.id for gateway in gateways]
+        # NOTE: 需将官方 SDK 放在前面，但官方标记 is_official 不在 Gateway 表中，因此需要获取数据后，再排序分页
+        # FIXME: 性能问题？
+        sorted_candidates = sorted(
+            gateway_candidates,
+            key=lambda gateway: (
+                -GatewayTypeHandler.is_official(gateway_auth_configs[gateway["id"]].gateway_type),
+                gateway["name"],
+            ),
+        )
+        page = self.paginate_queryset(sorted_candidates)
+        page_gateway_ids = [gateway["id"] for gateway in page]
+        gateway_map = {gateway.id: gateway for gateway in queryset.filter(id__in=page_gateway_ids)}
+        gateways = [gateway_map[gateway_id] for gateway_id in page_gateway_ids]
 
         # FIXME: gateway maintainers to display_name, only ee edition
         output_slz = GatewayOutputSLZ(
             gateways,
             many=True,
             context={
-                "gateway_auth_configs": GatewayAuthContext().get_gateway_id_to_auth_config(gateway_ids),
-                "gateway_sdks": GatewaySDKHandler.get_sdks(gateway_ids),
+                "gateway_auth_configs": gateway_auth_configs,
+                "gateway_id_to_bk_api_url_tmpl": GatewayHandler.get_gateway_id_to_bk_api_url_tmpl(page_gateway_ids),
+                "gateway_sdks": GatewaySDKHandler.get_sdks(page_gateway_ids),
             },
         )
 
-        # NOTE: 需将官方 SDK 放在前面，但官方标记 is_official 不在 Gateway 表中，因此需要获取数据后，再排序分页
-        # FIXME: 性能问题？
-        page = self.paginate_queryset(sorted(output_slz.data, key=lambda x: (-x["is_official"], x["name"])))
-        return self.get_paginated_response(page)
+        return self.get_paginated_response(output_slz.data)
 
 
 @method_decorator(

--- a/src/dashboard/apigateway/apigateway/biz/gateway/gateway.py
+++ b/src/dashboard/apigateway/apigateway/biz/gateway/gateway.py
@@ -393,10 +393,20 @@ class GatewayHandler:
             if binding.data_plane.bk_api_url_tmpl:
                 gateway_id_to_bk_api_url_tmpl[binding.gateway_id] = binding.data_plane.bk_api_url_tmpl
 
-        return {
-            gateway_id: gateway_id_to_bk_api_url_tmpl.get(gateway_id, settings.BK_API_URL_TMPL)
-            for gateway_id in gateway_ids
-        }
+        result = {}
+        for gateway_id in gateway_ids:
+            bk_api_url_tmpl = gateway_id_to_bk_api_url_tmpl.get(gateway_id)
+            if bk_api_url_tmpl:
+                result[gateway_id] = bk_api_url_tmpl
+                continue
+
+            logger.warning(
+                "Gateway %s has no data plane with bk_api_url_tmpl configured, falling back to settings.BK_API_URL_TMPL",
+                gateway_id,
+            )
+            result[gateway_id] = settings.BK_API_URL_TMPL
+
+        return result
 
     @staticmethod
     def get_gateway_domain(gateway: Gateway) -> str:

--- a/src/dashboard/apigateway/apigateway/biz/gateway/gateway.py
+++ b/src/dashboard/apigateway/apigateway/biz/gateway/gateway.py
@@ -377,6 +377,28 @@ class GatewayHandler:
         return settings.BK_API_URL_TMPL
 
     @staticmethod
+    def get_gateway_id_to_bk_api_url_tmpl(gateway_ids: List[int]) -> Dict[int, str]:
+        gateway_id_to_bk_api_url_tmpl: Dict[int, str] = {}
+        seen_gateway_ids = set()
+        bindings = (
+            GatewayDataPlaneBinding.objects.filter(gateway_id__in=gateway_ids)
+            .select_related("data_plane")
+            .order_by("gateway_id", "data_plane_id")
+        )
+        for binding in bindings:
+            if binding.gateway_id in seen_gateway_ids:
+                continue
+
+            seen_gateway_ids.add(binding.gateway_id)
+            if binding.data_plane.bk_api_url_tmpl:
+                gateway_id_to_bk_api_url_tmpl[binding.gateway_id] = binding.data_plane.bk_api_url_tmpl
+
+        return {
+            gateway_id: gateway_id_to_bk_api_url_tmpl.get(gateway_id, settings.BK_API_URL_TMPL)
+            for gateway_id in gateway_ids
+        }
+
+    @staticmethod
     def get_gateway_domain(gateway: Gateway) -> str:
         return GatewayHandler.get_bk_api_url_tmpl(gateway.id).format(api_name=gateway.name)
 

--- a/src/dashboard/apigateway/apigateway/tests/apis/web/docs/gateway/gateway/test_serializers.py
+++ b/src/dashboard/apigateway/apigateway/tests/apis/web/docs/gateway/gateway/test_serializers.py
@@ -28,6 +28,7 @@ class TestGatewayOutputSLZ:
             fake_gateway,
             context={
                 "gateway_auth_configs": GatewayAuthContext().get_gateway_id_to_auth_config([fake_gateway.id]),
+                "gateway_id_to_bk_api_url_tmpl": {fake_gateway.id: settings.BK_API_URL_TMPL},
                 "gateway_sdks": {},
             },
         )

--- a/src/dashboard/apigateway/apigateway/tests/apis/web/docs/gateway/gateway/test_views.py
+++ b/src/dashboard/apigateway/apigateway/tests/apis/web/docs/gateway/gateway/test_views.py
@@ -20,7 +20,9 @@ from ddf import G
 from django.test import Client
 from django.urls import reverse
 
-from apigateway.core.models import Release
+from apigateway.core.constants import GatewayTypeEnum
+from apigateway.core.models import Gateway, Release
+from apigateway.service.contexts import GatewayAuthContext
 
 
 class TestGatewayListApi:
@@ -35,6 +37,48 @@ class TestGatewayListApi:
 
         assert resp.status_code == 200
         assert len(result["data"]["results"]) >= 1
+
+    def test_list_paginates_after_official_sort(self, mocker, request_view, unique_id):
+        mock_get_gateway_domain = mocker.patch(
+            "apigateway.apis.web.docs.gateway.gateway.serializers.GatewayHandler.get_gateway_domain"
+        )
+        normal_gateway = G(
+            Gateway,
+            name=f"zz-normal-{unique_id[:8]}",
+            status=1,
+            is_public=True,
+            tenant_mode="single",
+            tenant_id="default",
+        )
+        official_gateway = G(
+            Gateway,
+            name=f"aa-official-{unique_id[:8]}",
+            status=1,
+            is_public=True,
+            tenant_mode="single",
+            tenant_id="default",
+        )
+        G(Release, gateway=normal_gateway)
+        G(Release, gateway=official_gateway)
+        GatewayAuthContext().save(normal_gateway.id, {"api_type": GatewayTypeEnum.CLOUDS_API.value})
+        GatewayAuthContext().save(official_gateway.id, {"api_type": GatewayTypeEnum.OFFICIAL_API.value})
+
+        resp = request_view(
+            method="GET",
+            view_name="docs.gateway.list",
+            data={
+                "keyword": unique_id[:8],
+                "limit": 1,
+            },
+        )
+        result = resp.json()
+
+        assert resp.status_code == 200
+        assert result["data"]["count"] == 2
+        assert len(result["data"]["results"]) == 1
+        assert result["data"]["results"][0]["id"] == official_gateway.id
+        assert result["data"]["results"][0]["is_official"] is True
+        mock_get_gateway_domain.assert_not_called()
 
 
 class TestGatewayRetrieveApi:

--- a/src/dashboard/apigateway/apigateway/tests/apis/web/docs/gateway/gateway/test_views.py
+++ b/src/dashboard/apigateway/apigateway/tests/apis/web/docs/gateway/gateway/test_views.py
@@ -38,10 +38,7 @@ class TestGatewayListApi:
         assert resp.status_code == 200
         assert len(result["data"]["results"]) >= 1
 
-    def test_list_paginates_after_official_sort(self, mocker, request_view, unique_id):
-        mock_get_gateway_domain = mocker.patch(
-            "apigateway.apis.web.docs.gateway.gateway.serializers.GatewayHandler.get_gateway_domain"
-        )
+    def test_list_paginates_after_official_sort(self, request_view, unique_id):
         normal_gateway = G(
             Gateway,
             name=f"zz-normal-{unique_id[:8]}",
@@ -78,7 +75,6 @@ class TestGatewayListApi:
         assert len(result["data"]["results"]) == 1
         assert result["data"]["results"][0]["id"] == official_gateway.id
         assert result["data"]["results"][0]["is_official"] is True
-        mock_get_gateway_domain.assert_not_called()
 
 
 class TestGatewayRetrieveApi:

--- a/src/dashboard/apigateway/apigateway/tests/biz/gateway/test_gateway.py
+++ b/src/dashboard/apigateway/apigateway/tests/biz/gateway/test_gateway.py
@@ -400,6 +400,40 @@ class TestGatewayHandler:
         result = GatewayHandler.get_docs_url(fake_gateway)
         assert result == ""
 
+    def test_get_gateway_id_to_bk_api_url_tmpl(self, mocker, settings):
+        settings.BK_API_URL_TMPL = "http://default.example.com/{api_name}"
+        mock_logger_warning = mocker.patch("apigateway.biz.gateway.gateway.logger.warning")
+        gateway_with_multiple_data_planes = G(Gateway, tenant_mode="single", tenant_id="default")
+        gateway_with_empty_data_plane_tmpl = G(Gateway, tenant_mode="single", tenant_id="default")
+        gateway_without_data_plane = G(Gateway, tenant_mode="single", tenant_id="default")
+        first_data_plane = G(DataPlane, name="dp-first", bk_api_url_tmpl="http://first.example.com/{api_name}")
+        second_data_plane = G(DataPlane, name="dp-second", bk_api_url_tmpl="http://second.example.com/{api_name}")
+        empty_tmpl_data_plane = G(DataPlane, name="dp-empty", bk_api_url_tmpl="")
+
+        G(GatewayDataPlaneBinding, gateway=gateway_with_multiple_data_planes, data_plane=first_data_plane)
+        G(GatewayDataPlaneBinding, gateway=gateway_with_multiple_data_planes, data_plane=second_data_plane)
+        G(GatewayDataPlaneBinding, gateway=gateway_with_empty_data_plane_tmpl, data_plane=empty_tmpl_data_plane)
+
+        result = GatewayHandler.get_gateway_id_to_bk_api_url_tmpl(
+            [
+                gateway_with_multiple_data_planes.id,
+                gateway_with_empty_data_plane_tmpl.id,
+                gateway_without_data_plane.id,
+            ]
+        )
+
+        assert result == {
+            gateway_with_multiple_data_planes.id: first_data_plane.bk_api_url_tmpl,
+            gateway_with_empty_data_plane_tmpl.id: settings.BK_API_URL_TMPL,
+            gateway_without_data_plane.id: settings.BK_API_URL_TMPL,
+        }
+        assert mock_logger_warning.call_count == 2
+        warning_gateway_ids = {call.args[1] for call in mock_logger_warning.call_args_list}
+        assert warning_gateway_ids == {
+            gateway_with_empty_data_plane_tmpl.id,
+            gateway_without_data_plane.id,
+        }
+
     def test_get_resource_count(self):
         gateway_1 = G(Gateway)
         gateway_2 = G(Gateway)


### PR DESCRIPTION
- 优化网关文档列表接口性能：先基于轻量字段完成官方优先排序和分页，再仅加载当页网关的完整数据、SDK 和访问地址模板；同时将批量获取网关访问地址模板的逻辑下沉到 GatewayHandler，避免 API 层重复实现数据平面查询逻辑。