### PR TITLE
fix: propagate itsm_ticket_id in inner permission list to build ITSM approval URL

### DIFF
--- a/src/dashboard/apigateway/apigateway/apis/v2/inner/views.py
+++ b/src/dashboard/apigateway/apigateway/apis/v2/inner/views.py
@@ -710,14 +710,16 @@ class MCPServerPermissionListApi(generics.ListAPIView):
                 is_deleted=False,
             )
             .order_by("-applied_time")
-            .values("mcp_server_id", "status", "handled_by")
+            .values("mcp_server_id", "status", "handled_by", "itsm_ticket_id")
         )
 
         mcp_server_permission_handled_by: Dict[int, str] = {}
+        mcp_server_permission_itsm_ticket_id: Dict[int, str] = {}
         for obj in mcp_server_permission_apply_status:
             mcp_server_permission_handled_by[obj["mcp_server_id"]] = obj["handled_by"]
             if not mcp_server_permission_status.get(obj["mcp_server_id"]):
                 mcp_server_permission_status[obj["mcp_server_id"]] = obj["status"]
+                mcp_server_permission_itsm_ticket_id[obj["mcp_server_id"]] = obj.get("itsm_ticket_id") or ""
 
         # 3. 已有实际权限的 mcp_server，状态覆盖为 OWNED
         for mcp_server_id in granted_mcp_server_ids:
@@ -735,6 +737,7 @@ class MCPServerPermissionListApi(generics.ListAPIView):
                 obj.id, MCPServerPermissionStatusEnum.NEED_APPLY.value
             )
             handled_by = mcp_server_permission_handled_by.get(obj.id)
+            itsm_ticket_id = mcp_server_permission_itsm_ticket_id.get(obj.id, "")
 
             if permission_status in [
                 MCPServerPermissionStatusEnum.REJECTED.value,
@@ -754,6 +757,7 @@ class MCPServerPermissionListApi(generics.ListAPIView):
                         "handled_by": [handled_by] if handled_by else obj.gateway.maintainers,
                         "mcp_server_id": obj.id,
                         "gateway_id": obj.gateway_id,
+                        "itsm_ticket_id": itsm_ticket_id,
                     },
                 }
             )

--- a/src/dashboard/apigateway/apigateway/tests/apis/v2/inner/test_views.py
+++ b/src/dashboard/apigateway/apigateway/tests/apis/v2/inner/test_views.py
@@ -284,6 +284,46 @@ class TestMCPServerPermissionListApi:
             f"/gateways/{fake_gateway.id}/mcp-servers/{mcp_server.id}/permissions/" in permission_data["approval_url"]
         )
 
+    def test_list_with_itsm_approval_url(self, request_view, fake_gateway, fake_stage, settings):
+        """测试 MCP Server 权限列表在存在 itsm_ticket_id 时返回 ITSM 审批链接"""
+        settings.BK_MCP_SERVER_PERMISSION_APPROVAL_URL_TMPL = (
+            "http://dashboard.example.com/gateways/{gateway_id}/mcp-servers/{mcp_server_id}/permissions/"
+        )
+        settings.BK_ITSM4_TICKET_URL_TEMPLATE = "http://itsm.example.com/ticket/{ticket_id}"
+
+        mcp_server = G(
+            MCPServer,
+            gateway=fake_gateway,
+            stage=fake_stage,
+            name="test-mcp-server-itsm",
+            is_public=True,
+            status=MCPServerStatusEnum.ACTIVE.value,
+            protocol_type=MCPServerProtocolTypeEnum.SSE.value,
+        )
+
+        G(
+            MCPServerAppPermissionApply,
+            bk_app_code="test-app",
+            mcp_server=mcp_server,
+            status=MCPServerAppPermissionApplyStatusEnum.PENDING.value,
+            handled_by="admin",
+            itsm_ticket_id="itsm-001",
+        )
+
+        resp = request_view(
+            method="GET",
+            view_name="openapi.v2.inner.mcp_server.permission.list",
+            data={"target_app_code": "test-app"},
+            app=mock.MagicMock(app_code="test"),
+        )
+        result = resp.json()
+
+        assert resp.status_code == 200
+        assert len(result["data"]) == 1
+
+        permission_data = result["data"][0]["permission"]
+        assert permission_data["approval_url"] == "http://itsm.example.com/ticket/itsm-001"
+
     def test_list_basic_functionality(self, request_view, fake_gateway, fake_stage):
         """测试 MCP Server 基本功能"""
         mcp_server = G(


### PR DESCRIPTION
- 修复了 inner 侧 MCP 权限列表接口未透传 itsm_ticket_id 的问题。此前该字段未进入序列化链路，导致 approval_url 无法按工单生成 ITSM 链接，部分场景会回退到非 ITSM 地址。