### PR TITLE
fix(mcp): support loading OpenAPI 3.1 schemas

### DIFF
--- a/src/mcp-proxy/go.mod
+++ b/src/mcp-proxy/go.mod
@@ -4,7 +4,7 @@ go 1.25.5
 
 require (
 	github.com/TencentBlueKing/gopkg v1.3.0
-	github.com/getkin/kin-openapi v0.132.0
+	github.com/getkin/kin-openapi v0.140.0
 	github.com/getsentry/sentry-go v0.34.1
 	github.com/gin-contrib/pprof v1.5.3
 	github.com/gin-gonic/gin v1.12.0
@@ -66,11 +66,12 @@ require (
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/go-openapi/analysis v0.23.0 // indirect
 	github.com/go-openapi/errors v0.22.1 // indirect
-	github.com/go-openapi/jsonpointer v0.21.1 // indirect
+	github.com/go-openapi/jsonpointer v0.22.5 // indirect
 	github.com/go-openapi/jsonreference v0.21.0 // indirect
 	github.com/go-openapi/loads v0.22.0 // indirect
 	github.com/go-openapi/spec v0.21.0 // indirect
 	github.com/go-openapi/swag v0.23.1 // indirect
+	github.com/go-openapi/swag/jsonname v0.25.5 // indirect
 	github.com/go-openapi/validate v0.24.0 // indirect
 	github.com/go-playground/locales v0.14.1 // indirect
 	github.com/go-playground/universal-translator v0.18.1 // indirect
@@ -102,16 +103,14 @@ require (
 	github.com/mitchellh/mapstructure v1.5.0 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.2 // indirect
-	github.com/mohae/deepcopy v0.0.0-20170929034955-c48cc78d4826 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
-	github.com/oasdiff/yaml v0.0.0-20250309154309-f31be36b4037 // indirect
-	github.com/oasdiff/yaml3 v0.0.0-20250309153720-d2182401db90 // indirect
+	github.com/oasdiff/yaml v0.1.0 // indirect
+	github.com/oasdiff/yaml3 v0.0.13 // indirect
 	github.com/oklog/ulid v1.3.1 // indirect
 	github.com/opentracing/opentracing-go v1.2.0 // indirect
 	github.com/patrickmn/go-cache v2.1.0+incompatible // indirect
 	github.com/paulmach/orb v0.11.1 // indirect
 	github.com/pelletier/go-toml/v2 v2.3.0 // indirect
-	github.com/perimeterx/marshmallow v1.1.5 // indirect
 	github.com/pierrec/lz4/v4 v4.1.22 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
@@ -120,6 +119,7 @@ require (
 	github.com/quic-go/qpack v0.6.0 // indirect
 	github.com/quic-go/quic-go v0.59.1 // indirect
 	github.com/sagikazarmark/locafero v0.11.0 // indirect
+	github.com/santhosh-tekuri/jsonschema/v6 v6.0.2 // indirect
 	github.com/segmentio/asm v1.2.0 // indirect
 	github.com/segmentio/encoding v0.5.4 // indirect
 	github.com/shopspring/decimal v1.4.0 // indirect

--- a/src/mcp-proxy/go.sum
+++ b/src/mcp-proxy/go.sum
@@ -52,6 +52,8 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/dgraph-io/badger v1.6.0/go.mod h1:zwt7syl517jmP8s94KqSxTlM6IMsdhYy6psNgSztDR4=
 github.com/dgryski/go-farm v0.0.0-20190423205320-6a90982ecee2/go.mod h1:SqUrOPUnsFjfmXRMNPybcSiG0BgUW2AuFH8PAnS2iTw=
+github.com/dlclark/regexp2 v1.11.0 h1:G/nrcoOa7ZXlpoa/91N3X7mM3r8eIlMBBJZvsz/mxKI=
+github.com/dlclark/regexp2 v1.11.0/go.mod h1:DHkYz0B9wPfa6wondMfaivmHpzrQ3v9q8cnmRbL6yW8=
 github.com/dustin/go-humanize v1.0.0/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=
 github.com/eknkc/amber v0.0.0-20171010120322-cdade1c07385/go.mod h1:0vRUJqYpeSZifjYj7uP3BG/gKcuzL9xWVV/Y+cK33KM=
 github.com/etcd-io/bbolt v1.3.3/go.mod h1:ZF2nL25h33cCyBtcyWeZ2/I3HQOfTP+0PIEvHjkjCrw=
@@ -66,8 +68,8 @@ github.com/fsnotify/fsnotify v1.9.0/go.mod h1:8jBTzvmWwFyi3Pb8djgCCO5IBqzKJ/Jwo8
 github.com/gabriel-vasile/mimetype v1.4.13 h1:46nXokslUBsAJE/wMsp5gtO500a4F3Nkz9Ufpk2AcUM=
 github.com/gabriel-vasile/mimetype v1.4.13/go.mod h1:d+9Oxyo1wTzWdyVUPMmXFvp4F9tea18J8ufA774AB3s=
 github.com/gavv/httpexpect v2.0.0+incompatible/go.mod h1:x+9tiU1YnrOvnB725RkpoLv1M62hOWzwo5OXotisrKc=
-github.com/getkin/kin-openapi v0.132.0 h1:3ISeLMsQzcb5v26yeJrBcdTCEQTag36ZjaGk7MIRUwk=
-github.com/getkin/kin-openapi v0.132.0/go.mod h1:3OlG51PCYNsPByuiMB0t4fjnNlIDnaEDsjiKUV8nL58=
+github.com/getkin/kin-openapi v0.140.0 h1:JFn675aXRFjyiZKa/BFWploGldQlI0gobp4J5k0EZ2g=
+github.com/getkin/kin-openapi v0.140.0/go.mod h1:lISrB64F0CPcuDJ3LdtPTMJBY8VENjR9wJBdrcT6J3g=
 github.com/getsentry/sentry-go v0.12.0/go.mod h1:NSap0JBYWzHND8oMbyi0+XZhUalc1TBdRL1M71JZW2c=
 github.com/getsentry/sentry-go v0.34.1 h1:HSjc1C/OsnZttohEPrrqKH42Iud0HuLCXpv8cU1pWcw=
 github.com/getsentry/sentry-go v0.34.1/go.mod h1:C55omcY9ChRQIUcVcGcs+Zdy4ZpQGvNJ7JYHIoSWOtE=
@@ -97,8 +99,8 @@ github.com/go-openapi/analysis v0.23.0 h1:aGday7OWupfMs+LbmLZG4k0MYXIANxcuBTYUC0
 github.com/go-openapi/analysis v0.23.0/go.mod h1:9mz9ZWaSlV8TvjQHLl2mUW2PbZtemkE8yA5v22ohupo=
 github.com/go-openapi/errors v0.22.1 h1:kslMRRnK7NCb/CvR1q1VWuEQCEIsBGn5GgKD9e+HYhU=
 github.com/go-openapi/errors v0.22.1/go.mod h1:+n/5UdIqdVnLIJ6Q9Se8HNGUXYaY6CN8ImWzfi/Gzp0=
-github.com/go-openapi/jsonpointer v0.21.1 h1:whnzv/pNXtK2FbX/W9yJfRmE2gsmkfahjMKB0fZvcic=
-github.com/go-openapi/jsonpointer v0.21.1/go.mod h1:50I1STOfbY1ycR8jGz8DaMeLCdXiI6aDteEdRNNzpdk=
+github.com/go-openapi/jsonpointer v0.22.5 h1:8on/0Yp4uTb9f4XvTrM2+1CPrV05QPZXu+rvu2o9jcA=
+github.com/go-openapi/jsonpointer v0.22.5/go.mod h1:gyUR3sCvGSWchA2sUBJGluYMbe1zazrYWIkWPjjMUY0=
 github.com/go-openapi/jsonreference v0.21.0 h1:Rs+Y7hSXT83Jacb7kFyjn4ijOuVGSvOdF2+tg1TRrwQ=
 github.com/go-openapi/jsonreference v0.21.0/go.mod h1:LmZmgsrTkVg9LG4EaHeY8cBDslNPMo06cago5JNLkm4=
 github.com/go-openapi/loads v0.22.0 h1:ECPGd4jX1U6NApCGG1We+uEozOAvXvJSF4nnwHZ8Aco=
@@ -111,6 +113,10 @@ github.com/go-openapi/strfmt v0.23.0 h1:nlUS6BCqcnAk0pyhi9Y+kdDVZdZMHfEKQiS4HaMg
 github.com/go-openapi/strfmt v0.23.0/go.mod h1:NrtIpfKtWIygRkKVsxh7XQMDQW5HKQl6S5ik2elW+K4=
 github.com/go-openapi/swag v0.23.1 h1:lpsStH0n2ittzTnbaSloVZLuB5+fvSY/+hnagBjSNZU=
 github.com/go-openapi/swag v0.23.1/go.mod h1:STZs8TbRvEQQKUA+JZNAm3EWlgaOBGpyFDqQnDHMef0=
+github.com/go-openapi/swag/jsonname v0.25.5 h1:8p150i44rv/Drip4vWI3kGi9+4W9TdI3US3uUYSFhSo=
+github.com/go-openapi/swag/jsonname v0.25.5/go.mod h1:jNqqikyiAK56uS7n8sLkdaNY/uq6+D2m2LANat09pKU=
+github.com/go-openapi/testify/v2 v2.4.0 h1:8nsPrHVCWkQ4p8h1EsRVymA2XABB4OT40gcvAu+voFM=
+github.com/go-openapi/testify/v2 v2.4.0/go.mod h1:HCPmvFFnheKK2BuwSA0TbbdxJ3I16pjwMkYkP4Ywn54=
 github.com/go-openapi/validate v0.24.0 h1:LdfDKwNbpB6Vn40xhTdNZAnfLECL81w+VX3BumrGD58=
 github.com/go-openapi/validate v0.24.0/go.mod h1:iyeX1sEufmv3nPbBdX3ieNviWnOZaJ1+zquzJEf2BAQ=
 github.com/go-playground/assert/v2 v2.2.0 h1:JvknZsQTYeFEAhQwI4qEt9cyV5ONwRHC+lYKSsYSR8s=
@@ -126,8 +132,6 @@ github.com/go-sql-driver/mysql v1.9.3/go.mod h1:qn46aNg1333BRMNU69Lq93t8du/dwxI6
 github.com/go-task/slim-sprig v0.0.0-20210107165309-348f09dbbbc0/go.mod h1:fyg7847qk6SyHyPtNmDHnmrv/HOrqktSC+C9fM+CJOE=
 github.com/go-task/slim-sprig/v3 v3.0.0 h1:sUs3vkvUymDpBKi3qH1YSqBQk9+9D/8M2mN1vB6EwHI=
 github.com/go-task/slim-sprig/v3 v3.0.0/go.mod h1:W848ghGpv3Qj3dhTPRyJypKRiqCdHZiAzKg9hl15HA8=
-github.com/go-test/deep v1.0.8 h1:TDsG77qcSprGbC6vTN8OuXp5g+J+b5Pcguhf7Zt61VM=
-github.com/go-test/deep v1.0.8/go.mod h1:5C2ZWiW0ErCdrYzpqxLbTX7MG14M9iiw8DgHncVwcsE=
 github.com/go-viper/mapstructure/v2 v2.4.0 h1:EBsztssimR/CONLSZZ04E8qAkxNYq4Qp9LvH92wZUgs=
 github.com/go-viper/mapstructure/v2 v2.4.0/go.mod h1:oJDH3BJKyqBA2TXFhDsKDGDTlndYOZ6rGS0BRZIxGhM=
 github.com/gobwas/httphead v0.0.0-20180130184737-2c6c146eadee/go.mod h1:L0fX3K22YWvt/FAX9NnzrNzcI4wNYi9Yku4O0LKYflo=
@@ -288,8 +292,6 @@ github.com/modern-go/reflect2 v0.0.0-20180701023420-4b7aa43c6742/go.mod h1:bx2lN
 github.com/modern-go/reflect2 v1.0.1/go.mod h1:bx2lNnkwVCuqBIxFjflWJWanXIb3RllmbCylyMrvgv0=
 github.com/modern-go/reflect2 v1.0.2 h1:xBagoLtFs94CBntxluKeaWgTMpvLxC4ur3nMaC9Gz0M=
 github.com/modern-go/reflect2 v1.0.2/go.mod h1:yWuevngMOJpCy52FWWMvUC8ws7m/LJsjYzDa0/r8luk=
-github.com/mohae/deepcopy v0.0.0-20170929034955-c48cc78d4826 h1:RWengNIwukTxcDr9M+97sNutRR1RKhG96O6jWumTTnw=
-github.com/mohae/deepcopy v0.0.0-20170929034955-c48cc78d4826/go.mod h1:TaXosZuwdSHYgviHp1DAtfrULt5eUgsSMsZf+YrPgl8=
 github.com/montanaflynn/stats v0.0.0-20171201202039-1bf9dbcd8cbe/go.mod h1:wL8QJuTMNUDYhXwkmfOly8iTdp5TEcJFWZD2D7SIkUc=
 github.com/moul/http2curl v1.0.0/go.mod h1:8UbvGypXm98wA/IqH45anm5Y2Z6ep6O31QGOAZ3H0fQ=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 h1:C3w9PqII01/Oq1c1nUAm88MOHcQC9l5mIlSMApZMrHA=
@@ -300,10 +302,10 @@ github.com/nats-io/nkeys v0.1.0/go.mod h1:xpnFELMwJABBLVhffcfd1MZx6VsNRFpEugbxzi
 github.com/nats-io/nuid v1.0.1/go.mod h1:19wcPz3Ph3q0Jbyiqsd0kePYG7A95tJPxeL+1OSON2c=
 github.com/nxadm/tail v1.4.4/go.mod h1:kenIhsEOeOJmVchQTgglprH7qJGnHDVpk1VPCcaMI8A=
 github.com/nxadm/tail v1.4.8/go.mod h1:+ncqLTQzXmGhMZNUePPaPqPvBxHAIsmXswZKocGu+AU=
-github.com/oasdiff/yaml v0.0.0-20250309154309-f31be36b4037 h1:G7ERwszslrBzRxj//JalHPu/3yz+De2J+4aLtSRlHiY=
-github.com/oasdiff/yaml v0.0.0-20250309154309-f31be36b4037/go.mod h1:2bpvgLBZEtENV5scfDFEtB/5+1M4hkQhDQrccEJ/qGw=
-github.com/oasdiff/yaml3 v0.0.0-20250309153720-d2182401db90 h1:bQx3WeLcUWy+RletIKwUIt4x3t8n2SxavmoclizMb8c=
-github.com/oasdiff/yaml3 v0.0.0-20250309153720-d2182401db90/go.mod h1:y5+oSEHCPT/DGrS++Wc/479ERge0zTFxaF8PbGKcg2o=
+github.com/oasdiff/yaml v0.1.0 h1:0bqZjfKc/8S9urj4JuwepX41WX9EoA6ifhU3SV06cXg=
+github.com/oasdiff/yaml v0.1.0/go.mod h1:kOlRmMdL2X3vucLCEQO5u61SU22RysnfXvcttrZA1O0=
+github.com/oasdiff/yaml3 v0.0.13 h1:06svmvOHOVBqF81+sY2EUScvUI/iS/vl2VIeUUxZQwg=
+github.com/oasdiff/yaml3 v0.0.13/go.mod h1:y5+oSEHCPT/DGrS++Wc/479ERge0zTFxaF8PbGKcg2o=
 github.com/oklog/ulid v1.3.1 h1:EGfNDEx6MqHz8B3uNV6QAib1UR2Lm97sHi3ocA6ESJ4=
 github.com/oklog/ulid v1.3.1/go.mod h1:CirwcVhetQ6Lv90oh/F+FBtV6XMibvdAFo93nm5qn4U=
 github.com/onsi/ginkgo v1.6.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
@@ -328,8 +330,6 @@ github.com/paulmach/protoscan v0.2.1/go.mod h1:SpcSwydNLrxUGSDvXvO0P7g7AuhJ7lcKf
 github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=
 github.com/pelletier/go-toml/v2 v2.3.0 h1:k59bC/lIZREW0/iVaQR8nDHxVq8OVlIzYCOJf421CaM=
 github.com/pelletier/go-toml/v2 v2.3.0/go.mod h1:2gIqNv+qfxSVS7cM2xJQKtLSTLUE9V8t9Stt+h56mCY=
-github.com/perimeterx/marshmallow v1.1.5 h1:a2LALqQ1BlHM8PZblsDdidgv1mWi1DgC2UmX50IvK2s=
-github.com/perimeterx/marshmallow v1.1.5/go.mod h1:dsXbUu8CRzfYP5a87xpp0xq9S3u0Vchtcl8we9tYaXw=
 github.com/pierrec/lz4/v4 v4.1.22 h1:cKFw6uJDK+/gfw5BcDL0JL5aBsAFdsIT18eRtLj7VIU=
 github.com/pierrec/lz4/v4 v4.1.22/go.mod h1:gZWDp/Ze/IJXGXf23ltt2EXimqmTUXEy0GFuRQyBid4=
 github.com/pingcap/errors v0.11.4 h1:lFuQV/oaUMGcD2tqt+01ROSmJs75VG1ToEOkZIZ4nE4=
@@ -361,6 +361,8 @@ github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQD
 github.com/ryanuber/columnize v2.1.0+incompatible/go.mod h1:sm1tb6uqfes/u+d4ooFouqFdy9/2g9QGwK3SQygK0Ts=
 github.com/sagikazarmark/locafero v0.11.0 h1:1iurJgmM9G3PA/I+wWYIOw/5SyBtxapeHDcg+AAIFXc=
 github.com/sagikazarmark/locafero v0.11.0/go.mod h1:nVIGvgyzw595SUSUE6tvCp3YYTeHs15MvlmU87WwIik=
+github.com/santhosh-tekuri/jsonschema/v6 v6.0.2 h1:KRzFb2m7YtdldCEkzs6KqmJw4nqEVZGK7IN2kJkjTuQ=
+github.com/santhosh-tekuri/jsonschema/v6 v6.0.2/go.mod h1:JXeL+ps8p7/KNMjDQk3TCwPpBy0wYklyWTfbkIzdIFU=
 github.com/schollz/closestmatch v2.1.0+incompatible/go.mod h1:RtP1ddjLong6gTkbtmuhtR2uUrrJOpYzYRvbcPAid+g=
 github.com/segmentio/asm v1.2.0 h1:9BQrFxC+YOHJlTlHGkTrFWf59nbL3XnCoFLTwDCI7ys=
 github.com/segmentio/asm v1.2.0/go.mod h1:BqMnlJP91P8d+4ibuonYZw9mfnzI9HfxselHZr5aAcs=

--- a/src/mcp-proxy/pkg/infra/proxy/converter_test.go
+++ b/src/mcp-proxy/pkg/infra/proxy/converter_test.go
@@ -431,6 +431,7 @@ var _ = Describe("Converter", func() {
 
 		It("should preserve request body schema with OpenAPI exclusive minimum", func() {
 			minimum := float64(0)
+			exclusiveMinimum := true
 			spec := &openapi3.T{
 				OpenAPI: "3.0.0",
 				Info:    &openapi3.Info{Title: "Test API", Version: "1.0.0"},
@@ -461,9 +462,11 @@ var _ = Describe("Converter", func() {
 														Type: &openapi3.Types{
 															"number",
 														},
-														Min:          &minimum,
-														ExclusiveMin: true,
-														Description:  "起量预算（单位元，必须大于 0）。",
+														Min: &minimum,
+														ExclusiveMin: openapi3.ExclusiveBound{
+															Bool: &exclusiveMinimum,
+														},
+														Description: "起量预算（单位元，必须大于 0）。",
 													},
 												},
 											},
@@ -498,6 +501,7 @@ var _ = Describe("Converter", func() {
 
 		It("should preserve request body schema with OpenAPI exclusive maximum", func() {
 			maximum := float64(100)
+			exclusiveMaximum := true
 			spec := &openapi3.T{
 				OpenAPI: "3.0.0",
 				Info:    &openapi3.Info{Title: "Test API", Version: "1.0.0"},
@@ -522,8 +526,10 @@ var _ = Describe("Converter", func() {
 														Type: &openapi3.Types{
 															"number",
 														},
-														Max:          &maximum,
-														ExclusiveMax: true,
+														Max: &maximum,
+														ExclusiveMax: openapi3.ExclusiveBound{
+															Bool: &exclusiveMaximum,
+														},
 													},
 												},
 											},
@@ -546,6 +552,60 @@ var _ = Describe("Converter", func() {
 			discount := bodyParam["properties"].(map[string]any)["discount"].(map[string]any)
 			Expect(discount).To(HaveKeyWithValue("maximum", float64(100)))
 			Expect(discount).To(HaveKeyWithValue("exclusiveMaximum", float64(100)))
+		})
+
+		It("should preserve loaded OpenAPI 3.1 numeric exclusive bounds in MCP tool schema", func() {
+			spec, err := openapi3.NewLoader().LoadFromData([]byte(`{
+				"openapi": "3.1.0",
+				"info": {"title": "Test API", "version": "1.0.0"},
+				"servers": [{"url": "https://api.example.com/v1"}],
+				"paths": {
+					"/qrcode/json": {
+						"post": {
+							"operationId": "createQRCode",
+							"summary": "Create QR code",
+							"requestBody": {
+								"required": true,
+								"content": {
+									"application/json": {
+										"schema": {
+											"type": "object",
+											"required": ["box_size"],
+											"properties": {
+												"box_size": {
+													"type": "integer",
+													"minimum": 0,
+													"exclusiveMinimum": 0,
+													"maximum": 100,
+													"exclusiveMaximum": 100
+												}
+											}
+										}
+									}
+								}
+							},
+							"responses": {
+								"200": {
+									"description": "OK"
+								}
+							}
+						}
+					}
+				}
+			}`))
+			Expect(err).NotTo(HaveOccurred())
+
+			result := OpenapiToMcpToolConfig(spec, nil, nil)
+			Expect(result).To(HaveLen(1))
+
+			inputSchema := buildInputSchemaForTest(result[0])
+			bodyParam := inputSchema["properties"].(map[string]any)["body_param"].(map[string]any)
+			boxSize := bodyParam["properties"].(map[string]any)["box_size"].(map[string]any)
+			Expect(boxSize).To(HaveKeyWithValue("type", "integer"))
+			Expect(boxSize).To(HaveKeyWithValue("minimum", float64(0)))
+			Expect(boxSize).To(HaveKeyWithValue("exclusiveMinimum", float64(0)))
+			Expect(boxSize).To(HaveKeyWithValue("maximum", float64(100)))
+			Expect(boxSize).To(HaveKeyWithValue("exclusiveMaximum", float64(100)))
 		})
 
 		It("should use resolved schema ref value instead of dangling ref", func() {

--- a/src/mcp-proxy/pkg/mcp/export_test.go
+++ b/src/mcp-proxy/pkg/mcp/export_test.go
@@ -113,6 +113,16 @@ func NewConfigWithOpenAPISpec(resourceVersion int, openapiFileData *openapi3.T) 
 	}
 }
 
+// LoadOpenAPISpecForTest exposes loadOpenAPISpec for testing.
+func LoadOpenAPISpecForTest(schema string) (*openapi3.T, error) {
+	return loadOpenAPISpec(schema)
+}
+
+// GetOpenAPISpecVersionForTest exposes getOpenAPISpecVersion for testing.
+func GetOpenAPISpecVersionForTest(openapiFileData *openapi3.T) string {
+	return getOpenAPISpecVersion(openapiFileData)
+}
+
 // GetLoadStatsValues returns stats values for testing.
 func GetLoadStatsValues(stats *loadStats) (added, updated, skipped, errorCount int) {
 	return stats.addedCount, stats.updatedCount, stats.skippedCount, stats.errorCount

--- a/src/mcp-proxy/pkg/mcp/mcp.go
+++ b/src/mcp-proxy/pkg/mcp/mcp.go
@@ -544,10 +544,12 @@ func GetMCPServerConfigWithRelease(
 		return nil, err
 	}
 	// 根据openapi文件初始化mcp server的proxy
-	openapiFileData, err := openapi3.NewLoader().LoadFromData([]byte(openapiFile.Schema))
+	openapiFileData, err := loadOpenAPISpec(openapiFile.Schema)
 	if err != nil {
 		return nil, err
 	}
+	logging.GetLogger().Infof("mcp server[%s] loaded openapi spec version=%s, resource_version_id=%d",
+		server.Name, getOpenAPISpecVersion(openapiFileData), release.ResourceVersionID)
 	// 渲染openapi文件的server信息
 	endpoint := strings.TrimSuffix(config.G.McpServer.BkApiUrlTmpl, "/") + "/{stage}"
 	gateway, err := cacheimpls.GetGatewayByID(ctx, server.GatewayID)
@@ -570,6 +572,17 @@ func GetMCPServerConfigWithRelease(
 		resourceVersion: release.ResourceVersionID,
 		openapiFileData: openapiFileData,
 	}, nil
+}
+
+func loadOpenAPISpec(schema string) (*openapi3.T, error) {
+	return openapi3.NewLoader().LoadFromData([]byte(schema))
+}
+
+func getOpenAPISpecVersion(openapiFileData *openapi3.T) string {
+	if openapiFileData == nil || openapiFileData.OpenAPI == "" {
+		return "unknown"
+	}
+	return openapiFileData.OpenAPI
 }
 
 // loadMCPServerPrompts 加载 MCP Server 的 Prompts 配置

--- a/src/mcp-proxy/pkg/mcp/mcp_load_test.go
+++ b/src/mcp-proxy/pkg/mcp/mcp_load_test.go
@@ -69,6 +69,51 @@ var _ = Describe("MCP Load Functions", func() {
 		openapiSpec.Paths.Set("/users", pathItem)
 	})
 
+	Describe("openapi spec loading", func() {
+		It("should load OpenAPI 3.1 schema with numeric exclusive minimum", func() {
+			spec, err := mcppkg.LoadOpenAPISpecForTest(`{
+					"openapi": "3.1.0",
+					"info": {"title": "Test API", "version": "1.0.0"},
+					"servers": [{"url": "https://api.example.com"}],
+					"paths": {
+						"/qrcode/json": {
+							"post": {
+								"operationId": "qrcode_post_qrcode_json_post",
+								"requestBody": {
+									"required": true,
+									"content": {
+										"application/json": {
+											"schema": {
+												"type": "object",
+												"properties": {
+													"box_size": {
+														"type": "integer",
+														"exclusiveMinimum": 0
+													}
+												}
+											}
+										}
+									}
+								},
+								"responses": {
+									"200": {
+										"description": "OK"
+									}
+								}
+							}
+						}
+					}
+				}`)
+
+			Expect(err).NotTo(HaveOccurred())
+			Expect(mcppkg.GetOpenAPISpecVersionForTest(spec)).To(Equal("3.1.0"))
+		})
+
+		It("should report unknown version for nil spec", func() {
+			Expect(mcppkg.GetOpenAPISpecVersionForTest(nil)).To(Equal("unknown"))
+		})
+	})
+
 	Describe("checkNeedLoad", func() {
 		It("should return true when server does not exist in proxy", func() {
 			server := &model.MCPServer{Name: "new-server"}


### PR DESCRIPTION
## Summary
- upgrade mcp-proxy kin-openapi to v0.140.0 so OpenAPI 3.1 numeric exclusive bounds can be parsed
- log the loaded OpenAPI spec version during MCP server config load
- add regression coverage for loading a 3.1 schema with numeric exclusiveMinimum
- update converter tests for the new kin-openapi ExclusiveBound API

## Verification
- cd src/mcp-proxy && go test -mod=mod ./pkg/mcp ./pkg/infra/proxy
- cd src/mcp-proxy && make dep
- cd src/mcp-proxy && make test
- cd src/mcp-proxy && make lint
- cd src/mcp-proxy && go test -mod=vendor ./pkg/mcp ./pkg/infra/proxy
