### PR TITLE
fix(export): align MCP permission export display values

### DIFF
--- a/src/dashboard/apigateway/apigateway/apis/v2/inner/serializers.py
+++ b/src/dashboard/apigateway/apigateway/apis/v2/inner/serializers.py
@@ -65,16 +65,6 @@ def _get_categories_from_context(context, obj) -> List[Dict[str, str]]:
     return context.get("categories", {}).get(obj.id, [])
 
 
-def _get_gateway_maintainers_display_names(obj) -> List[str]:
-    # 已知问题：list 场景仍会在序列化阶段按网关同步查询 bk-user。
-    # 这次先保留现状，后续如需优化再改为视图层批量预取。
-    return ResourcePermissionHandler.convert_gateway_maintainers_to_display_names(
-        obj.tenant_mode,
-        obj.tenant_id,
-        obj.maintainers,
-    )
-
-
 class GatewayListInputSLZ(serializers.Serializer):
     name = serializers.CharField(required=False, allow_blank=True)
     fuzzy = serializers.BooleanField(required=False)
@@ -91,7 +81,11 @@ class GatewayListOutputSLZ(serializers.Serializer):
     doc_maintainers = serializers.SerializerMethodField()
 
     def get_maintainers(self, obj):
-        return _get_gateway_maintainers_display_names(obj)
+        return ResourcePermissionHandler.convert_gateway_maintainers_to_display_names(
+            obj.tenant_mode,
+            obj.tenant_id,
+            obj.maintainers,
+        )
 
     def get_doc_maintainers(self, obj):
         return obj.doc_maintainers
@@ -108,7 +102,11 @@ class GatewayRetrieveOutputSLZ(serializers.Serializer):
     doc_maintainers = serializers.SerializerMethodField()
 
     def get_maintainers(self, obj):
-        return _get_gateway_maintainers_display_names(obj)
+        return ResourcePermissionHandler.convert_gateway_maintainers_to_display_names(
+            obj.tenant_mode,
+            obj.tenant_id,
+            obj.maintainers,
+        )
 
     def get_doc_maintainers(self, obj):
         return obj.doc_maintainers

--- a/src/dashboard/apigateway/apigateway/apis/v2/inner/serializers.py
+++ b/src/dashboard/apigateway/apigateway/apis/v2/inner/serializers.py
@@ -44,8 +44,6 @@ from apigateway.biz.permission import ResourcePermissionHandler
 from apigateway.biz.validators import BKAppCodeValidator
 from apigateway.common.fields import TimestampField
 from apigateway.common.i18n.field import SerializerTranslatedField
-from apigateway.common.tenant.request import get_tenant_id_for_gateway_maintainers
-from apigateway.components.bkuser import query_display_names_for_readonly
 from apigateway.core.constants import GatewayStatusEnum
 from apigateway.service.bk_itsm import ItsmPermissionApplyHelper
 from apigateway.service.mcp import (
@@ -68,17 +66,13 @@ def _get_categories_from_context(context, obj) -> List[Dict[str, str]]:
 
 
 def _get_gateway_maintainers_display_names(obj) -> List[str]:
-    if not settings.ENABLE_MULTI_TENANT_MODE:
-        return obj.maintainers
-
     # 已知问题：list 场景仍会在序列化阶段按网关同步查询 bk-user。
     # 这次先保留现状，后续如需优化再改为视图层批量预取。
-    tenant_id = get_tenant_id_for_gateway_maintainers(obj.tenant_mode, obj.tenant_id)
-    try:
-        return query_display_names_for_readonly(tenant_id, obj.maintainers)
-    except Exception:  # pylint: disable=broad-except
-        logger.exception("failed to query gateway maintainer display names: gateway_id=%s", obj.id)
-        return obj.maintainers
+    return ResourcePermissionHandler.convert_gateway_maintainers_to_display_names(
+        obj.tenant_mode,
+        obj.tenant_id,
+        obj.maintainers,
+    )
 
 
 class GatewayListInputSLZ(serializers.Serializer):

--- a/src/dashboard/apigateway/apigateway/apis/web/mcp_server/serializers.py
+++ b/src/dashboard/apigateway/apigateway/apis/web/mcp_server/serializers.py
@@ -1016,6 +1016,19 @@ class GatewayMCPServerAppPermissionListOutputSLZ(serializers.Serializer):
         return _(MCPServerAppPermissionGrantTypeEnum.get_choice_label(obj.grant_type))
 
 
+class GatewayMCPServerAppPermissionExportOutputSLZ(GatewayMCPServerAppPermissionListOutputSLZ):
+    """网关下 MCPServer 应用权限导出输出序列化器"""
+
+    class Meta:
+        ref_name = "apigateway.apis.web.mcp_server.serializers.GatewayMCPServerAppPermissionExportOutputSLZ"
+
+    def get_applied_by(self, obj):
+        apply_record = self._get_apply_record(obj)
+        if apply_record:
+            return apply_record.applied_by
+        return obj.updated_by or obj.created_by or ""
+
+
 class GatewayMCPServerAppPermissionExportInputSLZ(GatewayMCPServerAppPermissionListInputSLZ):
     """网关下 MCPServer 应用权限导出输入序列化器"""
 

--- a/src/dashboard/apigateway/apigateway/apis/web/mcp_server/serializers.py
+++ b/src/dashboard/apigateway/apigateway/apis/web/mcp_server/serializers.py
@@ -1036,15 +1036,16 @@ class GatewayMCPServerAppPermissionExportOutputSLZ(GatewayMCPServerAppPermission
     def get_applied_by(self, obj):
         apply_record = self._get_apply_record(obj)
         if apply_record:
-            # 申请审批的申请人属于应用租户，需按 bk_app_code 查询展示名。
+            # 申请审批的申请人属于应用租户，需按 bk_app_code 查询展示名
             return ResourcePermissionHandler.convert_applied_by_to_display_name(
                 obj.bk_app_code,
                 apply_record.applied_by,
                 self.context.get("gateway_tenant_mode"),
                 self.context.get("gateway_tenant_id"),
+                force_convert=True,
             )
 
-        # 主动授权没有申请单，这里展示的是网关侧操作人。
+        # 主动授权没有申请单，这里展示的是网关侧操作人
         return self._convert_gateway_user_to_display_name(obj.updated_by or obj.created_by or "")
 
     def get_handled_by(self, obj):

--- a/src/dashboard/apigateway/apigateway/apis/web/mcp_server/serializers.py
+++ b/src/dashboard/apigateway/apigateway/apis/web/mcp_server/serializers.py
@@ -1040,8 +1040,8 @@ class GatewayMCPServerAppPermissionExportOutputSLZ(GatewayMCPServerAppPermission
             return ResourcePermissionHandler.convert_applied_by_to_display_name(
                 obj.bk_app_code,
                 apply_record.applied_by,
-                self.context.get("gateway_tenant_mode"),
-                self.context.get("gateway_tenant_id"),
+                "",
+                "",
                 force_convert=True,
             )
 

--- a/src/dashboard/apigateway/apigateway/apis/web/mcp_server/serializers.py
+++ b/src/dashboard/apigateway/apigateway/apis/web/mcp_server/serializers.py
@@ -1022,11 +1022,33 @@ class GatewayMCPServerAppPermissionExportOutputSLZ(GatewayMCPServerAppPermission
     class Meta:
         ref_name = "apigateway.apis.web.mcp_server.serializers.GatewayMCPServerAppPermissionExportOutputSLZ"
 
+    def _convert_gateway_user_to_display_name(self, username: str) -> str:
+        if not username:
+            return ""
+
+        display_names = ResourcePermissionHandler.convert_gateway_maintainers_to_display_names(
+            self.context.get("gateway_tenant_mode"),
+            self.context.get("gateway_tenant_id"),
+            [username],
+        )
+        return display_names[0] if display_names else username
+
     def get_applied_by(self, obj):
         apply_record = self._get_apply_record(obj)
         if apply_record:
-            return apply_record.applied_by
-        return obj.updated_by or obj.created_by or ""
+            # 申请审批的申请人属于应用租户，需按 bk_app_code 查询展示名。
+            return ResourcePermissionHandler.convert_applied_by_to_display_name(
+                obj.bk_app_code,
+                apply_record.applied_by,
+                self.context.get("gateway_tenant_mode"),
+                self.context.get("gateway_tenant_id"),
+            )
+
+        # 主动授权没有申请单，这里展示的是网关侧操作人。
+        return self._convert_gateway_user_to_display_name(obj.updated_by or obj.created_by or "")
+
+    def get_handled_by(self, obj):
+        return self._convert_gateway_user_to_display_name(super().get_handled_by(obj))
 
 
 class GatewayMCPServerAppPermissionExportInputSLZ(GatewayMCPServerAppPermissionListInputSLZ):

--- a/src/dashboard/apigateway/apigateway/apis/web/mcp_server/views.py
+++ b/src/dashboard/apigateway/apigateway/apis/web/mcp_server/views.py
@@ -62,6 +62,7 @@ from apigateway.utils.time import now_datetime
 
 from .serializers import (
     GatewayMCPServerAppPermissionExportInputSLZ,
+    GatewayMCPServerAppPermissionExportOutputSLZ,
     GatewayMCPServerAppPermissionListInputSLZ,
     GatewayMCPServerAppPermissionListOutputSLZ,
     MCPServerAppPermissionAppCodeListInputSLZ,
@@ -1288,7 +1289,7 @@ class GatewayMCPServerAppPermissionExportApi(generics.CreateAPIView):
             queryset = queryset.filter(id__in=data["selected_ids"])
 
         permissions = list(queryset.order_by("mcp_server__name", "bk_app_code"))
-        slz = GatewayMCPServerAppPermissionListOutputSLZ(
+        slz = GatewayMCPServerAppPermissionExportOutputSLZ(
             permissions,
             many=True,
             context={
@@ -1344,9 +1345,7 @@ class GatewayMCPServerAppPermissionExportApi(generics.CreateAPIView):
             {
                 "mcp_server_name": item["mcp_server"]["name"],
                 "bk_app_code": item["bk_app_code"],
-                "applied_by": self._convert_gateway_user_to_display_name(item["applied_by"])
-                if item["grant_type"] == MCPServerAppPermissionGrantTypeEnum.GRANT.value
-                else item["applied_by"],
+                "applied_by": self._convert_gateway_user_to_display_name(item["applied_by"]),
                 "effective_time": item["effective_time"],
                 "handled_by": self._convert_gateway_user_to_display_name(item["handled_by"]),
                 "grant_type_display": self._get_export_grant_type_display(item["grant_type"]),

--- a/src/dashboard/apigateway/apigateway/apis/web/mcp_server/views.py
+++ b/src/dashboard/apigateway/apigateway/apis/web/mcp_server/views.py
@@ -49,7 +49,6 @@ from apigateway.apps.mcp_server.models import (
 )
 from apigateway.biz.audit import Auditor
 from apigateway.biz.mcp_server import MCPServerHandler, MCPServerPromptHandler
-from apigateway.biz.permission import ResourcePermissionHandler
 from apigateway.common.constants import CallSourceTypeEnum
 from apigateway.common.error_codes import error_codes
 from apigateway.common.tenant.request import get_user_tenant_id
@@ -1306,16 +1305,6 @@ class GatewayMCPServerAppPermissionExportApi(generics.CreateAPIView):
         response.charset = "utf-8-sig" if "windows" in request.headers.get("User-Agent", "").lower() else "utf-8"
         return response
 
-    def _convert_gateway_user_to_display_name(self, username: str) -> str:
-        if not username:
-            return ""
-        display_names = ResourcePermissionHandler.convert_gateway_maintainers_to_display_names(
-            self.request.gateway.tenant_mode,
-            self.request.gateway.tenant_id,
-            [username],
-        )
-        return display_names[0] if display_names else username
-
     def _get_export_grant_type_display(self, grant_type: str) -> str:
         if grant_type == MCPServerAppPermissionGrantTypeEnum.GRANT.value:
             return _("主动授权")
@@ -1345,9 +1334,9 @@ class GatewayMCPServerAppPermissionExportApi(generics.CreateAPIView):
             {
                 "mcp_server_name": item["mcp_server"]["name"],
                 "bk_app_code": item["bk_app_code"],
-                "applied_by": self._convert_gateway_user_to_display_name(item["applied_by"]),
+                "applied_by": item["applied_by"],
                 "effective_time": item["effective_time"],
-                "handled_by": self._convert_gateway_user_to_display_name(item["handled_by"]),
+                "handled_by": item["handled_by"],
                 "grant_type_display": self._get_export_grant_type_display(item["grant_type"]),
             }
             for item in data

--- a/src/dashboard/apigateway/apigateway/apis/web/mcp_server/views.py
+++ b/src/dashboard/apigateway/apigateway/apis/web/mcp_server/views.py
@@ -49,6 +49,7 @@ from apigateway.apps.mcp_server.models import (
 )
 from apigateway.biz.audit import Auditor
 from apigateway.biz.mcp_server import MCPServerHandler, MCPServerPromptHandler
+from apigateway.biz.permission import ResourcePermissionHandler
 from apigateway.common.constants import CallSourceTypeEnum
 from apigateway.common.error_codes import error_codes
 from apigateway.common.tenant.request import get_user_tenant_id
@@ -1304,6 +1305,22 @@ class GatewayMCPServerAppPermissionExportApi(generics.CreateAPIView):
         response.charset = "utf-8-sig" if "windows" in request.headers.get("User-Agent", "").lower() else "utf-8"
         return response
 
+    def _convert_gateway_user_to_display_name(self, username: str) -> str:
+        if not username:
+            return ""
+        return ResourcePermissionHandler.convert_gateway_user_to_display_name(
+            username,
+            self.request.gateway.tenant_mode,
+            self.request.gateway.tenant_id,
+        )
+
+    def _get_export_grant_type_display(self, grant_type: str) -> str:
+        if grant_type == MCPServerAppPermissionGrantTypeEnum.GRANT.value:
+            return _("主动授权")
+        if grant_type == MCPServerAppPermissionGrantTypeEnum.APPLY.value:
+            return _("申请审批")
+        return _(MCPServerAppPermissionGrantTypeEnum.get_choice_label(grant_type))
+
     def _get_csv_content(self, data):
         headers = [
             "mcp_server_name",
@@ -1326,10 +1343,12 @@ class GatewayMCPServerAppPermissionExportApi(generics.CreateAPIView):
             {
                 "mcp_server_name": item["mcp_server"]["name"],
                 "bk_app_code": item["bk_app_code"],
-                "applied_by": item["applied_by"],
+                "applied_by": self._convert_gateway_user_to_display_name(item["applied_by"])
+                if item["grant_type"] == MCPServerAppPermissionGrantTypeEnum.GRANT.value
+                else item["applied_by"],
                 "effective_time": item["effective_time"],
-                "handled_by": item["handled_by"],
-                "grant_type_display": item["grant_type_display"],
+                "handled_by": self._convert_gateway_user_to_display_name(item["handled_by"]),
+                "grant_type_display": self._get_export_grant_type_display(item["grant_type"]),
             }
             for item in data
         ]

--- a/src/dashboard/apigateway/apigateway/apis/web/mcp_server/views.py
+++ b/src/dashboard/apigateway/apigateway/apis/web/mcp_server/views.py
@@ -1308,11 +1308,12 @@ class GatewayMCPServerAppPermissionExportApi(generics.CreateAPIView):
     def _convert_gateway_user_to_display_name(self, username: str) -> str:
         if not username:
             return ""
-        return ResourcePermissionHandler.convert_gateway_user_to_display_name(
-            username,
+        display_names = ResourcePermissionHandler.convert_gateway_maintainers_to_display_names(
             self.request.gateway.tenant_mode,
             self.request.gateway.tenant_id,
+            [username],
         )
+        return display_names[0] if display_names else username
 
     def _get_export_grant_type_display(self, grant_type: str) -> str:
         if grant_type == MCPServerAppPermissionGrantTypeEnum.GRANT.value:

--- a/src/dashboard/apigateway/apigateway/biz/permission/permission.py
+++ b/src/dashboard/apigateway/apigateway/biz/permission/permission.py
@@ -204,3 +204,23 @@ class ResourcePermissionHandler:
             return applied_by
 
         return applied_by
+
+    @staticmethod
+    def convert_gateway_user_to_display_name(username: str, gateway_tenant_mode: str, gateway_tenant_id: str) -> str:
+        """
+        将网关侧操作人转换为显示名称，用于导出审批人/授权人的展示
+        """
+        if not settings.ENABLE_MULTI_TENANT_MODE or not username:
+            return username
+
+        if gateway_tenant_mode != TenantModeEnum.GLOBAL.value:
+            return username
+
+        try:
+            display_names = query_display_names_cached(TENANT_ID_OPERATION, username)
+            if display_names:
+                return display_names[0].get("display_name", username)
+        except Exception:  # pylint: disable=broad-except
+            return username
+
+        return username

--- a/src/dashboard/apigateway/apigateway/biz/permission/permission.py
+++ b/src/dashboard/apigateway/apigateway/biz/permission/permission.py
@@ -182,7 +182,11 @@ class ResourcePermissionHandler:
 
     @staticmethod
     def convert_applied_by_to_display_name(
-        bk_app_code: str, applied_by: str, gateway_tenant_mode: str, gateway_tenant_id: str
+        bk_app_code: str,
+        applied_by: str,
+        gateway_tenant_mode: str,
+        gateway_tenant_id: str,
+        force_convert: bool = False,
     ) -> str:
         """
         将申请人转换为显示名称，用于非 global 租户申请 global 网关权限时前端用户的展示
@@ -192,7 +196,7 @@ class ResourcePermissionHandler:
 
         try:
             app_tenant_mode, app_tenant_id = get_app_tenant_info_cached(bk_app_code)
-            if app_tenant_mode == gateway_tenant_mode and app_tenant_id == gateway_tenant_id:
+            if not force_convert and app_tenant_mode == gateway_tenant_mode and app_tenant_id == gateway_tenant_id:
                 return applied_by
 
             if app_tenant_mode == TenantModeEnum.GLOBAL.value:

--- a/src/dashboard/apigateway/apigateway/biz/permission/permission.py
+++ b/src/dashboard/apigateway/apigateway/biz/permission/permission.py
@@ -214,6 +214,9 @@ class ResourcePermissionHandler:
     ) -> List[str]:
         """
         将网关维护人转换为查看态展示名称
+
+        已知问题：list 场景仍会在序列化阶段按网关同步查询 bk-user。
+        这次先保留现状，后续如需优化再改为视图层批量预取。
         """
         if not settings.ENABLE_MULTI_TENANT_MODE:
             return maintainers

--- a/src/dashboard/apigateway/apigateway/biz/permission/permission.py
+++ b/src/dashboard/apigateway/apigateway/biz/permission/permission.py
@@ -36,8 +36,9 @@ from apigateway.common.tenant.constants import (
     TenantModeEnum,
 )
 from apigateway.common.tenant.query import gateway_filter_by_maintainer_tenant_id
+from apigateway.common.tenant.request import get_tenant_id_for_gateway_maintainers
 from apigateway.components.bkauth import get_app_tenant_info_cached
-from apigateway.components.bkuser import query_display_names_cached
+from apigateway.components.bkuser import query_display_names_cached, query_display_names_for_readonly
 from apigateway.core.models import Gateway, Resource
 
 
@@ -206,21 +207,19 @@ class ResourcePermissionHandler:
         return applied_by
 
     @staticmethod
-    def convert_gateway_user_to_display_name(username: str, gateway_tenant_mode: str, gateway_tenant_id: str) -> str:
+    def convert_gateway_maintainers_to_display_names(
+        gateway_tenant_mode: str,
+        gateway_tenant_id: str,
+        maintainers: List[str],
+    ) -> List[str]:
         """
-        将网关侧操作人转换为显示名称，用于导出审批人/授权人的展示
+        将网关维护人转换为查看态展示名称
         """
-        if not settings.ENABLE_MULTI_TENANT_MODE or not username:
-            return username
+        if not settings.ENABLE_MULTI_TENANT_MODE:
+            return maintainers
 
-        if gateway_tenant_mode != TenantModeEnum.GLOBAL.value:
-            return username
-
+        tenant_id = get_tenant_id_for_gateway_maintainers(gateway_tenant_mode, gateway_tenant_id)
         try:
-            display_names = query_display_names_cached(TENANT_ID_OPERATION, username)
-            if display_names:
-                return display_names[0].get("display_name", username)
+            return query_display_names_for_readonly(tenant_id, maintainers)
         except Exception:  # pylint: disable=broad-except
-            return username
-
-        return username
+            return maintainers

--- a/src/dashboard/apigateway/apigateway/tests/apis/v2/inner/test_views.py
+++ b/src/dashboard/apigateway/apigateway/tests/apis/v2/inner/test_views.py
@@ -93,8 +93,8 @@ class TestGatewayOutputSLZ:
             inner_serializers.GatewayRetrieveOutputSLZ,
         ],
     )
-    @patch("apigateway.apis.v2.inner.serializers.settings.ENABLE_MULTI_TENANT_MODE", True)
-    @patch("apigateway.apis.v2.inner.serializers.query_display_names_for_readonly")
+    @patch("apigateway.biz.permission.permission.settings.ENABLE_MULTI_TENANT_MODE", True)
+    @patch("apigateway.biz.permission.permission.query_display_names_for_readonly")
     def test_converts_maintainers_for_cross_tenant_gateway(
         self,
         mock_query_display_names_for_readonly,
@@ -118,9 +118,9 @@ class TestGatewayOutputSLZ:
             inner_serializers.GatewayRetrieveOutputSLZ,
         ],
     )
-    @patch("apigateway.apis.v2.inner.serializers.settings.ENABLE_MULTI_TENANT_MODE", True)
+    @patch("apigateway.biz.permission.permission.settings.ENABLE_MULTI_TENANT_MODE", True)
     @patch(
-        "apigateway.apis.v2.inner.serializers.query_display_names_for_readonly",
+        "apigateway.biz.permission.permission.query_display_names_for_readonly",
         side_effect=RuntimeError("bk-user unavailable"),
     )
     def test_falls_back_to_original_maintainers_when_display_name_lookup_fails(

--- a/src/dashboard/apigateway/apigateway/tests/apis/web/mcp_server/test_views.py
+++ b/src/dashboard/apigateway/apigateway/tests/apis/web/mcp_server/test_views.py
@@ -3737,6 +3737,10 @@ class TestGatewayMCPServerAppPermissionExportApi:
             "apigateway.biz.permission.permission.query_display_names_cached",
             side_effect=lambda _tenant_id, username: [{"display_name": f"display-{username}"}],
         )
+        mocker.patch(
+            "apigateway.biz.permission.permission.query_display_names_for_readonly",
+            side_effect=lambda _tenant_id, usernames: [f"display-{username}" for username in usernames],
+        )
         G(
             MCPServerAppPermission,
             mcp_server=fake_mcp_server,

--- a/src/dashboard/apigateway/apigateway/tests/apis/web/mcp_server/test_views.py
+++ b/src/dashboard/apigateway/apigateway/tests/apis/web/mcp_server/test_views.py
@@ -3785,7 +3785,9 @@ class TestGatewayMCPServerAppPermissionExportApi:
         assert rows_by_app["apply-app"]["审批人/授权人"] == "display-handled-user"
         assert rows_by_app["apply-app"]["授权类型"] == "申请审批"
 
-    def test_export_single_tenant_keeps_username(self, mocker, request_view, settings, fake_gateway, fake_mcp_server):
+    def test_export_single_tenant_converts_app_applied_by(
+        self, mocker, request_view, settings, fake_gateway, fake_mcp_server
+    ):
         settings.ENABLE_MULTI_TENANT_MODE = True
         fake_gateway.tenant_mode = "single"
         fake_gateway.tenant_id = "tenant-1"
@@ -3837,7 +3839,7 @@ class TestGatewayMCPServerAppPermissionExportApi:
         rows_by_app = {row["蓝鲸应用ID"]: row for row in rows}
         assert rows_by_app["grant-app"]["申请人"] == "grant-user"
         assert rows_by_app["grant-app"]["审批人/授权人"] == "grant-user"
-        assert rows_by_app["apply-app"]["申请人"] == "apply-user"
+        assert rows_by_app["apply-app"]["申请人"] == "display-apply-user"
         assert rows_by_app["apply-app"]["审批人/授权人"] == "handled-user"
 
     def test_export_selected_empty_ids(self, request_view, fake_gateway):

--- a/src/dashboard/apigateway/apigateway/tests/apis/web/mcp_server/test_views.py
+++ b/src/dashboard/apigateway/apigateway/tests/apis/web/mcp_server/test_views.py
@@ -16,8 +16,10 @@
 # We undertake not to change the open source license (MIT license) applicable
 # to the current version of the project delivered to anyone in the future.
 #
+import csv
 import datetime
 import json
+from io import StringIO
 
 import pytest
 from ddf import G
@@ -3721,6 +3723,118 @@ class TestGatewayMCPServerAppPermissionExportApi:
             },
         )
         assert resp.status_code == 200
+
+    def test_export_display_values(self, mocker, request_view, settings, fake_gateway, fake_mcp_server):
+        settings.ENABLE_MULTI_TENANT_MODE = True
+        fake_gateway.tenant_mode = "global"
+        fake_gateway.tenant_id = ""
+        fake_gateway.save(update_fields=["tenant_mode", "tenant_id"])
+        mocker.patch(
+            "apigateway.biz.permission.permission.get_app_tenant_info_cached",
+            return_value=("single", "tenant-1"),
+        )
+        mocker.patch(
+            "apigateway.biz.permission.permission.query_display_names_cached",
+            side_effect=lambda _tenant_id, username: [{"display_name": f"display-{username}"}],
+        )
+        G(
+            MCPServerAppPermission,
+            mcp_server=fake_mcp_server,
+            bk_app_code="grant-app",
+            grant_type=MCPServerAppPermissionGrantTypeEnum.GRANT.value,
+            created_by="grant-user",
+        )
+        G(
+            MCPServerAppPermission,
+            mcp_server=fake_mcp_server,
+            bk_app_code="apply-app",
+            grant_type=MCPServerAppPermissionGrantTypeEnum.APPLY.value,
+        )
+        G(
+            MCPServerAppPermissionApply,
+            mcp_server=fake_mcp_server,
+            bk_app_code="apply-app",
+            applied_by="apply-user",
+            applied_time=now_datetime(),
+            handled_by="handled-user",
+            handled_time=now_datetime(),
+            status=MCPServerAppPermissionApplyStatusEnum.APPROVED.value,
+            is_deleted=False,
+        )
+
+        resp = request_view(
+            method="POST",
+            view_name="mcp_server.gateway_app_permission.export",
+            path_params={"gateway_id": fake_gateway.id},
+            gateway=fake_gateway,
+            data={"export_type": ExportTypeEnum.ALL.value},
+        )
+        assert resp.status_code == 200
+
+        content = b"".join(resp.streaming_content).decode(resp.charset)
+        rows = list(csv.DictReader(StringIO(content)))
+        rows_by_app = {row["蓝鲸应用ID"]: row for row in rows}
+        assert rows_by_app["grant-app"]["申请人"] == "display-grant-user"
+        assert rows_by_app["grant-app"]["审批人/授权人"] == "display-grant-user"
+        assert rows_by_app["grant-app"]["授权类型"] == "主动授权"
+        assert rows_by_app["apply-app"]["申请人"] == "display-apply-user"
+        assert rows_by_app["apply-app"]["审批人/授权人"] == "display-handled-user"
+        assert rows_by_app["apply-app"]["授权类型"] == "申请审批"
+
+    def test_export_single_tenant_keeps_username(self, mocker, request_view, settings, fake_gateway, fake_mcp_server):
+        settings.ENABLE_MULTI_TENANT_MODE = True
+        fake_gateway.tenant_mode = "single"
+        fake_gateway.tenant_id = "tenant-1"
+        fake_gateway.save(update_fields=["tenant_mode", "tenant_id"])
+        mocker.patch(
+            "apigateway.biz.permission.permission.get_app_tenant_info_cached",
+            return_value=("single", "tenant-1"),
+        )
+        mocker.patch(
+            "apigateway.biz.permission.permission.query_display_names_cached",
+            side_effect=lambda _tenant_id, username: [{"display_name": f"display-{username}"}],
+        )
+        G(
+            MCPServerAppPermission,
+            mcp_server=fake_mcp_server,
+            bk_app_code="grant-app",
+            grant_type=MCPServerAppPermissionGrantTypeEnum.GRANT.value,
+            created_by="grant-user",
+        )
+        G(
+            MCPServerAppPermission,
+            mcp_server=fake_mcp_server,
+            bk_app_code="apply-app",
+            grant_type=MCPServerAppPermissionGrantTypeEnum.APPLY.value,
+        )
+        G(
+            MCPServerAppPermissionApply,
+            mcp_server=fake_mcp_server,
+            bk_app_code="apply-app",
+            applied_by="apply-user",
+            applied_time=now_datetime(),
+            handled_by="handled-user",
+            handled_time=now_datetime(),
+            status=MCPServerAppPermissionApplyStatusEnum.APPROVED.value,
+            is_deleted=False,
+        )
+
+        resp = request_view(
+            method="POST",
+            view_name="mcp_server.gateway_app_permission.export",
+            path_params={"gateway_id": fake_gateway.id},
+            gateway=fake_gateway,
+            data={"export_type": ExportTypeEnum.ALL.value},
+        )
+        assert resp.status_code == 200
+
+        content = b"".join(resp.streaming_content).decode(resp.charset)
+        rows = list(csv.DictReader(StringIO(content)))
+        rows_by_app = {row["蓝鲸应用ID"]: row for row in rows}
+        assert rows_by_app["grant-app"]["申请人"] == "grant-user"
+        assert rows_by_app["grant-app"]["审批人/授权人"] == "grant-user"
+        assert rows_by_app["apply-app"]["申请人"] == "apply-user"
+        assert rows_by_app["apply-app"]["审批人/授权人"] == "handled-user"
 
     def test_export_selected_empty_ids(self, request_view, fake_gateway):
         resp = request_view(

--- a/src/dashboard/apigateway/apigateway/tests/biz/permission/test_permission.py
+++ b/src/dashboard/apigateway/apigateway/tests/biz/permission/test_permission.py
@@ -146,6 +146,25 @@ class TestConvertAppliedByToDisplayName:
     @patch("apigateway.biz.permission.permission.settings.ENABLE_MULTI_TENANT_MODE", True)
     @patch("apigateway.biz.permission.permission.get_app_tenant_info_cached")
     @patch("apigateway.biz.permission.permission.query_display_names_cached")
+    def test_force_convert_same_tenant(self, mock_query_display_names, mock_get_app_tenant_info):
+        """When force_convert is True, should convert display name even in same tenant"""
+        mock_get_app_tenant_info.return_value = ("global", "tenant-1")
+        mock_query_display_names.return_value = [{"display_name": "Admin User"}]
+
+        result = ResourcePermissionHandler.convert_applied_by_to_display_name(
+            bk_app_code="test-app",
+            applied_by="admin",
+            gateway_tenant_mode="global",
+            gateway_tenant_id="tenant-1",
+            force_convert=True,
+        )
+        assert result == "Admin User"
+        mock_get_app_tenant_info.assert_called_once_with("test-app")
+        mock_query_display_names.assert_called_once_with(TENANT_ID_OPERATION, "admin")
+
+    @patch("apigateway.biz.permission.permission.settings.ENABLE_MULTI_TENANT_MODE", True)
+    @patch("apigateway.biz.permission.permission.get_app_tenant_info_cached")
+    @patch("apigateway.biz.permission.permission.query_display_names_cached")
     def test_different_tenant_with_display_name_found(self, mock_query_display_names, mock_get_app_tenant_info):
         """When tenants are different and display name is found, should return the display name"""
         mock_get_app_tenant_info.return_value = ("private", "tenant-2")

--- a/src/dashboard/apigateway/apigateway/tests/biz/permission/test_permission.py
+++ b/src/dashboard/apigateway/apigateway/tests/biz/permission/test_permission.py
@@ -154,8 +154,8 @@ class TestConvertAppliedByToDisplayName:
         result = ResourcePermissionHandler.convert_applied_by_to_display_name(
             bk_app_code="test-app",
             applied_by="admin",
-            gateway_tenant_mode="global",
-            gateway_tenant_id="tenant-1",
+            gateway_tenant_mode="",
+            gateway_tenant_id="",
             force_convert=True,
         )
         assert result == "Admin User"


### PR DESCRIPTION
- 修复多租户情况下，导出 MCP 权限申请记录的申请人和授权类型与前端界面显示不一致问题