### PR TITLE
feat: add is_official to inner mcp server permission apis

### DIFF
--- a/src/dashboard/apigateway/apigateway/apis/v2/inner/serializers.py
+++ b/src/dashboard/apigateway/apigateway/apis/v2/inner/serializers.py
@@ -25,6 +25,7 @@ from django.utils.translation import gettext as _
 from rest_framework import serializers
 
 from apigateway.apps.mcp_server.constants import (
+    OFFICIAL_MCP_CATEGORY_NAME,
     MCPServerAppPermissionApplyStatusEnum,
     MCPServerProtocolTypeEnum,
 )
@@ -400,6 +401,7 @@ class MCPServerBaseSLZ(serializers.Serializer):
     )
     url = serializers.SerializerMethodField(help_text="MCPServer 访问 URL")
     categories = serializers.SerializerMethodField(help_text="MCPServer 分类列表")
+    is_official = serializers.SerializerMethodField(help_text="是否为官方")
 
     def get_title(self, obj) -> str:
         return obj.title if obj.title else obj.name
@@ -412,6 +414,11 @@ class MCPServerBaseSLZ(serializers.Serializer):
 
     def get_categories(self, obj) -> List[Dict[str, str]]:
         return _get_categories_from_context(self.context, obj)
+
+    def get_is_official(self, obj) -> bool:
+        return any(
+            cat["name"] == OFFICIAL_MCP_CATEGORY_NAME for cat in _get_categories_from_context(self.context, obj)
+        )
 
     class Meta:
         ref_name = "apigateway.apis.v2.inner.serializers.MCPServerBaseSLZ"

--- a/src/dashboard/apigateway/apigateway/data/apidocs/zh/v2_inner_list_mcp_server_app_permissions.md
+++ b/src/dashboard/apigateway/apigateway/data/apidocs/zh/v2_inner_list_mcp_server_app_permissions.md
@@ -29,7 +29,8 @@ mcp_server 已申请权限列表
         "categories": [
           {"name": "official", "display_name": "官方"},
           {"name": "ai", "display_name": "AI"}
-        ]
+        ],
+        "is_official": true
       },
       "permission": {
         "status": "owned",
@@ -70,6 +71,7 @@ mcp_server 已申请权限列表
 | url             | string | mcp_server 访问 URL，根据最低权限级别自适应返回普通 URL 或应用态 URL |
 | doc_link        | string | mcp_server 文档访问地址 |
 | categories      | array  | mcp_server 分类列表，每项包含 name（英文标识）和 display_name（显示名称） |
+| is_official     | bool   | 是否为官方 MCPServer |
 
 #### data.permission
 

--- a/src/dashboard/apigateway/apigateway/data/apidocs/zh/v2_inner_list_mcp_server_permission_apply_records.md
+++ b/src/dashboard/apigateway/apigateway/data/apidocs/zh/v2_inner_list_mcp_server_permission_apply_records.md
@@ -34,7 +34,8 @@ mcp_server 申请记录列表
         "categories": [
           {"name": "official", "display_name": "官方"},
           {"name": "ai", "display_name": "AI"}
-        ]
+        ],
+        "is_official": true
       },
       "record": {
         "id": 1,
@@ -82,6 +83,7 @@ mcp_server 申请记录列表
 | url             | string | mcp_server 访问 URL，根据最低权限级别自适应返回普通 URL 或应用态 URL |
 | doc_link        | string | mcp_server 文档访问地址    |
 | categories      | array  | mcp_server 分类列表，每项包含 name（英文标识）和 display_name（显示名称） |
+| is_official     | bool   | 是否为官方 MCPServer |
 
 #### data.record
 

--- a/src/dashboard/apigateway/apigateway/data/apidocs/zh/v2_inner_list_mcp_server_permissions.md
+++ b/src/dashboard/apigateway/apigateway/data/apidocs/zh/v2_inner_list_mcp_server_permissions.md
@@ -30,7 +30,8 @@ mcp_server 申请权限列表
         "categories": [
           {"name": "official", "display_name": "官方"},
           {"name": "ai", "display_name": "AI"}
-        ]
+        ],
+        "is_official": true
       },
       "permission": {
         "status": "pending",
@@ -51,7 +52,8 @@ mcp_server 申请权限列表
         "protocol_type": "sse",
         "url": "https://mcp.example.com/bk-esb-prod-test2/sse",
         "doc_link": "",
-        "categories": []
+        "categories": [],
+        "is_official": false
       },
       "permission": {
         "status": "need_apply",
@@ -92,6 +94,7 @@ mcp_server 申请权限列表
 | url             | string | mcp_server 访问 URL，根据最低权限级别自适应返回普通 URL 或应用态 URL |
 | doc_link        | string | mcp_server 文档访问地址 |
 | categories      | array  | mcp_server 分类列表，每项包含 name（英文标识）和 display_name（显示名称） |
+| is_official     | bool   | 是否为官方 MCPServer |
 
 #### data.permission
 

--- a/src/dashboard/apigateway/apigateway/data/apidocs/zh/v2_inner_retrieve_mcp_server_permission_apply_record.md
+++ b/src/dashboard/apigateway/apigateway/data/apidocs/zh/v2_inner_retrieve_mcp_server_permission_apply_record.md
@@ -31,7 +31,8 @@ mcp_server 申请记录详情
       "categories": [
         {"name": "official", "display_name": "官方"},
         {"name": "ai", "display_name": "AI"}
-      ]
+      ],
+      "is_official": true
     },
     "record": {
       "id": 1,
@@ -77,6 +78,7 @@ mcp_server 申请记录详情
 | tool_names | array | MCPServer 工具名称列表 |
 | protocol_type | string | MCPServer 协议类型 |
 | categories | array | mcp_server 分类列表，每项包含 name（英文标识）和 display_name（显示名称） |
+| is_official | bool | 是否为官方 MCPServer |
 
 #### data.record
 

--- a/src/dashboard/apigateway/apigateway/tests/apis/v2/inner/test_views.py
+++ b/src/dashboard/apigateway/apigateway/tests/apis/v2/inner/test_views.py
@@ -30,13 +30,19 @@ import apigateway.apis.v2.inner.views as inner_views
 from apigateway.apps.audit.constants import OpObjectTypeEnum
 from apigateway.apps.audit.models import AuditEventLog
 from apigateway.apps.mcp_server.constants import (
+    OFFICIAL_MCP_CATEGORY_NAME,
     MCPServerAppPermissionApplyStatusEnum,
     MCPServerAppPermissionGrantTypeEnum,
     MCPServerPermissionStatusEnum,
     MCPServerProtocolTypeEnum,
     MCPServerStatusEnum,
 )
-from apigateway.apps.mcp_server.models import MCPServer, MCPServerAppPermission, MCPServerAppPermissionApply
+from apigateway.apps.mcp_server.models import (
+    MCPServer,
+    MCPServerAppPermission,
+    MCPServerAppPermissionApply,
+    MCPServerCategory,
+)
 from apigateway.apps.monitor.constants import AlarmStatusEnum, AlarmTypeEnum
 from apigateway.apps.monitor.models import AlarmRecord
 from apigateway.apps.permission.models import AppPermissionRecord
@@ -214,6 +220,34 @@ class TestMCPServerPermissionListApi:
         assert mcp_server_data["name"] == "test-mcp-server"
         assert mcp_server_data["title"] == "Test MCP Server"
         assert mcp_server_data["protocol_type"] == MCPServerProtocolTypeEnum.SSE.value
+
+    def test_list_with_is_official(self, request_view, fake_gateway, fake_stage):
+        """测试 MCP Server 权限列表包含是否官方字段"""
+        official_category, _ = MCPServerCategory.objects.update_or_create(
+            name=OFFICIAL_MCP_CATEGORY_NAME,
+            defaults={"display_name": "官方", "is_active": True},
+        )
+        mcp_server = G(
+            MCPServer,
+            gateway=fake_gateway,
+            stage=fake_stage,
+            name="test-official-mcp-server",
+            is_public=True,
+            status=MCPServerStatusEnum.ACTIVE.value,
+        )
+        mcp_server.categories.add(official_category)
+
+        resp = request_view(
+            method="GET",
+            view_name="openapi.v2.inner.mcp_server.permission.list",
+            data={"target_app_code": "test-app"},
+            app=mock.MagicMock(app_code="test"),
+        )
+        result = resp.json()
+
+        assert resp.status_code == 200
+        assert len(result["data"]) == 1
+        assert result["data"][0]["mcp_server"]["is_official"] is True
 
     def test_list_with_tool_names(self, request_view, fake_gateway, fake_stage):
         """测试 MCP Server 权限列表包含 tool_names 字段（重命名后的工具名称）"""


### PR DESCRIPTION
- 为 PaaS 侧 MCP Server 权限相关 inner 接口补充 is_official 返回字段，便于调用方直接判断 MCP Server 是否为官方服务。