### PR TITLE
feat: return oauth2_public_client_enabled in inner mcp server responses and update docs

### DIFF
--- a/src/dashboard/apigateway/apigateway/apis/v2/inner/serializers.py
+++ b/src/dashboard/apigateway/apigateway/apis/v2/inner/serializers.py
@@ -402,6 +402,9 @@ class MCPServerBaseSLZ(serializers.Serializer):
     url = serializers.SerializerMethodField(help_text="MCPServer 访问 URL")
     categories = serializers.SerializerMethodField(help_text="MCPServer 分类列表")
     is_official = serializers.SerializerMethodField(help_text="是否为官方")
+    oauth2_public_client_enabled = serializers.BooleanField(
+        read_only=True, help_text="是否开启 OAuth2 公开客户端模式，开启后将会对 bk_app_code=public 的应用进行授权"
+    )
 
     def get_title(self, obj) -> str:
         return obj.title if obj.title else obj.name

--- a/src/dashboard/apigateway/apigateway/data/apidocs/zh/v2_inner_list_mcp_server_app_permissions.md
+++ b/src/dashboard/apigateway/apigateway/data/apidocs/zh/v2_inner_list_mcp_server_app_permissions.md
@@ -30,7 +30,8 @@ mcp_server 已申请权限列表
           {"name": "official", "display_name": "官方"},
           {"name": "ai", "display_name": "AI"}
         ],
-        "is_official": true
+        "is_official": true,
+        "oauth2_public_client_enabled": false
       },
       "permission": {
         "status": "owned",
@@ -72,6 +73,7 @@ mcp_server 已申请权限列表
 | doc_link        | string | mcp_server 文档访问地址 |
 | categories      | array  | mcp_server 分类列表，每项包含 name（英文标识）和 display_name（显示名称） |
 | is_official     | bool   | 是否为官方 MCPServer |
+| oauth2_public_client_enabled | bool | 是否开启 OAuth2 公开客户端模式，开启后将会对 bk_app_code=public 的应用进行授权 |
 
 #### data.permission
 

--- a/src/dashboard/apigateway/apigateway/data/apidocs/zh/v2_inner_list_mcp_server_permission_apply_records.md
+++ b/src/dashboard/apigateway/apigateway/data/apidocs/zh/v2_inner_list_mcp_server_permission_apply_records.md
@@ -35,7 +35,8 @@ mcp_server 申请记录列表
           {"name": "official", "display_name": "官方"},
           {"name": "ai", "display_name": "AI"}
         ],
-        "is_official": true
+        "is_official": true,
+        "oauth2_public_client_enabled": false
       },
       "record": {
         "id": 1,
@@ -84,6 +85,7 @@ mcp_server 申请记录列表
 | doc_link        | string | mcp_server 文档访问地址    |
 | categories      | array  | mcp_server 分类列表，每项包含 name（英文标识）和 display_name（显示名称） |
 | is_official     | bool   | 是否为官方 MCPServer |
+| oauth2_public_client_enabled | bool | 是否开启 OAuth2 公开客户端模式，开启后将会对 bk_app_code=public 的应用进行授权 |
 
 #### data.record
 

--- a/src/dashboard/apigateway/apigateway/data/apidocs/zh/v2_inner_list_mcp_server_permissions.md
+++ b/src/dashboard/apigateway/apigateway/data/apidocs/zh/v2_inner_list_mcp_server_permissions.md
@@ -31,7 +31,8 @@ mcp_server 申请权限列表
           {"name": "official", "display_name": "官方"},
           {"name": "ai", "display_name": "AI"}
         ],
-        "is_official": true
+        "is_official": true,
+        "oauth2_public_client_enabled": false
       },
       "permission": {
         "status": "pending",
@@ -53,7 +54,8 @@ mcp_server 申请权限列表
         "url": "https://mcp.example.com/bk-esb-prod-test2/sse",
         "doc_link": "",
         "categories": [],
-        "is_official": false
+        "is_official": false,
+        "oauth2_public_client_enabled": false
       },
       "permission": {
         "status": "need_apply",
@@ -95,6 +97,7 @@ mcp_server 申请权限列表
 | doc_link        | string | mcp_server 文档访问地址 |
 | categories      | array  | mcp_server 分类列表，每项包含 name（英文标识）和 display_name（显示名称） |
 | is_official     | bool   | 是否为官方 MCPServer |
+| oauth2_public_client_enabled | bool | 是否开启 OAuth2 公开客户端模式，开启后将会对 bk_app_code=public 的应用进行授权 |
 
 #### data.permission
 

--- a/src/dashboard/apigateway/apigateway/data/apidocs/zh/v2_inner_retrieve_mcp_server_permission_apply_record.md
+++ b/src/dashboard/apigateway/apigateway/data/apidocs/zh/v2_inner_retrieve_mcp_server_permission_apply_record.md
@@ -32,7 +32,8 @@ mcp_server 申请记录详情
         {"name": "official", "display_name": "官方"},
         {"name": "ai", "display_name": "AI"}
       ],
-      "is_official": true
+      "is_official": true,
+      "oauth2_public_client_enabled": false
     },
     "record": {
       "id": 1,
@@ -79,6 +80,7 @@ mcp_server 申请记录详情
 | protocol_type | string | MCPServer 协议类型 |
 | categories | array | mcp_server 分类列表，每项包含 name（英文标识）和 display_name（显示名称） |
 | is_official | bool | 是否为官方 MCPServer |
+| oauth2_public_client_enabled | bool | 是否开启 OAuth2 公开客户端模式，开启后将会对 bk_app_code=public 的应用进行授权 |
 
 #### data.record
 


### PR DESCRIPTION
- 为 v2_inner 的 MCPServer 相关接口补充返回字段 oauth2_public_client_enabled，用于标识是否开启 OAuth2 公开客户端模式，便于调用方在权限申请与展示场景中直接判断能力状态。