### PR TITLE
fix(plugin): filter incompatible stage plugins on publish

### DIFF
--- a/docs/ai-gateway-models.md
+++ b/docs/ai-gateway-models.md
@@ -15,7 +15,7 @@ AI Gateway 继续复用现有网关、环境、后端服务、资源和发布模
 - `Resource.kind` 区分普通 API 和模型代理 API。
 - `Proxy` 仍然只保留一个 `backend` 外键，不增加 `model_backend` 外键。
 - `Backend.type` 和 `Proxy.type` 保持现有的协议语义，不用于区分普通服务和模型服务。
-- Service 和 Route 的用户绑定插件在绑定或资源同步写入时按 Backend.kind / Resource.kind 校验；controller 信任已保存的绑定关系，不在发布时重复校验或过滤。
+- Stage 插件绑定和同步写入不按 Backend.kind 限制；发布时普通 Service 保留全部 Stage 插件，模型 Service 由 controller 过滤不兼容插件并记录日志。Resource 插件仍在绑定或资源同步写入时按 Resource.kind 校验。
 - 第一期不增加模型请求的 AI 专用出站 Header 限制；模型访问日志默认只记录统计摘要，不记录 Prompt 和模型回复正文。
 - 模型代理 API 不能配置为 MCP Server 的工具资源，MCP Server 只允许关联 `Resource.kind=standard` 的 API。
 - 模型代理 API 保留用户配置的外部 Resource.path，HTTP Method 固定为 POST；第一期只支持 Chat Completions。
@@ -533,7 +533,7 @@ common service plugins
 - 模型 Service 的 `file-logger` 配置不得引用请求体、响应体、查询字符串、上游地址或模型厂商凭证。
 - `bk-response-check` 继续提供现有网关、应用、Backend 和 Resource 维度的通用请求指标；LLM 模型、Token 和首 Token 延迟等指标由 APISIX Prometheus LLM metrics 提供。
 
-`ai-proxy` / `ai-proxy-multi` 只能由 controller 根据 BackendConfig 生成。即使 `PluginType` 中存在 `ai-proxy`，也不允许通过页面、导入或同步将其绑定到 Stage 或 Resource，避免 Route 插件覆盖 Service 上由 BackendConfig 派生的模型配置。
+模型 Service 中的 `ai-proxy` / `ai-proxy-multi` 只能由 controller 根据 BackendConfig 生成。Stage 可以保存同名插件绑定，但 controller 在模型 Service 转换时会将其过滤；模型 Resource 仍不允许绑定，避免用户配置覆盖由 BackendConfig 派生的模型配置。
 
 #### 8.3.2 Stage 与 Resource 绑定插件
 
@@ -542,20 +542,20 @@ common service plugins
 | 策略 | 插件 | 说明 |
 | --- | --- | --- |
 | 允许用于普通和模型链路 | `bk-cors`、`bk-rate-limit`、`bk-ip-restriction`、`request-validation`、`bk-request-body-limit`、`bk-user-restriction`、`bk-access-token-source`、`bk-username-required`、OAuth2 认证插件、`uri-blocker`、`bk-header-rewrite`、`bk-query-string-rewrite`、`bk-traffic-label` | 处理入口认证、访问控制、请求校验或按已有通用规则改写请求 |
-| 只允许用于模型链路 | `ai-rate-limiting` | 依赖 `ai-proxy` 选中的 instance 和模型 Token usage |
+| 模型 Service 允许的 AI 专用能力 | `ai-prompt-decorator`、`ai-prompt-guard`、`ai-rate-limiting` | 依赖模型请求内容、`ai-proxy` 选中的 instance 或模型 Token usage |
 | 模型链路禁止 | `bk-status-rewrite`、`api-breaker`、`response-rewrite`、`proxy-cache`、`bk-legacy-invalid-params` | 普通 upstream 状态对 AI driver 无效；响应改写和缓存可能破坏 SSE |
 | 第一期不开放给模型链路 | `bk-mock`、`redirect`、`fault-injection` | 技术上可以短路请求，但会绕过模型调用或破坏模型响应契约；有明确产品场景后再开放 |
 
-Stage 绑定会应用到该 Stage 生成的全部 Service，因此绑定时必须与该 Stage 当前所有 Backend.kind 兼容：
+Stage 配置和同步入口只校验插件自身的 scope 与配置格式，不按该 Stage 当前的 Backend.kind 限制绑定。发布时由 Service 转换按 Backend.kind 处理：
 
-- 只有普通 Backend 的 Stage 可以绑定 standard-only 插件。
-- 只有模型 Backend 的 Stage 可以绑定 ai-only 插件。
-- 同时包含普通和模型 Backend 的 Stage 只能绑定两类 Service 都兼容的通用插件。
-- Web API 创建 Stage 插件绑定时执行校验；未登记兼容性的插件视为 standard-only。
+- 普通 Backend 生成的 Service 保持现有行为，合并该 Stage 的全部绑定插件。
+- 模型 Backend 生成的 Service 只合并显式允许列表中的 Stage 插件。
+- 不在允许列表中的 Stage 插件会从模型 Service 配置中跳过，并按 gateway、stage 和插件类型记录 warning 日志；日志不得包含插件配置或模型凭证。
+- 同一 Stage 同时包含普通和模型 Backend 时，两类 Service 各自按上述规则生成，不反向限制 Stage 的持久化配置。
 
 Resource 绑定插件按 Resource.kind 校验。Web API 创建 Resource 插件绑定，以及 `/apis/open` 和 `/apis/v2/sync` 同步带插件的 Resource 时，模型 Resource 绑定不在允许列表中的插件会直接报错。
 
-插件兼容策略由代码中的显式策略表维护。绑定和同步入口负责保证持久化关系合法；controller 发布逻辑信任该关系，原样合并 Stage/Resource 绑定插件，不再执行兼容性校验或过滤。前端可选插件过滤可在后续复用同一策略，但不能替代服务端写入校验。
+插件兼容策略由代码中的显式策略表维护。该策略表是模型 Service 发布转换和 Resource 写入校验的共同依据：Stage 入口不消费该策略，controller 在发布模型 Service 时过滤；Resource 的绑定和同步入口继续拒绝不兼容关系。前端不应按 Stage 当前 Backend 组合隐藏插件。
 
 #### 8.3.3 模型请求出站 Header
 
@@ -683,7 +683,7 @@ bk_backend_name = Backend.name
 - 凭证：AI 配置经 view/biz 写入后数据库只保存完整配置 JSON 的嵌套密文，且与 `DataPlane.etcd_configs` 使用相同的 `get_crypto()` 入口和运行时算法、密钥配置；普通配置及其存量记录保持原始 JSON 明文。ORM 读取与 Django Admin 返回可信明文，Web API 与审计在明文长度小于 4 时返回 `****`，否则保留前后各 2 位；Web 更新 API 对掩码 value 的恢复、非掩码替换、清空和解密失败路径均有覆盖。
 - Stage 同步：普通网关拒绝 `ai_backends`；AI Gateway 支持纯模型 Stage、双字段事务 upsert、缺省不修改、空数组不删除和同名不同 kind 冲突。
 - Resource：Web 创建/更新和 `/apis/open`、`/apis/v2/sync` 同步均拒绝 kind 与 Backend.kind 不一致的关系；模型资源固定 POST、Proxy.config 为空；导入导出遵循 `x-bk-apigateway-resource.kind` 的兼容规则。
-- 插件兼容性：Web Stage/Resource 绑定和 `/apis/open`、`/apis/v2/sync` Resource 插件同步拒绝不兼容关系；controller 发布信任持久化关系，不再校验或过滤。
+- 插件兼容性：Web Stage 绑定和 Stage 同步不按 Backend.kind 限制；普通 Service 保留全部 Stage 插件，模型 Service 发布时过滤不兼容 Stage 插件并记录不含配置或凭证的日志；Web Resource 绑定和 `/apis/open`、`/apis/v2/sync` Resource 插件同步仍拒绝不兼容关系。
 - MCP Server：候选列表、创建更新、自动化同步、异步发布、运行时工具加载和权限同步均排除模型 Resource，且按 ResourceVersion 快照判断。
 - controller：普通 Backend 的 Service/Route 输出保持不变；模型 Backend 生成无 upstream 的 Service、`ai-proxy`、包含 `bk-error-wrapper` 的安全插件 Profile 和关联 service_id 的 Route；Route 转换信任持久化的 Resource/Backend 关系，不重复校验 kind。
 - data plane：AI Gateway 仅允许绑定 APISIX 3.16 及以上版本的数据面，创建和同步在持久化绑定前失败；controller 在生成资源前保留同一规则的防御性检查。普通网关继续支持 APISIX 3.13，且不包含 AI 专用变更。

--- a/src/dashboard/apigateway/apigateway/apis/web/plugin/views.py
+++ b/src/dashboard/apigateway/apigateway/apis/web/plugin/views.py
@@ -130,17 +130,16 @@ class PluginTypeListApi(generics.ListAPIView):
         queryset = PluginType.objects.filter(is_public=True).filter(
             Q(scope=PluginTypeScopeEnum.STAGE_AND_RESOURCE.value) | Q(scope=scope)
         )
-        resource_kind = None
         if scope_type == PluginBindingScopeEnum.RESOURCE.value:
             resource_kind = (
                 Resource.objects.filter(gateway=self.request.gateway, id=data["scope_id"])
                 .values_list("kind", flat=True)
                 .first()
             )
-        if resource_kind == ResourceKindEnum.AI.value:
-            queryset = queryset.filter(code__in=AI_COMPATIBLE_PLUGIN_CODES)
-        else:
-            queryset = queryset.exclude(code__in=AI_ONLY_PLUGIN_CODES | CONTROLLER_MANAGED_PLUGIN_CODES)
+            if resource_kind == ResourceKindEnum.AI.value:
+                queryset = queryset.filter(code__in=AI_COMPATIBLE_PLUGIN_CODES)
+            else:
+                queryset = queryset.exclude(code__in=AI_ONLY_PLUGIN_CODES | CONTROLLER_MANAGED_PLUGIN_CODES)
 
         # 支持 keyword=abc 搜索
         keyword = data.get("keyword")
@@ -203,12 +202,12 @@ class PluginTypeCodeValidationMixin:
 
     def validate_plugin_binding(self):
         scope_type = self.kwargs["scope_type"]
+        if scope_type != PluginBindingScopeEnum.RESOURCE.value:
+            return
+
         scope_id = self.kwargs["scope_id"]
         plugin_type_code = self.kwargs["code"]
-
-        resource_kind = None
-        if scope_type == PluginBindingScopeEnum.RESOURCE.value:
-            resource_kind = Resource.objects.get(gateway=self.request.gateway, id=scope_id).kind
+        resource_kind = Resource.objects.get(gateway=self.request.gateway, id=scope_id).kind
 
         if not is_plugin_compatible_with_resource_kind(plugin_type_code, resource_kind):
             raise error_codes.INVALID_ARGUMENT.format(

--- a/src/dashboard/apigateway/apigateway/controller/convertor/service.py
+++ b/src/dashboard/apigateway/apigateway/controller/convertor/service.py
@@ -17,6 +17,7 @@
 #
 
 import base64
+import logging
 from typing import TYPE_CHECKING, Any, Dict, List, Optional
 
 from django.conf import settings
@@ -47,6 +48,7 @@ from apigateway.controller.models.constants import (
 )
 from apigateway.controller.uri_render import URIRender
 from apigateway.core.constants import BackendKindEnum, LoadBalanceTypeEnum
+from apigateway.service.plugin import AI_COMPATIBLE_PLUGIN_CODES
 
 from .base import GatewayResourceConvertor
 from .constants import LABEL_KEY_BACKEND_ID
@@ -54,6 +56,8 @@ from .utils import UrlInfo, truncate_string
 
 if TYPE_CHECKING:
     from apigateway.controller.release_data import ReleaseData, StageBackendConfig
+
+logger = logging.getLogger(__name__)
 
 
 def _build_ai_log_format() -> Dict[str, str]:
@@ -275,7 +279,7 @@ class ServiceConvertor(GatewayResourceConvertor):
     def _build_service_plugins(self, backend_kind: str) -> Dict[str, Plugin]:
         plugins = self._get_common_default_plugins()
         plugins.update(self._get_kind_default_plugins(backend_kind))
-        plugins.update(self._get_stage_binding_plugins())
+        plugins.update(self._get_stage_binding_plugins(backend_kind))
         plugins.update(self._get_stage_extra_plugins(backend_kind))
         return plugins
 
@@ -332,10 +336,24 @@ class ServiceConvertor(GatewayResourceConvertor):
             return {"file-logger": Plugin(path="logs/access.log")}
         raise ValueError(f"unsupported backend kind: {backend_kind}")
 
-    def _get_stage_binding_plugins(self) -> Dict[str, Plugin]:
-        return {
-            plugin_data.name: Plugin(**plugin_data.config) for plugin_data in self._release_data.get_stage_plugins()
-        }
+    def _get_stage_binding_plugins(self, backend_kind: str) -> Dict[str, Plugin]:
+        stage_plugins = self._release_data.get_stage_plugins()
+        if backend_kind == BackendKindEnum.AI.value:
+            skipped_plugin_codes = sorted(
+                {plugin_data.type_code for plugin_data in stage_plugins} - AI_COMPATIBLE_PLUGIN_CODES
+            )
+            if skipped_plugin_codes:
+                logger.warning(
+                    "skip incompatible stage plugins for AI service: gateway_id=%s, stage_id=%s, plugin_codes=%s",
+                    self.gateway_id,
+                    self.stage_id,
+                    ",".join(skipped_plugin_codes),
+                )
+            stage_plugins = [
+                plugin_data for plugin_data in stage_plugins if plugin_data.type_code in AI_COMPATIBLE_PLUGIN_CODES
+            ]
+
+        return {plugin_data.name: Plugin(**plugin_data.config) for plugin_data in stage_plugins}
 
     def _get_stage_extra_plugins(self, backend_kind: str) -> Dict[str, Plugin]:
         if (

--- a/src/dashboard/apigateway/apigateway/tests/apis/web/plugin/test_views.py
+++ b/src/dashboard/apigateway/apigateway/tests/apis/web/plugin/test_views.py
@@ -21,8 +21,7 @@ from django_dynamic_fixture import G
 from apigateway.apis.web.plugin.views import PluginConfigRetrieveUpdateDestroyApi
 from apigateway.apps.plugin.constants import PluginTypeCodeEnum, PluginTypeScopeEnum
 from apigateway.apps.plugin.models import PluginBinding, PluginType
-from apigateway.core.constants import BackendKindEnum, ResourceKindEnum
-from apigateway.core.models import Backend, BackendConfig
+from apigateway.core.constants import ResourceKindEnum
 from apigateway.utils.yaml import yaml_dumps
 
 AI_ONLY_PLUGIN_CODES = (
@@ -96,6 +95,33 @@ class TestPluginTypeListApi:
 
         result = response.json()
         assert not result["data"]["results"]
+
+    @pytest.mark.parametrize("plugin_type_code", [*AI_ONLY_PLUGIN_CODES, "ai-proxy", "ai-proxy-multi"])
+    def test_list_includes_all_public_plugins_for_stage(
+        self,
+        request_view,
+        fake_gateway,
+        fake_stage,
+        plugin_type_code,
+    ):
+        G(
+            PluginType,
+            code=plugin_type_code,
+            is_public=True,
+            scope=PluginTypeScopeEnum.STAGE_AND_RESOURCE.value,
+        )
+
+        response = request_view(
+            "GET",
+            "plugins.types",
+            gateway=fake_gateway,
+            path_params={"gateway_id": fake_gateway.id},
+            data={"scope_type": "stage", "scope_id": fake_stage.id},
+        )
+
+        assert response.status_code == 200
+        codes = {item["code"] for item in response.json()["data"]["results"]}
+        assert plugin_type_code in codes
 
     @pytest.mark.parametrize("plugin_type_code", AI_ONLY_PLUGIN_CODES)
     @pytest.mark.parametrize("resource_kind", [ResourceKindEnum.STANDARD.value, ResourceKindEnum.AI.value])
@@ -292,17 +318,20 @@ class TestPluginConfigCreateApi:
             scope_id=fake_resource.id,
         ).exists()
 
-    @pytest.mark.parametrize("plugin_type_code", AI_ONLY_PLUGIN_CODES)
-    def test_create_rejects_ai_only_plugin_for_stage(
+    @pytest.mark.parametrize("plugin_type_code", [*AI_ONLY_PLUGIN_CODES, "ai-proxy", "ai-proxy-multi"])
+    def test_create_allows_plugin_for_stage(
         self,
         request_view,
         fake_gateway,
         fake_stage,
         plugin_type_code,
     ):
-        plugin_type = _create_ai_only_plugin_type(plugin_type_code)
-        backend = G(Backend, gateway=fake_gateway, kind=BackendKindEnum.AI.value)
-        G(BackendConfig, gateway=fake_gateway, stage=fake_stage, backend=backend)
+        plugin_type = G(
+            PluginType,
+            code=plugin_type_code,
+            is_public=True,
+            scope=PluginTypeScopeEnum.STAGE_AND_RESOURCE.value,
+        )
 
         response = request_view(
             "POST",
@@ -322,8 +351,8 @@ class TestPluginConfigCreateApi:
             },
         )
 
-        assert response.status_code == 400
-        assert not PluginBinding.objects.filter(
+        assert response.status_code == 201
+        assert PluginBinding.objects.filter(
             gateway=fake_gateway,
             scope_type="stage",
             scope_id=fake_stage.id,

--- a/src/dashboard/apigateway/apigateway/tests/controller/convertor/test_service.py
+++ b/src/dashboard/apigateway/apigateway/tests/controller/convertor/test_service.py
@@ -380,7 +380,7 @@ class TestServiceConvertor:
         assert ai_service.upstream is None
         assert "ai-proxy" in ai_service.plugins
 
-    def test_stage_plugin_bindings_are_trusted_for_each_service(self, mock_release_data):
+    def test_ai_service_filters_incompatible_stage_plugins(self, mock_release_data, caplog):
         mock_release_data.stage_backend_configs = {
             1: _standard_backend_config(
                 1,
@@ -396,6 +396,7 @@ class TestServiceConvertor:
             PluginData("bk-cors", {}, "stage"),
             PluginData("bk-header-rewrite", {}, "stage"),
             PluginData("ai-rate-limiting", {}, "stage"),
+            PluginData("response-rewrite", {"body": "must-not-log"}, "stage"),
         ]
         mock_release_data.jwt_private_key = "test-key"
         mock_release_data.gateway_auth_config = {}
@@ -412,6 +413,12 @@ class TestServiceConvertor:
         assert "bk-stage-header-rewrite" in ai_service.plugins
         assert "ai-rate-limiting" in standard_service.plugins
         assert "ai-rate-limiting" in ai_service.plugins
+        assert "response-rewrite" in standard_service.plugins
+        assert "response-rewrite" not in ai_service.plugins
+        assert "gateway_id=123" in caplog.text
+        assert "stage_id=456" in caplog.text
+        assert "response-rewrite" in caplog.text
+        assert "must-not-log" not in caplog.text
 
     def test_controller_generated_ai_proxy_takes_precedence(self, mock_release_data):
         mock_release_data.stage_backend_configs = {
@@ -645,7 +652,7 @@ class TestServiceConvertor:
         mock_release_data.get_stage_plugins.return_value = []
 
         convertor = ServiceConvertor(mock_release_data, publish_id=123, apisix_version=APISIX_VERSION_3_13)
-        result = convertor._get_stage_binding_plugins()
+        result = convertor._get_stage_binding_plugins(BackendKindEnum.STANDARD.value)
 
         assert result == {}
 
@@ -665,7 +672,7 @@ class TestServiceConvertor:
         mock_release_data.get_stage_plugins.return_value = [mock_plugin1, mock_plugin2]
 
         convertor = ServiceConvertor(mock_release_data, publish_id=123, apisix_version=APISIX_VERSION_3_13)
-        result = convertor._get_stage_binding_plugins()
+        result = convertor._get_stage_binding_plugins(BackendKindEnum.STANDARD.value)
 
         # Check that plugins are created with correct names and configs
         assert "test-plugin-1" in result


### PR DESCRIPTION
## Summary
- allow public, scope-compatible plugins to be listed and bound at Stage scope without checking the Stage backend-kind mix
- keep existing Resource plugin compatibility validation unchanged
- filter Stage plugins against `AI_COMPATIBLE_PLUGIN_CODES` only when converting an AI backend into a Service
- keep every Stage plugin on Standard Services and log skipped AI Service plugin type codes without plugin configuration or provider credentials
- update the AI Gateway design document with the publish-time filtering contract and the complete AI-only plugin set

## Behavior
- configuration and Stage sync stay permissive
- Standard Service publication preserves existing Stage plugin behavior
- AI Service publication skips unsupported Stage plugins and continues publishing
- controller-generated `ai-proxy` / `ai-proxy-multi` remains authoritative for AI Services

## Verification
- TDD red: 11 focused regressions failed against the previous implementation for Stage list/create and AI Service filtering
- focused green: 83 passed
- `make edition-ee && uv run make lint-check`: passed, including ruff, mypy, and 6 import-linter contracts
- `make edition-ee && uv run make test`: 3327 passed
- pre-commit: formatter, ruff, mypy, import-linter, and sensitive-info checks passed
- scope audit: 5 changed files; no Open/v2 sync, backend lifecycle, Stage sync, or compatibility-helper changes remain
