### PR TITLE
fix(dashboard): require active health checks

### DIFF
--- a/src/dashboard/apigateway/apigateway/apis/open/stage/serializers.py
+++ b/src/dashboard/apigateway/apigateway/apis/open/stage/serializers.py
@@ -189,23 +189,13 @@ class PassiveCheckSLZ(serializers.Serializer):
 
 
 class CheckSLZ(serializers.Serializer):
-    """Health check configuration (active and/or passive)"""
+    """Health check configuration (active required, passive optional)"""
 
-    active = ActiveCheckSLZ(required=False, allow_null=True, help_text="主动健康检查")
+    active = ActiveCheckSLZ(help_text="主动健康检查")
     passive = PassiveCheckSLZ(required=False, allow_null=True, help_text="被动健康检查")
 
     class Meta:
         ref_name = "apis.open.stage.CheckSLZ"
-
-    def validate(self, attrs):
-        """Ensure at least one of active or passive is provided"""
-        active = attrs.get("active")
-        passive = attrs.get("passive")
-
-        if not active and not passive:
-            raise serializers.ValidationError("至少需要配置主动健康检查或被动健康检查中的一项")
-
-        return attrs
 
 
 class UpstreamsSLZ(serializers.Serializer):

--- a/src/dashboard/apigateway/apigateway/apis/v2/sync/serializers.py
+++ b/src/dashboard/apigateway/apigateway/apis/v2/sync/serializers.py
@@ -304,23 +304,13 @@ class PassiveCheckSLZ(serializers.Serializer):
 
 
 class CheckSLZ(serializers.Serializer):
-    """Health check configuration (active and/or passive)"""
+    """Health check configuration (active required, passive optional)"""
 
-    active = ActiveCheckSLZ(required=False, allow_null=True, help_text="主动健康检查")
+    active = ActiveCheckSLZ(help_text="主动健康检查")
     passive = PassiveCheckSLZ(required=False, allow_null=True, help_text="被动健康检查")
 
     class Meta:
         ref_name = "apigateway.apis.v2.sync.serializers.CheckSLZ"
-
-    def validate(self, attrs):
-        """Ensure at least one of active or passive is provided"""
-        active = attrs.get("active")
-        passive = attrs.get("passive")
-
-        if not active and not passive:
-            raise serializers.ValidationError("至少需要配置主动健康检查或被动健康检查中的一项")
-
-        return attrs
 
 
 class UpstreamsSLZ(serializers.Serializer):

--- a/src/dashboard/apigateway/apigateway/apis/web/serializers.py
+++ b/src/dashboard/apigateway/apigateway/apis/web/serializers.py
@@ -139,23 +139,13 @@ class PassiveCheckSLZ(serializers.Serializer):
 
 
 class CheckSLZ(serializers.Serializer):
-    """Health check configuration (active and/or passive)"""
+    """Health check configuration (active required, passive optional)"""
 
-    active = ActiveCheckSLZ(required=False, allow_null=True, help_text="主动健康检查")
+    active = ActiveCheckSLZ(help_text="主动健康检查")
     passive = PassiveCheckSLZ(required=False, allow_null=True, help_text="被动健康检查")
 
     class Meta:
         ref_name = "apigateway.apis.web.serializers.CheckSLZ"
-
-    def validate(self, attrs):
-        """Ensure at least one of active or passive is provided"""
-        active = attrs.get("active")
-        passive = attrs.get("passive")
-
-        if not active and not passive:
-            raise serializers.ValidationError("至少需要配置主动健康检查或被动健康检查中的一项")
-
-        return attrs
 
 
 class BaseBackendConfigSLZ(serializers.Serializer):

--- a/src/dashboard/apigateway/apigateway/tests/apis/open/stage/test_serializers.py
+++ b/src/dashboard/apigateway/apigateway/tests/apis/open/stage/test_serializers.py
@@ -69,6 +69,40 @@ class TestStageWithResourceVersionV1SLZ:
         assert slz.data == expected
 
 
+class TestCheckSLZ:
+    def test_active_with_passive_valid(self):
+        data = {
+            "active": {
+                "type": "http",
+                "timeout": 5,
+                "http_path": "/health",
+                "healthy": {"interval": 10, "successes": 2, "http_statuses": [200, 201]},
+            },
+            "passive": {
+                "type": "http",
+                "healthy": {"successes": 2, "http_statuses": [200]},
+                "unhealthy": {"http_failures": 3, "tcp_failures": 2, "http_statuses": [500, 502]},
+            },
+        }
+        slz = serializers.CheckSLZ(data=data)
+        assert slz.is_valid()
+
+    def test_passive_only_invalid(self):
+        data = {"passive": {"type": "http", "unhealthy": {"http_failures": 3}}}
+        slz = serializers.CheckSLZ(data=data)
+        assert not slz.is_valid()
+        assert "active" in slz.errors
+
+    def test_null_active_with_passive_invalid(self):
+        data = {
+            "active": None,
+            "passive": {"type": "http", "unhealthy": {"http_failures": 3}},
+        }
+        slz = serializers.CheckSLZ(data=data)
+        assert not slz.is_valid()
+        assert "active" in slz.errors
+
+
 class TestStageSLZ:
     def test_validate_delegates_plugin_validation_to_stage_sync_handler(self, mocker, fake_gateway):
         mocked_validate = mocker.patch(

--- a/src/dashboard/apigateway/apigateway/tests/apis/v2/sync/test_health_check_serializers.py
+++ b/src/dashboard/apigateway/apigateway/tests/apis/v2/sync/test_health_check_serializers.py
@@ -177,18 +177,17 @@ class TestCheckSLZ:
         assert slz.validated_data["active"] is not None
         assert slz.validated_data.get("passive") is None
 
-    def test_passive_only(self):
+    def test_passive_only_invalid(self):
         data = {"passive": {"type": "http", "unhealthy": {"http_failures": 3}}}
         slz = CheckSLZ(data=data)
-        assert slz.is_valid()
-        assert slz.validated_data["passive"] is not None
-        assert slz.validated_data.get("active") is None
+        assert not slz.is_valid()
+        assert "active" in slz.errors
 
     def test_neither_active_nor_passive(self):
         data = {}
         slz = CheckSLZ(data=data)
         assert not slz.is_valid()
-        assert "至少需要配置" in str(slz.errors)
+        assert "active" in slz.errors
 
     def test_active_with_full_config(self):
         data = {
@@ -204,13 +203,19 @@ class TestCheckSLZ:
         slz = CheckSLZ(data=data)
         assert slz.is_valid()
 
-    def test_passive_with_full_config(self):
+    def test_active_with_passive_full_config(self):
         data = {
+            "active": {
+                "type": "http",
+                "timeout": 5,
+                "http_path": "/health",
+                "healthy": {"interval": 10, "successes": 2, "http_statuses": [200, 201]},
+            },
             "passive": {
                 "type": "http",
                 "healthy": {"successes": 2, "http_statuses": [200]},
                 "unhealthy": {"http_failures": 3, "tcp_failures": 2, "http_statuses": [500, 502]},
-            }
+            },
         }
         slz = CheckSLZ(data=data)
         assert slz.is_valid()
@@ -247,8 +252,8 @@ class TestBackendConfigSLZ:
         assert slz.validated_data["checks"] is not None
         assert slz.validated_data["checks"]["active"] is not None
 
-    def test_backend_config_with_passive_checks(self):
-        """Test backend config with passive health checks"""
+    def test_backend_config_with_passive_only_checks_invalid(self):
+        """Test backend config rejects passive-only health checks"""
         data = {
             "loadbalance": "roundrobin",
             "timeout": 30,
@@ -256,9 +261,8 @@ class TestBackendConfigSLZ:
             "checks": {"passive": {"type": "http", "unhealthy": {"http_failures": 3}}},
         }
         slz = BackendConfigSLZ(data=data)
-        assert slz.is_valid()
-        assert slz.validated_data["checks"] is not None
-        assert slz.validated_data["checks"]["passive"] is not None
+        assert not slz.is_valid()
+        assert "active" in slz.errors["checks"]
 
     def test_backend_config_with_null_checks(self):
         """Test backend config with null checks field"""

--- a/src/dashboard/apigateway/apigateway/tests/apis/v2/sync/test_health_check_serializers.py
+++ b/src/dashboard/apigateway/apigateway/tests/apis/v2/sync/test_health_check_serializers.py
@@ -183,6 +183,15 @@ class TestCheckSLZ:
         assert not slz.is_valid()
         assert "active" in slz.errors
 
+    def test_null_active_with_passive_invalid(self):
+        data = {
+            "active": None,
+            "passive": {"type": "http", "unhealthy": {"http_failures": 3}},
+        }
+        slz = CheckSLZ(data=data)
+        assert not slz.is_valid()
+        assert "active" in slz.errors
+
     def test_neither_active_nor_passive(self):
         data = {}
         slz = CheckSLZ(data=data)

--- a/src/dashboard/apigateway/apigateway/tests/apis/web/backend/test_health_check_serializers.py
+++ b/src/dashboard/apigateway/apigateway/tests/apis/web/backend/test_health_check_serializers.py
@@ -176,18 +176,17 @@ class TestCheckSLZ:
         assert slz.validated_data["active"] is not None
         assert slz.validated_data.get("passive") is None
 
-    def test_passive_only(self):
+    def test_passive_only_invalid(self):
         data = {"passive": {"type": "http", "unhealthy": {"http_failures": 3}}}
         slz = CheckSLZ(data=data)
-        assert slz.is_valid()
-        assert slz.validated_data["passive"] is not None
-        assert slz.validated_data.get("active") is None
+        assert not slz.is_valid()
+        assert "active" in slz.errors
 
     def test_neither_active_nor_passive(self):
         data = {}
         slz = CheckSLZ(data=data)
         assert not slz.is_valid()
-        assert "至少需要配置" in str(slz.errors)
+        assert "active" in slz.errors
 
     def test_active_with_full_config(self):
         data = {
@@ -203,13 +202,19 @@ class TestCheckSLZ:
         slz = CheckSLZ(data=data)
         assert slz.is_valid()
 
-    def test_passive_with_full_config(self):
+    def test_active_with_passive_full_config(self):
         data = {
+            "active": {
+                "type": "http",
+                "timeout": 5,
+                "http_path": "/health",
+                "healthy": {"interval": 10, "successes": 2, "http_statuses": [200, 201]},
+            },
             "passive": {
                 "type": "http",
                 "healthy": {"successes": 2, "http_statuses": [200]},
                 "unhealthy": {"http_failures": 3, "tcp_failures": 2, "http_statuses": [500, 502]},
-            }
+            },
         }
         slz = CheckSLZ(data=data)
         assert slz.is_valid()

--- a/src/dashboard/apigateway/apigateway/tests/apis/web/backend/test_health_check_serializers.py
+++ b/src/dashboard/apigateway/apigateway/tests/apis/web/backend/test_health_check_serializers.py
@@ -182,6 +182,15 @@ class TestCheckSLZ:
         assert not slz.is_valid()
         assert "active" in slz.errors
 
+    def test_null_active_with_passive_invalid(self):
+        data = {
+            "active": None,
+            "passive": {"type": "http", "unhealthy": {"http_failures": 3}},
+        }
+        slz = CheckSLZ(data=data)
+        assert not slz.is_valid()
+        assert "active" in slz.errors
+
     def test_neither_active_nor_passive(self):
         data = {}
         slz = CheckSLZ(data=data)

--- a/src/dashboard/apigateway/apigateway/tests/apis/web/backend/test_views.py
+++ b/src/dashboard/apigateway/apigateway/tests/apis/web/backend/test_views.py
@@ -216,11 +216,16 @@ class TestBackendHealthCheckApi:
                     "loadbalance": "roundrobin",
                     "hosts": [{"scheme": "http", "host": "www.example.com", "weight": 1}],
                     "checks": {
+                        "active": {
+                            "type": "http",
+                            "http_path": "/health",
+                            "healthy": {"interval": 10, "successes": 2, "http_statuses": [200, 201]},
+                        },
                         "passive": {
                             "type": "http",
                             "healthy": {"successes": 2, "http_statuses": [200]},
                             "unhealthy": {"http_failures": 3, "http_statuses": [500, 502]},
-                        }
+                        },
                     },
                 }
             ],


### PR DESCRIPTION
## Summary
- require `checks.active` whenever backend health checks are provided
- keep passive health checks as an optional add-on to active checks across web, open stage, and v2 sync serializers
- update health-check serializer/view tests for the new contract

## Verification
- `. apigateway/conf/unittest_env && /data/workspace/tx/wklken/blueking-apigateway/src/dashboard/.venv/bin/pytest --ds apigateway.settings --reuse-db apigateway/tests/apis/web/backend/test_health_check_serializers.py apigateway/tests/apis/v2/sync/test_health_check_serializers.py apigateway/tests/apis/web/backend/test_views.py` — 60 passed
- `make check-openapi` — exit 0, 0 errors, 42 existing warnings
- `PATH="/data/workspace/tx/wklken/blueking-apigateway/src/dashboard/.venv/bin:$PATH" make lint-check` — passed
- `PATH="/data/workspace/tx/wklken/blueking-apigateway/src/dashboard/.venv/bin:$PATH" make test` — 3050 passed