### PR TITLE
fix(ai-gateway): close MCP and export kind gaps

### DIFF
--- a/src/dashboard/apigateway/apigateway/apis/v2/sync/views.py
+++ b/src/dashboard/apigateway/apigateway/apis/v2/sync/views.py
@@ -49,9 +49,9 @@ from apigateway.biz.sdk import generate_sdks_for_resource_version
 from apigateway.common.constants import CallSourceTypeEnum
 from apigateway.common.error_codes import error_codes
 from apigateway.components.bkauth import get_app_tenant_info
-from apigateway.core.constants import ReleaseHistoryStatusEnum, ReleaseStatusEnum, ResourceKindEnum
+from apigateway.core.constants import ReleaseHistoryStatusEnum, ReleaseStatusEnum
 from apigateway.core.models import JWT, Gateway, Release, Resource, ResourceVersion, Stage
-from apigateway.service.resource_version import get_resource_names_set
+from apigateway.service.resource_version import get_standard_resource_names_set
 from apigateway.utils.django import get_model_dict, get_object_or_None
 from apigateway.utils.responses import FailJsonResponse, OKJsonResponse
 
@@ -641,10 +641,7 @@ class GatewayMcpServerSyncViewSet(generics.CreateAPIView):
         resource_name_to_schema = ResourceVersionHandler().get_resource_name_to_schema_by_resource_version(
             validate_resource_version_id
         )
-        valid_resource_names = get_resource_names_set(
-            validate_resource_version_id,
-            resource_kind=ResourceKindEnum.STANDARD.value,
-        )
+        valid_resource_names = get_standard_resource_names_set(validate_resource_version_id)
         resource_name_to_schema = {
             name: schema for name, schema in resource_name_to_schema.items() if name in valid_resource_names
         }

--- a/src/dashboard/apigateway/apigateway/apis/v2/sync/views.py
+++ b/src/dashboard/apigateway/apigateway/apis/v2/sync/views.py
@@ -51,7 +51,6 @@ from apigateway.common.error_codes import error_codes
 from apigateway.components.bkauth import get_app_tenant_info
 from apigateway.core.constants import ReleaseHistoryStatusEnum, ReleaseStatusEnum
 from apigateway.core.models import JWT, Gateway, Release, Resource, ResourceVersion, Stage
-from apigateway.service.resource_version import get_standard_resource_names_set
 from apigateway.utils.django import get_model_dict, get_object_or_None
 from apigateway.utils.responses import FailJsonResponse, OKJsonResponse
 
@@ -638,13 +637,9 @@ class GatewayMcpServerSyncViewSet(generics.CreateAPIView):
             raise error_codes.NOT_FOUND.format(
                 _("该环境：{stage_name} 未发布资源版本").format(stage_name=stage_name), replace=True
             )
-        resource_name_to_schema = ResourceVersionHandler().get_resource_name_to_schema_by_resource_version(
+        resource_name_to_schema = ResourceVersionHandler().get_standard_resource_name_to_schema_by_resource_version(
             validate_resource_version_id
         )
-        valid_resource_names = get_standard_resource_names_set(validate_resource_version_id)
-        resource_name_to_schema = {
-            name: schema for name, schema in resource_name_to_schema.items() if name in valid_resource_names
-        }
 
         context = {
             "gateway": request.gateway,

--- a/src/dashboard/apigateway/apigateway/apis/v2/sync/views.py
+++ b/src/dashboard/apigateway/apigateway/apis/v2/sync/views.py
@@ -49,8 +49,9 @@ from apigateway.biz.sdk import generate_sdks_for_resource_version
 from apigateway.common.constants import CallSourceTypeEnum
 from apigateway.common.error_codes import error_codes
 from apigateway.components.bkauth import get_app_tenant_info
-from apigateway.core.constants import ReleaseHistoryStatusEnum, ReleaseStatusEnum
+from apigateway.core.constants import ReleaseHistoryStatusEnum, ReleaseStatusEnum, ResourceKindEnum
 from apigateway.core.models import JWT, Gateway, Release, Resource, ResourceVersion, Stage
+from apigateway.service.resource_version import get_resource_names_set
 from apigateway.utils.django import get_model_dict, get_object_or_None
 from apigateway.utils.responses import FailJsonResponse, OKJsonResponse
 
@@ -640,6 +641,13 @@ class GatewayMcpServerSyncViewSet(generics.CreateAPIView):
         resource_name_to_schema = ResourceVersionHandler().get_resource_name_to_schema_by_resource_version(
             validate_resource_version_id
         )
+        valid_resource_names = get_resource_names_set(
+            validate_resource_version_id,
+            resource_kind=ResourceKindEnum.STANDARD.value,
+        )
+        resource_name_to_schema = {
+            name: schema for name, schema in resource_name_to_schema.items() if name in valid_resource_names
+        }
 
         context = {
             "gateway": request.gateway,

--- a/src/dashboard/apigateway/apigateway/apis/web/mcp_server/views.py
+++ b/src/dashboard/apigateway/apigateway/apis/web/mcp_server/views.py
@@ -53,9 +53,8 @@ from apigateway.common.constants import CallSourceTypeEnum
 from apigateway.common.error_codes import error_codes
 from apigateway.common.tenant.request import get_user_tenant_id
 from apigateway.common.tenant.user_credentials import get_user_credentials_from_request
-from apigateway.core.constants import ResourceKindEnum
 from apigateway.core.models import Stage
-from apigateway.service.resource_version import get_resource_names_set
+from apigateway.service.resource_version import get_standard_resource_names_set
 from apigateway.utils.django import get_model_dict
 from apigateway.utils.responses import DownloadableResponse, OKJsonResponse
 from apigateway.utils.time import now_datetime
@@ -687,11 +686,7 @@ class MCPServerStageReleaseCheckApi(generics.RetrieveAPIView):
             return OKJsonResponse(data=data)
 
         changed_mcp_servers = []
-        valid_resource_names = get_resource_names_set(
-            resource_version_id,
-            raise_exception=True,
-            resource_kind=ResourceKindEnum.STANDARD.value,
-        )
+        valid_resource_names = get_standard_resource_names_set(resource_version_id, raise_exception=True)
         for mcp_server in mcp_servers:
             mcp_server_resource_names = set(mcp_server.resource_names)
             changed_resource_names = mcp_server_resource_names - valid_resource_names

--- a/src/dashboard/apigateway/apigateway/apis/web/mcp_server/views.py
+++ b/src/dashboard/apigateway/apigateway/apis/web/mcp_server/views.py
@@ -53,6 +53,7 @@ from apigateway.common.constants import CallSourceTypeEnum
 from apigateway.common.error_codes import error_codes
 from apigateway.common.tenant.request import get_user_tenant_id
 from apigateway.common.tenant.user_credentials import get_user_credentials_from_request
+from apigateway.core.constants import ResourceKindEnum
 from apigateway.core.models import Stage
 from apigateway.service.resource_version import get_resource_names_set
 from apigateway.utils.django import get_model_dict
@@ -686,7 +687,11 @@ class MCPServerStageReleaseCheckApi(generics.RetrieveAPIView):
             return OKJsonResponse(data=data)
 
         changed_mcp_servers = []
-        valid_resource_names = get_resource_names_set(resource_version_id, raise_exception=True)
+        valid_resource_names = get_resource_names_set(
+            resource_version_id,
+            raise_exception=True,
+            resource_kind=ResourceKindEnum.STANDARD.value,
+        )
         for mcp_server in mcp_servers:
             mcp_server_resource_names = set(mcp_server.resource_names)
             changed_resource_names = mcp_server_resource_names - valid_resource_names

--- a/src/dashboard/apigateway/apigateway/apis/web/resource/serializers.py
+++ b/src/dashboard/apigateway/apigateway/apis/web/resource/serializers.py
@@ -857,6 +857,7 @@ class ResourceExportInputSLZ(serializers.Serializer):
 
 class ResourceExportOutputSLZ(serializers.Serializer):
     name = serializers.CharField(help_text="资源名称")
+    kind = serializers.CharField(help_text="资源类型")
     description = serializers.CharField(help_text="资源描述")
     description_en = serializers.CharField(help_text="资源英文描述")
     method = serializers.CharField(help_text="请求方法")

--- a/src/dashboard/apigateway/apigateway/biz/mcp_server/mcp_server.py
+++ b/src/dashboard/apigateway/apigateway/biz/mcp_server/mcp_server.py
@@ -58,14 +58,14 @@ from apigateway.biz.resource_doc import ResourceDocHandler
 from apigateway.common.django.translation import get_current_language_code
 from apigateway.common.error_codes import error_codes
 from apigateway.components import bkaidev
-from apigateway.core.constants import GatewayStatusEnum, ResourceKindEnum, StageStatusEnum
+from apigateway.core.constants import GatewayStatusEnum, StageStatusEnum
 from apigateway.core.models import Gateway, Release, Resource, Stage
 from apigateway.service.mcp import build_mcp_server_application_url, build_mcp_server_url, validate_mcp_prompts_payload
 from apigateway.service.resource import get_resource_id_to_labels_by_label_ids
 from apigateway.service.resource_version import (
     get_resource_id_to_schema_by_resource_version,
-    get_resource_names_set,
     get_resource_schema,
+    get_standard_resource_names_set,
 )
 from apigateway.utils.django import get_model_dict
 from apigateway.utils.time import NeverExpiresTime
@@ -103,11 +103,10 @@ class MCPServerHandler:
         """
         tool_resource_names = set(resource_names)
 
-        stage_released_resources = ReleasedResourceHandler.get_public_released_resource_data_list(
+        stage_released_resources = ReleasedResourceHandler.get_public_standard_released_resource_data_list(
             gateway_id,
             stage_name,
             False,
-            resource_kind=ResourceKindEnum.STANDARD.value,
         )
 
         # only need the resources in the resource_names
@@ -131,10 +130,7 @@ class MCPServerHandler:
             raise error_codes.FAILED_PRECONDITION.format(
                 _("环境已下架或者未发布，请先发布资源到该环境，再更新 MCPServer。"), replace=True
             )
-        return get_resource_names_set(
-            release.resource_version.id,
-            resource_kind=ResourceKindEnum.STANDARD.value,
-        )
+        return get_standard_resource_names_set(release.resource_version.id)
 
     @staticmethod
     def get_tool_doc(gateway_id: int, stage_name: str, tool_name: str) -> Dict:
@@ -382,10 +378,7 @@ class MCPServerHandler:
             return
         release = Release.objects.filter(gateway_id=mcp_server.gateway_id, stage_id=mcp_server.stage_id).first()
         if release:
-            valid_resource_names = get_resource_names_set(
-                release.resource_version.id,
-                resource_kind=ResourceKindEnum.STANDARD.value,
-            )
+            valid_resource_names = get_standard_resource_names_set(release.resource_version.id)
             resource_names = [name for name in resource_names if name in valid_resource_names]
         resource_ids = Resource.objects.filter(gateway_id=mcp_server.gateway_id, name__in=resource_names).values_list(
             "id", flat=True

--- a/src/dashboard/apigateway/apigateway/biz/mcp_server/mcp_server.py
+++ b/src/dashboard/apigateway/apigateway/biz/mcp_server/mcp_server.py
@@ -58,7 +58,7 @@ from apigateway.biz.resource_doc import ResourceDocHandler
 from apigateway.common.django.translation import get_current_language_code
 from apigateway.common.error_codes import error_codes
 from apigateway.components import bkaidev
-from apigateway.core.constants import GatewayStatusEnum, StageStatusEnum
+from apigateway.core.constants import GatewayStatusEnum, ResourceKindEnum, StageStatusEnum
 from apigateway.core.models import Gateway, Release, Resource, Stage
 from apigateway.service.mcp import build_mcp_server_application_url, build_mcp_server_url, validate_mcp_prompts_payload
 from apigateway.service.resource import get_resource_id_to_labels_by_label_ids
@@ -107,6 +107,7 @@ class MCPServerHandler:
             gateway_id,
             stage_name,
             False,
+            resource_kind=ResourceKindEnum.STANDARD.value,
         )
 
         # only need the resources in the resource_names
@@ -130,7 +131,10 @@ class MCPServerHandler:
             raise error_codes.FAILED_PRECONDITION.format(
                 _("环境已下架或者未发布，请先发布资源到该环境，再更新 MCPServer。"), replace=True
             )
-        return get_resource_names_set(release.resource_version.id)
+        return get_resource_names_set(
+            release.resource_version.id,
+            resource_kind=ResourceKindEnum.STANDARD.value,
+        )
 
     @staticmethod
     def get_tool_doc(gateway_id: int, stage_name: str, tool_name: str) -> Dict:
@@ -202,6 +206,17 @@ class MCPServerHandler:
         Returns:
             操作结果列表，每项包含 name, action, id
         """
+        valid_resource_names = MCPServerHandler.get_valid_resource_names(gateway_id, stage_id)
+        for mcp_data in mcp_servers_data:
+            invalid_resource_names = set(mcp_data.get("resource_names", [])) - valid_resource_names
+            if invalid_resource_names:
+                invalid_resource_name = sorted(invalid_resource_names)[0]
+                raise error_codes.INVALID_ARGUMENT.format(
+                    _("资源名称列表非法，请检查当前环境发布的最新版本中对应资源名称是否存在")
+                    + f"resource_name={invalid_resource_name}",
+                    replace=True,
+                )
+
         mcp_servers_data_for_audit = copy.deepcopy(mcp_servers_data)
         permission_data_before_map: Dict[str, Dict[str, Dict[str, Any]]] = {}
         data_before_map = get_mcp_server_sync_data_before_map(
@@ -365,6 +380,13 @@ class MCPServerHandler:
         if not resource_names:
             logger.debug("no resource_names, skip sync the permissions of the mcp_server %d", mcp_server_id)
             return
+        release = Release.objects.filter(gateway_id=mcp_server.gateway_id, stage_id=mcp_server.stage_id).first()
+        if release:
+            valid_resource_names = get_resource_names_set(
+                release.resource_version.id,
+                resource_kind=ResourceKindEnum.STANDARD.value,
+            )
+            resource_names = [name for name in resource_names if name in valid_resource_names]
         resource_ids = Resource.objects.filter(gateway_id=mcp_server.gateway_id, name__in=resource_names).values_list(
             "id", flat=True
         )

--- a/src/dashboard/apigateway/apigateway/biz/released_resource/released_resource.py
+++ b/src/dashboard/apigateway/apigateway/biz/released_resource/released_resource.py
@@ -19,7 +19,7 @@ import json
 from dataclasses import dataclass, field
 from typing import Any, Dict, List, Optional
 
-from apigateway.core.constants import StageStatusEnum
+from apigateway.core.constants import ResourceKindEnum, StageStatusEnum
 from apigateway.core.models import Gateway, Release, ReleasedResource, Stage
 from apigateway.core.utils import get_path_display
 from apigateway.service.utils import get_resource_doc_link
@@ -163,7 +163,10 @@ class ReleasedResourceHandler:
 
     @staticmethod
     def get_public_released_resource_data_list(
-        gateway_id: int, stage_name: str, is_only_public: Optional[bool] = True
+        gateway_id: int,
+        stage_name: str,
+        is_only_public: Optional[bool] = True,
+        resource_kind: Optional[str] = None,
     ) -> List[ReleasedResourceData]:
         """获取网关环境下，已发布的资源数据"""
         release = (
@@ -174,7 +177,11 @@ class ReleasedResourceHandler:
         if not release:
             return []
 
-        resources = [ReleasedResourceData.from_data(resource) for resource in release.resource_version.data]
+        resources = [
+            ReleasedResourceData.from_data(resource)
+            for resource in release.resource_version.data
+            if resource_kind is None or resource.get("kind", ResourceKindEnum.STANDARD.value) == resource_kind
+        ]
         if is_only_public:
             return list(filter(lambda resource: resource.is_public, resources))
         return resources

--- a/src/dashboard/apigateway/apigateway/biz/released_resource/released_resource.py
+++ b/src/dashboard/apigateway/apigateway/biz/released_resource/released_resource.py
@@ -63,7 +63,7 @@ class ReleasedResourceData:
             match_subpath=released_resource_data.get("match_subpath", False),
             enable_websocket=released_resource_data.get("enable_websocket", False),
             is_public=released_resource_data["is_public"],
-            kind=released_resource_data.get("kind", ResourceKindEnum.STANDARD.value),
+            kind=released_resource_data.get("kind") or ResourceKindEnum.STANDARD.value,
             allow_apply_permission=released_resource_data.get("allow_apply_permission", True),
             disabled_stages=released_resource_data.get("disabled_stages") or [],
             contexts=released_resource_data["contexts"],

--- a/src/dashboard/apigateway/apigateway/biz/released_resource/released_resource.py
+++ b/src/dashboard/apigateway/apigateway/biz/released_resource/released_resource.py
@@ -36,6 +36,7 @@ class ReleasedResourceData:
     match_subpath: bool = field(default=False)
     enable_websocket: bool = field(default=False)
     is_public: bool = field(default=False)
+    kind: str = field(default=ResourceKindEnum.STANDARD.value)
     allow_apply_permission: bool = field(default=False)
     disabled_stages: List[str] = field(default_factory=list)
     contexts: Dict[str, Any] = field(default_factory=dict)
@@ -62,6 +63,7 @@ class ReleasedResourceData:
             match_subpath=released_resource_data.get("match_subpath", False),
             enable_websocket=released_resource_data.get("enable_websocket", False),
             is_public=released_resource_data["is_public"],
+            kind=released_resource_data.get("kind", ResourceKindEnum.STANDARD.value),
             allow_apply_permission=released_resource_data.get("allow_apply_permission", True),
             disabled_stages=released_resource_data.get("disabled_stages") or [],
             contexts=released_resource_data["contexts"],
@@ -163,10 +165,7 @@ class ReleasedResourceHandler:
 
     @staticmethod
     def get_public_released_resource_data_list(
-        gateway_id: int,
-        stage_name: str,
-        is_only_public: Optional[bool] = True,
-        resource_kind: Optional[str] = None,
+        gateway_id: int, stage_name: str, is_only_public: Optional[bool] = True
     ) -> List[ReleasedResourceData]:
         """获取网关环境下，已发布的资源数据"""
         release = (
@@ -177,14 +176,22 @@ class ReleasedResourceHandler:
         if not release:
             return []
 
-        resources = [
-            ReleasedResourceData.from_data(resource)
-            for resource in release.resource_version.data
-            if resource_kind is None or resource.get("kind", ResourceKindEnum.STANDARD.value) == resource_kind
-        ]
+        resources = [ReleasedResourceData.from_data(resource) for resource in release.resource_version.data]
         if is_only_public:
             return list(filter(lambda resource: resource.is_public, resources))
         return resources
+
+    @staticmethod
+    def get_public_standard_released_resource_data_list(
+        gateway_id: int, stage_name: str, is_only_public: Optional[bool] = True
+    ) -> List[ReleasedResourceData]:
+        """获取网关环境下，已发布的普通资源数据"""
+        resources = ReleasedResourceHandler.get_public_released_resource_data_list(
+            gateway_id,
+            stage_name,
+            is_only_public,
+        )
+        return [resource for resource in resources if resource.kind == ResourceKindEnum.STANDARD.value]
 
     @staticmethod
     def get_released_resource(gateway_id: int, stage_name: str, resource_name: str) -> Optional[ReleasedResource]:

--- a/src/dashboard/apigateway/apigateway/biz/resource_version/resource_version.py
+++ b/src/dashboard/apigateway/apigateway/biz/resource_version/resource_version.py
@@ -31,7 +31,7 @@ from apigateway.apps.plugin.models import PluginBinding
 from apigateway.apps.support.models import GatewaySDK, ReleasedResourceDoc
 from apigateway.biz.audit import Auditor
 from apigateway.biz.context import ContextHandler
-from apigateway.core.constants import ContextScopeTypeEnum, ResourceVersionSchemaEnum
+from apigateway.core.constants import ContextScopeTypeEnum, ResourceKindEnum, ResourceVersionSchemaEnum
 from apigateway.core.models import Gateway, Release, ReleasedResource, Resource, ResourceVersion, Stage
 from apigateway.service.resource import (
     filter_disabled_stages_by_gateway,
@@ -233,9 +233,9 @@ class ResourceVersionHandler:
         return ResourceVersion.objects.filter(gateway_id=gateway_id).values_list("created_time", flat=True).last()
 
     @staticmethod
-    def get_resource_name_to_schema_by_resource_version(resource_version_id: int) -> dict:
+    def get_standard_resource_name_to_schema_by_resource_version(resource_version_id: int) -> dict:
         """
-        获取资源版本下的资源name 与 api schema 的映射关系
+        获取资源版本下的普通资源 name 与 api schema 的映射关系
         """
         resources_version_schema = OpenAPIResourceSchemaVersion.objects.filter(
             resource_version_id=resource_version_id
@@ -243,12 +243,15 @@ class ResourceVersionHandler:
         if resources_version_schema is None:
             return {}
         resource_id_to_name = {
-            resource["id"]: resource["name"] for resource in resources_version_schema.resource_version.data
+            resource["id"]: resource["name"]
+            for resource in resources_version_schema.resource_version.data
+            if (resource.get("kind") or ResourceKindEnum.STANDARD.value) == ResourceKindEnum.STANDARD.value
         }
 
         return {
             resource_id_to_name[schema_info["resource_id"]]: schema_info["schema"]
             for schema_info in resources_version_schema.schema
+            if schema_info["resource_id"] in resource_id_to_name
         }
 
     @staticmethod

--- a/src/dashboard/apigateway/apigateway/service/mcp/mcp_server.py
+++ b/src/dashboard/apigateway/apigateway/service/mcp/mcp_server.py
@@ -22,9 +22,8 @@ from django.conf import settings
 
 from apigateway.apps.mcp_server.constants import MCPServerProtocolTypeEnum
 from apigateway.apps.mcp_server.models import MCPServer
-from apigateway.core.constants import ResourceKindEnum
 from apigateway.service.bk_itsm import ItsmPermissionApplyHelper
-from apigateway.service.resource_version import get_resource_names_set
+from apigateway.service.resource_version import get_standard_resource_names_set
 
 
 def update_stage_mcp_server_related_resource_names(
@@ -43,10 +42,7 @@ def update_stage_mcp_server_related_resource_names(
     if not mcp_servers:
         return
 
-    resource_version_resource_names = get_resource_names_set(
-        resource_version_id,
-        resource_kind=ResourceKindEnum.STANDARD.value,
-    )
+    resource_version_resource_names = get_standard_resource_names_set(resource_version_id)
 
     to_update: List[MCPServer] = []
     for mcp_server in mcp_servers:

--- a/src/dashboard/apigateway/apigateway/service/mcp/mcp_server.py
+++ b/src/dashboard/apigateway/apigateway/service/mcp/mcp_server.py
@@ -22,8 +22,9 @@ from django.conf import settings
 
 from apigateway.apps.mcp_server.constants import MCPServerProtocolTypeEnum
 from apigateway.apps.mcp_server.models import MCPServer
-from apigateway.core.models import ResourceVersion
+from apigateway.core.constants import ResourceKindEnum
 from apigateway.service.bk_itsm import ItsmPermissionApplyHelper
+from apigateway.service.resource_version import get_resource_names_set
 
 
 def update_stage_mcp_server_related_resource_names(
@@ -42,12 +43,10 @@ def update_stage_mcp_server_related_resource_names(
     if not mcp_servers:
         return
 
-    # get the resource names of the resource version
-    resource_version = ResourceVersion.objects.filter(id=resource_version_id).first()
-    if not resource_version:
-        resource_version_resource_names = set()
-    else:
-        resource_version_resource_names = {resource["name"] for resource in resource_version.data}
+    resource_version_resource_names = get_resource_names_set(
+        resource_version_id,
+        resource_kind=ResourceKindEnum.STANDARD.value,
+    )
 
     to_update: List[MCPServer] = []
     for mcp_server in mcp_servers:

--- a/src/dashboard/apigateway/apigateway/service/resource_version/__init__.py
+++ b/src/dashboard/apigateway/apigateway/service/resource_version/__init__.py
@@ -20,6 +20,7 @@ from .schema import (
     get_resource_id_to_schema_by_resource_version,
     get_resource_names_set,
     get_resource_schema,
+    get_standard_resource_names_set,
     get_used_stage_vars,
     make_resource_schema_version,
 )
@@ -34,6 +35,7 @@ __all__ = [
     "get_resource_id_to_schema_by_resource_version",
     "get_resource_names_set",
     "get_resource_schema",
+    "get_standard_resource_names_set",
     "get_used_stage_vars",
     "has_openapi_schema",
     "make_resource_schema_version",

--- a/src/dashboard/apigateway/apigateway/service/resource_version/schema.py
+++ b/src/dashboard/apigateway/apigateway/service/resource_version/schema.py
@@ -18,7 +18,7 @@
 
 """Resource-version schema lookup and schema-version creation helpers."""
 
-from typing import Optional, Set
+from typing import Set
 
 from cachetools import TTLCache, cached
 from django.utils.translation import gettext_lazy as _
@@ -81,7 +81,6 @@ def get_resource_id_to_schema_by_resource_version(resource_version_id: int) -> d
 def get_resource_names_set(
     resource_version_id: int,
     raise_exception: bool = False,
-    resource_kind: Optional[str] = None,
 ) -> Set[str]:
     """获取资源版本中的资源名称集合，用于权限、MCP Server 等名称存在性判断。
 
@@ -90,10 +89,28 @@ def get_resource_names_set(
     Args:
         resource_version_id (int): 资源版本 ID。
         raise_exception (bool): 资源版本不存在时是否抛出 NOT_FOUND；为 False 时返回空集合。
-        resource_kind (str | None): 仅返回指定 kind 的资源；旧快照缺少 kind 时按 standard 处理。
-
     Returns:
         Set[str]: 资源名称集合；资源版本不存在且不抛异常时返回空集合。
+    """
+    resource_version = ResourceVersion.objects.filter(id=resource_version_id).first()
+    if not resource_version:
+        if raise_exception:
+            raise error_codes.NOT_FOUND.format(_("资源版本不存在"))
+        return set()
+
+    return {resource["name"] for resource in resource_version.data}
+
+
+@cached(cache=TTLCache(maxsize=300, ttl=CACHE_TIME_5_MINUTES))
+def get_standard_resource_names_set(resource_version_id: int, raise_exception: bool = False) -> Set[str]:
+    """获取资源版本中的普通资源名称集合，用于 MCP Server 等仅接受普通资源的场景。
+
+    Args:
+        resource_version_id (int): 资源版本 ID。
+        raise_exception (bool): 资源版本不存在时是否抛出 NOT_FOUND；为 False 时返回空集合。
+
+    Returns:
+        Set[str]: 普通资源名称集合；旧快照缺少 kind 时按 standard 处理。
     """
     resource_version = ResourceVersion.objects.filter(id=resource_version_id).first()
     if not resource_version:
@@ -104,7 +121,7 @@ def get_resource_names_set(
     return {
         resource["name"]
         for resource in resource_version.data
-        if resource_kind is None or resource.get("kind", ResourceKindEnum.STANDARD.value) == resource_kind
+        if resource.get("kind", ResourceKindEnum.STANDARD.value) == ResourceKindEnum.STANDARD.value
     }
 
 

--- a/src/dashboard/apigateway/apigateway/service/resource_version/schema.py
+++ b/src/dashboard/apigateway/apigateway/service/resource_version/schema.py
@@ -110,7 +110,7 @@ def get_standard_resource_names_set(resource_version_id: int, raise_exception: b
         raise_exception (bool): 资源版本不存在时是否抛出 NOT_FOUND；为 False 时返回空集合。
 
     Returns:
-        Set[str]: 普通资源名称集合；旧快照缺少 kind 时按 standard 处理。
+        Set[str]: 普通资源名称集合；旧快照缺少或未设置 kind 时按 standard 处理。
     """
     resource_version = ResourceVersion.objects.filter(id=resource_version_id).first()
     if not resource_version:
@@ -121,7 +121,7 @@ def get_standard_resource_names_set(resource_version_id: int, raise_exception: b
     return {
         resource["name"]
         for resource in resource_version.data
-        if resource.get("kind", ResourceKindEnum.STANDARD.value) == ResourceKindEnum.STANDARD.value
+        if (resource.get("kind") or ResourceKindEnum.STANDARD.value) == ResourceKindEnum.STANDARD.value
     }
 
 

--- a/src/dashboard/apigateway/apigateway/service/resource_version/schema.py
+++ b/src/dashboard/apigateway/apigateway/service/resource_version/schema.py
@@ -18,7 +18,7 @@
 
 """Resource-version schema lookup and schema-version creation helpers."""
 
-from typing import Set
+from typing import Optional, Set
 
 from cachetools import TTLCache, cached
 from django.utils.translation import gettext_lazy as _
@@ -78,7 +78,11 @@ def get_resource_id_to_schema_by_resource_version(resource_version_id: int) -> d
 
 
 @cached(cache=TTLCache(maxsize=300, ttl=CACHE_TIME_5_MINUTES))
-def get_resource_names_set(resource_version_id: int, raise_exception: bool = False) -> Set[str]:
+def get_resource_names_set(
+    resource_version_id: int,
+    raise_exception: bool = False,
+    resource_kind: Optional[str] = None,
+) -> Set[str]:
     """获取资源版本中的资源名称集合，用于权限、MCP Server 等名称存在性判断。
 
     频繁读取同一资源版本名称集合的路径使用；结果会缓存 5 分钟。
@@ -86,6 +90,7 @@ def get_resource_names_set(resource_version_id: int, raise_exception: bool = Fal
     Args:
         resource_version_id (int): 资源版本 ID。
         raise_exception (bool): 资源版本不存在时是否抛出 NOT_FOUND；为 False 时返回空集合。
+        resource_kind (str | None): 仅返回指定 kind 的资源；旧快照缺少 kind 时按 standard 处理。
 
     Returns:
         Set[str]: 资源名称集合；资源版本不存在且不抛异常时返回空集合。
@@ -96,7 +101,11 @@ def get_resource_names_set(resource_version_id: int, raise_exception: bool = Fal
             raise error_codes.NOT_FOUND.format(_("资源版本不存在"))
         return set()
 
-    return {resource["name"] for resource in resource_version.data}
+    return {
+        resource["name"]
+        for resource in resource_version.data
+        if resource_kind is None or resource.get("kind", ResourceKindEnum.STANDARD.value) == resource_kind
+    }
 
 
 # TODO: 缓存优化：可使用 django cache(with database backend) or dogpile 缓存

--- a/src/dashboard/apigateway/apigateway/tests/apis/v2/sync/test_views.py
+++ b/src/dashboard/apigateway/apigateway/tests/apis/v2/sync/test_views.py
@@ -42,8 +42,15 @@ from apigateway.core.models import (
     Stage,
 )
 from apigateway.service.gateway_jwt import GatewayJWTHandler
-from apigateway.service.resource_version import make_resource_schema_version
+from apigateway.service.resource_version import get_resource_names_set, make_resource_schema_version
 from apigateway.utils.yaml import yaml_loads
+
+
+@pytest.fixture(autouse=True)
+def clear_resource_names_cache():
+    get_resource_names_set.cache_clear()
+    yield
+    get_resource_names_set.cache_clear()
 
 
 @pytest.fixture()
@@ -774,6 +781,42 @@ class TestSyncApi:
         assert permission_audit_logs.count() == 2
         assert set(permission_audit_logs.values_list("op_object", flat=True)) == {"app1", "app2"}
         assert set(permission_audit_logs.values_list("op_type", flat=True)) == {OpTypeEnum.CREATE.value}
+
+    def test_mcp_server_sync_rejects_ai_resource_from_release_snapshot(
+        self,
+        request_view,
+        fake_gateway,
+        fake_stage,
+        fake_resource,
+        fake_resource_schema_with_body,
+        fake_release_v2,
+        disable_app_permission,
+    ):
+        resources = fake_release_v2.resource_version.data
+        resources[0]["kind"] = ResourceKindEnum.AI.value
+        fake_release_v2.resource_version.data = resources
+        fake_release_v2.resource_version.save()
+        make_resource_schema_version(fake_release_v2.resource_version)
+
+        resp = request_view(
+            method="POST",
+            gateway=fake_gateway,
+            view_name="openapi.v2.sync.gateway.stages.mcp_servers.sync",
+            path_params={"gateway_name": fake_gateway.name, "stage_name": fake_stage.name},
+            data={
+                "mcp_servers": [
+                    {
+                        "name": "ai-resource-server",
+                        "resource_names": [fake_resource.name],
+                        "is_public": True,
+                        "description": "AI resource must not become an MCP tool",
+                    }
+                ]
+            },
+        )
+
+        assert resp.status_code == 400
+        assert not MCPServer.objects.filter(gateway=fake_gateway, stage=fake_stage).exists()
 
     def test_mcp_server_sync_with_update(
         self,

--- a/src/dashboard/apigateway/apigateway/tests/apis/v2/sync/test_views.py
+++ b/src/dashboard/apigateway/apigateway/tests/apis/v2/sync/test_views.py
@@ -42,15 +42,15 @@ from apigateway.core.models import (
     Stage,
 )
 from apigateway.service.gateway_jwt import GatewayJWTHandler
-from apigateway.service.resource_version import get_resource_names_set, make_resource_schema_version
+from apigateway.service.resource_version import get_standard_resource_names_set, make_resource_schema_version
 from apigateway.utils.yaml import yaml_loads
 
 
 @pytest.fixture(autouse=True)
 def clear_resource_names_cache():
-    get_resource_names_set.cache_clear()
+    get_standard_resource_names_set.cache_clear()
     yield
-    get_resource_names_set.cache_clear()
+    get_standard_resource_names_set.cache_clear()
 
 
 @pytest.fixture()

--- a/src/dashboard/apigateway/apigateway/tests/apis/v2/sync/test_views.py
+++ b/src/dashboard/apigateway/apigateway/tests/apis/v2/sync/test_views.py
@@ -42,15 +42,8 @@ from apigateway.core.models import (
     Stage,
 )
 from apigateway.service.gateway_jwt import GatewayJWTHandler
-from apigateway.service.resource_version import get_standard_resource_names_set, make_resource_schema_version
+from apigateway.service.resource_version import make_resource_schema_version
 from apigateway.utils.yaml import yaml_loads
-
-
-@pytest.fixture(autouse=True)
-def clear_resource_names_cache():
-    get_standard_resource_names_set.cache_clear()
-    yield
-    get_standard_resource_names_set.cache_clear()
 
 
 @pytest.fixture()

--- a/src/dashboard/apigateway/apigateway/tests/apis/web/mcp_server/test_views.py
+++ b/src/dashboard/apigateway/apigateway/tests/apis/web/mcp_server/test_views.py
@@ -1193,7 +1193,7 @@ class TestMCPServerStageReleaseCheckApi:
 
     def test_check_with_mcp_servers(self, mocker, request_view, fake_gateway, fake_mcp_server):
         mocker.patch(
-            "apigateway.apis.web.mcp_server.views.get_resource_names_set",
+            "apigateway.apis.web.mcp_server.views.get_standard_resource_names_set",
             return_value={"resource1"},
         )
 
@@ -1871,7 +1871,7 @@ class TestMCPServerStageReleaseCheckApiNoChanges:
 
     def test_check_no_changes(self, mocker, request_view, fake_gateway, fake_mcp_server):
         mocker.patch(
-            "apigateway.apis.web.mcp_server.views.get_resource_names_set",
+            "apigateway.apis.web.mcp_server.views.get_standard_resource_names_set",
             return_value={"resource1", "resource2"},  # 包含所有 mcp_server 的资源
         )
 

--- a/src/dashboard/apigateway/apigateway/tests/apis/web/resource/test_serializers.py
+++ b/src/dashboard/apigateway/apigateway/tests/apis/web/resource/test_serializers.py
@@ -31,6 +31,7 @@ from apigateway.apis.web.resource.serializers import (
     ResourceInputSLZ,
     ResourceListOutputSLZ,
 )
+from apigateway.core.constants import ResourceKindEnum
 from apigateway.core.models import (
     Backend,
     Proxy,
@@ -255,6 +256,8 @@ class TestResourceDataImportSLZ:
 
 class TestResourceExportOutputSLZ:
     def test_to_representation(self, fake_resource, echo_plugin_resource_binding):
+        fake_resource.kind = ResourceKindEnum.AI.value
+        fake_resource.save()
         proxies = {proxy.resource_id: proxy for proxy in Proxy.objects.filter(resource__in=[fake_resource])}
         backends = {backend.id: backend for backend in Backend.objects.filter(gateway=fake_resource.gateway)}
 
@@ -271,6 +274,7 @@ class TestResourceExportOutputSLZ:
             },
         )
         assert len(slz.data) == 1
+        assert slz.data[0]["kind"] == ResourceKindEnum.AI.value
 
 
 class TestBackendPathCheckInputSLZ:

--- a/src/dashboard/apigateway/apigateway/tests/biz/mcp_server/test_mcp_server.py
+++ b/src/dashboard/apigateway/apigateway/tests/biz/mcp_server/test_mcp_server.py
@@ -39,8 +39,10 @@ from apigateway.apps.mcp_server.models import (
 from apigateway.apps.permission.constants import GrantTypeEnum
 from apigateway.apps.permission.models import AppResourcePermission
 from apigateway.biz.mcp_server import MCPServerHandler
-from apigateway.core.constants import GatewayStatusEnum, StageStatusEnum
+from apigateway.common.error_codes import APIError
+from apigateway.core.constants import GatewayStatusEnum, ResourceKindEnum, StageStatusEnum
 from apigateway.core.models import Gateway, Release, Resource, ResourceVersion, Stage
+from apigateway.service.resource_version import get_resource_names_set
 from apigateway.tests.utils.testing import create_gateway
 from apigateway.utils.time import NeverExpiresTime, now_datetime
 
@@ -48,7 +50,10 @@ from apigateway.utils.time import NeverExpiresTime, now_datetime
 class TestMCPServerHandler:
     @pytest.fixture(autouse=True)
     def setup_fixtures(self):
+        get_resource_names_set.cache_clear()
         self.gateway = create_gateway()
+        yield
+        get_resource_names_set.cache_clear()
 
     def test_virtual_app_code_prefix(self):
         assert MCPServerHandler._virtual_app_code_prefix(1) == "v_mcp_1_"
@@ -223,6 +228,39 @@ class TestMCPServerHandler:
             assert permission.expires == NeverExpiresTime.time
             assert permission.grant_type == GrantTypeEnum.SYNC.value
 
+    def test_sync_permissions_excludes_ai_resources_from_release_snapshot(self, fake_gateway, fake_stage):
+        standard_resource = G(
+            Resource,
+            gateway=fake_gateway,
+            name="standard-resource",
+            kind=ResourceKindEnum.STANDARD.value,
+        )
+        ai_resource = G(
+            Resource,
+            gateway=fake_gateway,
+            name="ai-resource",
+            kind=ResourceKindEnum.AI.value,
+        )
+        resource_version = G(ResourceVersion, gateway=fake_gateway)
+        resource_version.data = [
+            {"id": standard_resource.id, "name": standard_resource.name, "kind": ResourceKindEnum.STANDARD.value},
+            {"id": ai_resource.id, "name": ai_resource.name, "kind": ResourceKindEnum.AI.value},
+        ]
+        resource_version.save()
+        G(Release, gateway=fake_gateway, stage=fake_stage, resource_version=resource_version)
+        mcp_server = G(
+            MCPServer,
+            gateway=fake_gateway,
+            stage=fake_stage,
+            _resource_names="standard-resource;ai-resource",
+        )
+        G(MCPServerAppPermission, mcp_server=mcp_server, bk_app_code="app1")
+
+        MCPServerHandler.sync_permissions(mcp_server.id)
+
+        permissions = AppResourcePermission.objects.filter(bk_app_code__startswith=f"v_mcp_{mcp_server.id}_")
+        assert set(permissions.values_list("resource_id", flat=True)) == {standard_resource.id}
+
     def test_sync_permissions_delete_permissions(self, fake_gateway, fake_stage):
         """Test sync_permissions when existing permissions need to be deleted"""
         # Create resources
@@ -313,12 +351,31 @@ class TestMCPServerHandler:
         assert permissions.filter(bk_app_code=f"v_mcp_{mcp_server.id}_app2").count() == 2
 
     def test_get_valid_resource_names(self, fake_gateway, fake_stage, fake_resource_version):
+        fake_resource_version.data = [
+            {"name": "legacy-resource"},
+            {"name": "standard-resource", "kind": ResourceKindEnum.STANDARD.value},
+            {"name": "ai-resource", "kind": ResourceKindEnum.AI.value},
+        ]
+        fake_resource_version.save()
         G(Release, gateway=fake_gateway, stage=fake_stage, resource_version=fake_resource_version)
 
-        expected_resource_names = {resource["name"] for resource in fake_resource_version.data}
-
         resource_names = MCPServerHandler().get_valid_resource_names(fake_gateway.id, fake_stage.id)
-        assert resource_names == expected_resource_names
+        assert resource_names == {"legacy-resource", "standard-resource"}
+
+    def test_get_tools_resources_and_labels_requests_only_standard_resources(self, mocker):
+        get_released_resources = mocker.patch(
+            "apigateway.biz.mcp_server.mcp_server.ReleasedResourceHandler.get_public_released_resource_data_list",
+            return_value=[],
+        )
+
+        MCPServerHandler.get_tools_resources_and_labels(1, "prod", ["resource1"])
+
+        get_released_resources.assert_called_once_with(
+            1,
+            "prod",
+            False,
+            resource_kind=ResourceKindEnum.STANDARD.value,
+        )
 
     def test_get_valid_resource_names_no_release(
         self,
@@ -1615,7 +1672,10 @@ class TestMCPServerHandler:
 
     def test_save_mcp_servers_create(self, fake_gateway, fake_stage):
         """创建新的 MCP Server"""
-        with patch.object(MCPServerHandler, "sync_permissions"):
+        with (
+            patch.object(MCPServerHandler, "get_valid_resource_names", return_value={"res1"}),
+            patch.object(MCPServerHandler, "sync_permissions"),
+        ):
             results = MCPServerHandler.save_mcp_servers(
                 gateway_id=fake_gateway.id,
                 gateway_name=fake_gateway.name,
@@ -1655,7 +1715,10 @@ class TestMCPServerHandler:
             status=MCPServerStatusEnum.INACTIVE.value,
         )
 
-        with patch.object(MCPServerHandler, "sync_permissions"):
+        with (
+            patch.object(MCPServerHandler, "get_valid_resource_names", return_value={"res1"}),
+            patch.object(MCPServerHandler, "sync_permissions"),
+        ):
             results = MCPServerHandler.save_mcp_servers(
                 gateway_id=fake_gateway.id,
                 gateway_name=fake_gateway.name,
@@ -1683,7 +1746,10 @@ class TestMCPServerHandler:
 
     def test_save_mcp_servers_with_permissions(self, fake_gateway, fake_stage):
         """创建时同步权限"""
-        with patch.object(MCPServerHandler, "sync_permissions") as mock_sync:
+        with (
+            patch.object(MCPServerHandler, "get_valid_resource_names", return_value={"res1"}),
+            patch.object(MCPServerHandler, "sync_permissions") as mock_sync,
+        ):
             results = MCPServerHandler.save_mcp_servers(
                 gateway_id=fake_gateway.id,
                 gateway_name=fake_gateway.name,
@@ -1710,7 +1776,10 @@ class TestMCPServerHandler:
         """创建时同步分类"""
         MCPServerCategory.objects.get_or_create(name="Official", defaults={"display_name": "官方"})
 
-        with patch.object(MCPServerHandler, "sync_permissions"):
+        with (
+            patch.object(MCPServerHandler, "get_valid_resource_names", return_value={"res1"}),
+            patch.object(MCPServerHandler, "sync_permissions"),
+        ):
             results = MCPServerHandler.save_mcp_servers(
                 gateway_id=fake_gateway.id,
                 gateway_name=fake_gateway.name,
@@ -1731,6 +1800,33 @@ class TestMCPServerHandler:
 
         instance = MCPServer.objects.get(id=results[0]["id"])
         assert list(instance.categories.values_list("name", flat=True)) == ["Official"]
+
+    def test_save_mcp_servers_rejects_ai_resource(self, fake_gateway, fake_stage):
+        resource_version = G(ResourceVersion, gateway=fake_gateway)
+        resource_version.data = [{"name": "ai-resource", "kind": ResourceKindEnum.AI.value}]
+        resource_version.save()
+        G(Release, gateway=fake_gateway, stage=fake_stage, resource_version=resource_version)
+
+        with pytest.raises(APIError) as exc_info:
+            MCPServerHandler.save_mcp_servers(
+                gateway_id=fake_gateway.id,
+                gateway_name=fake_gateway.name,
+                stage_id=fake_stage.id,
+                stage_name=fake_stage.name,
+                mcp_servers_data=[
+                    {
+                        "name": "server1",
+                        "description": "test",
+                        "resource_names": ["ai-resource"],
+                        "tool_names": ["ai-resource"],
+                        "is_public": True,
+                        "status": MCPServerStatusEnum.ACTIVE.value,
+                    }
+                ],
+            )
+
+        assert "ai-resource" in exc_info.value.code.message
+        assert not MCPServer.objects.filter(gateway=fake_gateway, stage=fake_stage).exists()
 
     # ========== _sync_mcp_server_permissions 测试 ==========
 

--- a/src/dashboard/apigateway/apigateway/tests/biz/mcp_server/test_mcp_server.py
+++ b/src/dashboard/apigateway/apigateway/tests/biz/mcp_server/test_mcp_server.py
@@ -42,7 +42,7 @@ from apigateway.biz.mcp_server import MCPServerHandler
 from apigateway.common.error_codes import APIError
 from apigateway.core.constants import GatewayStatusEnum, ResourceKindEnum, StageStatusEnum
 from apigateway.core.models import Gateway, Release, Resource, ResourceVersion, Stage
-from apigateway.service.resource_version import get_resource_names_set
+from apigateway.service.resource_version import get_standard_resource_names_set
 from apigateway.tests.utils.testing import create_gateway
 from apigateway.utils.time import NeverExpiresTime, now_datetime
 
@@ -50,10 +50,10 @@ from apigateway.utils.time import NeverExpiresTime, now_datetime
 class TestMCPServerHandler:
     @pytest.fixture(autouse=True)
     def setup_fixtures(self):
-        get_resource_names_set.cache_clear()
+        get_standard_resource_names_set.cache_clear()
         self.gateway = create_gateway()
         yield
-        get_resource_names_set.cache_clear()
+        get_standard_resource_names_set.cache_clear()
 
     def test_virtual_app_code_prefix(self):
         assert MCPServerHandler._virtual_app_code_prefix(1) == "v_mcp_1_"
@@ -364,7 +364,7 @@ class TestMCPServerHandler:
 
     def test_get_tools_resources_and_labels_requests_only_standard_resources(self, mocker):
         get_released_resources = mocker.patch(
-            "apigateway.biz.mcp_server.mcp_server.ReleasedResourceHandler.get_public_released_resource_data_list",
+            "apigateway.biz.mcp_server.mcp_server.ReleasedResourceHandler.get_public_standard_released_resource_data_list",
             return_value=[],
         )
 
@@ -374,7 +374,6 @@ class TestMCPServerHandler:
             1,
             "prod",
             False,
-            resource_kind=ResourceKindEnum.STANDARD.value,
         )
 
     def test_get_valid_resource_names_no_release(

--- a/src/dashboard/apigateway/apigateway/tests/biz/released_resource/test_released_resource.py
+++ b/src/dashboard/apigateway/apigateway/tests/biz/released_resource/test_released_resource.py
@@ -25,6 +25,7 @@ from apigateway.biz.released_resource import (
     ReleasedResourceHandler,
     get_released_resource_data,
 )
+from apigateway.core.constants import ResourceKindEnum
 from apigateway.core.models import Gateway, Release, ReleasedResource, ResourceVersion, Stage
 from apigateway.tests.utils.testing import dummy_time
 
@@ -145,6 +146,20 @@ class TestReleasedResourceHandler:
 
         result = ReleasedResourceHandler.get_public_released_resource_data_list(fake_gateway.id, "")
         assert len(result) == 0
+
+    def test_get_public_released_resource_data_list_filters_by_kind(self, fake_gateway, fake_stage, fake_release):
+        resources = fake_release.resource_version.data
+        resources[0]["kind"] = ResourceKindEnum.AI.value
+        fake_release.resource_version.data = resources
+        fake_release.resource_version.save()
+
+        result = ReleasedResourceHandler.get_public_released_resource_data_list(
+            fake_gateway.id,
+            fake_stage.name,
+            resource_kind=ResourceKindEnum.STANDARD.value,
+        )
+
+        assert {resource.name for resource in result} == {resource["name"] for resource in resources[1:]}
 
     def test_get_released_resource(self, fake_gateway, fake_stage, fake_released_resource):
         result = ReleasedResourceHandler.get_released_resource(

--- a/src/dashboard/apigateway/apigateway/tests/biz/released_resource/test_released_resource.py
+++ b/src/dashboard/apigateway/apigateway/tests/biz/released_resource/test_released_resource.py
@@ -152,6 +152,7 @@ class TestReleasedResourceHandler:
     ):
         resources = fake_release.resource_version.data
         resources[0]["kind"] = ResourceKindEnum.AI.value
+        resources[1]["kind"] = None
         fake_release.resource_version.data = resources
         fake_release.resource_version.save()
 
@@ -161,6 +162,9 @@ class TestReleasedResourceHandler:
         )
 
         assert {resource.name for resource in result} == {resource["name"] for resource in resources[1:]}
+        assert next(resource for resource in result if resource.name == resources[1]["name"]).kind == (
+            ResourceKindEnum.STANDARD.value
+        )
 
     def test_get_released_resource(self, fake_gateway, fake_stage, fake_released_resource):
         result = ReleasedResourceHandler.get_released_resource(

--- a/src/dashboard/apigateway/apigateway/tests/biz/released_resource/test_released_resource.py
+++ b/src/dashboard/apigateway/apigateway/tests/biz/released_resource/test_released_resource.py
@@ -147,16 +147,17 @@ class TestReleasedResourceHandler:
         result = ReleasedResourceHandler.get_public_released_resource_data_list(fake_gateway.id, "")
         assert len(result) == 0
 
-    def test_get_public_released_resource_data_list_filters_by_kind(self, fake_gateway, fake_stage, fake_release):
+    def test_get_public_standard_released_resource_data_list_filters_ai_resources(
+        self, fake_gateway, fake_stage, fake_release
+    ):
         resources = fake_release.resource_version.data
         resources[0]["kind"] = ResourceKindEnum.AI.value
         fake_release.resource_version.data = resources
         fake_release.resource_version.save()
 
-        result = ReleasedResourceHandler.get_public_released_resource_data_list(
+        result = ReleasedResourceHandler.get_public_standard_released_resource_data_list(
             fake_gateway.id,
             fake_stage.name,
-            resource_kind=ResourceKindEnum.STANDARD.value,
         )
 
         assert {resource.name for resource in result} == {resource["name"] for resource in resources[1:]}

--- a/src/dashboard/apigateway/apigateway/tests/biz/resource_version/test_resource_version.py
+++ b/src/dashboard/apigateway/apigateway/tests/biz/resource_version/test_resource_version.py
@@ -26,7 +26,7 @@ from apigateway.apps.openapi.models import OpenAPIFileResourceSchemaVersion, Ope
 from apigateway.apps.support.models import GatewaySDK, ReleasedResourceDoc, ResourceDoc, ResourceDocVersion
 from apigateway.biz.resource import ResourceHandler
 from apigateway.biz.resource_version import ResourceVersionArtifactHandler, ResourceVersionHandler
-from apigateway.core.constants import StageStatusEnum
+from apigateway.core.constants import ResourceKindEnum, StageStatusEnum
 from apigateway.core.models import Gateway, Release, ReleasedResource, ResourceVersion, Stage
 from apigateway.utils.time import now_datetime
 
@@ -241,6 +241,35 @@ class TestResourceVersionHandler:
         resource_version_3 = G(ResourceVersion, gateway=fake_gateway, version="2.0.0", created_time=now_datetime())
         result = ResourceVersionHandler.get_latest_version_by_gateway(fake_gateway.id)
         assert result == resource_version_3.version
+
+    def test_get_standard_resource_name_to_schema_by_resource_version(self, fake_resource_version):
+        fake_resource_version.data = [
+            {"id": 1, "name": "legacy-resource"},
+            {"id": 2, "name": "empty-kind-resource", "kind": None},
+            {"id": 3, "name": "standard-resource", "kind": ResourceKindEnum.STANDARD.value},
+            {"id": 4, "name": "ai-resource", "kind": ResourceKindEnum.AI.value},
+        ]
+        fake_resource_version.save()
+        G(
+            OpenAPIResourceSchemaVersion,
+            resource_version=fake_resource_version,
+            schema=[
+                {"resource_id": 1, "schema": {"operationId": "legacy-resource"}},
+                {"resource_id": 2, "schema": {"operationId": "empty-kind-resource"}},
+                {"resource_id": 3, "schema": {"operationId": "standard-resource"}},
+                {"resource_id": 4, "schema": {"operationId": "ai-resource"}},
+            ],
+        )
+
+        result = ResourceVersionHandler.get_standard_resource_name_to_schema_by_resource_version(
+            fake_resource_version.id
+        )
+
+        assert result == {
+            "legacy-resource": {"operationId": "legacy-resource"},
+            "empty-kind-resource": {"operationId": "empty-kind-resource"},
+            "standard-resource": {"operationId": "standard-resource"},
+        }
 
     def test_is_resource_version_referenced_by_release(self, fake_gateway):
         rv = G(ResourceVersion, gateway=fake_gateway, version="1.0.0")

--- a/src/dashboard/apigateway/apigateway/tests/service/mcp/test_mcp_server.py
+++ b/src/dashboard/apigateway/apigateway/tests/service/mcp/test_mcp_server.py
@@ -29,14 +29,14 @@ from apigateway.service.mcp import (
     build_mcp_server_url,
     update_stage_mcp_server_related_resource_names,
 )
-from apigateway.service.resource_version import get_resource_names_set
+from apigateway.service.resource_version import get_standard_resource_names_set
 
 
 @pytest.fixture(autouse=True)
 def clear_resource_names_cache():
-    get_resource_names_set.cache_clear()
+    get_standard_resource_names_set.cache_clear()
     yield
-    get_resource_names_set.cache_clear()
+    get_standard_resource_names_set.cache_clear()
 
 
 class TestUpdateStageMcpServerRelatedResourceNames:

--- a/src/dashboard/apigateway/apigateway/tests/service/mcp/test_mcp_server.py
+++ b/src/dashboard/apigateway/apigateway/tests/service/mcp/test_mcp_server.py
@@ -22,12 +22,21 @@ from ddf import G
 
 from apigateway.apps.mcp_server.constants import MCPServerStatusEnum
 from apigateway.apps.mcp_server.models import MCPServer
+from apigateway.core.constants import ResourceKindEnum
 from apigateway.core.models import Gateway, ResourceVersion, Stage
 from apigateway.service.mcp import (
     build_mcp_server_permission_approval_url,
     build_mcp_server_url,
     update_stage_mcp_server_related_resource_names,
 )
+from apigateway.service.resource_version import get_resource_names_set
+
+
+@pytest.fixture(autouse=True)
+def clear_resource_names_cache():
+    get_resource_names_set.cache_clear()
+    yield
+    get_resource_names_set.cache_clear()
 
 
 class TestUpdateStageMcpServerRelatedResourceNames:
@@ -133,6 +142,25 @@ class TestUpdateStageMcpServerRelatedResourceNames:
         # Only existing resources should remain
         mcp_server.refresh_from_db()
         assert set(mcp_server.resource_names) == {"resource1", "resource2"}
+
+    def test_ai_resources_are_removed(self, stage, resource_version):
+        resource_version.data = [
+            {"name": "resource1", "kind": ResourceKindEnum.STANDARD.value},
+            {"name": "resource2", "kind": ResourceKindEnum.AI.value},
+        ]
+        resource_version.save()
+        mcp_server = G(
+            MCPServer,
+            stage=stage,
+            gateway=stage.gateway,
+            status=MCPServerStatusEnum.ACTIVE.value,
+            _resource_names="resource1;resource2",
+        )
+
+        update_stage_mcp_server_related_resource_names(stage.id, resource_version.id)
+
+        mcp_server.refresh_from_db()
+        assert mcp_server.resource_names == ["resource1"]
 
     def test_all_resources_deleted(self, stage, resource_version):
         """Test when all MCP server resources are deleted from resource version"""

--- a/src/dashboard/apigateway/apigateway/tests/service/resource_version/test_schema.py
+++ b/src/dashboard/apigateway/apigateway/tests/service/resource_version/test_schema.py
@@ -27,6 +27,7 @@ from apigateway.service.resource_version import (
     get_resource_id_to_schema_by_resource_version,
     get_resource_names_set,
     get_resource_schema,
+    get_standard_resource_names_set,
     get_used_stage_vars,
     make_resource_schema_version,
 )
@@ -35,9 +36,11 @@ from apigateway.service.resource_version import (
 @pytest.fixture(autouse=True)
 def clear_resource_version_schema_caches():
     get_resource_names_set.cache_clear()
+    get_standard_resource_names_set.cache_clear()
     get_used_stage_vars.cache_clear()
     yield
     get_resource_names_set.cache_clear()
+    get_standard_resource_names_set.cache_clear()
     get_used_stage_vars.cache_clear()
 
 
@@ -102,7 +105,7 @@ def test_get_resource_names_set_returns_names(fake_resource_version):
     }
 
 
-def test_get_resource_names_set_filters_by_kind_and_treats_missing_kind_as_standard(fake_resource_version):
+def test_get_standard_resource_names_set_filters_ai_and_treats_missing_kind_as_standard(fake_resource_version):
     fake_resource_version.data = [
         {"name": "legacy-resource"},
         {"name": "standard-resource", "kind": ResourceKindEnum.STANDARD.value},
@@ -110,10 +113,7 @@ def test_get_resource_names_set_filters_by_kind_and_treats_missing_kind_as_stand
     ]
     fake_resource_version.save()
 
-    assert get_resource_names_set(
-        fake_resource_version.id,
-        resource_kind=ResourceKindEnum.STANDARD.value,
-    ) == {"legacy-resource", "standard-resource"}
+    assert get_standard_resource_names_set(fake_resource_version.id) == {"legacy-resource", "standard-resource"}
 
 
 @pytest.mark.parametrize(

--- a/src/dashboard/apigateway/apigateway/tests/service/resource_version/test_schema.py
+++ b/src/dashboard/apigateway/apigateway/tests/service/resource_version/test_schema.py
@@ -102,6 +102,20 @@ def test_get_resource_names_set_returns_names(fake_resource_version):
     }
 
 
+def test_get_resource_names_set_filters_by_kind_and_treats_missing_kind_as_standard(fake_resource_version):
+    fake_resource_version.data = [
+        {"name": "legacy-resource"},
+        {"name": "standard-resource", "kind": ResourceKindEnum.STANDARD.value},
+        {"name": "ai-resource", "kind": ResourceKindEnum.AI.value},
+    ]
+    fake_resource_version.save()
+
+    assert get_resource_names_set(
+        fake_resource_version.id,
+        resource_kind=ResourceKindEnum.STANDARD.value,
+    ) == {"legacy-resource", "standard-resource"}
+
+
 @pytest.mark.parametrize(
     "resource_data, expected",
     [

--- a/src/dashboard/apigateway/apigateway/tests/service/resource_version/test_schema.py
+++ b/src/dashboard/apigateway/apigateway/tests/service/resource_version/test_schema.py
@@ -105,15 +105,20 @@ def test_get_resource_names_set_returns_names(fake_resource_version):
     }
 
 
-def test_get_standard_resource_names_set_filters_ai_and_treats_missing_kind_as_standard(fake_resource_version):
+def test_get_standard_resource_names_set_filters_ai_and_treats_empty_kind_as_standard(fake_resource_version):
     fake_resource_version.data = [
         {"name": "legacy-resource"},
+        {"name": "empty-kind-resource", "kind": None},
         {"name": "standard-resource", "kind": ResourceKindEnum.STANDARD.value},
         {"name": "ai-resource", "kind": ResourceKindEnum.AI.value},
     ]
     fake_resource_version.save()
 
-    assert get_standard_resource_names_set(fake_resource_version.id) == {"legacy-resource", "standard-resource"}
+    assert get_standard_resource_names_set(fake_resource_version.id) == {
+        "legacy-resource",
+        "empty-kind-resource",
+        "standard-resource",
+    }
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary
- restrict MCP resource candidates, validation, sync, post-release cleanup, tool loading, release checks, and permission sync to standard resources from the ResourceVersion snapshot
- treat legacy snapshots without kind as standard and reject invalid resource names again inside MCP Server persistence
- include Resource.kind in Web resource export serialization so AI resources export with kind: ai

## Verification
- uv run ruff format --config=pyproject.toml --check (13 changed Python files)
- uv run make lint-check
- uv run make check-openapi (0 errors; 42 existing warnings)
- uv run make test (3273 passed)