### PR TITLE
chore(agents): make OpenAPI checks opt-in

### DIFF
--- a/.agents/skills/bk-apigateway-openapi-check/SKILL.md
+++ b/.agents/skills/bk-apigateway-openapi-check/SKILL.md
@@ -1,7 +1,9 @@
 ---
 name: bk-apigateway-openapi-check
-description: "检查 API 代码实现、YAML 网关资源定义、API 文档三者是否一致。当用户请求检查 API 一致性、校验代码和文档匹配、check api consistency、check yaml matches code、openapi 一致性检查、网关资源定义检查、API 文档对齐、检查 operationId 一致性、检查 backend 路径、grant_permissions 检查、MCP Server 配置检查、鉴权配置检查时使用。Actions: validate, check, analyze, fix. Triggers: api-consistency-check, 检查 API 一致性, 检查代码和文档匹配, check api consistency, check yaml matches code, openapi 检查, 网关资源检查, 文档对齐检查, operationId 检查, backend 路径检查, 三层一致性, YAML 代码文档一致性."
+description: "仅限用户显式调用的 API 一致性检查技能。只有当用户明确要求调用或使用 `bk-apigateway-openapi-check` 时才使用；仅提及、编辑或评审该技能，以及任务涉及 API、OpenAPI、YAML、API 文档或一致性检查，均不得触发本技能。"
 ---
+
+TRIGGER RULE: 本技能禁止主动调用。只有用户在当前请求中明确要求调用或使用 `bk-apigateway-openapi-check` 时，才进入下方工作流。仅提及、编辑或评审本技能不算授权；OpenAPI、API、YAML、文档相关任务以及常规 lint、test、preflight 也不算授权。
 
 IRON LAW: 检查操作均为只读，禁止直接修改 YAML 资源定义或代码路由。`--fix` 仅允许生成文档模板。每条检查结果必须包含具体的 operationId 和问题描述，禁止输出模糊结论。
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -57,7 +57,9 @@ Agent skills are located in `.agents/skills/`. Before executing any agent task d
 
 These skills are designed to work with **any AI coding agent** (Claude Code, Codex, Cursor, Windsurf, Aider, etc.) that has access to Playwright MCP browser tools, file system operations, and shell commands.
 
+`bk-apigateway-openapi-check` is opt-in. Do not invoke it unless the user explicitly asks to use that skill. Merely mentioning, editing, or reviewing the skill, or working on OpenAPI-related files, does not authorize its use.
+
 | Skill | File | Description |
 |-------|------|-------------|
 | bdd-test-gen | `.agents/skills/bdd-test-gen/SKILL.md` | Generate executable Playwright test scripts from BDD case files by exploring a live environment |
-| bk-apigateway-openapi-check | `.agents/skills/bk-apigateway-openapi-check/SKILL.md` | Check consistency between API code, YAML gateway definitions, and API docs (8 checks incl. parameter consistency). Usage: `cd src/dashboard && make check-openapi` — see [src/dashboard/AGENTS.md](src/dashboard/AGENTS.md) for details |
+| bk-apigateway-openapi-check | `.agents/skills/bk-apigateway-openapi-check/SKILL.md` | Explicit invocation only. Checks consistency between API code, YAML gateway definitions, and API docs (8 checks incl. parameter consistency). |

--- a/src/dashboard/AGENTS.md
+++ b/src/dashboard/AGENTS.md
@@ -389,7 +389,14 @@ When changing an open API, keep these three surfaces aligned:
 - Gateway YAML definitions: `apigateway/apigateway/data/apigw-definitions/`.
 - Markdown docs: `apigateway/apigateway/data/apidocs/zh/`.
 
-Run the consistency checker:
+The consistency checker is opt-in for agents. Do not run `make check-openapi`,
+`make check-openapi-help`, or any variant unless the user explicitly asks in
+the current request to run that command or invoke
+`bk-apigateway-openapi-check`. Open API, YAML, serializer, or API documentation
+changes, normal verification, preflight, and CI parity do not authorize it. If
+the user did not opt in, do not treat the checker as required verification.
+
+When explicitly requested, the available commands are:
 
 ```bash
 cd src/dashboard
@@ -406,8 +413,9 @@ make check-openapi FIX=1
 For changed or new endpoints, update the matching markdown doc with method,
 path, parameters or request body, response fields, status codes, and error
 examples. The frontend team uses these docs for integration. CI runs
-`make check-openapi` for dashboard changes, so API, YAML, serializer, and docs
-drift should be fixed before push.
+`make check-openapi` for dashboard changes, but this does not make it a default
+agent-side check. Keep API, YAML, serializer, and docs aligned without invoking
+the checker unless the user opts in.
 
 ## Response And Validation Patterns
 
@@ -461,9 +469,12 @@ For code changes:
 3. Run the narrow relevant pytest target first.
 4. Run `make edition-ee && make lint-check` for the CI-style lint gate, or
    `make edition-ee && make lint` first if you want auto-format/fix behavior.
-5. Run `make check-openapi` if any open API, YAML definition, serializer, or API
-   markdown doc changed; CI runs it for all dashboard changes.
+5. Do not run `make check-openapi` or any variant unless the user explicitly
+   requests it in the current task. Open API, YAML definition, serializer, or
+   API markdown changes and CI parity do not opt in to this check.
 6. Run `make edition-ee && make test` for broad code changes or when shared
    behavior is touched.
 
-If a verification command is skipped, say exactly why.
+If a required verification command is skipped, say exactly why.
+`check-openapi` is not a default verification command, so do not report it as a
+skipped required check when the user did not explicitly request it.


### PR DESCRIPTION
## Summary
- require an explicit user request before invoking `bk-apigateway-openapi-check`
- remove `make check-openapi` from agent default verification while keeping the Makefile target unchanged
- clarify that mentions, file changes, preflight, and CI parity do not grant opt-in

## Verification
- `git diff --check`
- verified only the three intended Markdown instruction files changed
- verified `src/dashboard/Makefile` has no diff
- did not run `make lint`, `make test`, or `make check-openapi` because this is a documentation-only instruction change and the checker is explicitly opt-in