### PR TITLE
fix(ai-gateway): enforce publish safety checks

### DIFF
--- a/src/dashboard/apigateway/apigateway/apis/web/plugin/views.py
+++ b/src/dashboard/apigateway/apigateway/apis/web/plugin/views.py
@@ -42,10 +42,10 @@ from apigateway.common.pagination import StandardLimitOffsetPagination
 from apigateway.common.renderers import BkStandardApiJSONRenderer
 from apigateway.controller.publisher.publish import trigger_gateway_publish
 from apigateway.core.constants import PublishSourceEnum, ResourceKindEnum
-from apigateway.core.models import Resource, Stage
+from apigateway.core.models import BackendConfig, Resource, Stage
 from apigateway.service.plugin import (
+    AI_COMMON_PLUGIN_CODES,
     AI_ONLY_PLUGIN_CODES,
-    AI_RESOURCE_INCOMPATIBLE_PLUGIN_CODES,
     is_plugin_compatible_with_resource_kind,
 )
 from apigateway.utils.django import get_model_dict
@@ -65,6 +65,17 @@ from .serializers import (
 
 class PluginPagination(StandardLimitOffsetPagination):
     default_limit = 100
+
+
+def _get_binding_resource_kinds(gateway, scope_type: str, scope_id: int) -> set[str]:
+    if scope_type == PluginBindingScopeEnum.RESOURCE.value:
+        resource_kind = Resource.objects.filter(gateway=gateway, id=scope_id).values_list("kind", flat=True).first()
+        return {resource_kind or ResourceKindEnum.STANDARD.value}
+
+    resource_kinds = set(
+        BackendConfig.objects.filter(gateway=gateway, stage_id=scope_id).values_list("backend__kind", flat=True)
+    )
+    return resource_kinds or {ResourceKindEnum.STANDARD.value}
 
 
 @method_decorator(
@@ -129,15 +140,12 @@ class PluginTypeListApi(generics.ListAPIView):
         queryset = PluginType.objects.filter(is_public=True).filter(
             Q(scope=PluginTypeScopeEnum.STAGE_AND_RESOURCE.value) | Q(scope=scope)
         )
-        resource_kind = None
-        if scope_type == PluginBindingScopeEnum.RESOURCE.value:
-            resource_kind = (
-                Resource.objects.filter(gateway=self.request.gateway, id=data["scope_id"])
-                .values_list("kind", flat=True)
-                .first()
-            )
-        if resource_kind == ResourceKindEnum.AI.value:
-            queryset = queryset.exclude(code__in=AI_RESOURCE_INCOMPATIBLE_PLUGIN_CODES)
+        resource_kinds = _get_binding_resource_kinds(self.request.gateway, scope_type, data["scope_id"])
+        if ResourceKindEnum.AI.value in resource_kinds:
+            compatible_plugin_codes = AI_COMMON_PLUGIN_CODES
+            if resource_kinds == {ResourceKindEnum.AI.value}:
+                compatible_plugin_codes |= AI_ONLY_PLUGIN_CODES
+            queryset = queryset.filter(code__in=compatible_plugin_codes)
         else:
             queryset = queryset.exclude(code__in=AI_ONLY_PLUGIN_CODES)
 
@@ -205,11 +213,11 @@ class PluginTypeCodeValidationMixin:
         scope_id = self.kwargs["scope_id"]
         plugin_type_code = self.kwargs["code"]
 
-        resource_kind = None
-        if scope_type == PluginBindingScopeEnum.RESOURCE.value:
-            resource_kind = Resource.objects.get(gateway=self.request.gateway, id=scope_id).kind
-
-        if not is_plugin_compatible_with_resource_kind(plugin_type_code, resource_kind):
+        resource_kinds = _get_binding_resource_kinds(self.request.gateway, scope_type, scope_id)
+        if any(
+            not is_plugin_compatible_with_resource_kind(plugin_type_code, resource_kind)
+            for resource_kind in resource_kinds
+        ):
             raise error_codes.INVALID_ARGUMENT.format(
                 _("插件 {plugin_type_code} 与当前资源类型不兼容。").format(plugin_type_code=plugin_type_code)
             )

--- a/src/dashboard/apigateway/apigateway/biz/release/gateway_releaser.py
+++ b/src/dashboard/apigateway/apigateway/biz/release/gateway_releaser.py
@@ -22,9 +22,11 @@ from typing import List
 
 from blue_krill.async_utils.django_utils import delay_on_commit
 from django.conf import settings
+from django.utils.translation import gettext as _
 from rest_framework.exceptions import ValidationError
 
 from apigateway.apps.audit.constants import OpTypeEnum
+from apigateway.apps.data_plane.constants import DataPlaneApisixVersionEnum
 from apigateway.apps.data_plane.models import DataPlane, GatewayDataPlaneBinding
 from apigateway.apps.programmable_gateway.models import ProgrammableGatewayDeployHistory
 from apigateway.biz.audit import Auditor
@@ -109,7 +111,7 @@ class GatewayReleaser:
         if not data_planes:
             raise ReleaseError("Gateway must be bound to at least one active data plane")
 
-        self._pre_release()
+        self._pre_release(data_planes)
 
         # 如果是编程网关，查询一下 deploy 部署历史
         deploy_history = None
@@ -162,16 +164,15 @@ class GatewayReleaser:
             raise ReleaseError("Failed to create release history for any data plane")
         return first_history
 
-    def _pre_release(self):
+    def _pre_release(self, data_planes: List[DataPlane]):
         # 环境、部署信息校验
         # 普通参数校验失败，不需要记录发布日志，环境参数校验失败，需记录发布日志
         # 因此，将普通参数校验，环境参数校验分开处理
         try:
-            self._validate()
+            self._validate(data_planes)
         except (ValidationError, ReleaseValidationError) as err:
             message = err.detail[0] if isinstance(err, ValidationError) else str(err)
             # Get the first active data_plane for error recording
-            data_planes = self._get_active_data_planes()
             if data_planes:
                 history = self._save_release_history(data_plane=data_planes[0])
                 PublishEventReporter.report_config_validate_failure(history, message)
@@ -184,10 +185,25 @@ class GatewayReleaser:
                 )
             raise ReleaseError(message) from err
 
-    def _validate(self):
+    def _validate(self, data_planes: List[DataPlane]):
         """校验待发布数据"""
         publish_validator = PublishValidator(self.gateway, self.stage, self.resource_version)
         publish_validator()
+
+        if not self.gateway.is_ai_gateway:
+            return
+
+        incompatible_data_planes = sorted(
+            data_plane.name
+            for data_plane in data_planes
+            if data_plane.apisix_version != DataPlaneApisixVersionEnum.V3_16.value
+        )
+        if incompatible_data_planes:
+            raise ReleaseValidationError(
+                _("模型网关仅支持发布到 APISIX 3.16 数据面，不兼容的数据面：{data_planes}").format(
+                    data_planes=", ".join(incompatible_data_planes)
+                )
+            )
 
     def _do_release(
         self,

--- a/src/dashboard/apigateway/apigateway/controller/distributor/etcd.py
+++ b/src/dashboard/apigateway/apigateway/controller/distributor/etcd.py
@@ -133,11 +133,6 @@ class GatewayResourceDistributor(BaseDistributor):
         publish_id: int,
     ) -> Tuple[bool, str]:
         """将 release 发布到 micro-gateway 对应的 registry 中"""
-        transformer = GatewayApisixResourceTransformer(
-            self.release,
-            self.data_plane.apisix_version,
-            publish_id=publish_id,
-        )
         registry = self._get_registry(self.gateway, self.stage)
 
         procedure_logger = ReleaseProcedureLogger(
@@ -152,6 +147,11 @@ class GatewayResourceDistributor(BaseDistributor):
         try:
             # step 1: 将网关资源转换为 apisix 资源
             with procedure_logger.step("convert to gateway apisix resources"):
+                transformer = GatewayApisixResourceTransformer(
+                    self.release,
+                    self.data_plane.apisix_version,
+                    publish_id=publish_id,
+                )
                 transformer.transform()
 
             resources = list(transformer.get_transformed_resources())
@@ -215,14 +215,13 @@ class GatewayResourceDistributor(BaseDistributor):
         #         return False, fail_msg
         #     return True, "ok"
 
-        transformer = GatewayApisixResourceTransformer(
-            self.release,
-            self.data_plane.apisix_version,
-            publish_id=publish_id,
-            revoke_flag=True,
-        )
-
         try:
+            transformer = GatewayApisixResourceTransformer(
+                self.release,
+                self.data_plane.apisix_version,
+                publish_id=publish_id,
+                revoke_flag=True,
+            )
             with procedure_logger.step(f"delete gateway resources from etcd by key_prefix({registry.key_prefix})"):
                 registry.delete_resources_by_key_prefix()
 

--- a/src/dashboard/apigateway/apigateway/controller/transformer.py
+++ b/src/dashboard/apigateway/apigateway/controller/transformer.py
@@ -80,7 +80,11 @@ class GatewayApisixResourceTransformer(BaseTransformer):
         publish_id: Optional[int] = None,
         revoke_flag: Optional[bool] = False,
     ):
-        if release.gateway.is_ai_gateway and apisix_version != DataPlaneApisixVersionEnum.V3_16.value:
+        if (
+            not revoke_flag
+            and release.gateway.is_ai_gateway
+            and apisix_version != DataPlaneApisixVersionEnum.V3_16.value
+        ):
             raise ValueError("AI Gateway only supports APISIX 3.16")
 
         if release.resource_version.is_schema_v2 or revoke_flag:

--- a/src/dashboard/apigateway/apigateway/core/backend_config.py
+++ b/src/dashboard/apigateway/apigateway/core/backend_config.py
@@ -1,7 +1,9 @@
 from typing import Any, Literal, Self
+from urllib.parse import urlsplit
 
 from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 
+from apigateway.common.security import is_forbidden_host
 from apigateway.core.constants import AI_BACKEND_BUILTIN_PROVIDERS, AIBackendProviderEnum, BackendKindEnum
 
 
@@ -127,6 +129,24 @@ class AIBackendConfig(BaseModel):
         _validate_object_keys(override, allowed={"endpoint"}, required={"endpoint"}, path=path)
         if not isinstance(override["endpoint"], str) or not override["endpoint"]:
             raise ValueError(f"{path}.endpoint: must be a non-empty string")
+
+        endpoint = override["endpoint"]
+        try:
+            parsed_endpoint = urlsplit(endpoint)
+            port = parsed_endpoint.port
+        except ValueError:
+            raise ValueError(f"{path}.endpoint: port is invalid") from None
+
+        if parsed_endpoint.scheme not in {"http", "https"}:
+            raise ValueError(f"{path}.endpoint: scheme must be http or https")
+        if not parsed_endpoint.hostname:
+            raise ValueError(f"{path}.endpoint: hostname is required")
+        if parsed_endpoint.username is not None or parsed_endpoint.password is not None:
+            raise ValueError(f"{path}.endpoint: userinfo is not allowed")
+        if is_forbidden_host(parsed_endpoint.hostname):
+            raise ValueError(f"{path}.endpoint: host is forbidden")
+        if port is not None and is_forbidden_host(f"{parsed_endpoint.hostname}:{port}"):
+            raise ValueError(f"{path}.endpoint: port is forbidden")
 
     @model_validator(mode="after")
     def validate_provider_contract(self) -> Self:

--- a/src/dashboard/apigateway/apigateway/service/plugin/__init__.py
+++ b/src/dashboard/apigateway/apigateway/service/plugin/__init__.py
@@ -34,8 +34,8 @@ from .checker import (
     check_vars,
 )
 from .compatibility import (
+    AI_COMMON_PLUGIN_CODES,
     AI_ONLY_PLUGIN_CODES,
-    AI_RESOURCE_INCOMPATIBLE_PLUGIN_CODES,
     is_plugin_compatible_with_resource_kind,
 )
 from .convertor import (
@@ -61,8 +61,8 @@ from .validator import PluginConfigYamlValidator
 
 __all__ = [
     # constant
+    "AI_COMMON_PLUGIN_CODES",
     "AI_ONLY_PLUGIN_CODES",
-    "AI_RESOURCE_INCOMPATIBLE_PLUGIN_CODES",
     # Enum
     # class
     "AIProxyConvertor",

--- a/src/dashboard/apigateway/apigateway/service/plugin/compatibility.py
+++ b/src/dashboard/apigateway/apigateway/service/plugin/compatibility.py
@@ -19,35 +19,35 @@
 
 from __future__ import annotations
 
+from apigateway.apps.plugin.constants import PluginTypeCodeEnum
 from apigateway.core.constants import ResourceKindEnum
 
-AI_ONLY_PLUGIN_CODES = frozenset(
+AI_COMMON_PLUGIN_CODES = frozenset(
     {
-        "ai-prompt-decorator",
-        "ai-prompt-guard",
-        "ai-rate-limiting",
+        PluginTypeCodeEnum.BK_ACCESS_TOKEN_SOURCE.value,
+        PluginTypeCodeEnum.BK_CORS.value,
+        PluginTypeCodeEnum.BK_IP_RESTRICTION.value,
+        PluginTypeCodeEnum.BK_OAUTH2_AUDIENCE_VALIDATE.value,
+        PluginTypeCodeEnum.BK_OAUTH2_PROTECTED_RESOURCE.value,
+        PluginTypeCodeEnum.BK_OAUTH2_VERIFY.value,
+        PluginTypeCodeEnum.BK_RATE_LIMIT.value,
+        PluginTypeCodeEnum.BK_REQUEST_BODY_LIMIT.value,
+        PluginTypeCodeEnum.BK_USERNAME_REQUIRED.value,
+        PluginTypeCodeEnum.BK_USER_RESTRICTION.value,
+        PluginTypeCodeEnum.REQUEST_VALIDATION.value,
+        PluginTypeCodeEnum.URI_BLOCKER.value,
     }
 )
 
-AI_RESOURCE_INCOMPATIBLE_PLUGIN_CODES = frozenset(
+AI_ONLY_PLUGIN_CODES = frozenset(
     {
-        "api-breaker",
-        "bk-header-rewrite",
-        "bk-legacy-invalid-params",
-        "bk-query-string-rewrite",
-        "bk-status-rewrite",
-        "bk-traffic-label",
-        "proxy-cache",
-        "response-rewrite",
+        PluginTypeCodeEnum.AI_RATE_LIMITING.value,
     }
 )
 
 
 def is_plugin_compatible_with_resource_kind(plugin_code: str, resource_kind: str | None) -> bool:
-    if plugin_code in AI_ONLY_PLUGIN_CODES:
-        return resource_kind == ResourceKindEnum.AI.value
-
     if resource_kind == ResourceKindEnum.AI.value:
-        return plugin_code not in AI_RESOURCE_INCOMPATIBLE_PLUGIN_CODES
+        return plugin_code in AI_COMMON_PLUGIN_CODES or plugin_code in AI_ONLY_PLUGIN_CODES
 
-    return True
+    return plugin_code not in AI_ONLY_PLUGIN_CODES

--- a/src/dashboard/apigateway/apigateway/tests/apis/web/plugin/test_views.py
+++ b/src/dashboard/apigateway/apigateway/tests/apis/web/plugin/test_views.py
@@ -25,11 +25,7 @@ from apigateway.core.constants import BackendKindEnum, ResourceKindEnum
 from apigateway.core.models import Backend, BackendConfig
 from apigateway.utils.yaml import yaml_dumps
 
-AI_ONLY_PLUGIN_CODES = (
-    "ai-rate-limiting",
-    "ai-prompt-guard",
-    "ai-prompt-decorator",
-)
+AI_ONLY_PLUGIN_CODES = ("ai-rate-limiting",)
 
 AI_INCOMPATIBLE_PLUGIN_CODES = (
     "bk-header-rewrite",
@@ -40,15 +36,18 @@ AI_INCOMPATIBLE_PLUGIN_CODES = (
     "response-rewrite",
     "proxy-cache",
     "bk-legacy-invalid-params",
+    "bk-mock",
+    "redirect",
+    "fault-injection",
 )
 
 
-def _create_ai_only_plugin_type(plugin_type_code):
+def _create_ai_only_plugin_type(plugin_type_code, scope=PluginTypeScopeEnum.RESOURCE.value):
     return G(
         PluginType,
         code=plugin_type_code,
         is_public=True,
-        scope=PluginTypeScopeEnum.RESOURCE.value,
+        scope=scope,
     )
 
 
@@ -159,6 +158,69 @@ class TestPluginTypeListApi:
         codes = {item["code"] for item in response.json()["data"]["results"]}
         assert plugin_type_code not in codes
 
+    @pytest.mark.parametrize(
+        ("backend_kinds", "is_listed"),
+        [
+            ([BackendKindEnum.AI.value], True),
+            ([BackendKindEnum.STANDARD.value], False),
+            ([BackendKindEnum.STANDARD.value, BackendKindEnum.AI.value], False),
+        ],
+    )
+    def test_list_ai_only_plugin_by_stage_backend_kinds(
+        self,
+        request_view,
+        fake_gateway,
+        fake_stage,
+        backend_kinds,
+        is_listed,
+    ):
+        plugin_type = _create_ai_only_plugin_type(
+            PluginTypeCodeEnum.AI_RATE_LIMITING.value,
+            scope=PluginTypeScopeEnum.STAGE_AND_RESOURCE.value,
+        )
+        for backend_kind in backend_kinds:
+            backend = G(Backend, gateway=fake_gateway, kind=backend_kind)
+            G(BackendConfig, gateway=fake_gateway, stage=fake_stage, backend=backend)
+
+        response = request_view(
+            "GET",
+            "plugins.types",
+            gateway=fake_gateway,
+            path_params={"gateway_id": fake_gateway.id},
+            data={"scope_type": "stage", "scope_id": fake_stage.id},
+        )
+
+        assert response.status_code == 200
+        codes = {item["code"] for item in response.json()["data"]["results"]}
+        assert (plugin_type.code in codes) is is_listed
+
+    def test_list_excludes_unlisted_plugin_for_ai_resource(
+        self,
+        request_view,
+        fake_gateway,
+        fake_resource,
+    ):
+        fake_resource.kind = ResourceKindEnum.AI.value
+        fake_resource.save(update_fields=["kind"])
+        plugin_type = G(
+            PluginType,
+            code="unlisted-plugin",
+            is_public=True,
+            scope=PluginTypeScopeEnum.RESOURCE.value,
+        )
+
+        response = request_view(
+            "GET",
+            "plugins.types",
+            gateway=fake_gateway,
+            path_params={"gateway_id": fake_gateway.id},
+            data={"scope_type": "resource", "scope_id": fake_resource.id},
+        )
+
+        assert response.status_code == 200
+        codes = {item["code"] for item in response.json()["data"]["results"]}
+        assert plugin_type.code not in codes
+
 
 class TestScopePluginConfigListApi:
     def test_list(
@@ -261,17 +323,30 @@ class TestPluginConfigCreateApi:
             scope_id=fake_resource.id,
         ).exists()
 
-    @pytest.mark.parametrize("plugin_type_code", AI_ONLY_PLUGIN_CODES)
-    def test_create_rejects_ai_only_plugin_for_stage(
+    @pytest.mark.parametrize(
+        ("backend_kinds", "status_code"),
+        [
+            ([BackendKindEnum.AI.value], 201),
+            ([BackendKindEnum.STANDARD.value], 400),
+            ([BackendKindEnum.STANDARD.value, BackendKindEnum.AI.value], 400),
+        ],
+    )
+    def test_create_ai_only_plugin_by_stage_backend_kinds(
         self,
         request_view,
         fake_gateway,
         fake_stage,
-        plugin_type_code,
+        backend_kinds,
+        status_code,
     ):
-        plugin_type = _create_ai_only_plugin_type(plugin_type_code)
-        backend = G(Backend, gateway=fake_gateway, kind=BackendKindEnum.AI.value)
-        G(BackendConfig, gateway=fake_gateway, stage=fake_stage, backend=backend)
+        plugin_type_code = PluginTypeCodeEnum.AI_RATE_LIMITING.value
+        plugin_type = _create_ai_only_plugin_type(
+            plugin_type_code,
+            scope=PluginTypeScopeEnum.STAGE_AND_RESOURCE.value,
+        )
+        for backend_kind in backend_kinds:
+            backend = G(Backend, gateway=fake_gateway, kind=backend_kind)
+            G(BackendConfig, gateway=fake_gateway, stage=fake_stage, backend=backend)
 
         response = request_view(
             "POST",
@@ -291,12 +366,58 @@ class TestPluginConfigCreateApi:
             },
         )
 
-        assert response.status_code == 400
-        assert not PluginBinding.objects.filter(
+        assert response.status_code == status_code
+        assert PluginBinding.objects.filter(
             gateway=fake_gateway,
             scope_type="stage",
             scope_id=fake_stage.id,
-        ).exists()
+        ).exists() is (status_code == 201)
+
+    @pytest.mark.parametrize(
+        ("backend_kinds", "status_code"),
+        [
+            ([BackendKindEnum.STANDARD.value], 201),
+            ([BackendKindEnum.AI.value], 400),
+            ([BackendKindEnum.STANDARD.value, BackendKindEnum.AI.value], 400),
+        ],
+    )
+    def test_create_standard_only_plugin_by_stage_backend_kinds(
+        self,
+        request_view,
+        fake_gateway,
+        fake_stage,
+        fake_plugin_type_bk_header_rewrite,
+        backend_kinds,
+        status_code,
+    ):
+        for backend_kind in backend_kinds:
+            backend = G(Backend, gateway=fake_gateway, kind=backend_kind)
+            G(BackendConfig, gateway=fake_gateway, stage=fake_stage, backend=backend)
+
+        response = request_view(
+            "POST",
+            "plugins.config.create",
+            gateway=fake_gateway,
+            path_params={
+                "gateway_id": fake_gateway.id,
+                "scope_type": "stage",
+                "scope_id": fake_stage.id,
+                "code": fake_plugin_type_bk_header_rewrite.code,
+            },
+            data={
+                "type_id": fake_plugin_type_bk_header_rewrite.pk,
+                "description": "description",
+                "name": "name",
+                "yaml": yaml_dumps({"set": [{"key": "foo", "value": "bar"}], "remove": []}),
+            },
+        )
+
+        assert response.status_code == status_code
+        assert PluginBinding.objects.filter(
+            gateway=fake_gateway,
+            scope_type="stage",
+            scope_id=fake_stage.id,
+        ).exists() is (status_code == 201)
 
     @pytest.mark.parametrize("plugin_type_code", AI_ONLY_PLUGIN_CODES)
     @pytest.mark.parametrize(

--- a/src/dashboard/apigateway/apigateway/tests/biz/gateway/test_releaser.py
+++ b/src/dashboard/apigateway/apigateway/tests/biz/gateway/test_releaser.py
@@ -21,13 +21,14 @@ import json
 import pytest
 from ddf import G
 
+from apigateway.apps.data_plane.constants import DataPlaneApisixVersionEnum
 from apigateway.apps.data_plane.models import DataPlane, GatewayDataPlaneBinding
 from apigateway.biz.release.gateway_releaser import (
     GatewayReleaser,
     ReleaseError,
     ReleaseValidationError,
 )
-from apigateway.core.constants import PublishEventEnum, PublishEventStatusEnum
+from apigateway.core.constants import GatewayKindEnum, PublishEventEnum, PublishEventStatusEnum
 from apigateway.core.models import PublishEvent, Release, ReleaseHistory, ResourceVersion, Stage
 
 pytestmark = pytest.mark.django_db(transaction=True)
@@ -158,3 +159,28 @@ class TestGatewayReleaser:
         assert ReleaseHistory.objects.filter(
             id=fake_release_history.id,
         ).exists()
+
+    @pytest.mark.parametrize(
+        ("gateway_kind", "apisix_version", "will_error"),
+        [
+            (GatewayKindEnum.AI.value, DataPlaneApisixVersionEnum.V3_13.value, True),
+            (GatewayKindEnum.AI.value, DataPlaneApisixVersionEnum.V3_16.value, False),
+            (GatewayKindEnum.PROGRAMMABLE.value, DataPlaneApisixVersionEnum.V3_13.value, False),
+        ],
+    )
+    def test_validate_target_data_plane_versions(
+        self,
+        mocker,
+        gateway_kind,
+        apisix_version,
+        will_error,
+    ):
+        self.gateway.kind = gateway_kind
+        data_plane = G(DataPlane, name="target-plane", apisix_version=apisix_version)
+        mocker.patch("apigateway.biz.release.gateway_releaser.PublishValidator")
+
+        if will_error:
+            with pytest.raises(ReleaseValidationError, match="APISIX 3.16.*target-plane"):
+                self.releaser._validate([data_plane])
+        else:
+            self.releaser._validate([data_plane])

--- a/src/dashboard/apigateway/apigateway/tests/biz/resource/importer/test_validate.py
+++ b/src/dashboard/apigateway/apigateway/tests/biz/resource/importer/test_validate.py
@@ -29,11 +29,7 @@ from apigateway.core.constants import BackendKindEnum, GatewayKindEnum, Resource
 from apigateway.core.models import Backend, Resource
 from apigateway.utils.yaml import yaml_dumps
 
-AI_ONLY_PLUGIN_CODES = (
-    "ai-rate-limiting",
-    "ai-prompt-guard",
-    "ai-prompt-decorator",
-)
+AI_ONLY_PLUGIN_CODES = ("ai-rate-limiting",)
 
 
 def _plugin_yaml(plugin_type_code):

--- a/src/dashboard/apigateway/apigateway/tests/controller/distributor/test_etcd.py
+++ b/src/dashboard/apigateway/apigateway/tests/controller/distributor/test_etcd.py
@@ -176,6 +176,26 @@ class TestGatewayResourceDistributor:
         assert "distribute gateway resources to etcd failed" in message
         assert "Test error" in message
 
+    def test_distribute_handles_transformer_initialization_failure(self, mocker):
+        mock_release = mocker.Mock()
+        mock_release.gateway = mocker.Mock(name="test-gateway")
+        mock_release.stage = mocker.Mock(name="prod")
+        mocker.patch(
+            "apigateway.controller.distributor.etcd.GatewayApisixResourceTransformer",
+            side_effect=ValueError("Unsupported APISIX version"),
+        )
+        mocker.patch("apigateway.controller.distributor.etcd.EtcdRegistry")
+        mocker.patch("apigateway.controller.distributor.etcd.ReleaseProcedureLogger")
+        mock_data_plane = mocker.Mock(apisix_version=APISIX_VERSION_3_13)
+        mocker.patch("apigateway.controller.distributor.etcd.new_etcd_client")
+        distributor = GatewayResourceDistributor(mock_release, mock_data_plane)
+
+        success, message = distributor.distribute(release_task_id="test-task-id", publish_id=123)
+
+        assert success is False
+        assert "distribute gateway resources to etcd failed" in message
+        assert "Unsupported APISIX version" in message
+
     def test_revoke_with_delete_publish_id(self, mocker):
         """Test revoke method with DELETE_PUBLISH_ID"""
         mock_release = mocker.Mock()
@@ -255,6 +275,27 @@ class TestGatewayResourceDistributor:
         assert success is False
         assert "revoke gateway resources from etcd failed" in message
         assert "Delete error" in message
+
+    def test_revoke_handles_transformer_initialization_failure(self, mocker):
+        mock_release = mocker.Mock()
+        mock_release.gateway = mocker.Mock(name="test-gateway")
+        mock_release.stage = mocker.Mock(name="prod")
+        mocker.patch(
+            "apigateway.controller.distributor.etcd.GatewayApisixResourceTransformer",
+            side_effect=ValueError("Invalid release data"),
+        )
+        mock_registry = mocker.patch("apigateway.controller.distributor.etcd.EtcdRegistry")
+        mocker.patch("apigateway.controller.distributor.etcd.ReleaseProcedureLogger")
+        mock_data_plane = mocker.Mock(apisix_version=APISIX_VERSION_3_13)
+        mocker.patch("apigateway.controller.distributor.etcd.new_etcd_client")
+        distributor = GatewayResourceDistributor(mock_release, mock_data_plane)
+
+        success, message = distributor.revoke(release_task_id="test-task-id", publish_id=123)
+
+        assert success is False
+        assert "revoke gateway resources from etcd failed" in message
+        assert "Invalid release data" in message
+        mock_registry.return_value.delete_resources_by_key_prefix.assert_not_called()
 
     def test_distribute_passes_data_plane_apisix_version(self, mocker):
         """distribute should pass the data plane apisix_version into the transformer"""

--- a/src/dashboard/apigateway/apigateway/tests/controller/test_transformer.py
+++ b/src/dashboard/apigateway/apigateway/tests/controller/test_transformer.py
@@ -168,6 +168,11 @@ class TestGatewayApisixResourceConvertor:
         with pytest.raises(ValueError, match="APISIX 3.16"):
             GatewayApisixResourceTransformer(mock_release, APISIX_VERSION_3_13)
 
+    def test_ai_gateway_revoke_accepts_3_13(self, mock_release):
+        mock_release.gateway.is_ai_gateway = True
+
+        GatewayApisixResourceTransformer(mock_release, APISIX_VERSION_3_13, revoke_flag=True)
+
     def test_transform_ai_gateway_resources(self, mock_release, mocker):
         mock_release.gateway.is_ai_gateway = True
 

--- a/src/dashboard/apigateway/apigateway/tests/core/test_backend_config.py
+++ b/src/dashboard/apigateway/apigateway/tests/core/test_backend_config.py
@@ -249,6 +249,47 @@ def test_ai_backend_config_validates_provider_contract(ai_backend_config, provid
         AIBackendConfig.model_validate(ai_backend_config)
 
 
+@pytest.mark.parametrize(
+    "endpoint",
+    [
+        "https://example.com/v1",
+        "http://example.com:8080/v1",
+    ],
+)
+def test_ai_backend_config_accepts_valid_override_endpoint(ai_backend_config, endpoint):
+    instance = ai_backend_config["instances"][0]
+    instance["provider"] = "openai-compatible"
+    instance["override"] = {"endpoint": endpoint}
+
+    config = AIBackendConfig.model_validate(ai_backend_config)
+
+    assert config.instances[0]["override"]["endpoint"] == endpoint
+
+
+@pytest.mark.parametrize(
+    ("endpoint", "error"),
+    [
+        ("localhost", "scheme must be http or https"),
+        ("ftp://example.com/v1", "scheme must be http or https"),
+        ("https:///v1", "hostname is required"),
+        ("https://user:password@example.com/v1", "userinfo is not allowed"),
+        ("https://example.com:not-a-port/v1", "port is invalid"),
+        ("https://localhost/v1", "host is forbidden"),
+        ("https://127.0.0.1:8080/v1", "host is forbidden"),
+        ("https://example.com:22/v1", "port is forbidden"),
+    ],
+)
+def test_ai_backend_config_rejects_invalid_override_endpoint(ai_backend_config, settings, endpoint, error):
+    settings.FORBIDDEN_HOSTS = ["localhost", "127.0.0.1", "0.0.0.0"]
+    settings.FORBIDDEN_PORTS = [22]
+    instance = ai_backend_config["instances"][0]
+    instance["provider"] = "openai-compatible"
+    instance["override"] = {"endpoint": endpoint}
+
+    with pytest.raises(ValueError, match=error):
+        AIBackendConfig.model_validate(ai_backend_config)
+
+
 def test_model_rejects_plaintext_in_private_storage(fake_stage, ai_backend, ai_backend_config):
     backend_config = BackendConfig.objects.create(
         gateway=fake_stage.gateway,

--- a/src/dashboard/apigateway/apigateway/tests/service/plugin/test_compatibility.py
+++ b/src/dashboard/apigateway/apigateway/tests/service/plugin/test_compatibility.py
@@ -22,22 +22,16 @@ from apigateway.service.plugin import AI_ONLY_PLUGIN_CODES, is_plugin_compatible
 
 
 def test_ai_only_plugin_codes():
-    assert {
-        "ai-rate-limiting",
-        "ai-prompt-guard",
-        "ai-prompt-decorator",
-    } == AI_ONLY_PLUGIN_CODES
+    assert {"ai-rate-limiting"} == AI_ONLY_PLUGIN_CODES
 
 
 @pytest.mark.parametrize(
     ("resource_kind", "plugin_type_code", "expected"),
     [
         (ResourceKindEnum.AI.value, "ai-rate-limiting", True),
-        (ResourceKindEnum.AI.value, "ai-prompt-guard", True),
-        (ResourceKindEnum.AI.value, "ai-prompt-decorator", True),
+        (ResourceKindEnum.AI.value, "ai-prompt-guard", False),
+        (ResourceKindEnum.AI.value, "ai-prompt-decorator", False),
         (ResourceKindEnum.STANDARD.value, "ai-rate-limiting", False),
-        (ResourceKindEnum.STANDARD.value, "ai-prompt-guard", False),
-        (ResourceKindEnum.STANDARD.value, "ai-prompt-decorator", False),
         (None, "ai-rate-limiting", False),
         (ResourceKindEnum.AI.value, "bk-cors", True),
         (ResourceKindEnum.AI.value, "bk-header-rewrite", False),
@@ -48,8 +42,13 @@ def test_ai_only_plugin_codes():
         (ResourceKindEnum.AI.value, "response-rewrite", False),
         (ResourceKindEnum.AI.value, "proxy-cache", False),
         (ResourceKindEnum.AI.value, "bk-legacy-invalid-params", False),
+        (ResourceKindEnum.AI.value, "bk-mock", False),
+        (ResourceKindEnum.AI.value, "redirect", False),
+        (ResourceKindEnum.AI.value, "fault-injection", False),
+        (ResourceKindEnum.AI.value, "unlisted-plugin", False),
         (ResourceKindEnum.STANDARD.value, "bk-cors", True),
         (ResourceKindEnum.STANDARD.value, "bk-header-rewrite", True),
+        (ResourceKindEnum.STANDARD.value, "unlisted-plugin", True),
         (None, "bk-cors", True),
         (None, "bk-header-rewrite", True),
     ],

--- a/src/dashboard/apigateway/apigateway/tests/service/test_public_api_contract.py
+++ b/src/dashboard/apigateway/apigateway/tests/service/test_public_api_contract.py
@@ -130,5 +130,6 @@ def test_service_private_helpers_are_prefixed_with_underscore():
 def test_plugin_compatibility_contract_is_public():
     exported_names = _package_dunder_all(SERVICE_DIR / "plugin")
 
+    assert "AI_COMMON_PLUGIN_CODES" in exported_names
     assert "AI_ONLY_PLUGIN_CODES" in exported_names
     assert "is_plugin_compatible_with_resource_kind" in exported_names


### PR DESCRIPTION
## Summary

Follow up on the verified post-merge findings from #2998:

- enforce the documented explicit AI plugin matrix for Resource bindings and every Backend kind in a Stage
- reject incompatible APISIX data planes before publish while keeping revoke available for cleanup
- validate custom AI endpoints for scheme, hostname, userinfo, port, and existing forbidden host/port policy
- add regression coverage for findings 1, 2, 3, 7, and 8

Finding 5 is intentionally not changed here because the current model outbound-header behavior is explicitly documented and requires separate product/security acceptance or a dedicated policy change.

## Verification

- `uv run make lint`
- `uv run make lint-check`
- `uv run make check-openapi` — 0 errors; 42 existing warnings
- focused remediation suite — 232 passed
- `uv run make test` — 3283 passed
- commit hooks — formatter, ruff, mypy, import-linter, and sensitive-info checks passed
