### PR TITLE
fix(MCP): 创建/编辑MCP关闭侧边栏后会重复触发表单校验、生成 SDK弹框关闭未重置表单校验 --story=160390689

### DIFF
--- a/src/dashboard-front/src/hooks/use-table-setting.tsx
+++ b/src/dashboard-front/src/hooks/use-table-setting.tsx
@@ -55,9 +55,6 @@ export function useTableSetting(
           console.error(e);
         }
       }
-      else {
-        console.warn(`table(cacheIdentifier: ${cacheIdentifier}) settings are not initialized yet`);
-      }
     }
   };
 

--- a/src/dashboard-front/src/views/mcp-server/components/CreateSlider.vue
+++ b/src/dashboard-front/src/views/mcp-server/components/CreateSlider.vue
@@ -52,6 +52,7 @@
               <ServerBasicForm
                 ref="serverBasicFormRef"
                 v-model:form-data="formData"
+                :is-show-slider="isShow"
                 :stage-list="stageList"
                 :no-valid-stage="noValidStage"
                 :is-edit-mode="isEditMode"

--- a/src/dashboard-front/src/views/mcp-server/components/ServerBasicForm.vue
+++ b/src/dashboard-front/src/views/mcp-server/components/ServerBasicForm.vue
@@ -51,12 +51,12 @@
       {
         required: true,
         message: t('服务名称不能为空'),
-        trigger: 'change',
+        trigger: formTrigger
       },
       {
         validator: (value: string) => /^[a-z0-9]+(?:-[a-z0-9]+)*$/?.test(value),
         message: t('服务名称只能包含小写字母、数字和短横线'),
-        trigger: 'change',
+        trigger: formTrigger
       }
     ]"
     class="custom-form-item-required"
@@ -79,7 +79,7 @@
       {
         validator: (value: string) => value?.trim()?.length >= 3,
         message: t('服务展示名不能小于3个字符'),
-        trigger: 'change',
+        trigger: formTrigger
       },
     ]"
     class="custom-form-item-required"
@@ -99,7 +99,7 @@
       {
         validator: (value: string) => value?.trim()?.length >= 10,
         message: t('描述不能小于10个字符'),
-        trigger: 'change',
+        trigger: formTrigger
       },
     ]"
     class="custom-form-item-required"
@@ -261,6 +261,7 @@ interface IProps {
   stageList?: IStageListItem[]
   noValidStage?: boolean
   isEditMode?: boolean
+  isShowSlider?: boolean
 }
 
 interface IEmits { 'stage-change': [number] }
@@ -275,6 +276,7 @@ const {
   categoriesList = [],
   noValidStage = false,
   isEditMode = false,
+  isShowSlider = false,
 } = defineProps<IProps>();
 
 const emit = defineEmits<IEmits>();
@@ -309,6 +311,8 @@ const previewUrl = computed(() => {
 
   return `${prefix || ''}/${serverNamePrefix.value}${formData.value.name}/${protocolUrl}`;
 });
+// 重置表单数据会触发change, formTrigger 用于动态设置表单验证触发事件，isShowSlider 为 true 时使用 'change'，否则使用 'blur'
+const formTrigger = computed(() => (isShowSlider ? 'change' : 'blur'));
 
 const handleStageSelectChange = (value: number) => {
   formData.value.stage_id = value;

--- a/src/dashboard-front/src/views/resource-management/versions/components/CreateSDK.vue
+++ b/src/dashboard-front/src/views/resource-management/versions/components/CreateSDK.vue
@@ -26,7 +26,7 @@
       quick-close
       width="600"
       class="dialog-scroll-y"
-      @closed="() => (dialogConfig.isShow = false)"
+      @closed="handleClosed"
       @confirm="handleCreate"
     >
       <BkAlert
@@ -204,7 +204,7 @@ const handleCreate = async () => {
       message: t('创建成功'),
       theme: 'success',
     });
-    dialogConfig.isShow = false;
+    handleClosed();
     setTimeout(() => {
       emit('done');
     }, 300);
@@ -212,6 +212,11 @@ const handleCreate = async () => {
   finally {
     dialogConfig.loading = false;
   }
+};
+
+const handleClosed = () => {
+  dialogConfig.isShow = false;
+  baseInfoRef.value?.clearValidate();
 };
 
 // 显示弹窗


### PR DESCRIPTION
### Description

<!-- 关联相关issue Please include a summary of the change and which issue is fixed. -->
<!-- 给出必要的上下文以及review需要的必要信息 Please also include relevant motivation and context. -->

Fixes # (issue)

### Checklist

- [ ] 填写 PR 描述及相关 issue (write PR description and related issue)
- [ ] 代码风格检查通过 (code style check passed)
- [ ] PR 中包含单元测试 (include unit test)
- [ ] 单元测试通过 (unit test passed)
- [ ] 本地开发联调环境验证通过 (local development environment verification passed)
