### PR TITLE
feat(operator): limit concurrent gateway syncs

### DIFF
--- a/src/operator/AGENTS.md
+++ b/src/operator/AGENTS.md
@@ -96,7 +96,7 @@ Important entry points:
 - `pkg/core/agent/agent.go`: consumes watch events and updates the release timer.
 - `pkg/core/agent/timer/timer.go`: batches release work per stage or global resource.
 - `pkg/core/committer/committer.go`: reads full target config, retries failures, and sends work to the synchronizer.
-- `pkg/core/synchronizer/synchronizer.go`: serializes APISIX sync operations.
+- `pkg/core/synchronizer/synchronizer.go`: limits concurrent gateway sync operations and serializes global syncs.
 - `pkg/core/store/store.go`: diffs cached APISIX resources and writes/deletes data-plane etcd keys.
 - `pkg/eventreporter/reporter.go`: reports publish lifecycle events to CoreAPI and probes APISIX load status.
 - `pkg/server/*` and `pkg/apis/open/*`: debug and list APIs.
@@ -179,7 +179,11 @@ Commit details:
 
 Sync details:
 
-- `ApisixConfigSynchronizer` has a process-wide `flushMux`, so APISIX writes are serialized.
+- `ApisixConfigSynchronizer` limits concurrent Stage syncs with `operator.gatewaySyncConcurrency`. The
+  Committer still serializes stages of the same gateway, so each active slot represents one gateway in the
+  production path. A slot is held for the complete Stage sync, including put/delete intervals.
+- Global resource syncs remain exclusive with Stage syncs. They do not consume gateway synchronization slots,
+  but wait for active Stage syncs to finish before updating global resources and the virtual Stage.
 - `ApisixEtcdStore.Alter()` diffs the target stage config against the cached APISIX state.
 - Put order is SSL, Service, sleep `operator.etcdPutInterval`, then Route.
 - Delete order is Route, SSL, sleep `operator.etcdDelInterval`, then Service.
@@ -299,6 +303,7 @@ Important defaults from `newDefaultConfig()`:
 - `operator.agentEventsWaitingTimeWindow`: `2s`
 - `operator.agentForceUpdateTimeWindow`: `10s`
 - `operator.agentCommitTimeWindow`: `5s`
+- `operator.gatewaySyncConcurrency`: `5`
 - `operator.etcdPutInterval`: `50ms`
 - `operator.etcdDelInterval`: `16s`
 - `operator.etcdSyncTimeout`: `60s`

--- a/src/operator/config.yaml.tpl
+++ b/src/operator/config.yaml.tpl
@@ -6,6 +6,8 @@ operator:
   #write apisix etcd interval
   etcdPutInterval: "100ms"
   etcdDelInterval: "15s"
+  # maximum number of gateways syncing to apisix etcd concurrently
+  gatewaySyncConcurrency: 5
 
 dashboard:
   etcd:

--- a/src/operator/pkg/config/config.go
+++ b/src/operator/pkg/config/config.go
@@ -40,6 +40,9 @@ const (
 // ReleaseVersionResourceID 发布版本资源 ID
 const ReleaseVersionResourceID = -1
 
+// DefaultGatewaySyncConcurrency is the default number of gateways that can sync concurrently.
+const DefaultGatewaySyncConcurrency = 5
+
 // InstanceName ...
 var (
 	InstanceName string
@@ -93,6 +96,7 @@ type Operator struct {
 	AgentForceUpdateTimeWindow   time.Duration
 	AgentCommitTimeWindow        time.Duration
 	AgentConcurrencyLimit        int
+	GatewaySyncConcurrency       int
 
 	// etcd put interval
 	EtcdPutInterval time.Duration
@@ -240,6 +244,7 @@ func newDefaultConfig() *Config {
 			AgentForceUpdateTimeWindow:   10 * time.Second,
 			AgentCommitTimeWindow:        5 * time.Second,
 			AgentConcurrencyLimit:        4,
+			GatewaySyncConcurrency:       DefaultGatewaySyncConcurrency,
 			EtcdPutInterval:              50 * time.Millisecond,
 			EtcdDelInterval:              16 * time.Second,
 			EtcdSyncTimeout:              60 * time.Second,
@@ -285,6 +290,10 @@ func Load(v *viper.Viper) (*Config, error) {
 }
 
 func (c *Config) init() {
+	if c.Operator.GatewaySyncConcurrency <= 0 {
+		c.Operator.GatewaySyncConcurrency = DefaultGatewaySyncConcurrency
+	}
+
 	hostName, _ := os.Hostname()
 	InstanceName = envx.Get(envPodName, hostName+"_"+utils.GetGeneratedUUID())
 	InstanceIP = envx.Get(envPodIP, "127.0.0.1")

--- a/src/operator/pkg/config/config_test.go
+++ b/src/operator/pkg/config/config_test.go
@@ -1,0 +1,52 @@
+/*
+ * TencentBlueKing is pleased to support the open source community by making
+ * 蓝鲸智云 - API 网关(BlueKing - APIGateway) available.
+ * Copyright (C) Tencent. All rights reserved.
+ * Licensed under the MIT License (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ *     http://opensource.org/licenses/MIT
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * We undertake not to change the open source license (MIT license) applicable
+ * to the current version of the project delivered to anyone in the future.
+ */
+
+package config
+
+import (
+	"testing"
+
+	"github.com/spf13/viper"
+	"github.com/stretchr/testify/require"
+)
+
+func TestLoadGatewaySyncConcurrency(t *testing.T) {
+	t.Run("default", func(t *testing.T) {
+		cfg, err := Load(viper.New())
+		require.NoError(t, err)
+		require.Equal(t, 5, cfg.Operator.GatewaySyncConcurrency)
+	})
+
+	t.Run("override", func(t *testing.T) {
+		v := viper.New()
+		v.Set("operator.gatewaySyncConcurrency", 3)
+
+		cfg, err := Load(v)
+		require.NoError(t, err)
+		require.Equal(t, 3, cfg.Operator.GatewaySyncConcurrency)
+	})
+
+	t.Run("non-positive override uses default", func(t *testing.T) {
+		v := viper.New()
+		v.Set("operator.gatewaySyncConcurrency", 0)
+
+		cfg, err := Load(v)
+		require.NoError(t, err)
+		require.Equal(t, 5, cfg.Operator.GatewaySyncConcurrency)
+	})
+}

--- a/src/operator/pkg/core/runner/etcd.go
+++ b/src/operator/pkg/core/runner/etcd.go
@@ -102,7 +102,11 @@ func (r *EtcdAgentRunner) init() {
 		os.Exit(1)
 	}
 	r.apisixEtcdstore = apisixEtcdStore
-	r.synchronizer = synchronizer.NewSynchronizer(apisixEtcdStore, "/healthz")
+	r.synchronizer = synchronizer.NewSynchronizer(
+		apisixEtcdStore,
+		"/healthz",
+		r.cfg.Operator.GatewaySyncConcurrency,
+	)
 
 	stageTimer := timer.NewReleaseTimer()
 	// 5. init committer

--- a/src/operator/pkg/core/synchronizer/synchronizer.go
+++ b/src/operator/pkg/core/synchronizer/synchronizer.go
@@ -37,8 +37,9 @@ import (
 
 // ApisixConfigSynchronizer synchronizes the API Gateway configuration.
 type ApisixConfigSynchronizer struct {
-	store    *store.ApisixEtcdStore
-	flushMux sync.Mutex
+	store          *store.ApisixEtcdStore
+	gatewaySyncSem chan struct{}
+	syncMux        sync.RWMutex
 
 	apisixHealthzURI string
 
@@ -46,9 +47,18 @@ type ApisixConfigSynchronizer struct {
 }
 
 // NewSynchronizer create new Synchronizer
-func NewSynchronizer(store *store.ApisixEtcdStore, apisixHealthzURI string) *ApisixConfigSynchronizer {
+func NewSynchronizer(
+	store *store.ApisixEtcdStore,
+	apisixHealthzURI string,
+	gatewaySyncConcurrency int,
+) *ApisixConfigSynchronizer {
+	if gatewaySyncConcurrency <= 0 {
+		gatewaySyncConcurrency = cfg.DefaultGatewaySyncConcurrency
+	}
 	syncer := &ApisixConfigSynchronizer{
-		store:            store,
+		store:          store,
+		gatewaySyncSem: make(chan struct{}, gatewaySyncConcurrency),
+
 		apisixHealthzURI: apisixHealthzURI,
 		logger:           logging.GetLogger().Named("apisix-config-synchronizer"),
 	}
@@ -66,8 +76,12 @@ func (as *ApisixConfigSynchronizer) SyncRelease(
 	}
 	key := releaseInfo.GetStageKey()
 
-	as.flushMux.Lock()
-	defer as.flushMux.Unlock()
+	as.gatewaySyncSem <- struct{}{}
+	defer func() {
+		<-as.gatewaySyncSem
+	}()
+	as.syncMux.RLock()
+	defer as.syncMux.RUnlock()
 
 	as.logger.Debugw("flush changes", append(releaseInfo.LogFields(), "key", key, "config", config)...)
 	err := as.store.AlterStage(ctx, releaseInfo, config)
@@ -90,8 +104,8 @@ func (as *ApisixConfigSynchronizer) SyncGlobal(
 	ctx context.Context,
 	config *entity.ApisixGlobalResource,
 ) error {
-	as.flushMux.Lock()
-	defer as.flushMux.Unlock()
+	as.syncMux.Lock()
+	defer as.syncMux.Unlock()
 	as.logger.Debugw("flush global changes", "config", config)
 	err := as.store.AlterGlobal(ctx, config)
 	if err != nil {

--- a/src/operator/pkg/core/synchronizer/synchronizer_test.go
+++ b/src/operator/pkg/core/synchronizer/synchronizer_test.go
@@ -22,6 +22,7 @@ import (
 	"context"
 	"encoding/json"
 	"os"
+	"sync"
 	"time"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -63,6 +64,28 @@ func createReleaseInfo(gateway, stage string) *entity.ReleaseInfo {
 	}
 }
 
+func createStageConfigWithService(gateway, stage string) *entity.ApisixStageResource {
+	routeID := gateway + "-route"
+	serviceID := gateway + "-service"
+	labels := &entity.LabelInfo{Gateway: gateway, Stage: stage}
+	return &entity.ApisixStageResource{
+		Routes: map[string]*entity.Route{
+			routeID: {
+				ResourceMetadata: entity.ResourceMetadata{ID: routeID, Labels: labels},
+				ServiceID:        serviceID,
+				URI:              "/" + gateway + "/*",
+				Status:           1,
+			},
+		},
+		Services: map[string]*entity.Service{
+			serviceID: {
+				ResourceMetadata: entity.ResourceMetadata{ID: serviceID, Labels: labels},
+			},
+		},
+		SSLs: make(map[string]*entity.SSL),
+	}
+}
+
 var _ = Describe("ApisixConfigSynchronizer", func() {
 	var (
 		syncer           *synchronizer.ApisixConfigSynchronizer
@@ -92,7 +115,7 @@ var _ = Describe("ApisixConfigSynchronizer", func() {
 
 		// Create a mock store (nil for unit testing without etcd)
 		mockStore = nil
-		syncer = synchronizer.NewSynchronizer(mockStore, apisixHealthzURI)
+		syncer = synchronizer.NewSynchronizer(mockStore, apisixHealthzURI, 5)
 	})
 
 	Describe("NewSynchronizer", func() {
@@ -102,8 +125,26 @@ var _ = Describe("ApisixConfigSynchronizer", func() {
 
 		It("should create synchronizer with different healthz URI", func() {
 			customURI := "/api/healthz"
-			customSyncer := synchronizer.NewSynchronizer(nil, customURI)
+			customSyncer := synchronizer.NewSynchronizer(nil, customURI, 5)
 			Expect(customSyncer).NotTo(BeNil())
+		})
+
+		It("should use the default concurrency when configured with a non-positive value", func() {
+			customSyncer := synchronizer.NewSynchronizer(nil, apisixHealthzURI, 0)
+			done := make(chan struct{})
+			go func() {
+				defer close(done)
+				defer func() {
+					_ = recover()
+				}()
+				_ = customSyncer.SyncRelease(
+					ctx,
+					createReleaseInfo("gateway", "stage"),
+					entity.NewEmptyApisixConfiguration(),
+				)
+			}()
+
+			Eventually(done, 200*time.Millisecond).Should(BeClosed())
 		})
 	})
 
@@ -156,7 +197,7 @@ var _ = Describe("ApisixConfigSynchronizer", func() {
 
 	Describe("Concurrent Operations", func() {
 		It("should handle concurrent Sync calls safely", func() {
-			// Test that flushMux properly handles concurrent access
+			// Test that concurrent calls can enter the gateway synchronization path safely.
 			// Since store is nil, we just verify no race conditions occur
 			done := make(chan bool, 3)
 
@@ -253,7 +294,7 @@ var _ = Describe("ApisixConfigSynchronizer with EmbedEtcd", func() {
 		Expect(err).ShouldNot(HaveOccurred())
 
 		// Create synchronizer with real store
-		syncer = synchronizer.NewSynchronizer(etcdStore, apisixHealthzURI)
+		syncer = synchronizer.NewSynchronizer(etcdStore, apisixHealthzURI, 5)
 	})
 
 	AfterEach(func() {
@@ -515,6 +556,140 @@ var _ = Describe("ApisixConfigSynchronizer with EmbedEtcd", func() {
 	})
 
 	Describe("Sync with multiple gateways", func() {
+		It("should limit concurrent gateway syncs without serializing every gateway", func() {
+			const (
+				gatewaySyncConcurrency = 2
+				delInterval            = 2 * time.Second
+			)
+
+			concurrencyStore, err := store.NewApisixEtcdStore(
+				ctx,
+				client,
+				"/concurrency-apisix",
+				10*time.Millisecond,
+				delInterval,
+				5*time.Second,
+			)
+			Expect(err).ShouldNot(HaveOccurred())
+			DeferCleanup(concurrencyStore.Close)
+
+			concurrencySyncer := synchronizer.NewSynchronizer(
+				concurrencyStore,
+				apisixHealthzURI,
+				gatewaySyncConcurrency,
+			)
+			gateways := []string{"gateway-1", "gateway-2", "gateway-3"}
+			for _, gateway := range gateways {
+				err = concurrencySyncer.SyncRelease(
+					ctx,
+					createReleaseInfo(gateway, "prod"),
+					createStageConfigWithService(gateway, "prod"),
+				)
+				Expect(err).ShouldNot(HaveOccurred())
+			}
+
+			Eventually(func() int {
+				resourceCount := 0
+				for _, gateway := range gateways {
+					stageConfig := concurrencyStore.Get(config.GenStagePrimaryKey(gateway, "prod"))
+					resourceCount += len(stageConfig.Routes) + len(stageConfig.Services)
+				}
+				return resourceCount
+			}, 2*time.Second, 10*time.Millisecond).Should(Equal(6))
+
+			start := make(chan struct{})
+			errCh := make(chan error, len(gateways))
+			var wg sync.WaitGroup
+			for _, gateway := range gateways {
+				gateway := gateway
+				wg.Add(1)
+				go func() {
+					defer wg.Done()
+					<-start
+					errCh <- concurrencySyncer.SyncRelease(
+						ctx,
+						createReleaseInfo(gateway, "prod"),
+						entity.NewEmptyApisixConfiguration(),
+					)
+				}()
+			}
+			close(start)
+			defer wg.Wait()
+
+			Eventually(func() int {
+				resp, getErr := client.Get(ctx, "/concurrency-apisix/routes/", clientv3.WithPrefix())
+				Expect(getErr).ShouldNot(HaveOccurred())
+				return len(resp.Kvs)
+			}, delInterval/2, 10*time.Millisecond).Should(Equal(1))
+
+			wg.Wait()
+			close(errCh)
+			for syncErr := range errCh {
+				Expect(syncErr).ShouldNot(HaveOccurred())
+			}
+		})
+
+		It("should keep global synchronization exclusive from gateway synchronization", func() {
+			const delInterval = 500 * time.Millisecond
+			exclusiveStore, err := store.NewApisixEtcdStore(
+				ctx,
+				client,
+				"/exclusive-apisix",
+				10*time.Millisecond,
+				delInterval,
+				5*time.Second,
+			)
+			Expect(err).ShouldNot(HaveOccurred())
+			DeferCleanup(exclusiveStore.Close)
+
+			exclusiveSyncer := synchronizer.NewSynchronizer(exclusiveStore, apisixHealthzURI, 2)
+			gateway := "exclusive-gateway"
+			err = exclusiveSyncer.SyncRelease(
+				ctx,
+				createReleaseInfo(gateway, "prod"),
+				createStageConfigWithService(gateway, "prod"),
+			)
+			Expect(err).ShouldNot(HaveOccurred())
+			Eventually(func() int {
+				stageConfig := exclusiveStore.Get(config.GenStagePrimaryKey(gateway, "prod"))
+				return len(stageConfig.Routes) + len(stageConfig.Services)
+			}, 2*time.Second, 10*time.Millisecond).Should(Equal(2))
+
+			stageErrCh := make(chan error, 1)
+			globalErrCh := make(chan error, 1)
+			globalDone := make(chan struct{})
+			var wg sync.WaitGroup
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				stageErrCh <- exclusiveSyncer.SyncRelease(
+					ctx,
+					createReleaseInfo(gateway, "prod"),
+					entity.NewEmptyApisixConfiguration(),
+				)
+			}()
+			defer wg.Wait()
+
+			Eventually(func() int {
+				resp, getErr := client.Get(ctx, "/exclusive-apisix/routes/", clientv3.WithPrefix())
+				Expect(getErr).ShouldNot(HaveOccurred())
+				return len(resp.Kvs)
+			}, 2*time.Second, 10*time.Millisecond).Should(BeZero())
+
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				defer close(globalDone)
+				globalErrCh <- exclusiveSyncer.SyncGlobal(ctx, entity.NewEmptyApisixGlobalResource())
+			}()
+
+			Consistently(globalDone, delInterval/2).ShouldNot(BeClosed())
+
+			wg.Wait()
+			Expect(<-stageErrCh).ShouldNot(HaveOccurred())
+			Expect(<-globalErrCh).ShouldNot(HaveOccurred())
+		})
+
 		It("should handle multiple gateways independently", func() {
 			// Config for gateway-1
 			config1 := &entity.ApisixStageResource{


### PR DESCRIPTION
## Summary
- replace the process-wide Stage flush mutex with a configurable gateway-level semaphore
- default `operator.gatewaySyncConcurrency` to 5 and keep global resource synchronization exclusive
- add config, embedded-etcd concurrency, and global exclusivity coverage

## Verification
- `make fmt`: passed
- `make lint`: passed (0 issues)
- `make build`: passed
- `make test`: passed (18 suites, composite coverage 50.7%)
- `make integration`: passed (1/1 specs)
- focused race test: passed

## Review
- reviewed with the repository code-quality workflow
- fixed the finding that global synchronization could overlap Stage synchronization; no required findings remain
