### PR TITLE
fix(ai-gateway): address verified PR #3003 findings

### DIFF
--- a/docs/ai-gateway-models.md
+++ b/docs/ai-gateway-models.md
@@ -615,8 +615,8 @@ controller 同时将 BackendConfig.timeout 原样转换为 `ai-proxy.timeout`，
 
 #### APISIX version boundary
 
-- An AI Gateway may publish only when its `DataPlane.apisix_version` is `3.16`.
-- The dashboard transformer fails before generating resources when an AI Gateway targets any other version.
+- An AI Gateway may bind and publish only when its `DataPlane.apisix_version` is `3.16` or later.
+- Gateway creation and synchronization fail before persisting an incompatible binding; the dashboard transformer keeps the same defensive check before generating resources.
 - APISIX 3.13 remains supported for standard gateways and receives no AI-specific changes.
 
 ### 8.6 bk-backend-context、日志与 metrics
@@ -686,7 +686,7 @@ bk_backend_name = Backend.name
 - 插件兼容性：Web Stage/Resource 绑定和 `/apis/open`、`/apis/v2/sync` Resource 插件同步拒绝不兼容关系；controller 发布信任持久化关系，不再校验或过滤。
 - MCP Server：候选列表、创建更新、自动化同步、异步发布、运行时工具加载和权限同步均排除模型 Resource，且按 ResourceVersion 快照判断。
 - controller：普通 Backend 的 Service/Route 输出保持不变；模型 Backend 生成无 upstream 的 Service、`ai-proxy`、包含 `bk-error-wrapper` 的安全插件 Profile 和关联 service_id 的 Route；Route 转换信任持久化的 Resource/Backend 关系，不重复校验 kind。
-- controller：AI Gateway 仅允许发布到 APISIX 3.16，非 3.16 在生成资源前失败；普通网关继续支持 APISIX 3.13，且不包含 AI 专用变更。
+- data plane：AI Gateway 仅允许绑定 APISIX 3.16 及以上版本的数据面，创建和同步在持久化绑定前失败；controller 在生成资源前保留同一规则的防御性检查。普通网关继续支持 APISIX 3.13，且不包含 AI 专用变更。
 - 请求链路：普通响应和 SSE 流式响应均可用；BlueKing 网关插件错误由 `bk-error-wrapper` 统一包装，`ai-proxy` 和模型服务错误保持原始响应；第一期不增加 AI 专用出站 Header 过滤。
 - 回归：普通网关、可编程网关以及 AI Gateway 中的普通 Backend/Resource 沿用现有行为。
 

--- a/docs/ai-gateway-models.md
+++ b/docs/ai-gateway-models.md
@@ -541,9 +541,9 @@ common service plugins
 
 | 策略 | 插件 | 说明 |
 | --- | --- | --- |
-| 允许用于普通和模型链路 | `bk-cors`、`bk-rate-limit`、`bk-ip-restriction`、`request-validation`、`bk-request-body-limit`、`bk-user-restriction`、`bk-access-token-source`、`bk-username-required`、OAuth2 认证插件、`uri-blocker` | 处理入口认证、访问控制或请求校验 |
+| 允许用于普通和模型链路 | `bk-cors`、`bk-rate-limit`、`bk-ip-restriction`、`request-validation`、`bk-request-body-limit`、`bk-user-restriction`、`bk-access-token-source`、`bk-username-required`、OAuth2 认证插件、`uri-blocker`、`bk-header-rewrite`、`bk-query-string-rewrite`、`bk-traffic-label` | 处理入口认证、访问控制、请求校验或按已有通用规则改写请求 |
 | 只允许用于模型链路 | `ai-rate-limiting` | 依赖 `ai-proxy` 选中的 instance 和模型 Token usage |
-| 模型链路禁止 | `bk-header-rewrite`、`bk-query-string-rewrite`、`bk-status-rewrite`、`bk-traffic-label`、`api-breaker`、`response-rewrite`、`proxy-cache`、`bk-legacy-invalid-params` | 请求改写可能覆盖模型认证；普通 query/upstream 状态对 AI driver 无效；响应改写和缓存可能破坏 SSE |
+| 模型链路禁止 | `bk-status-rewrite`、`api-breaker`、`response-rewrite`、`proxy-cache`、`bk-legacy-invalid-params` | 普通 upstream 状态对 AI driver 无效；响应改写和缓存可能破坏 SSE |
 | 第一期不开放给模型链路 | `bk-mock`、`redirect`、`fault-injection` | 技术上可以短路请求，但会绕过模型调用或破坏模型响应契约；有明确产品场景后再开放 |
 
 Stage 绑定会应用到该 Stage 生成的全部 Service，因此绑定时必须与该 Stage 当前所有 Backend.kind 兼容：

--- a/src/dashboard/apigateway/apigateway/apis/web/backend/serializers.py
+++ b/src/dashboard/apigateway/apigateway/apis/web/backend/serializers.py
@@ -16,6 +16,7 @@
 # We undertake not to change the open source license (MIT license) applicable
 # to the current version of the project delivered to anyone in the future.
 #
+import logging
 from collections.abc import Mapping
 
 from django.utils.translation import gettext as _
@@ -33,6 +34,8 @@ from apigateway.core.constants import DEFAULT_BACKEND_NAME, BackendKindEnum, Bac
 from apigateway.core.models import Backend, BackendConfig, Stage
 
 from .constants import BACKEND_NAME_PATTERN
+
+logger = logging.getLogger(__name__)
 
 
 class BackendConfigSLZ(BaseBackendConfigSLZ):
@@ -130,10 +133,17 @@ class BackendInputSLZ(serializers.Serializer):
     def _validate_config_values(self, attrs, stage_id_name):
         existing_configs = {}
         if self.instance:
-            existing_configs = {
-                item.stage_id: item.config
-                for item in BackendConfig.objects.filter(backend=self.instance).select_related("backend")
-            }
+            for item in BackendConfig.objects.filter(backend=self.instance).select_related("backend"):
+                try:
+                    existing_configs[item.stage_id] = item.config
+                except ValueError:
+                    logger.exception(
+                        "failed to read backend config id=%s for backend_id=%s stage_id=%s",
+                        item.id,
+                        item.backend_id,
+                        item.stage_id,
+                    )
+                    raise serializers.ValidationError({"configs": _("已有后端配置无法读取，请联系管理员。")}) from None
 
         for backend_config in attrs["configs"]:
             if attrs["kind"] == BackendKindEnum.AI.value:

--- a/src/dashboard/apigateway/apigateway/apis/web/plugin/views.py
+++ b/src/dashboard/apigateway/apigateway/apis/web/plugin/views.py
@@ -44,8 +44,9 @@ from apigateway.controller.publisher.publish import trigger_gateway_publish
 from apigateway.core.constants import PublishSourceEnum, ResourceKindEnum
 from apigateway.core.models import Resource, Stage
 from apigateway.service.plugin import (
+    AI_COMPATIBLE_PLUGIN_CODES,
     AI_ONLY_PLUGIN_CODES,
-    AI_RESOURCE_INCOMPATIBLE_PLUGIN_CODES,
+    CONTROLLER_MANAGED_PLUGIN_CODES,
     is_plugin_compatible_with_resource_kind,
 )
 from apigateway.utils.django import get_model_dict
@@ -137,9 +138,9 @@ class PluginTypeListApi(generics.ListAPIView):
                 .first()
             )
         if resource_kind == ResourceKindEnum.AI.value:
-            queryset = queryset.exclude(code__in=AI_RESOURCE_INCOMPATIBLE_PLUGIN_CODES)
+            queryset = queryset.filter(code__in=AI_COMPATIBLE_PLUGIN_CODES)
         else:
-            queryset = queryset.exclude(code__in=AI_ONLY_PLUGIN_CODES)
+            queryset = queryset.exclude(code__in=AI_ONLY_PLUGIN_CODES | CONTROLLER_MANAGED_PLUGIN_CODES)
 
         # 支持 keyword=abc 搜索
         keyword = data.get("keyword")

--- a/src/dashboard/apigateway/apigateway/apis/web/stage/serializers.py
+++ b/src/dashboard/apigateway/apigateway/apis/web/stage/serializers.py
@@ -16,6 +16,8 @@
 # to the current version of the project delivered to anyone in the future.
 #
 
+import logging
+
 from django.conf import settings
 from django.utils.translation import gettext as _
 from django.utils.translation import gettext_lazy
@@ -45,6 +47,8 @@ from apigateway.core.constants import (
 from apigateway.core.models import Backend, BackendConfig, Stage
 from apigateway.service.release import PublishValidator, ReleaseValidationError
 from apigateway.utils.version import is_version1_greater_than_version2
+
+logger = logging.getLogger(__name__)
 
 
 class StageOutputSLZ(serializers.ModelSerializer):
@@ -221,12 +225,7 @@ class StageInputSLZ(serializers.Serializer):
                     _("请求参数中，缺少后端服务【{backend_id}】的配置。").format(backend_name=backend.name)
                 )
 
-        existing_configs = {}
-        if self.instance:
-            existing_configs = {
-                backend_config.backend_id: backend_config.config
-                for backend_config in BackendConfig.objects.filter(stage=self.instance).select_related("backend")
-            }
+        existing_configs = self._get_existing_configs()
 
         for input_backend in attrs["backends"]:
             backend = backend_dict[input_backend["id"]]
@@ -252,6 +251,24 @@ class StageInputSLZ(serializers.Serializer):
                 check_backend_host_scheme(backend, host)
 
         return attrs
+
+    def _get_existing_configs(self):
+        if not self.instance:
+            return {}
+
+        existing_configs = {}
+        for backend_config in BackendConfig.objects.filter(stage=self.instance).select_related("backend"):
+            try:
+                existing_configs[backend_config.backend_id] = backend_config.config
+            except ValueError:
+                logger.exception(
+                    "failed to read backend config id=%s for backend_id=%s stage_id=%s",
+                    backend_config.id,
+                    backend_config.backend_id,
+                    backend_config.stage_id,
+                )
+                raise serializers.ValidationError({"backends": _("已有后端配置无法读取，请联系管理员。")}) from None
+        return existing_configs
 
 
 def check_backend_host_scheme(backend, host):

--- a/src/dashboard/apigateway/apigateway/apps/data_plane/constants.py
+++ b/src/dashboard/apigateway/apigateway/apps/data_plane/constants.py
@@ -17,6 +17,7 @@
 #
 
 from blue_krill.data_types.enum import EnumField, StructuredEnum
+from packaging.version import InvalidVersion, Version
 
 
 class DataPlaneStatusEnum(StructuredEnum):
@@ -34,6 +35,14 @@ class DataPlaneApisixVersionEnum(StructuredEnum):
 
 
 CURRENT_DATA_PLANE_APISIX_VERSION = DataPlaneApisixVersionEnum.V3_16.value
+AI_GATEWAY_MIN_APISIX_VERSION = DataPlaneApisixVersionEnum.V3_16.value
+
+
+def is_apisix_version_supported_for_ai_gateway(apisix_version: str) -> bool:
+    try:
+        return Version(apisix_version) >= Version(AI_GATEWAY_MIN_APISIX_VERSION)
+    except InvalidVersion, TypeError:
+        return False
 
 
 class BkPluginsDataPlaneGrayStageEnum(StructuredEnum):

--- a/src/dashboard/apigateway/apigateway/apps/data_plane/managers.py
+++ b/src/dashboard/apigateway/apigateway/apps/data_plane/managers.py
@@ -21,7 +21,12 @@ from django.db import models
 
 from apigateway.core.models import Gateway
 
-from .constants import DEFAULT_DATA_PLANE_NAME, DataPlaneStatusEnum
+from .constants import (
+    AI_GATEWAY_MIN_APISIX_VERSION,
+    DEFAULT_DATA_PLANE_NAME,
+    DataPlaneStatusEnum,
+    is_apisix_version_supported_for_ai_gateway,
+)
 
 if TYPE_CHECKING:
     from .models import DataPlane, GatewayDataPlaneBinding
@@ -68,6 +73,9 @@ class GatewayDataPlaneBindingManager(models.Manager):
         self, gateway: Gateway, data_plane: "DataPlane", created_by: str = ""
     ) -> "GatewayDataPlaneBinding":
         """Bind a gateway to a data plane"""
+        if gateway.is_ai_gateway and not is_apisix_version_supported_for_ai_gateway(data_plane.apisix_version):
+            raise ValueError(f"AI Gateway requires APISIX {AI_GATEWAY_MIN_APISIX_VERSION} or later")
+
         binding, _ = self.get_or_create(
             gateway=gateway,
             data_plane=data_plane,

--- a/src/dashboard/apigateway/apigateway/biz/gateway/gateway.py
+++ b/src/dashboard/apigateway/apigateway/biz/gateway/gateway.py
@@ -46,6 +46,7 @@ from apigateway.core.gateway_auth import GatewayAuthConfig
 from apigateway.core.models import Backend, BackendConfig, Context, Gateway, Release, Resource, Stage
 from apigateway.service.alarm_strategy import create_default_alarm_strategy
 from apigateway.service.contexts import GatewayAuthContext
+from apigateway.service.data_plane import validate_gateway_data_plane_compatibility
 from apigateway.service.gateway_jwt import GatewayJWTHandler
 from apigateway.service.resource import delete_gateway_resource_versions, delete_gateway_resources
 from apigateway.utils.dict import deep_update
@@ -288,6 +289,7 @@ class GatewayHandler:
         """Bind a gateway to the given data planes."""
         data_planes = DataPlane.objects.filter(id__in=data_plane_ids)
         data_plane_map = {dp.id: dp for dp in data_planes}
+        validate_gateway_data_plane_compatibility(gateway, data_plane_map.values())
 
         for dp_id in data_plane_ids:
             data_plane = data_plane_map.get(dp_id)
@@ -548,7 +550,7 @@ class GatewaySaver:
         return self._gateway
 
     def _create_gateway(self):
-        # 1. save gateway
+        # 1. resolve and validate data planes before saving the gateway
         self._gateway = gateway = Gateway(
             name=self._gateway_data.name,
             description=self._gateway_data.description,
@@ -563,9 +565,12 @@ class GatewaySaver:
             created_by=self.username,
             updated_by=self.username,
         )
+        data_planes_to_bind = self._resolve_data_planes_to_bind(gateway)
+
+        # 2. save gateway
         gateway.save()
 
-        # 2. save related data
+        # 3. save related data
         GatewayHandler.save_related_data(
             gateway=gateway,
             user_auth_type=settings.DEFAULT_USER_AUTH_TYPE,
@@ -579,11 +584,10 @@ class GatewaySaver:
             source=self._source,
         )
 
-        # 3. bind to data plane(s)
-        self._bind_to_data_planes(gateway)
+        # 4. bind to data plane(s)
+        self._bind_to_data_planes(gateway, data_planes_to_bind)
 
-    def _bind_to_data_planes(self, gateway: Gateway):
-        """Bind newly created gateway to data plane(s)"""
+    def _resolve_data_planes_to_bind(self, gateway: Gateway) -> List[DataPlane]:
         data_planes_to_bind: List[DataPlane] = []
 
         # If data_plane_ids provided, bind to those data planes
@@ -601,8 +605,12 @@ class GatewaySaver:
             default_data_plane = DataPlane.objects.get_default()
             data_planes_to_bind.append(default_data_plane)
 
-        # Bind to all resolved data planes
-        for data_plane in data_planes_to_bind:
+        validate_gateway_data_plane_compatibility(gateway, data_planes_to_bind)
+        return data_planes_to_bind
+
+    def _bind_to_data_planes(self, gateway: Gateway, data_planes: List[DataPlane]):
+        """Bind a newly created gateway to data planes that have already been validated."""
+        for data_plane in data_planes:
             GatewayDataPlaneBinding.objects.bind_gateway_to_data_plane(
                 gateway=gateway,
                 data_plane=data_plane,

--- a/src/dashboard/apigateway/apigateway/biz/mcp_server/mcp_server.py
+++ b/src/dashboard/apigateway/apigateway/biz/mcp_server/mcp_server.py
@@ -58,7 +58,7 @@ from apigateway.biz.resource_doc import ResourceDocHandler
 from apigateway.common.django.translation import get_current_language_code
 from apigateway.common.error_codes import error_codes
 from apigateway.components import bkaidev
-from apigateway.core.constants import GatewayStatusEnum, StageStatusEnum
+from apigateway.core.constants import GatewayStatusEnum, ResourceKindEnum, StageStatusEnum
 from apigateway.core.models import Gateway, Release, Resource, Stage
 from apigateway.service.mcp import build_mcp_server_application_url, build_mcp_server_url, validate_mcp_prompts_payload
 from apigateway.service.resource import get_resource_id_to_labels_by_label_ids
@@ -380,9 +380,11 @@ class MCPServerHandler:
         if release:
             valid_resource_names = get_standard_resource_names_set(release.resource_version.id)
             resource_names = [name for name in resource_names if name in valid_resource_names]
-        resource_ids = Resource.objects.filter(gateway_id=mcp_server.gateway_id, name__in=resource_names).values_list(
-            "id", flat=True
-        )
+        resource_ids = Resource.objects.filter(
+            gateway_id=mcp_server.gateway_id,
+            name__in=resource_names,
+            kind=ResourceKindEnum.STANDARD.value,
+        ).values_list("id", flat=True)
 
         # 3. sync the permission
         newest_virtual_app_code_resource_id_set = {

--- a/src/dashboard/apigateway/apigateway/biz/openapi/parser.py
+++ b/src/dashboard/apigateway/apigateway/biz/openapi/parser.py
@@ -283,6 +283,10 @@ class BaseParser:
         if backend_type != ProxyTypeEnum.HTTP.value:
             raise ValueError(f"unsupported backend type: {backend['type']}")
 
+        missing_fields = [field for field in ("method", "path") if field not in backend]
+        if missing_fields:
+            raise ValueError(f"standard resource HTTP backend requires {', '.join(missing_fields)}")
+
         return {
             "method": backend["method"].upper(),
             "path": backend["path"],

--- a/src/dashboard/apigateway/apigateway/biz/openapi/schemas/openapi_2.0_schema.json
+++ b/src/dashboard/apigateway/apigateway/biz/openapi/schemas/openapi_2.0_schema.json
@@ -447,7 +447,36 @@
                 "type": "string"
               }
             }
-          }
+          },
+          "allOf": [
+            {
+              "anyOf": [
+                {
+                  "required": ["kind"],
+                  "properties": {
+                    "kind": {
+                      "enum": ["ai"]
+                    }
+                  }
+                },
+                {
+                  "properties": {
+                    "backend": {
+                      "not": {
+                        "additionalProperties": false,
+                        "properties": {
+                          "name": {
+                            "type": "string"
+                          }
+                        },
+                        "required": ["name"]
+                      }
+                    }
+                  }
+                }
+              ]
+            }
+          ]
         }
       },
       "required": [

--- a/src/dashboard/apigateway/apigateway/biz/openapi/schemas/openapi_3.0_schema.json
+++ b/src/dashboard/apigateway/apigateway/biz/openapi/schemas/openapi_3.0_schema.json
@@ -488,7 +488,36 @@
                 "type": "string"
               }
             }
-          }
+          },
+          "allOf": [
+            {
+              "anyOf": [
+                {
+                  "required": ["kind"],
+                  "properties": {
+                    "kind": {
+                      "enum": ["ai"]
+                    }
+                  }
+                },
+                {
+                  "properties": {
+                    "backend": {
+                      "not": {
+                        "additionalProperties": false,
+                        "properties": {
+                          "name": {
+                            "type": "string"
+                          }
+                        },
+                        "required": ["name"]
+                      }
+                    }
+                  }
+                }
+              ]
+            }
+          ]
         },
         "callbacks": {
           "$ref": "#/definitions/callbacksOrReferences"

--- a/src/dashboard/apigateway/apigateway/biz/openapi/schemas/openapi_3.1_schema.json
+++ b/src/dashboard/apigateway/apigateway/biz/openapi/schemas/openapi_3.1_schema.json
@@ -543,7 +543,36 @@
                 "type": "string"
               }
             }
-          }
+          },
+          "allOf": [
+            {
+              "anyOf": [
+                {
+                  "required": ["kind"],
+                  "properties": {
+                    "kind": {
+                      "enum": ["ai"]
+                    }
+                  }
+                },
+                {
+                  "properties": {
+                    "backend": {
+                      "not": {
+                        "additionalProperties": false,
+                        "properties": {
+                          "name": {
+                            "type": "string"
+                          }
+                        },
+                        "required": ["name"]
+                      }
+                    }
+                  }
+                }
+              ]
+            }
+          ]
         },
         "callbacks": {
           "type": "object",

--- a/src/dashboard/apigateway/apigateway/controller/transformer.py
+++ b/src/dashboard/apigateway/apigateway/controller/transformer.py
@@ -19,7 +19,6 @@ import logging
 from abc import ABC, abstractmethod
 from typing import TYPE_CHECKING, Dict, Iterable, List, Optional
 
-from apigateway.apps.data_plane.constants import DataPlaneApisixVersionEnum
 from apigateway.controller.convertor import (
     BkReleaseConvertor,
     RouteConvertor,
@@ -28,6 +27,10 @@ from apigateway.controller.convertor import (
 from apigateway.controller.convertor.constants import LABEL_KEY_BACKEND_ID
 from apigateway.controller.convertor.plugin_metadata import PluginMetadataConvertor
 from apigateway.controller.release_data import ReleaseData
+from apigateway.service.data_plane import (
+    AI_GATEWAY_MIN_APISIX_VERSION,
+    is_apisix_version_supported_for_ai_gateway,
+)
 
 if TYPE_CHECKING:
     from apigateway.controller.models import ApisixModel, GatewayApisixModel
@@ -83,9 +86,9 @@ class GatewayApisixResourceTransformer(BaseTransformer):
         if (
             not revoke_flag
             and release.gateway.is_ai_gateway
-            and apisix_version != DataPlaneApisixVersionEnum.V3_16.value
+            and not is_apisix_version_supported_for_ai_gateway(apisix_version)
         ):
-            raise ValueError("AI Gateway only supports APISIX 3.16")
+            raise ValueError(f"AI Gateway requires APISIX {AI_GATEWAY_MIN_APISIX_VERSION} or later")
 
         if release.resource_version.is_schema_v2 or revoke_flag:
             # note: revoke_flag is True, allow to use schema v1 to revoke resources

--- a/src/dashboard/apigateway/apigateway/service/data_plane.py
+++ b/src/dashboard/apigateway/apigateway/service/data_plane.py
@@ -1,0 +1,52 @@
+#
+# TencentBlueKing is pleased to support the open source community by making
+# 蓝鲸智云 - API 网关(BlueKing - APIGateway) available.
+# Copyright (C) Tencent. All rights reserved.
+# Licensed under the MIT License (the "License"); you may not use this file except
+# in compliance with the License. You may obtain a copy of the License at
+#
+# https://opensource.org/licenses/MIT
+#
+# Unless required by applicable law or agreed to in writing, software distributed under
+# the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+# either express or implied. See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# We undertake not to change the open source license (MIT license) applicable
+# to the current version of the project delivered to anyone in the future.
+#
+
+from typing import TYPE_CHECKING
+
+from rest_framework.exceptions import ValidationError
+
+from apigateway.apps.data_plane.constants import (
+    AI_GATEWAY_MIN_APISIX_VERSION,
+    is_apisix_version_supported_for_ai_gateway,
+)
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable
+
+    from apigateway.apps.data_plane.models import DataPlane
+    from apigateway.core.models import Gateway
+
+
+def validate_gateway_data_plane_compatibility(gateway: Gateway, data_planes: Iterable[DataPlane]) -> None:
+    if not gateway.is_ai_gateway:
+        return
+
+    incompatible_data_planes = [
+        f"{data_plane.name} ({data_plane.apisix_version})"
+        for data_plane in data_planes
+        if not is_apisix_version_supported_for_ai_gateway(data_plane.apisix_version)
+    ]
+    if incompatible_data_planes:
+        raise ValidationError(
+            {
+                "data_planes": (
+                    f"AI Gateway requires APISIX {AI_GATEWAY_MIN_APISIX_VERSION} or later; "
+                    f"incompatible data planes: {', '.join(incompatible_data_planes)}"
+                )
+            }
+        )

--- a/src/dashboard/apigateway/apigateway/service/plugin/__init__.py
+++ b/src/dashboard/apigateway/apigateway/service/plugin/__init__.py
@@ -34,8 +34,9 @@ from .checker import (
     check_vars,
 )
 from .compatibility import (
+    AI_COMPATIBLE_PLUGIN_CODES,
     AI_ONLY_PLUGIN_CODES,
-    AI_RESOURCE_INCOMPATIBLE_PLUGIN_CODES,
+    CONTROLLER_MANAGED_PLUGIN_CODES,
     is_plugin_compatible_with_resource_kind,
 )
 from .convertor import (
@@ -61,8 +62,9 @@ from .validator import PluginConfigYamlValidator
 
 __all__ = [
     # constant
+    "AI_COMPATIBLE_PLUGIN_CODES",
     "AI_ONLY_PLUGIN_CODES",
-    "AI_RESOURCE_INCOMPATIBLE_PLUGIN_CODES",
+    "CONTROLLER_MANAGED_PLUGIN_CODES",
     # Enum
     # class
     "AIProxyConvertor",

--- a/src/dashboard/apigateway/apigateway/service/plugin/compatibility.py
+++ b/src/dashboard/apigateway/apigateway/service/plugin/compatibility.py
@@ -33,16 +33,16 @@ AI_ONLY_PLUGIN_CODES = frozenset(
 AI_RESOURCE_INCOMPATIBLE_PLUGIN_CODES = frozenset(
     {
         PluginTypeCodeEnum.API_BREAKER.value,
-        PluginTypeCodeEnum.BK_HEADER_REWRITE.value,
         PluginTypeCodeEnum.BK_LEGACY_INVALID_PARAMS.value,
-        PluginTypeCodeEnum.BK_QUERY_STRING_REWRITE.value,
         PluginTypeCodeEnum.BK_STATUS_REWRITE.value,
-        PluginTypeCodeEnum.BK_TRAFFIC_LABEL.value,
         PluginTypeCodeEnum.PROXY_CACHE.value,
         PluginTypeCodeEnum.RESPONSE_REWRITE.value,
         PluginTypeCodeEnum.BK_MOCK.value,
         PluginTypeCodeEnum.REDIRECT.value,
         PluginTypeCodeEnum.FAULT_INJECTION.value,
+        # PluginTypeCodeEnum.BK_HEADER_REWRITE.value,
+        # PluginTypeCodeEnum.BK_QUERY_STRING_REWRITE.value,
+        # PluginTypeCodeEnum.BK_TRAFFIC_LABEL.value,
     }
 )
 

--- a/src/dashboard/apigateway/apigateway/service/plugin/compatibility.py
+++ b/src/dashboard/apigateway/apigateway/service/plugin/compatibility.py
@@ -30,28 +30,45 @@ AI_ONLY_PLUGIN_CODES = frozenset(
     }
 )
 
-AI_RESOURCE_INCOMPATIBLE_PLUGIN_CODES = frozenset(
+CONTROLLER_MANAGED_PLUGIN_CODES = frozenset(
     {
-        PluginTypeCodeEnum.API_BREAKER.value,
-        PluginTypeCodeEnum.BK_LEGACY_INVALID_PARAMS.value,
-        PluginTypeCodeEnum.BK_STATUS_REWRITE.value,
-        PluginTypeCodeEnum.PROXY_CACHE.value,
-        PluginTypeCodeEnum.RESPONSE_REWRITE.value,
-        PluginTypeCodeEnum.BK_MOCK.value,
-        PluginTypeCodeEnum.REDIRECT.value,
-        PluginTypeCodeEnum.FAULT_INJECTION.value,
-        # PluginTypeCodeEnum.BK_HEADER_REWRITE.value,
-        # PluginTypeCodeEnum.BK_QUERY_STRING_REWRITE.value,
-        # PluginTypeCodeEnum.BK_TRAFFIC_LABEL.value,
+        "ai-proxy",
+        "ai-proxy-multi",
     }
+)
+
+AI_COMPATIBLE_PLUGIN_CODES = (
+    frozenset(
+        {
+            PluginTypeCodeEnum.BK_CORS.value,
+            PluginTypeCodeEnum.BK_RATE_LIMIT.value,
+            PluginTypeCodeEnum.BK_IP_RESTRICTION.value,
+            PluginTypeCodeEnum.REQUEST_VALIDATION.value,
+            PluginTypeCodeEnum.BK_REQUEST_BODY_LIMIT.value,
+            PluginTypeCodeEnum.BK_USER_RESTRICTION.value,
+            PluginTypeCodeEnum.BK_ACCESS_TOKEN_SOURCE.value,
+            PluginTypeCodeEnum.BK_USERNAME_REQUIRED.value,
+            PluginTypeCodeEnum.BK_OAUTH2_PROTECTED_RESOURCE.value,
+            PluginTypeCodeEnum.BK_OAUTH2_VERIFY.value,
+            PluginTypeCodeEnum.BK_OAUTH2_AUDIENCE_VALIDATE.value,
+            PluginTypeCodeEnum.URI_BLOCKER.value,
+            PluginTypeCodeEnum.BK_HEADER_REWRITE.value,
+            PluginTypeCodeEnum.BK_QUERY_STRING_REWRITE.value,
+            PluginTypeCodeEnum.BK_TRAFFIC_LABEL.value,
+        }
+    )
+    | AI_ONLY_PLUGIN_CODES
 )
 
 
 def is_plugin_compatible_with_resource_kind(plugin_code: str, resource_kind: str | None) -> bool:
+    if plugin_code in CONTROLLER_MANAGED_PLUGIN_CODES:
+        return False
+
     if plugin_code in AI_ONLY_PLUGIN_CODES:
         return resource_kind == ResourceKindEnum.AI.value
 
     if resource_kind == ResourceKindEnum.AI.value:
-        return plugin_code not in AI_RESOURCE_INCOMPATIBLE_PLUGIN_CODES
+        return plugin_code in AI_COMPATIBLE_PLUGIN_CODES
 
     return True

--- a/src/dashboard/apigateway/apigateway/tests/apis/v2/sync/test_views.py
+++ b/src/dashboard/apigateway/apigateway/tests/apis/v2/sync/test_views.py
@@ -352,6 +352,23 @@ class TestSyncApi:
         assert response.status_code == 200, response.json()
         assert Gateway.objects.get(name=unique_gateway_name).kind == GatewayKindEnum.AI.value
 
+    def test_gateway_sync_ai_gateway_rejects_older_default_data_plane(
+        self, mocker, request_view, unique_gateway_name, disable_app_permission, default_data_plane
+    ):
+        DataPlane.objects.filter(id=default_data_plane.id).update(apisix_version="3.13")
+
+        response = request_view(
+            method="POST",
+            view_name="openapi.v2.sync.gateway.sync",
+            path_params={"gateway_name": unique_gateway_name},
+            data={"kind": "ai"},
+            app=mocker.MagicMock(app_code="foo"),
+        )
+
+        assert response.status_code == 400
+        assert "APISIX 3.16 or later" in response.json()["error"]["message"]
+        assert not Gateway.objects.filter(name=unique_gateway_name).exists()
+
     def test_gateway_sync_ignores_kind_when_updating(
         self, mocker, request_view, fake_gateway, disable_app_permission, default_data_plane
     ):

--- a/src/dashboard/apigateway/apigateway/tests/apis/web/backend/test_serializers.py
+++ b/src/dashboard/apigateway/apigateway/tests/apis/web/backend/test_serializers.py
@@ -16,11 +16,14 @@
 # We undertake not to change the open source license (MIT license) applicable
 # to the current version of the project delivered to anyone in the future.
 #
+import logging
+
 import pytest
 from django_dynamic_fixture import G
 from rest_framework.exceptions import ValidationError
 
 from apigateway.apis.web.backend import serializers
+from apigateway.core.constants import BackendKindEnum, GatewayKindEnum
 from apigateway.core.models import BackendConfig, Stage
 
 
@@ -302,6 +305,45 @@ class TestBackendInputSLZ:
 
         with django_assert_num_queries(2):
             slz.is_valid(raise_exception=True)
+
+    def test_update_reports_corrupted_existing_ai_config(self, caplog, fake_backend, fake_stage):
+        fake_stage.gateway.kind = GatewayKindEnum.AI.value
+        fake_stage.gateway.save(update_fields=["kind"])
+        fake_backend.kind = BackendKindEnum.AI.value
+        fake_backend.save(update_fields=["kind"])
+        ciphertext = "backend-ciphertext-sentinel"
+        BackendConfig.objects.filter(backend=fake_backend, stage=fake_stage).update(_config={"encrypted": ciphertext})
+        slz = serializers.BackendInputSLZ(
+            instance=fake_backend,
+            data={
+                "name": fake_backend.name,
+                "description": fake_backend.description,
+                "type": fake_backend.type,
+                "configs": [
+                    {
+                        "stage_id": fake_stage.id,
+                        "timeout": 30000,
+                        "instances": [
+                            {
+                                "name": "primary",
+                                "provider": "openai",
+                                "weight": 1,
+                                "auth": {"header": {"Authorization": "Bearer secret"}},
+                                "options": {"model": "gpt-4o"},
+                            }
+                        ],
+                    }
+                ],
+            },
+            context={"gateway": fake_stage.gateway},
+        )
+
+        with caplog.at_level(logging.ERROR), pytest.raises(ValidationError) as exc_info:
+            slz.is_valid(raise_exception=True)
+
+        assert "configs" in exc_info.value.detail
+        assert "已有后端配置无法读取" in str(exc_info.value.detail["configs"])
+        assert ciphertext not in caplog.text
 
 
 def test_backend_retrieve_selects_stage_and_backend(django_assert_num_queries, fake_backend, fake_stage):

--- a/src/dashboard/apigateway/apigateway/tests/apis/web/gateway/test_views.py
+++ b/src/dashboard/apigateway/apigateway/tests/apis/web/gateway/test_views.py
@@ -22,7 +22,7 @@ from django_dynamic_fixture import G
 
 from apigateway.apps.audit.constants import OpObjectTypeEnum
 from apigateway.apps.audit.models import AuditEventLog
-from apigateway.apps.data_plane.models import GatewayDataPlaneBinding
+from apigateway.apps.data_plane.models import DataPlane, GatewayDataPlaneBinding
 from apigateway.apps.gateway.models import GatewayAppBinding
 from apigateway.apps.mcp_server.constants import MCPServerStatusEnum
 from apigateway.apps.mcp_server.models import MCPServer
@@ -104,6 +104,29 @@ class TestGatewayListCreateApi:
 
         assert response.status_code == 200
         assert [item["id"] for item in response.json()["data"]["results"]] == [gateway.id]
+
+    def test_create_ai_gateway_rejects_older_default_data_plane(
+        self, request_view, unique_gateway_name, default_data_plane
+    ):
+        DataPlane.objects.filter(id=default_data_plane.id).update(apisix_version="3.13")
+
+        response = request_view(
+            method="POST",
+            view_name="gateways.list_create",
+            data={
+                "name": unique_gateway_name,
+                "description": "AI gateway",
+                "maintainers": ["admin"],
+                "is_public": False,
+                "kind": GatewayKindEnum.AI.value,
+                "tenant_mode": "single",
+                "tenant_id": "default",
+            },
+        )
+
+        assert response.status_code == 400
+        assert "APISIX 3.16 or later" in response.json()["error"]["message"]
+        assert not Gateway.objects.filter(name=unique_gateway_name).exists()
 
     def test_create_programmable_gateway_without_repo_authorization__non_te(
         self,

--- a/src/dashboard/apigateway/apigateway/tests/apis/web/plugin/test_views.py
+++ b/src/dashboard/apigateway/apigateway/tests/apis/web/plugin/test_views.py
@@ -32,10 +32,7 @@ AI_ONLY_PLUGIN_CODES = (
 )
 
 AI_INCOMPATIBLE_PLUGIN_CODES = (
-    "bk-header-rewrite",
-    "bk-query-string-rewrite",
     "bk-status-rewrite",
-    "bk-traffic-label",
     "api-breaker",
     "response-rewrite",
     "proxy-cache",
@@ -159,6 +156,33 @@ class TestPluginTypeListApi:
         codes = {item["code"] for item in response.json()["data"]["results"]}
         assert plugin_type_code not in codes
 
+    @pytest.mark.parametrize("plugin_type_code", ["unknown-plugin", "ai-proxy", "ai-proxy-multi"])
+    def test_list_excludes_unregistered_and_controller_managed_plugins_for_ai_resource(
+        self,
+        request_view,
+        fake_gateway,
+        fake_resource,
+        plugin_type_code,
+    ):
+        fake_resource.kind = ResourceKindEnum.AI.value
+        fake_resource.save(update_fields=["kind"])
+        PluginType.objects.update_or_create(
+            code=plugin_type_code,
+            defaults={"is_public": True, "scope": PluginTypeScopeEnum.RESOURCE.value},
+        )
+
+        response = request_view(
+            "GET",
+            "plugins.types",
+            gateway=fake_gateway,
+            path_params={"gateway_id": fake_gateway.id},
+            data={"scope_type": "resource", "scope_id": fake_resource.id},
+        )
+
+        assert response.status_code == 200
+        codes = {item["code"] for item in response.json()["data"]["results"]}
+        assert plugin_type_code not in codes
+
 
 class TestScopePluginConfigListApi:
     def test_list(
@@ -226,15 +250,22 @@ class TestPluginConfigCreateApi:
         )
         assert response.status_code == status_code
 
-    def test_create_rejects_incompatible_plugin_for_ai_resource(
+    @pytest.mark.parametrize("plugin_type_code", ["unknown-plugin", "ai-proxy", "ai-proxy-multi"])
+    def test_create_rejects_unregistered_and_controller_managed_plugin_for_ai_resource(
         self,
         request_view,
         fake_gateway,
         fake_resource,
-        fake_plugin_type_bk_header_rewrite,
+        plugin_type_code,
     ):
         fake_resource.kind = ResourceKindEnum.AI.value
         fake_resource.save(update_fields=["kind"])
+        plugin_type = G(
+            PluginType,
+            code=plugin_type_code,
+            is_public=True,
+            scope=PluginTypeScopeEnum.RESOURCE.value,
+        )
 
         response = request_view(
             "POST",
@@ -244,13 +275,13 @@ class TestPluginConfigCreateApi:
                 "gateway_id": fake_gateway.id,
                 "scope_type": "resource",
                 "scope_id": fake_resource.id,
-                "code": fake_plugin_type_bk_header_rewrite.code,
+                "code": plugin_type.code,
             },
             data={
-                "type_id": fake_plugin_type_bk_header_rewrite.pk,
+                "type_id": plugin_type.pk,
                 "description": "description",
                 "name": "name",
-                "yaml": yaml_dumps({"set": [{"key": "foo", "value": "bar"}], "remove": []}),
+                "yaml": yaml_dumps({"enabled": True}),
             },
         )
 
@@ -426,6 +457,8 @@ class TestPluginConfigRetrieveUpdateDestroyApi:
         fake_plugin_type_bk_header_rewrite,
         fake_plugin_resource_bk_header_rewrite_binding,
     ):
+        fake_plugin_type_bk_header_rewrite.code = PluginTypeCodeEnum.BK_STATUS_REWRITE.value
+        fake_plugin_type_bk_header_rewrite.save(update_fields=["code"])
         fake_resource.kind = ResourceKindEnum.AI.value
         fake_resource.save(update_fields=["kind"])
 

--- a/src/dashboard/apigateway/apigateway/tests/apis/web/stage/test_serializers.py
+++ b/src/dashboard/apigateway/apigateway/tests/apis/web/stage/test_serializers.py
@@ -16,10 +16,15 @@
 # We undertake not to change the open source license (MIT license) applicable
 # to the current version of the project delivered to anyone in the future.
 #
+import logging
+
 import pytest
+from django_dynamic_fixture import G
 from rest_framework.exceptions import ValidationError
 
 from apigateway.apis.web.stage import serializers
+from apigateway.core.constants import BackendKindEnum, GatewayKindEnum
+from apigateway.core.models import Backend, BackendConfig
 
 
 def test_ai_backend_config_rejects_non_mapping_instance():
@@ -101,6 +106,51 @@ class TestStageInputSLZ:
 
             with pytest.raises(ValidationError):
                 slz.is_valid(raise_exception=True)
+
+    def test_update_reports_corrupted_existing_ai_config(self, caplog, fake_gateway, fake_stage):
+        fake_gateway.kind = GatewayKindEnum.AI.value
+        fake_gateway.save(update_fields=["kind"])
+        backend = G(Backend, gateway=fake_gateway, kind=BackendKindEnum.AI.value)
+        ciphertext = "stage-ciphertext-sentinel"
+        G(
+            BackendConfig,
+            gateway=fake_gateway,
+            stage=fake_stage,
+            backend=backend,
+            _config={"encrypted": ciphertext},
+        )
+        slz = serializers.StageInputSLZ(
+            instance=fake_stage,
+            data={
+                "gateway": fake_gateway,
+                "name": fake_stage.name,
+                "description": fake_stage.description,
+                "backends": [
+                    {
+                        "id": backend.id,
+                        "config": {
+                            "timeout": 30000,
+                            "instances": [
+                                {
+                                    "name": "primary",
+                                    "provider": "openai",
+                                    "weight": 1,
+                                    "options": {},
+                                }
+                            ],
+                        },
+                    }
+                ],
+            },
+            context={"gateway": fake_gateway},
+        )
+
+        with caplog.at_level(logging.ERROR), pytest.raises(ValidationError) as exc_info:
+            slz.is_valid(raise_exception=True)
+
+        assert "backends" in exc_info.value.detail
+        assert "已有后端配置无法读取" in str(exc_info.value.detail["backends"])
+        assert ciphertext not in caplog.text
 
     def test_http_scheme(self, fake_gateway, fake_backend, fake_grpc_backend):
         data = [

--- a/src/dashboard/apigateway/apigateway/tests/apps/data_plane/test_models.py
+++ b/src/dashboard/apigateway/apigateway/tests/apps/data_plane/test_models.py
@@ -22,6 +22,7 @@ from django.db.models import ProtectedError
 
 from apigateway.apps.data_plane.constants import DataPlaneStatusEnum
 from apigateway.apps.data_plane.models import DataPlane, GatewayDataPlaneBinding
+from apigateway.core.constants import GatewayKindEnum
 from apigateway.core.models import Gateway
 
 pytestmark = pytest.mark.django_db
@@ -115,6 +116,21 @@ class TestGatewayDataPlaneBindingManager:
 
         assert binding1.id == binding2.id
         assert binding1.created_by == "user1"  # Should keep original created_by
+
+    def test_bind_ai_gateway_rejects_older_apisix_version(self):
+        self.gateway1.kind = GatewayKindEnum.AI.value
+        self.data_plane_active1.apisix_version = "3.13"
+
+        with pytest.raises(ValueError, match="APISIX 3.16 or later"):
+            GatewayDataPlaneBinding.objects.bind_gateway_to_data_plane(
+                gateway=self.gateway1,
+                data_plane=self.data_plane_active1,
+            )
+
+        assert not GatewayDataPlaneBinding.objects.filter(
+            gateway=self.gateway1,
+            data_plane=self.data_plane_active1,
+        ).exists()
 
     def test_unbind_gateway_from_data_plane_deletes_binding(self):
         """Test unbind_gateway_from_data_plane removes the binding"""

--- a/src/dashboard/apigateway/apigateway/tests/biz/gateway/test_gateway.py
+++ b/src/dashboard/apigateway/apigateway/tests/biz/gateway/test_gateway.py
@@ -21,6 +21,7 @@ import pytest
 from django.core.exceptions import ObjectDoesNotExist
 from django.utils import timezone
 from django_dynamic_fixture import G
+from rest_framework.exceptions import ValidationError
 
 from apigateway.apps.data_plane.constants import DataPlaneStatusEnum
 from apigateway.apps.data_plane.models import DataPlane, GatewayDataPlaneBinding
@@ -32,6 +33,7 @@ from apigateway.biz.gateway import OPERATION_STATUS_DELTA_DAYS, GatewayHandler
 from apigateway.core.constants import (
     ContextScopeTypeEnum,
     ContextTypeEnum,
+    GatewayKindEnum,
     GatewayOperationStatusEnum,
     GatewayStatusEnum,
     GatewayTypeEnum,
@@ -508,3 +510,12 @@ class TestGatewayHandler:
         GatewayHandler.bind_to_data_planes(gateway=gateway, data_plane_ids=[dp.id], username="admin")
 
         assert GatewayDataPlaneBinding.objects.filter(gateway=gateway, data_plane=dp).count() == 1
+
+    def test_bind_ai_gateway_rejects_older_data_plane(self):
+        gateway = G(Gateway, kind=GatewayKindEnum.AI.value, tenant_mode="single", tenant_id="default")
+        data_plane = G(DataPlane, name="apisix-3-13", apisix_version="3.13")
+
+        with pytest.raises(ValidationError, match="APISIX 3.16 or later"):
+            GatewayHandler.bind_to_data_planes(gateway=gateway, data_plane_ids=[data_plane.id])
+
+        assert not GatewayDataPlaneBinding.objects.filter(gateway=gateway).exists()

--- a/src/dashboard/apigateway/apigateway/tests/biz/gateway/test_saver.py
+++ b/src/dashboard/apigateway/apigateway/tests/biz/gateway/test_saver.py
@@ -18,6 +18,7 @@
 import pytest
 from ddf import G
 from pydantic import TypeAdapter
+from rest_framework.exceptions import ValidationError
 
 from apigateway.apps.data_plane.models import DataPlane, GatewayDataPlaneBinding
 from apigateway.biz.gateway import GatewayData, GatewayHandler, GatewaySaver
@@ -272,6 +273,25 @@ class TestGatewaySaver:
         bound_plane_ids = {b.data_plane_id for b in bindings}
         assert data_plane1.id in bound_plane_ids
         assert data_plane2.id in bound_plane_ids
+
+    def test_save_ai_gateway_rejects_older_data_plane_before_persisting(self, unique_gateway_name):
+        data_plane = G(DataPlane, name="apisix-3-13", apisix_version="3.13")
+        saver = GatewaySaver(
+            None,
+            GatewayData(
+                name=unique_gateway_name,
+                status=0,
+                tenant_mode="single",
+                tenant_id="default",
+                kind=GatewayKindEnum.AI.value,
+            ),
+            data_plane_ids=[data_plane.id],
+        )
+
+        with pytest.raises(ValidationError, match="APISIX 3.16 or later"):
+            saver.save()
+
+        assert not Gateway.objects.filter(name=unique_gateway_name).exists()
 
     def test_save_without_data_plane_ids_binds_to_default(self, unique_gateway_name, default_data_plane):
         """Test save without data_plane_ids binds to default data plane on new gateway"""

--- a/src/dashboard/apigateway/apigateway/tests/biz/mcp_server/test_mcp_server.py
+++ b/src/dashboard/apigateway/apigateway/tests/biz/mcp_server/test_mcp_server.py
@@ -261,6 +261,53 @@ class TestMCPServerHandler:
         permissions = AppResourcePermission.objects.filter(bk_app_code__startswith=f"v_mcp_{mcp_server.id}_")
         assert set(permissions.values_list("resource_id", flat=True)) == {standard_resource.id}
 
+    def test_sync_permissions_excludes_ai_resource_without_release(self, fake_gateway, fake_stage):
+        ai_resource = G(
+            Resource,
+            gateway=fake_gateway,
+            name="ai-resource",
+            kind=ResourceKindEnum.AI.value,
+        )
+        mcp_server = G(
+            MCPServer,
+            gateway=fake_gateway,
+            stage=fake_stage,
+            _resource_names=ai_resource.name,
+        )
+        G(MCPServerAppPermission, mcp_server=mcp_server, bk_app_code="app1")
+
+        MCPServerHandler.sync_permissions(mcp_server.id)
+
+        assert not AppResourcePermission.objects.filter(bk_app_code__startswith=f"v_mcp_{mcp_server.id}_").exists()
+
+    def test_sync_permissions_excludes_live_ai_resource_with_standard_snapshot(self, fake_gateway, fake_stage):
+        resource = G(
+            Resource,
+            gateway=fake_gateway,
+            name="changed-resource",
+            kind=ResourceKindEnum.STANDARD.value,
+        )
+        resource_version = G(ResourceVersion, gateway=fake_gateway)
+        resource_version.data = [
+            {"id": resource.id, "name": resource.name, "kind": ResourceKindEnum.STANDARD.value},
+        ]
+        resource_version.save()
+        G(Release, gateway=fake_gateway, stage=fake_stage, resource_version=resource_version)
+
+        resource.kind = ResourceKindEnum.AI.value
+        resource.save(update_fields=["kind"])
+        mcp_server = G(
+            MCPServer,
+            gateway=fake_gateway,
+            stage=fake_stage,
+            _resource_names=resource.name,
+        )
+        G(MCPServerAppPermission, mcp_server=mcp_server, bk_app_code="app1")
+
+        MCPServerHandler.sync_permissions(mcp_server.id)
+
+        assert not AppResourcePermission.objects.filter(bk_app_code__startswith=f"v_mcp_{mcp_server.id}_").exists()
+
     def test_sync_permissions_delete_permissions(self, fake_gateway, fake_stage):
         """Test sync_permissions when existing permissions need to be deleted"""
         # Create resources

--- a/src/dashboard/apigateway/apigateway/tests/biz/resource/importer/test_openapi.py
+++ b/src/dashboard/apigateway/apigateway/tests/biz/resource/importer/test_openapi.py
@@ -24,6 +24,7 @@ from openapi_spec_validator.versions import get_spec_version
 
 from apigateway.apps.support.constants import OpenAPIFormatEnum
 from apigateway.biz.openapi import OpenAPIImportManager
+from apigateway.biz.openapi.schema import openapi_validator_mapping
 from apigateway.biz.resource.importer import sync_openapi_resources_from_content
 from apigateway.core.constants import DEFAULT_BACKEND_NAME
 from apigateway.core.models import Backend, Gateway
@@ -766,6 +767,44 @@ class TestOpenAPIImportManagerParse:
         manager = OpenAPIImportManager(gateway=gateway, data=data)
         manager.version = get_spec_version(data)
         return manager
+
+    @pytest.mark.parametrize("openapi_version", ["2.0", "3.0.1", "3.1.0"])
+    @pytest.mark.parametrize("resource_kind", [None, "standard"])
+    def test_schema_rejects_name_only_backend_for_standard_resource(self, openapi_version, resource_kind):
+        data = self._name_only_backend_document(openapi_version, resource_kind)
+
+        errors = list(openapi_validator_mapping[get_spec_version(data)].cls(data).iter_errors())
+
+        assert errors
+
+    @pytest.mark.parametrize("openapi_version", ["2.0", "3.0.1", "3.1.0"])
+    def test_schema_accepts_name_only_backend_for_ai_resource(self, openapi_version):
+        data = self._name_only_backend_document(openapi_version, "ai")
+
+        errors = list(openapi_validator_mapping[get_spec_version(data)].cls(data).iter_errors())
+
+        assert not errors
+
+    @staticmethod
+    def _name_only_backend_document(openapi_version, resource_kind):
+        extension = {"backend": {"name": "openai-primary"}}
+        if resource_kind is not None:
+            extension["kind"] = resource_kind
+
+        version = {"swagger": openapi_version} if openapi_version == "2.0" else {"openapi": openapi_version}
+        return {
+            **version,
+            "info": {"version": "0.1", "title": "Test"},
+            "paths": {
+                "/chat": {
+                    "post": {
+                        "operationId": "chat",
+                        "responses": {"200": {"description": "OK"}},
+                        "x-bk-apigateway-resource": extension,
+                    }
+                }
+            },
+        }
 
     def test_parse_swagger2_dict(self):
         data = {

--- a/src/dashboard/apigateway/apigateway/tests/biz/resource/importer/test_parser.py
+++ b/src/dashboard/apigateway/apigateway/tests/biz/resource/importer/test_parser.py
@@ -155,6 +155,26 @@ class TestBaseParser:
         assert resource["backend_name"] == "openai-primary"
         assert resource["backend_config"] is None
 
+    def test_get_standard_resource_rejects_name_only_backend(self):
+        parser = BaseParser(
+            _openapi_data={
+                "basePath": "/",
+                "paths": {
+                    "/users": {
+                        "get": {
+                            "operationId": "get_users",
+                            "x-bk-apigateway-resource": {
+                                "backend": {"name": "default"},
+                            },
+                        }
+                    }
+                },
+            }
+        )
+
+        with pytest.raises(ValueError, match="standard resource HTTP backend requires method, path"):
+            parser.get_resources()
+
     @pytest.mark.parametrize(
         "swagger_data, expected",
         [

--- a/src/dashboard/apigateway/apigateway/tests/biz/resource/importer/test_validate.py
+++ b/src/dashboard/apigateway/apigateway/tests/biz/resource/importer/test_validate.py
@@ -87,6 +87,8 @@ class TestResourceImportValidator:
         fake_gateway,
         fake_plugin_type_bk_header_rewrite,
     ):
+        fake_plugin_type_bk_header_rewrite.code = PluginTypeCodeEnum.BK_STATUS_REWRITE.value
+        fake_plugin_type_bk_header_rewrite.save(update_fields=["code"])
         fake_gateway.kind = GatewayKindEnum.AI.value
         fake_gateway.save(update_fields=["kind"])
         backend = G(Backend, gateway=fake_gateway, kind=BackendKindEnum.AI.value)
@@ -108,7 +110,7 @@ class TestResourceImportValidator:
 
         errors = ResourceImportValidator(fake_gateway, [resource_data]).validate()
 
-        assert any("bk-header-rewrite" in error.message and "不兼容" in error.message for error in errors)
+        assert any("bk-status-rewrite" in error.message and "不兼容" in error.message for error in errors)
 
     @pytest.mark.parametrize("plugin_type_code", AI_ONLY_PLUGIN_CODES)
     @pytest.mark.parametrize(

--- a/src/dashboard/apigateway/apigateway/tests/controller/test_transformer.py
+++ b/src/dashboard/apigateway/apigateway/tests/controller/test_transformer.py
@@ -32,6 +32,7 @@ from apigateway.core.constants import BackendKindEnum, BackendTypeEnum, ProxyTyp
 
 APISIX_VERSION_3_13 = DataPlaneApisixVersionEnum.V3_13.value
 APISIX_VERSION_3_16 = DataPlaneApisixVersionEnum.V3_16.value
+APISIX_VERSION_3_17 = "3.17"
 
 
 class TestBaseTransformer:
@@ -160,10 +161,11 @@ class TestGatewayApisixResourceConvertor:
 
         GatewayApisixResourceTransformer(mock_release, APISIX_VERSION_3_13)
 
-    def test_ai_gateway_accepts_only_3_16(self, mock_release):
+    def test_ai_gateway_accepts_3_16_or_later(self, mock_release):
         mock_release.gateway.is_ai_gateway = True
 
         GatewayApisixResourceTransformer(mock_release, APISIX_VERSION_3_16)
+        GatewayApisixResourceTransformer(mock_release, APISIX_VERSION_3_17)
 
         with pytest.raises(ValueError, match="APISIX 3.16"):
             GatewayApisixResourceTransformer(mock_release, APISIX_VERSION_3_13)

--- a/src/dashboard/apigateway/apigateway/tests/service/plugin/test_compatibility.py
+++ b/src/dashboard/apigateway/apigateway/tests/service/plugin/test_compatibility.py
@@ -18,7 +18,12 @@
 import pytest
 
 from apigateway.core.constants import ResourceKindEnum
-from apigateway.service.plugin import AI_ONLY_PLUGIN_CODES, is_plugin_compatible_with_resource_kind
+from apigateway.service.plugin import (
+    AI_COMPATIBLE_PLUGIN_CODES,
+    AI_ONLY_PLUGIN_CODES,
+    CONTROLLER_MANAGED_PLUGIN_CODES,
+    is_plugin_compatible_with_resource_kind,
+)
 
 
 def test_ai_only_plugin_codes():
@@ -27,6 +32,19 @@ def test_ai_only_plugin_codes():
         "ai-prompt-guard",
         "ai-prompt-decorator",
     } == AI_ONLY_PLUGIN_CODES
+
+
+def test_ai_plugin_policy_sets():
+    assert {
+        "ai-proxy",
+        "ai-proxy-multi",
+    } == CONTROLLER_MANAGED_PLUGIN_CODES
+    assert {
+        "bk-header-rewrite",
+        "bk-query-string-rewrite",
+        "bk-traffic-label",
+        "ai-rate-limiting",
+    } <= AI_COMPATIBLE_PLUGIN_CODES
 
 
 @pytest.mark.parametrize(
@@ -40,10 +58,10 @@ def test_ai_only_plugin_codes():
         (ResourceKindEnum.STANDARD.value, "ai-prompt-decorator", False),
         (None, "ai-rate-limiting", False),
         (ResourceKindEnum.AI.value, "bk-cors", True),
-        (ResourceKindEnum.AI.value, "bk-header-rewrite", False),
-        (ResourceKindEnum.AI.value, "bk-query-string-rewrite", False),
+        (ResourceKindEnum.AI.value, "bk-header-rewrite", True),
+        (ResourceKindEnum.AI.value, "bk-query-string-rewrite", True),
         (ResourceKindEnum.AI.value, "bk-status-rewrite", False),
-        (ResourceKindEnum.AI.value, "bk-traffic-label", False),
+        (ResourceKindEnum.AI.value, "bk-traffic-label", True),
         (ResourceKindEnum.AI.value, "api-breaker", False),
         (ResourceKindEnum.AI.value, "response-rewrite", False),
         (ResourceKindEnum.AI.value, "proxy-cache", False),
@@ -51,11 +69,17 @@ def test_ai_only_plugin_codes():
         (ResourceKindEnum.AI.value, "bk-mock", False),
         (ResourceKindEnum.AI.value, "redirect", False),
         (ResourceKindEnum.AI.value, "fault-injection", False),
+        (ResourceKindEnum.AI.value, "unknown-plugin", False),
+        (ResourceKindEnum.AI.value, "ai-proxy", False),
+        (ResourceKindEnum.AI.value, "ai-proxy-multi", False),
         (ResourceKindEnum.STANDARD.value, "bk-mock", True),
         (ResourceKindEnum.STANDARD.value, "redirect", True),
         (ResourceKindEnum.STANDARD.value, "fault-injection", True),
         (ResourceKindEnum.STANDARD.value, "bk-cors", True),
         (ResourceKindEnum.STANDARD.value, "bk-header-rewrite", True),
+        (ResourceKindEnum.STANDARD.value, "unknown-plugin", True),
+        (ResourceKindEnum.STANDARD.value, "ai-proxy", False),
+        (None, "ai-proxy-multi", False),
         (None, "bk-cors", True),
         (None, "bk-header-rewrite", True),
     ],

--- a/src/dashboard/apigateway/apigateway/tests/service/test_data_plane.py
+++ b/src/dashboard/apigateway/apigateway/tests/service/test_data_plane.py
@@ -1,0 +1,59 @@
+#
+# TencentBlueKing is pleased to support the open source community by making
+# 蓝鲸智云 - API 网关(BlueKing - APIGateway) available.
+# Copyright (C) Tencent. All rights reserved.
+# Licensed under the MIT License (the "License"); you may not use this file except
+# in compliance with the License. You may obtain a copy of the License at
+#
+# https://opensource.org/licenses/MIT
+#
+# Unless required by applicable law or agreed to in writing, software distributed under
+# the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+# either express or implied. See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# We undertake not to change the open source license (MIT license) applicable
+# to the current version of the project delivered to anyone in the future.
+#
+
+import pytest
+from ddf import G
+from rest_framework.exceptions import ValidationError
+
+from apigateway.apps.data_plane.models import DataPlane
+from apigateway.core.constants import GatewayKindEnum
+from apigateway.core.models import Gateway
+from apigateway.service.data_plane import (
+    is_apisix_version_supported_for_ai_gateway,
+    validate_gateway_data_plane_compatibility,
+)
+
+
+@pytest.mark.parametrize(
+    ("apisix_version", "expected"),
+    [
+        ("3.13", False),
+        ("3.16", True),
+        ("3.17", True),
+        ("invalid", False),
+    ],
+)
+def test_is_apisix_version_supported_for_ai_gateway(apisix_version, expected):
+    assert is_apisix_version_supported_for_ai_gateway(apisix_version) is expected
+
+
+@pytest.mark.django_db
+def test_validate_gateway_data_plane_compatibility_rejects_older_version():
+    gateway = G(Gateway, kind=GatewayKindEnum.AI.value)
+    data_plane = G(DataPlane, name="apisix-3-13", apisix_version="3.13")
+
+    with pytest.raises(ValidationError, match="APISIX 3.16 or later"):
+        validate_gateway_data_plane_compatibility(gateway, [data_plane])
+
+
+@pytest.mark.django_db
+def test_validate_gateway_data_plane_compatibility_keeps_standard_gateway_unchanged():
+    gateway = G(Gateway, kind=GatewayKindEnum.NORMAL.value)
+    data_plane = G(DataPlane, name="apisix-3-13", apisix_version="3.13")
+
+    validate_gateway_data_plane_compatibility(gateway, [data_plane])

--- a/src/dashboard/apigateway/apigateway/tests/service/test_public_api_contract.py
+++ b/src/dashboard/apigateway/apigateway/tests/service/test_public_api_contract.py
@@ -130,5 +130,7 @@ def test_service_private_helpers_are_prefixed_with_underscore():
 def test_plugin_compatibility_contract_is_public():
     exported_names = _package_dunder_all(SERVICE_DIR / "plugin")
 
+    assert "AI_COMPATIBLE_PLUGIN_CODES" in exported_names
     assert "AI_ONLY_PLUGIN_CODES" in exported_names
+    assert "CONTROLLER_MANAGED_PLUGIN_CODES" in exported_names
     assert "is_plugin_compatible_with_resource_kind" in exported_names


### PR DESCRIPTION
### Description

Address the verified C1, H1, H4, M1, M3, and M7 findings for PR #3003, plus carry the existing `compatibility.py` adjustment as its own commit.

Each requested finding is isolated in one commit with a detailed problem/solution body:

- C1: stop operator schema validation logs from printing full resources or raw plugin configs containing AI provider credentials.
- H1: replace the AI plugin denylist with an explicit allowlist, block controller-managed proxy plugins, align plugin listing, and remove stale bindable proxy rows.
- H4: require AI Gateway data planes to run APISIX 3.16 or later at every production binding entry and keep the same publishing safeguard.
- M1: allow name-only OpenAPI backends only for explicit AI resources across OpenAPI 2.0, 3.0, and 3.1, with a parser fallback error instead of `KeyError`.
- M3: require the final live MCP permission lookup to resolve only standard resources.
- M7: convert corrupted AI backend config decryption failures into sanitized field-level validation errors.

The carried compatibility commit keeps `bk-header-rewrite`, `bk-query-string-rewrite`, and `bk-traffic-label` available to AI resources and remains separate from H1.

Static verification performed:

- Per-commit pre-commit hooks passed, including ruff formatting/lint, mypy, import-linter, sensitive-info checks, and the operator Go hooks where applicable.
- `git diff --check upstream/ft_ai_gateway...HEAD` passed.
- All three modified OpenAPI schema files parse successfully with `jq`.
- Final review covered correctness, architecture, security, performance, commit isolation, and secret/logging boundaries.

Tests were not run per explicit request.

Out of scope per the latest instructions: L6, C2/SSRF, H2 Stage mixed-kind behavior, and duplicate Gateway kind-update coverage.

### Checklist

- [x] 填写 PR 描述及相关 issue (write PR description and related issue)
- [x] 代码风格检查通过 (code style check passed)
- [x] PR 中包含单元测试 (include unit test)
- [ ] 单元测试通过 (unit test passed; not run per request)
- [ ] 本地开发联调环境验证通过 (local development environment verification passed; not run)
