### PR TITLE
refactor(ai-gateway): centralize data plane compatibility

### DIFF
--- a/src/dashboard/apigateway/apigateway/apps/data_plane/constants.py
+++ b/src/dashboard/apigateway/apigateway/apps/data_plane/constants.py
@@ -16,8 +16,13 @@
 # to the current version of the project delivered to anyone in the future.
 #
 
+from typing import TYPE_CHECKING
+
 from blue_krill.data_types.enum import EnumField, StructuredEnum
 from packaging.version import InvalidVersion, Version
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable
 
 
 class DataPlaneStatusEnum(StructuredEnum):
@@ -36,6 +41,7 @@ class DataPlaneApisixVersionEnum(StructuredEnum):
 
 CURRENT_DATA_PLANE_APISIX_VERSION = DataPlaneApisixVersionEnum.V3_16.value
 AI_GATEWAY_MIN_APISIX_VERSION = DataPlaneApisixVersionEnum.V3_16.value
+AI_GATEWAY_APISIX_VERSION_ERROR = f"AI Gateway requires APISIX {AI_GATEWAY_MIN_APISIX_VERSION} or later"
 
 
 def is_apisix_version_supported_for_ai_gateway(apisix_version: str) -> bool:
@@ -43,6 +49,23 @@ def is_apisix_version_supported_for_ai_gateway(apisix_version: str) -> bool:
         return Version(apisix_version) >= Version(AI_GATEWAY_MIN_APISIX_VERSION)
     except InvalidVersion, TypeError:
         return False
+
+
+def get_ai_gateway_apisix_version_error(apisix_version: str) -> str | None:
+    if is_apisix_version_supported_for_ai_gateway(apisix_version):
+        return None
+    return AI_GATEWAY_APISIX_VERSION_ERROR
+
+
+def get_ai_gateway_data_planes_compatibility_error(data_planes: Iterable[tuple[str, str]]) -> str | None:
+    incompatible_data_planes = [
+        f"{name} ({apisix_version})"
+        for name, apisix_version in data_planes
+        if not is_apisix_version_supported_for_ai_gateway(apisix_version)
+    ]
+    if not incompatible_data_planes:
+        return None
+    return f"{AI_GATEWAY_APISIX_VERSION_ERROR}; incompatible data planes: {', '.join(incompatible_data_planes)}"
 
 
 class BkPluginsDataPlaneGrayStageEnum(StructuredEnum):

--- a/src/dashboard/apigateway/apigateway/apps/data_plane/managers.py
+++ b/src/dashboard/apigateway/apigateway/apps/data_plane/managers.py
@@ -22,10 +22,9 @@ from django.db import models
 from apigateway.core.models import Gateway
 
 from .constants import (
-    AI_GATEWAY_MIN_APISIX_VERSION,
     DEFAULT_DATA_PLANE_NAME,
     DataPlaneStatusEnum,
-    is_apisix_version_supported_for_ai_gateway,
+    get_ai_gateway_apisix_version_error,
 )
 
 if TYPE_CHECKING:
@@ -73,8 +72,10 @@ class GatewayDataPlaneBindingManager(models.Manager):
         self, gateway: Gateway, data_plane: "DataPlane", created_by: str = ""
     ) -> "GatewayDataPlaneBinding":
         """Bind a gateway to a data plane"""
-        if gateway.is_ai_gateway and not is_apisix_version_supported_for_ai_gateway(data_plane.apisix_version):
-            raise ValueError(f"AI Gateway requires APISIX {AI_GATEWAY_MIN_APISIX_VERSION} or later")
+        if gateway.is_ai_gateway:
+            compatibility_error = get_ai_gateway_apisix_version_error(data_plane.apisix_version)
+            if compatibility_error:
+                raise ValueError(compatibility_error)
 
         binding, _ = self.get_or_create(
             gateway=gateway,

--- a/src/dashboard/apigateway/apigateway/controller/convertor/service.py
+++ b/src/dashboard/apigateway/apigateway/controller/convertor/service.py
@@ -130,7 +130,7 @@ class ServiceConvertor(GatewayResourceConvertor):
         super().__init__(release_data=release_data, publish_id=publish_id, apisix_version=apisix_version)
         self._revoke_flag = revoke_flag
 
-    def convert(self) -> List[GatewayApisixModel]:  # noqa: C901, PLR0912
+    def convert(self) -> List[GatewayApisixModel]:
         # if revoke, we should not generate service, will delete the service from etcd
         if self._revoke_flag:
             return []
@@ -139,21 +139,6 @@ class ServiceConvertor(GatewayResourceConvertor):
         backend_configs = self._release_data.stage_backend_configs
         if not backend_configs:
             return []
-
-        # {
-        #   "type": "node",
-        #   "timeout": 60,
-        #   "loadbalance": "roundrobin", # or "chash"
-        #   "hash_on": "header",
-        #   "key": "content-type",
-        #   "hosts": [
-        #     {
-        #       "scheme": "http",
-        #       "host": "exmple.com",
-        #       "weight": 100
-        #     }
-        #   ]
-        # }
 
         services: List[GatewayApisixModel] = []
 

--- a/src/dashboard/apigateway/apigateway/controller/transformer.py
+++ b/src/dashboard/apigateway/apigateway/controller/transformer.py
@@ -19,6 +19,7 @@ import logging
 from abc import ABC, abstractmethod
 from typing import TYPE_CHECKING, Dict, Iterable, List, Optional
 
+from apigateway.apps.data_plane.constants import get_ai_gateway_apisix_version_error
 from apigateway.controller.convertor import (
     BkReleaseConvertor,
     RouteConvertor,
@@ -27,10 +28,6 @@ from apigateway.controller.convertor import (
 from apigateway.controller.convertor.constants import LABEL_KEY_BACKEND_ID
 from apigateway.controller.convertor.plugin_metadata import PluginMetadataConvertor
 from apigateway.controller.release_data import ReleaseData
-from apigateway.service.data_plane import (
-    AI_GATEWAY_MIN_APISIX_VERSION,
-    is_apisix_version_supported_for_ai_gateway,
-)
 
 if TYPE_CHECKING:
     from apigateway.controller.models import ApisixModel, GatewayApisixModel
@@ -83,12 +80,10 @@ class GatewayApisixResourceTransformer(BaseTransformer):
         publish_id: Optional[int] = None,
         revoke_flag: Optional[bool] = False,
     ):
-        if (
-            not revoke_flag
-            and release.gateway.is_ai_gateway
-            and not is_apisix_version_supported_for_ai_gateway(apisix_version)
-        ):
-            raise ValueError(f"AI Gateway requires APISIX {AI_GATEWAY_MIN_APISIX_VERSION} or later")
+        if not revoke_flag and release.gateway.is_ai_gateway:
+            compatibility_error = get_ai_gateway_apisix_version_error(apisix_version)
+            if compatibility_error:
+                raise ValueError(compatibility_error)
 
         if release.resource_version.is_schema_v2 or revoke_flag:
             # note: revoke_flag is True, allow to use schema v1 to revoke resources

--- a/src/dashboard/apigateway/apigateway/service/data_plane.py
+++ b/src/dashboard/apigateway/apigateway/service/data_plane.py
@@ -20,10 +20,7 @@ from typing import TYPE_CHECKING
 
 from rest_framework.exceptions import ValidationError
 
-from apigateway.apps.data_plane.constants import (
-    AI_GATEWAY_MIN_APISIX_VERSION,
-    is_apisix_version_supported_for_ai_gateway,
-)
+from apigateway.apps.data_plane.constants import get_ai_gateway_data_planes_compatibility_error
 
 if TYPE_CHECKING:
     from collections.abc import Iterable
@@ -36,17 +33,8 @@ def validate_gateway_data_plane_compatibility(gateway: Gateway, data_planes: Ite
     if not gateway.is_ai_gateway:
         return
 
-    incompatible_data_planes = [
-        f"{data_plane.name} ({data_plane.apisix_version})"
-        for data_plane in data_planes
-        if not is_apisix_version_supported_for_ai_gateway(data_plane.apisix_version)
-    ]
-    if incompatible_data_planes:
-        raise ValidationError(
-            {
-                "data_planes": (
-                    f"AI Gateway requires APISIX {AI_GATEWAY_MIN_APISIX_VERSION} or later; "
-                    f"incompatible data planes: {', '.join(incompatible_data_planes)}"
-                )
-            }
-        )
+    compatibility_error = get_ai_gateway_data_planes_compatibility_error(
+        (data_plane.name, data_plane.apisix_version) for data_plane in data_planes
+    )
+    if compatibility_error:
+        raise ValidationError({"data_planes": compatibility_error})

--- a/src/dashboard/apigateway/apigateway/tests/apps/data_plane/test_models.py
+++ b/src/dashboard/apigateway/apigateway/tests/apps/data_plane/test_models.py
@@ -121,11 +121,13 @@ class TestGatewayDataPlaneBindingManager:
         self.gateway1.kind = GatewayKindEnum.AI.value
         self.data_plane_active1.apisix_version = "3.13"
 
-        with pytest.raises(ValueError, match="APISIX 3.16 or later"):
+        with pytest.raises(ValueError) as exc_info:
             GatewayDataPlaneBinding.objects.bind_gateway_to_data_plane(
                 gateway=self.gateway1,
                 data_plane=self.data_plane_active1,
             )
+
+        assert str(exc_info.value) == "AI Gateway requires APISIX 3.16 or later"
 
         assert not GatewayDataPlaneBinding.objects.filter(
             gateway=self.gateway1,

--- a/src/dashboard/apigateway/apigateway/tests/controller/test_transformer.py
+++ b/src/dashboard/apigateway/apigateway/tests/controller/test_transformer.py
@@ -167,8 +167,10 @@ class TestGatewayApisixResourceConvertor:
         GatewayApisixResourceTransformer(mock_release, APISIX_VERSION_3_16)
         GatewayApisixResourceTransformer(mock_release, APISIX_VERSION_3_17)
 
-        with pytest.raises(ValueError, match="APISIX 3.16"):
+        with pytest.raises(ValueError) as exc_info:
             GatewayApisixResourceTransformer(mock_release, APISIX_VERSION_3_13)
+
+        assert str(exc_info.value) == "AI Gateway requires APISIX 3.16 or later"
 
     def test_ai_gateway_revoke_skips_apisix_version_check(self, mock_release):
         mock_release.gateway.is_ai_gateway = True

--- a/src/dashboard/apigateway/apigateway/tests/service/test_data_plane.py
+++ b/src/dashboard/apigateway/apigateway/tests/service/test_data_plane.py
@@ -20,13 +20,11 @@ import pytest
 from ddf import G
 from rest_framework.exceptions import ValidationError
 
+from apigateway.apps.data_plane.constants import is_apisix_version_supported_for_ai_gateway
 from apigateway.apps.data_plane.models import DataPlane
 from apigateway.core.constants import GatewayKindEnum
 from apigateway.core.models import Gateway
-from apigateway.service.data_plane import (
-    is_apisix_version_supported_for_ai_gateway,
-    validate_gateway_data_plane_compatibility,
-)
+from apigateway.service.data_plane import validate_gateway_data_plane_compatibility
 
 
 @pytest.mark.parametrize(
@@ -47,8 +45,12 @@ def test_validate_gateway_data_plane_compatibility_rejects_older_version():
     gateway = G(Gateway, kind=GatewayKindEnum.AI.value)
     data_plane = G(DataPlane, name="apisix-3-13", apisix_version="3.13")
 
-    with pytest.raises(ValidationError, match="APISIX 3.16 or later"):
+    with pytest.raises(ValidationError) as exc_info:
         validate_gateway_data_plane_compatibility(gateway, [data_plane])
+
+    assert str(exc_info.value.detail["data_planes"]) == (
+        "AI Gateway requires APISIX 3.16 or later; incompatible data planes: apisix-3-13 (3.13)"
+    )
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
## Summary
- centralize AI Gateway APISIX version compatibility and error construction in the data-plane policy layer
- preserve manager `ValueError`, service DRF `ValidationError`, and transformer publish-time defensive validation
- remove the unused `ServiceConvertor.convert` complexity suppression and stale inline standard-backend example

## Verification
- focused pytest: 76 passed
- `make lint-check`: passed (ruff, mypy, import-linter)
- `make test`: 3320 passed
- fast-refactor-audit: clear; no proxy-only wrappers, dead helpers, scope drift, or import-contract breakage