### PR TITLE
chore(mcp): remove unused database timeout config

### DIFF
--- a/src/mcp-proxy/config.yaml.tpl
+++ b/src/mcp-proxy/config.yaml.tpl
@@ -24,7 +24,6 @@ databases:
     maxOpenConns: 200
     maxIdleConns: 50
     connMaxLifetimeSecond: 600
-    timeout: 2
     # TLS配置（可选）
     tls:
       enabled: false

--- a/src/mcp-proxy/pkg/config/config.go
+++ b/src/mcp-proxy/pkg/config/config.go
@@ -102,8 +102,6 @@ type Database struct {
 	MaxOpenConns          int
 	MaxIdleConns          int
 	ConnMaxLifetimeSecond int
-	// connect: s
-	Timeout int
 	// tls
 	TLS TLS
 }


### PR DESCRIPTION
Summary

- Remove the unused Database.Timeout field from mcp-proxy config.
- Remove the matching timeout key from the mcp-proxy config template.

Verification

- go test -mod=vendor ./pkg/config
- make lint
- make test
