### PR TITLE
fix(dashboard): expose kind in gateway resource APIs

### DIFF
--- a/src/dashboard/apigateway/apigateway/apis/open/gateway/views.py
+++ b/src/dashboard/apigateway/apigateway/apis/open/gateway/views.py
@@ -44,7 +44,7 @@ from apigateway.common.constants import (
 )
 from apigateway.common.tenant.query import gateway_filter_by_app_tenant_id
 from apigateway.components.bkauth import get_app_tenant_info
-from apigateway.core.constants import convert_gateway_kind_name_to_value
+from apigateway.core.constants import convert_gateway_kind_name_to_value, convert_gateway_kind_to_name
 from apigateway.core.models import JWT, Gateway
 from apigateway.service.contexts import GatewayAuthContext
 from apigateway.utils.django import get_model_dict
@@ -253,6 +253,7 @@ class GatewaySyncApi(generics.CreateAPIView):
             data={
                 "id": gateway.id,
                 "name": gateway.name,
+                "kind": convert_gateway_kind_to_name(gateway.kind),
             },
         )
 

--- a/src/dashboard/apigateway/apigateway/apis/open/released/serializers.py
+++ b/src/dashboard/apigateway/apigateway/apis/open/released/serializers.py
@@ -19,6 +19,7 @@
 from rest_framework import serializers
 
 from apigateway.common.i18n.field import SerializerTranslatedField
+from apigateway.core.constants import ResourceKindEnum
 from apigateway.core.utils import get_path_display
 from apigateway.service.utils import get_resource_url
 
@@ -26,6 +27,9 @@ from apigateway.service.utils import get_resource_url
 class ResourceV1SLZ(serializers.Serializer):
     id = serializers.IntegerField()
     name = serializers.CharField()
+    kind = serializers.ChoiceField(
+        choices=ResourceKindEnum.get_choices(), read_only=True, default=ResourceKindEnum.STANDARD.value
+    )
     description = SerializerTranslatedField(
         default_field="description_i18n", translated_fields={"en": "description_en"}
     )
@@ -37,6 +41,9 @@ class ResourceV1SLZ(serializers.Serializer):
 class ReleasedResourceOutputSLZ(serializers.Serializer):
     id = serializers.IntegerField(read_only=True)
     name = serializers.CharField(read_only=True)
+    kind = serializers.ChoiceField(
+        choices=ResourceKindEnum.get_choices(), read_only=True, default=ResourceKindEnum.STANDARD.value
+    )
     method = serializers.CharField(read_only=True)
     path = serializers.CharField(read_only=True)
     schema = serializers.DictField(help_text="参数协议")

--- a/src/dashboard/apigateway/apigateway/apis/v2/inner/serializers.py
+++ b/src/dashboard/apigateway/apigateway/apis/v2/inner/serializers.py
@@ -46,7 +46,7 @@ from apigateway.common.fields import TimestampField
 from apigateway.common.i18n.field import SerializerTranslatedField
 from apigateway.common.tenant.request import get_tenant_id_for_gateway_maintainers
 from apigateway.components.bkuser import query_display_names_for_readonly
-from apigateway.core.constants import GatewayStatusEnum
+from apigateway.core.constants import GatewayStatusEnum, convert_gateway_kind_to_name
 from apigateway.service.bk_itsm import ItsmPermissionApplyHelper
 from apigateway.service.mcp import (
     build_mcp_server_detail_url,
@@ -95,12 +95,16 @@ class GatewayListOutputSLZ(serializers.Serializer):
     description = SerializerTranslatedField(default_field="description_i18n", allow_blank=True, read_only=True)
     maintainers = serializers.SerializerMethodField()
     doc_maintainers = serializers.SerializerMethodField()
+    kind = serializers.SerializerMethodField()
 
     def get_maintainers(self, obj):
         return _get_gateway_maintainers_display_names(obj)
 
     def get_doc_maintainers(self, obj):
         return obj.doc_maintainers
+
+    def get_kind(self, obj):
+        return convert_gateway_kind_to_name(obj.kind)
 
     class Meta:
         ref_name = "apigateway.apis.v2.inner.serializers.GatewayListOutputSLZ"
@@ -112,12 +116,16 @@ class GatewayRetrieveOutputSLZ(serializers.Serializer):
     description = SerializerTranslatedField(default_field="description_i18n", allow_blank=True, read_only=True)
     maintainers = serializers.SerializerMethodField()
     doc_maintainers = serializers.SerializerMethodField()
+    kind = serializers.SerializerMethodField()
 
     def get_maintainers(self, obj):
         return _get_gateway_maintainers_display_names(obj)
 
     def get_doc_maintainers(self, obj):
         return obj.doc_maintainers
+
+    def get_kind(self, obj):
+        return convert_gateway_kind_to_name(obj.kind)
 
     class Meta:
         ref_name = "apigateway.apis.v2.inner.serializers.GatewayRetrieveOutputSLZ"

--- a/src/dashboard/apigateway/apigateway/apis/v2/open/serializers.py
+++ b/src/dashboard/apigateway/apigateway/apis/v2/open/serializers.py
@@ -38,6 +38,7 @@ from apigateway.biz.mcp_server import MCPServerHandler
 from apigateway.biz.permission import PermissionDimensionManager, ResourcePermissionHandler
 from apigateway.biz.validators import BKAppCodeValidator
 from apigateway.common.i18n.field import SerializerTranslatedField
+from apigateway.core.constants import ResourceKindEnum, convert_gateway_kind_to_name
 from apigateway.core.models import Resource
 from apigateway.core.utils import get_path_display
 from apigateway.service.mcp import (
@@ -75,12 +76,16 @@ class GatewayListOutputSLZ(serializers.Serializer):
     description = SerializerTranslatedField(default_field="description_i18n", allow_blank=True, read_only=True)
     maintainers = serializers.SerializerMethodField()
     doc_maintainers = serializers.SerializerMethodField()
+    kind = serializers.SerializerMethodField()
 
     def get_maintainers(self, obj):
         return obj.maintainers
 
     def get_doc_maintainers(self, obj):
         return obj.doc_maintainers
+
+    def get_kind(self, obj):
+        return convert_gateway_kind_to_name(obj.kind)
 
     class Meta:
         ref_name = "apigateway.apis.v2.open.serializers.GatewayListOutputSLZ"
@@ -92,12 +97,16 @@ class GatewayRetrieveOutputSLZ(serializers.Serializer):
     description = SerializerTranslatedField(default_field="description_i18n", allow_blank=True, read_only=True)
     maintainers = serializers.SerializerMethodField()
     doc_maintainers = serializers.SerializerMethodField()
+    kind = serializers.SerializerMethodField()
 
     def get_maintainers(self, obj):
         return obj.maintainers
 
     def get_doc_maintainers(self, obj):
         return obj.doc_maintainers
+
+    def get_kind(self, obj):
+        return convert_gateway_kind_to_name(obj.kind)
 
     class Meta:
         ref_name = "apigateway.apis.v2.open.serializers.GatewayRetrieveOutputSLZ"
@@ -468,6 +477,12 @@ class GatewayResourceListOutputSLZ(serializers.Serializer):
 
     id = serializers.IntegerField(read_only=True, help_text="资源 ID")
     name = serializers.CharField(read_only=True, help_text="资源名称")
+    kind = serializers.ChoiceField(
+        choices=ResourceKindEnum.get_choices(),
+        read_only=True,
+        default=ResourceKindEnum.STANDARD.value,
+        help_text="资源类型",
+    )
     description = SerializerTranslatedField(
         default_field="description_i18n", translated_fields={"en": "description_en"}
     )
@@ -516,6 +531,12 @@ class GatewayResourceDetailOutputSLZ(serializers.Serializer):
 
     id = serializers.IntegerField(read_only=True, help_text="资源 ID")
     name = serializers.CharField(read_only=True, help_text="资源名称")
+    kind = serializers.ChoiceField(
+        choices=ResourceKindEnum.get_choices(),
+        read_only=True,
+        default=ResourceKindEnum.STANDARD.value,
+        help_text="资源类型",
+    )
     description = SerializerTranslatedField(
         default_field="description_i18n",
         translated_fields={"en": "description_en"},
@@ -761,6 +782,10 @@ class GatewayBatchQueryOutputSLZ(serializers.Serializer):
     id = serializers.IntegerField(read_only=True, help_text="网关 ID")
     name = serializers.CharField(read_only=True, help_text="网关名称")
     description = SerializerTranslatedField(default_field="description_i18n", allow_blank=True, read_only=True)
+    kind = serializers.SerializerMethodField()
+
+    def get_kind(self, obj):
+        return convert_gateway_kind_to_name(obj.kind)
 
     class Meta:
         ref_name = "apigateway.apis.v2.open.serializers.GatewayBatchQueryOutputSLZ"
@@ -783,6 +808,12 @@ class GatewayResourceListInputSLZ(serializers.Serializer):
 class GatewayResourceRetrieveByNameOutputSLZ(serializers.Serializer):
     id = serializers.IntegerField(read_only=True, help_text="资源 ID")
     name = serializers.CharField(read_only=True, help_text="资源名称")
+    kind = serializers.ChoiceField(
+        choices=ResourceKindEnum.get_choices(),
+        read_only=True,
+        default=ResourceKindEnum.STANDARD.value,
+        help_text="资源类型",
+    )
     description = SerializerTranslatedField(
         default_field="description_i18n", translated_fields={"en": "description_en"}
     )
@@ -803,6 +834,9 @@ class GatewayReleasedResourceOutputSLZ(serializers.Serializer):
 
     id = serializers.IntegerField(read_only=True)
     name = serializers.CharField(read_only=True)
+    kind = serializers.ChoiceField(
+        choices=ResourceKindEnum.get_choices(), read_only=True, default=ResourceKindEnum.STANDARD.value
+    )
     method = serializers.CharField(read_only=True)
     path = serializers.CharField(read_only=True)
     schema = serializers.DictField(read_only=True, help_text="参数协议")
@@ -816,6 +850,9 @@ class GatewayReleasedResourceListItemOutputSLZ(serializers.Serializer):
 
     id = serializers.IntegerField(read_only=True)
     name = serializers.CharField(read_only=True)
+    kind = serializers.ChoiceField(
+        choices=ResourceKindEnum.get_choices(), read_only=True, default=ResourceKindEnum.STANDARD.value
+    )
     description = SerializerTranslatedField(translated_fields={"en": "description_en"})
     method = serializers.CharField(read_only=True)
     url = serializers.SerializerMethodField()

--- a/src/dashboard/apigateway/apigateway/apis/v2/open/views.py
+++ b/src/dashboard/apigateway/apigateway/apis/v2/open/views.py
@@ -659,6 +659,7 @@ class GatewayResourceDetailApi(generics.RetrieveAPIView):
         result = {
             "id": resource_data.id,
             "name": resource_data.name,
+            "kind": resource_data.kind,
             "description": resource_data.description,
             "description_en": resource_data.description_en,
             "method": resource_data.method,

--- a/src/dashboard/apigateway/apigateway/apis/v2/sync/serializers.py
+++ b/src/dashboard/apigateway/apigateway/apis/v2/sync/serializers.py
@@ -65,6 +65,7 @@ from apigateway.core.constants import (
     HashOnTypeEnum,
     LoadBalanceTypeEnum,
     convert_gateway_kind_name_to_value,
+    convert_gateway_kind_to_name,
 )
 from apigateway.core.models import Backend, Gateway, ResourceVersion, Stage
 from apigateway.utils.time import NeverExpiresTime
@@ -185,6 +186,10 @@ class GatewaySyncInputSLZ(serializers.ModelSerializer):
 class GatewaySyncOutputSLZ(serializers.Serializer):
     id = serializers.IntegerField(read_only=True, help_text="网关ID")
     name = serializers.CharField(read_only=True, help_text="网关名称")
+    kind = serializers.SerializerMethodField(help_text="网关类型")
+
+    def get_kind(self, obj):
+        return convert_gateway_kind_to_name(obj.kind)
 
     class Meta:
         ref_name = "apigateway.apis.v2.sync.serializers.GatewaySyncOutputSLZ"

--- a/src/dashboard/apigateway/apigateway/apis/web/docs/gateway/gateway/serializers.py
+++ b/src/dashboard/apigateway/apigateway/apis/web/docs/gateway/gateway/serializers.py
@@ -19,7 +19,7 @@
 from rest_framework import serializers
 
 from apigateway.common.i18n.field import SerializerTranslatedField
-from apigateway.core.constants import PLUGIN_GATEWAY_PREFIX
+from apigateway.core.constants import PLUGIN_GATEWAY_PREFIX, GatewayKindEnum
 
 
 class GatewayQueryInputSLZ(serializers.Serializer):
@@ -39,6 +39,7 @@ class GatewayQueryInputSLZ(serializers.Serializer):
 class GatewayOutputSLZ(serializers.Serializer):
     id = serializers.IntegerField(help_text="网关 ID")
     name = serializers.CharField(help_text="网关名称")
+    kind = serializers.ChoiceField(choices=GatewayKindEnum.get_choices(), read_only=True, help_text="网关类型")
     description = SerializerTranslatedField(default_field="description_i18n", allow_blank=True, help_text="网关描述")
     tenant_mode = serializers.CharField(read_only=True, help_text="租户模式")
     tenant_id = serializers.CharField(read_only=True, help_text="租户 ID")

--- a/src/dashboard/apigateway/apigateway/apis/web/docs/gateway/resource/serializers.py
+++ b/src/dashboard/apigateway/apigateway/apis/web/docs/gateway/resource/serializers.py
@@ -19,6 +19,7 @@
 from rest_framework import serializers
 
 from apigateway.common.i18n.field import SerializerTranslatedField
+from apigateway.core.constants import ResourceKindEnum
 
 
 class ResourceListInputSLZ(serializers.Serializer):
@@ -28,6 +29,12 @@ class ResourceListInputSLZ(serializers.Serializer):
 class ResourceOutputSLZ(serializers.Serializer):
     id = serializers.IntegerField(read_only=True, help_text="资源 ID")
     name = serializers.CharField(read_only=True, help_text="资源名称")
+    kind = serializers.ChoiceField(
+        choices=ResourceKindEnum.get_choices(),
+        read_only=True,
+        default=ResourceKindEnum.STANDARD.value,
+        help_text="资源类型",
+    )
     description = SerializerTranslatedField(
         translated_fields={"en": "description_en"}, allow_blank=True, read_only=True, help_text="资源描述"
     )

--- a/src/dashboard/apigateway/apigateway/apis/web/release/serializers.py
+++ b/src/dashboard/apigateway/apigateway/apis/web/release/serializers.py
@@ -31,6 +31,7 @@ from apigateway.core.constants import (
     PublishEventStatusEnum,
     PublishSourceEnum,
     ReleaseHistoryStatusEnum,
+    ResourceKindEnum,
 )
 from apigateway.core.models import PublishEvent, ReleaseHistory, ResourceVersion, Stage
 
@@ -60,6 +61,12 @@ class ReleaseInputSLZ(serializers.Serializer):
 class ResourceOutputSLZ(serializers.Serializer):
     id = serializers.IntegerField(read_only=True, help_text="资源 ID")
     name = serializers.CharField(read_only=True, help_text="资源名称")
+    kind = serializers.ChoiceField(
+        choices=ResourceKindEnum.get_choices(),
+        read_only=True,
+        default=ResourceKindEnum.STANDARD.value,
+        help_text="资源类型",
+    )
     description = SerializerTranslatedField(
         translated_fields={"en": "description_en"}, allow_blank=True, read_only=True, help_text="资源描述"
     )

--- a/src/dashboard/apigateway/apigateway/apis/web/resource/serializers.py
+++ b/src/dashboard/apigateway/apigateway/apis/web/resource/serializers.py
@@ -947,6 +947,7 @@ class BackendPathCheckOutputSLZ(serializers.Serializer):
 class ResourceWithVerifiedUserRequiredOutputSLZ(serializers.Serializer):
     id = serializers.IntegerField(read_only=True, help_text="资源 ID")
     name = serializers.CharField(read_only=True, help_text="资源名称")
+    kind = serializers.ChoiceField(choices=ResourceKindEnum.get_choices(), read_only=True, help_text="资源类型")
 
     class Meta:
         ref_name = "apigateway.apis.web.resource.serializers.ResourceWithVerifiedUserRequiredOutputSLZ"

--- a/src/dashboard/apigateway/apigateway/apis/web/resource/views.py
+++ b/src/dashboard/apigateway/apigateway/apis/web/resource/views.py
@@ -723,7 +723,7 @@ class BackendPathCheckApi(ResourceQuerySetMixin, generics.RetrieveAPIView):
 class ResourcesWithVerifiedUserRequiredApi(ResourceQuerySetMixin, generics.ListAPIView):
     def list(self, request, *args, **kwargs):
         """过滤出需要认证用户的资源列表"""
-        resources = list(self.get_queryset().values("id", "name"))
+        resources = list(self.get_queryset().values("id", "name", "kind"))
         resource_ids = list(map(operator.itemgetter("id"), resources))
         auth_configs = ResourceAuthContext().get_resource_id_to_auth_config(resource_ids)
 

--- a/src/dashboard/apigateway/apigateway/apis/web/resource_doc/serializers.py
+++ b/src/dashboard/apigateway/apigateway/apis/web/resource_doc/serializers.py
@@ -19,6 +19,7 @@ from rest_framework import serializers
 
 from apigateway.apis.web.constants import ExportTypeEnum
 from apigateway.apps.support.constants import DocArchiveTypeEnum, DocLanguageEnum
+from apigateway.core.constants import ResourceKindEnum
 
 
 class DocArchiveParseInputSLZ(serializers.Serializer):
@@ -31,6 +32,7 @@ class DocArchiveParseInputSLZ(serializers.Serializer):
 class ArchiveParseOutputResourceSLZ(serializers.Serializer):
     id = serializers.IntegerField(read_only=True, help_text="资源 ID")
     name = serializers.CharField(read_only=True, help_text="资源名称")
+    kind = serializers.ChoiceField(choices=ResourceKindEnum.get_choices(), read_only=True, help_text="资源类型")
     method = serializers.CharField(read_only=True, help_text="请求方法")
     path = serializers.CharField(read_only=True, help_text="请求路径")
     description = serializers.CharField(read_only=True, help_text="资源描述")

--- a/src/dashboard/apigateway/apigateway/data/apidocs/zh/get_released_resource.md
+++ b/src/dashboard/apigateway/apigateway/data/apidocs/zh/get_released_resource.md
@@ -42,6 +42,7 @@ result = client.api.get_released_resources(
   "data": {
     "id": 2448,
     "name": "updatePet",
+    "kind": "standard",
     "method": "PUT",
     "path": "/api/v3/pet",
     "schema": {
@@ -253,6 +254,7 @@ result = client.api.get_released_resources(
 |--------| -------- |----------------|
 | id     | int      | ID             |
 | name   | string   | 资源名称           |
+| kind   | string   | 资源类型，`standard`：普通 API，`ai`：模型代理 API |
 | method | string   | 资源请求方法         |
 | path   | string   | 资源请求地址         |
 | schema | object   | 资源协议数据，详情见下面说明 |

--- a/src/dashboard/apigateway/apigateway/data/apidocs/zh/get_released_resources.md
+++ b/src/dashboard/apigateway/apigateway/data/apidocs/zh/get_released_resources.md
@@ -48,6 +48,7 @@ result = client.api.get_released_resources(
             {
                 "id": 3,
                 "name": "echo",
+                "kind": "standard",
                 "description": "",
                 "method": "GET",
                 "url": "https://bkapi.example.com/api/echo/prod/echo/",
@@ -85,6 +86,7 @@ data.results 中字段说明
 | ---------------------- | -------- | ------------------------------------------------------------------- |
 | id                     | int      | ID                                                                  |
 | name                   | string   | 资源名称                                                            |
+| kind                   | string   | 资源类型，`standard`：普通 API，`ai`：模型代理 API                    |
 | description            | string   | 资源描述                                                            |
 | method                 | string   | 资源请求方法                                                        |
 | url                    | string   | 资源请求地址                                                        |

--- a/src/dashboard/apigateway/apigateway/data/apidocs/zh/sync_api.md
+++ b/src/dashboard/apigateway/apigateway/data/apidocs/zh/sync_api.md
@@ -57,7 +57,8 @@ result = client.api.sync_api(
     "message": "OK",
     "data": {
         "id": 1,
-        "name": "demo"
+        "name": "demo",
+        "kind": "ai"
     }
 }
 ```
@@ -76,3 +77,4 @@ result = client.api.sync_api(
 | -------- | -------- | -------- |
 | id       | int      | 网关ID   |
 | name     | string   | 网关名称 |
+| kind     | string   | 网关类型：`normal`、`programmable` 或 `ai` |

--- a/src/dashboard/apigateway/apigateway/data/apidocs/zh/v2_inner_get_gateway.md
+++ b/src/dashboard/apigateway/apigateway/data/apidocs/zh/v2_inner_get_gateway.md
@@ -20,6 +20,7 @@
     "data": {
         "id": 1,
         "name": "bk-apigateway",
+        "kind": "normal",
         "description": "",
         "maintainers": [
             "张三"
@@ -50,6 +51,7 @@
 |-----------------|----------|----------|
 | id              | int      | 网关ID     |
 | name            | string   | 网关名称     |
+| kind            | string   | 网关类型：`normal`、`programmable` 或 `ai` |
 | description     | string   | 网关描述     |
 | maintainers     | array    | 网关管理员 display_name 列表；当 bk-user 查询失败时回退为 bk_username 列表 |
 | doc_maintainers | object   | 网关文档维护人员 |

--- a/src/dashboard/apigateway/apigateway/data/apidocs/zh/v2_inner_list_gateways.md
+++ b/src/dashboard/apigateway/apigateway/data/apidocs/zh/v2_inner_list_gateways.md
@@ -14,6 +14,7 @@
         {
             "id": 1,
             "name": "bk-apigateway",
+            "kind": "normal",
             "description": "",
             "maintainers": [
                 "张三"
@@ -45,6 +46,7 @@
 |-----------------|----------|----------|
 | id              | int      | 网关ID     |
 | name            | string   | 网关名称     |
+| kind            | string   | 网关类型：`normal`、`programmable` 或 `ai` |
 | description     | string   | 网关描述     |
 | maintainers     | array    | 网关管理员 display_name 列表；当 bk-user 查询失败时回退为 bk_username 列表 |
 | doc_maintainers | object   | 网关文档维护人员 |

--- a/src/dashboard/apigateway/apigateway/data/apidocs/zh/v2_open_batch_query_gateways.md
+++ b/src/dashboard/apigateway/apigateway/data/apidocs/zh/v2_open_batch_query_gateways.md
@@ -12,14 +12,14 @@
 | -------- | -------- | ---- | -------------------------------------------------------------------- |
 | ids      | array    | 否   | 网关 ID 列表（ids 和 names 至少提供一个）                             |
 | names    | array    | 否   | 网关名称列表（ids 和 names 至少提供一个）                             |
-| fields   | string   | 否   | 指定返回的字段列表，逗号分隔，如 `fields=id,name,description`；不传默认返回 `id` 和 `name` |
+| fields   | string   | 否   | 指定返回的字段列表，逗号分隔，如 `fields=id,name,description,kind`；不传默认返回 `id` 和 `name` |
 
 ### 请求示例
 
 ```json
 {
     "names": ["bk-apigateway", "bk-esb"],
-    "fields": "id,name,description"
+    "fields": "id,name,description,kind"
 }
 ```
 
@@ -42,7 +42,7 @@
 }
 ```
 
-#### 指定字段（fields=id,name,description）
+#### 指定字段（fields=id,name,description,kind）
 
 ```json
 {
@@ -50,11 +50,13 @@
         {
             "id": 1,
             "name": "bk-apigateway",
+            "kind": "normal",
             "description": "蓝鲸 API 网关"
         },
         {
             "id": 2,
             "name": "bk-esb",
+            "kind": "normal",
             "description": "蓝鲸 ESB"
         }
     ]
@@ -74,3 +76,4 @@
 | id          | int      | 网关 ID  |
 | name        | string   | 网关名称 |
 | description | string   | 网关描述 |
+| kind        | string   | 网关类型：`normal`、`programmable` 或 `ai` |

--- a/src/dashboard/apigateway/apigateway/data/apidocs/zh/v2_open_get_gateway.md
+++ b/src/dashboard/apigateway/apigateway/data/apidocs/zh/v2_open_get_gateway.md
@@ -18,6 +18,7 @@
     "data": {
         "id": 1,
         "name": "bk-apigateway",
+        "kind": "normal",
         "description": "",
         "maintainers": [
             "admin"
@@ -38,5 +39,6 @@ data
 | ----------- | -------- | ---------- |
 | id          | int      | 网关 ID     |
 | name        | string   | 网关名称   |
+| kind        | string   | 网关类型：`normal`、`programmable` 或 `ai` |
 | description | string   | 网关描述   |
 | maintainers | array    | 网关管理员 |

--- a/src/dashboard/apigateway/apigateway/data/apidocs/zh/v2_open_get_released_resource.md
+++ b/src/dashboard/apigateway/apigateway/data/apidocs/zh/v2_open_get_released_resource.md
@@ -19,6 +19,7 @@
   "data": {
     "id": 2448,
     "name": "updatePet",
+    "kind": "standard",
     "method": "PUT",
     "path": "/api/v3/pet",
     "schema": {
@@ -54,6 +55,7 @@
 |----------|----------|--------------|
 | id       | int      | 资源 ID      |
 | name     | string   | 资源名称     |
+| kind     | string   | 资源类型，`standard`：普通 API，`ai`：模型代理 API |
 | method   | string   | 资源请求方法 |
 | path     | string   | 资源请求地址 |
 | schema   | object   | 资源协议数据 |

--- a/src/dashboard/apigateway/apigateway/data/apidocs/zh/v2_open_get_released_resources.md
+++ b/src/dashboard/apigateway/apigateway/data/apidocs/zh/v2_open_get_released_resources.md
@@ -23,6 +23,7 @@
       {
         "id": 3,
         "name": "echo",
+        "kind": "standard",
         "description": "",
         "method": "GET",
         "url": "https://bkapi.example.com/api/bk-apigateway/prod/echo/",
@@ -58,6 +59,7 @@
 |------------------------|----------|----------------------------------|
 | id                     | int      | 资源 ID                          |
 | name                   | string   | 资源名称                         |
+| kind                   | string   | 资源类型，`standard`：普通 API，`ai`：模型代理 API |
 | description            | string   | 资源描述                         |
 | method                 | string   | 资源请求方法                     |
 | url                    | string   | 资源请求地址                     |

--- a/src/dashboard/apigateway/apigateway/data/apidocs/zh/v2_open_list_gateway_resources.md
+++ b/src/dashboard/apigateway/apigateway/data/apidocs/zh/v2_open_list_gateway_resources.md
@@ -19,7 +19,7 @@
 | 参数名称 | 参数类型 | 必选 | 描述 |
 |----------|----------|------|------|
 | keyword  | string   | 否   | 搜索关键字，模糊匹配资源 name、description 或标签名称 |
-| fields   | string   | 否   | 指定返回的字段列表，逗号分隔，如 `fields=id,name,method`；不传默认返回 `id` 和 `name` |
+| fields   | string   | 否   | 指定返回的字段列表，逗号分隔，如 `fields=id,name,method,kind`；不传默认返回 `id` 和 `name` |
 
 
 ### 响应示例
@@ -37,7 +37,7 @@
 }
 ```
 
-#### 指定全部字段（fields=id,name,description,method,path,match_subpath,enable_websocket,is_public,labels,auth_config）
+#### 指定全部字段（fields=id,name,kind,description,method,path,match_subpath,enable_websocket,is_public,labels,auth_config）
 
 ```json
 {
@@ -45,6 +45,7 @@
         {
             "id": 1,
             "name": "get_user_info",
+            "kind": "standard",
             "description": "获取用户信息",
             "method": "GET",
             "path": "/api/v1/users/{user_id}/",
@@ -82,6 +83,7 @@
 |-----------------------|---------|-------------------------|
 | id                    | int     | 资源 ID                   |
 | name                  | string  | 资源名称                    |
+| kind                  | string  | 资源类型：`standard` 或 `ai`   |
 | description           | string  | 资源描述                    |
 | method                | string  | 请求方法（GET、POST 等）        |
 | path                  | string  | 资源路径                    |

--- a/src/dashboard/apigateway/apigateway/data/apidocs/zh/v2_open_list_gateways.md
+++ b/src/dashboard/apigateway/apigateway/data/apidocs/zh/v2_open_list_gateways.md
@@ -24,6 +24,7 @@
         {
             "id": 1,
             "name": "bk-apigateway",
+            "kind": "normal",
             "description": "蓝鲸 API 网关",
             "maintainers": [
                 "admin"
@@ -48,6 +49,7 @@ data[]
 | -------- | -------- | ---- |
 | id | int | 网关 ID |
 | name | string | 网关名称 |
+| kind | string | 网关类型：`normal`、`programmable` 或 `ai` |
 | description | string | 网关描述 |
 | maintainers | array | 网关管理员 |
 | doc_maintainers | array | 文档管理员 |

--- a/src/dashboard/apigateway/apigateway/data/apidocs/zh/v2_open_retrieve_gateway_api_details.md
+++ b/src/dashboard/apigateway/apigateway/data/apidocs/zh/v2_open_retrieve_gateway_api_details.md
@@ -29,6 +29,7 @@
     "data": {
         "id": 1,
         "name": "get_user_info",
+        "kind": "standard",
         "description": "获取用户信息",
         "description_en": "Get user information",
         "method": "GET",
@@ -96,6 +97,7 @@
 |------------------------|---------|---------------------------|
 | id                     | int     | 资源 ID                     |
 | name                   | string  | 资源名称                      |
+| kind                   | string  | 资源类型：`standard` 或 `ai`     |
 | description            | string  | 资源描述（中文）                  |
 | description_en         | string  | 资源描述（英文）                  |
 | method                 | string  | 请求方法（GET、POST 等）          |
@@ -145,4 +147,3 @@ OpenAPI 3.0 格式的 Schema 定义，包含以下常见字段：
 
 - `404 Not Found`: 资源不存在、未公开或该环境未发布
 - 需要确保指定的 `stage_name` 已经发布过版本
-

--- a/src/dashboard/apigateway/apigateway/data/apidocs/zh/v2_open_retrieve_gateway_resource_info.md
+++ b/src/dashboard/apigateway/apigateway/data/apidocs/zh/v2_open_retrieve_gateway_resource_info.md
@@ -20,6 +20,7 @@
     "data": {
         "id": 1,
         "name": "get_user_info",
+        "kind": "standard",
         "description": "获取用户信息",
         "method": "GET",
         "path": "/api/v1/users/{user_id}/",
@@ -41,6 +42,7 @@
 | ------------- | -------- | -------------- |
 | id            | int      | 资源 ID        |
 | name          | string   | 资源名称       |
+| kind          | string   | 资源类型：`standard` 或 `ai` |
 | description   | string   | 资源描述       |
 | method        | string   | 请求方法       |
 | path          | string   | 资源路径       |

--- a/src/dashboard/apigateway/apigateway/data/apidocs/zh/v2_sync_gateway.md
+++ b/src/dashboard/apigateway/apigateway/data/apidocs/zh/v2_sync_gateway.md
@@ -38,7 +38,8 @@
 {
     "data": {
         "id": 1,
-        "name": "demo"
+        "name": "demo",
+        "kind": "ai"
     }
 }
 ```
@@ -55,3 +56,4 @@ data
 | -------- | -------- | -------- |
 | id       | int      | 网关ID   |
 | name     | string   | 网关名称 |
+| kind     | string   | 网关类型：`normal`、`programmable` 或 `ai` |

--- a/src/dashboard/apigateway/apigateway/data/apigw-definitions/bk-apigateway-resources.yaml
+++ b/src/dashboard/apigateway/apigateway/data/apigw-definitions/bk-apigateway-resources.yaml
@@ -854,6 +854,11 @@ paths:
                             name:
                               type: string
                               example: echo
+                            kind:
+                              type: string
+                              enum: [standard, ai]
+                              description: 资源类型，standard：普通 API，ai：模型代理 API
+                              example: standard
                             description:
                               type: string
                               example: ""
@@ -948,6 +953,11 @@ paths:
                         type: string
                         description: 资源名称
                         example: updatePet
+                      kind:
+                        type: string
+                        enum: [standard, ai]
+                        description: 资源类型，standard：普通 API，ai：模型代理 API
+                        example: standard
                       method:
                         type: string
                         description: 资源请求方法
@@ -1981,6 +1991,7 @@ paths:
                 data:
                   id: 1
                   name: demo
+                  kind: ai
       x-bk-apigateway-resource:
         isPublic: true
         allowApplyPermission: true
@@ -2218,12 +2229,18 @@ paths:
                         type: string
                         description: 网关名称
                         example: demo
+                      kind:
+                        type: string
+                        enum: [normal, programmable, ai]
+                        description: 网关类型
+                        example: ai
               example:
                 code: 0
                 message: OK
                 data:
                   id: 1
                   name: demo
+                  kind: ai
       x-bk-apigateway-resource:
         isPublic: true
         allowApplyPermission: true
@@ -2287,6 +2304,11 @@ paths:
                           type: string
                           description: 网关名称
                           example: bk-apigateway
+                        kind:
+                          type: string
+                          enum: [normal, programmable, ai]
+                          description: 网关类型
+                          example: normal
                         description:
                           type: string
                           description: 网关描述
@@ -2307,6 +2329,7 @@ paths:
                 data:
                   - id: 1
                     name: bk-apigateway
+                    kind: normal
                     description: 蓝鲸 API 网关
                     maintainers: ["admin"]
                     doc_maintainers: ["admin"]
@@ -2376,6 +2399,10 @@ paths:
                         description:
                           type: string
                           description: 网关描述
+                        kind:
+                          type: string
+                          enum: [normal, programmable, ai]
+                          description: 网关类型
       x-bk-apigateway-resource:
         isPublic: true
         allowApplyPermission: true
@@ -2426,6 +2453,11 @@ paths:
                         type: string
                         description: 网关名称
                         example: bk-apigateway
+                      kind:
+                        type: string
+                        enum: [normal, programmable, ai]
+                        description: 网关类型
+                        example: normal
                       description:
                         type: string
                         description: 网关描述
@@ -2440,6 +2472,7 @@ paths:
                 data:
                   id: 1
                   name: bk-apigateway
+                  kind: normal
                   description: ""
                   maintainers: ["admin"]
       x-bk-apigateway-resource:
@@ -2485,6 +2518,10 @@ paths:
                           name:
                             type: string
                             description: 资源name
+                          kind:
+                            type: string
+                            enum: [standard, ai]
+                            description: 资源类型，standard：普通 API，ai：模型代理 API
                           description:
                             type: string
                             description: 资源描述
@@ -2583,6 +2620,10 @@ paths:
                   name:
                     type: string
                     description: 资源名称
+                  kind:
+                    type: string
+                    enum: [standard, ai]
+                    description: 资源类型，standard：普通 API，ai：模型代理 API
                   description:
                     type: string
                     description: 资源描述（中文）
@@ -2697,6 +2738,26 @@ paths:
                 properties:
                   data:
                     type: object
+                    properties:
+                      count:
+                        type: integer
+                      has_next:
+                        type: boolean
+                      has_previous:
+                        type: boolean
+                      results:
+                        type: array
+                        items:
+                          type: object
+                          properties:
+                            id:
+                              type: integer
+                            name:
+                              type: string
+                            kind:
+                              type: string
+                              enum: [standard, ai]
+                              description: 资源类型，standard：普通 API，ai：模型代理 API
       x-bk-apigateway-resource:
         isPublic: true
         allowApplyPermission: true
@@ -2749,6 +2810,15 @@ paths:
                 properties:
                   data:
                     type: object
+                    properties:
+                      id:
+                        type: integer
+                      name:
+                        type: string
+                      kind:
+                        type: string
+                        enum: [standard, ai]
+                        description: 资源类型，standard：普通 API，ai：模型代理 API
       x-bk-apigateway-resource:
         isPublic: true
         allowApplyPermission: true
@@ -2802,6 +2872,10 @@ paths:
                       name:
                         type: string
                         description: 资源名称
+                      kind:
+                        type: string
+                        enum: [standard, ai]
+                        description: 资源类型，standard：普通 API，ai：模型代理 API
                       description:
                         type: string
                         description: 资源描述
@@ -5191,6 +5265,11 @@ paths:
                         type: string
                         description: 网关名称
                         example: demo
+                      kind:
+                        type: string
+                        enum: [normal, programmable, ai]
+                        description: 网关类型
+                        example: ai
       x-bk-apigateway-resource:
         isPublic: true
         allowApplyPermission: false
@@ -5918,6 +5997,11 @@ paths:
                           type: string
                           description: 网关名称
                           example: bk-apigateway
+                        kind:
+                          type: string
+                          enum: [normal, programmable, ai]
+                          description: 网关类型
+                          example: normal
                         description:
                           type: string
                           description: 网关描述
@@ -6000,6 +6084,11 @@ paths:
                         type: string
                         description: 网关名称
                         example: bk-apigateway
+                      kind:
+                        type: string
+                        enum: [normal, programmable, ai]
+                        description: 网关类型
+                        example: normal
                       description:
                         type: string
                         description: 网关描述

--- a/src/dashboard/apigateway/apigateway/tests/apis/open/gateway/test_views.py
+++ b/src/dashboard/apigateway/apigateway/tests/apis/open/gateway/test_views.py
@@ -163,6 +163,7 @@ class TestGatewaySyncApi:
         )
 
         assert response.status_code == 200
+        assert response.json()["data"]["kind"] == "ai"
         assert Gateway.objects.get(name=unique_gateway_name).kind == GatewayKindEnum.AI.value
 
     def test_post(self, mocker, request_view, unique_gateway_name, disable_app_permission, default_data_plane):

--- a/src/dashboard/apigateway/apigateway/tests/apis/open/released/test_views.py
+++ b/src/dashboard/apigateway/apigateway/tests/apis/open/released/test_views.py
@@ -43,7 +43,7 @@ class TestReleasedResourceRetrieveApi:
                 },
                 {},
                 False,
-                {"id": 1, "name": "test", "method": "GET", "path": "/test/", "schema": {}},
+                {"id": 1, "name": "test", "method": "GET", "path": "/test/", "kind": "standard", "schema": {}},
             ),
             (
                 1,
@@ -73,6 +73,7 @@ class TestReleasedResourceRetrieveApi:
                     "name": "test",
                     "method": "GET",
                     "path": "/test/",
+                    "kind": "standard",
                     "schema": {
                         "parameters": [
                             {
@@ -230,6 +231,7 @@ class TestReleasedResourceListByGatewayNameApi:
                         {
                             "id": 1,
                             "name": "test",
+                            "kind": "standard",
                             "description": "test",
                             "method": "GET",
                             "url": "http://bkapi.example.com/test/",
@@ -242,6 +244,7 @@ class TestReleasedResourceListByGatewayNameApi:
                         {
                             "id": 2,
                             "name": "test",
+                            "kind": "standard",
                             "description": "test",
                             "method": "POST",
                             "url": "http://bkapi.example.com/test/",

--- a/src/dashboard/apigateway/apigateway/tests/apis/v2/inner/test_views.py
+++ b/src/dashboard/apigateway/apigateway/tests/apis/v2/inner/test_views.py
@@ -40,13 +40,16 @@ from apigateway.apps.mcp_server.models import MCPServer, MCPServerAppPermission,
 from apigateway.apps.monitor.constants import AlarmStatusEnum, AlarmTypeEnum
 from apigateway.apps.monitor.models import AlarmRecord
 from apigateway.apps.permission.models import AppPermissionRecord
-from apigateway.core.constants import GatewayStatusEnum, StageStatusEnum
+from apigateway.core.constants import GatewayKindEnum, GatewayStatusEnum, StageStatusEnum
 from apigateway.core.models import Gateway, Release, Resource, Stage
 from apigateway.tests.utils.testing import get_response_json
 
 
 class TestGatewayListApi:
     def test_list(self, request_view, fake_gateway, mocker):
+        fake_gateway.kind = GatewayKindEnum.AI.value
+        fake_gateway.save(update_fields=["kind"])
+
         g1 = G(Gateway, status=GatewayStatusEnum.ACTIVE.value, is_public=False)
         G(Release, gateway=g1)
         g2 = G(Gateway, status=GatewayStatusEnum.INACTIVE.value, is_public=True)
@@ -67,10 +70,14 @@ class TestGatewayListApi:
         result = resp.json()
         assert resp.status_code == 200
         assert len(result["data"]) == 2
+        assert next(item for item in result["data"] if item["name"] == fake_gateway.name)["kind"] == "ai"
 
 
 class TestGatewayRetrieveApi:
     def test_retrieve(self, request_to_view, request_factory, fake_gateway):
+        fake_gateway.kind = GatewayKindEnum.AI.value
+        fake_gateway.save(update_fields=["kind"])
+
         request = request_factory.get("")
         request.gateway = fake_gateway
         request.app = mock.MagicMock(app_code="test")
@@ -83,6 +90,7 @@ class TestGatewayRetrieveApi:
 
         assert response.status_code == 200
         assert result["data"]["name"] == fake_gateway.name
+        assert result["data"]["kind"] == "ai"
 
 
 class TestGatewayOutputSLZ:

--- a/src/dashboard/apigateway/apigateway/tests/apis/v2/open/test_views.py
+++ b/src/dashboard/apigateway/apigateway/tests/apis/v2/open/test_views.py
@@ -33,13 +33,17 @@ from apigateway.apps.mcp_server.constants import (
     MCPServerStatusEnum,
 )
 from apigateway.apps.mcp_server.models import MCPServer, MCPServerAppPermissionApply, MCPServerCategory
-from apigateway.core.constants import GatewayStatusEnum, StageStatusEnum
+from apigateway.biz.released_resource import ReleasedResourceData
+from apigateway.core.constants import GatewayKindEnum, GatewayStatusEnum, ResourceKindEnum, StageStatusEnum
 from apigateway.core.models import Gateway, Release, Resource, Stage
 from apigateway.tests.utils.testing import get_response_json
 
 
 class TestGatewayListApi:
     def test_list(self, request_view, fake_gateway, mocker):
+        fake_gateway.kind = GatewayKindEnum.AI.value
+        fake_gateway.save(update_fields=["kind"])
+
         g1 = G(Gateway, status=GatewayStatusEnum.ACTIVE.value, is_public=False)
         G(Release, gateway=g1)
         g2 = G(Gateway, status=GatewayStatusEnum.INACTIVE.value, is_public=True)
@@ -60,10 +64,14 @@ class TestGatewayListApi:
         result = resp.json()
         assert resp.status_code == 200
         assert len(result["data"]) == 2
+        assert next(item for item in result["data"] if item["name"] == fake_gateway.name)["kind"] == "ai"
 
 
 class TestGatewayRetrieveApi:
     def test_retrieve(self, request_to_view, request_factory, fake_gateway):
+        fake_gateway.kind = GatewayKindEnum.AI.value
+        fake_gateway.save(update_fields=["kind"])
+
         request = request_factory.get("")
         request.gateway = fake_gateway
         request.app = mock.MagicMock(app_code="test")
@@ -76,6 +84,7 @@ class TestGatewayRetrieveApi:
 
         assert response.status_code == 200
         assert result["data"]["name"] == fake_gateway.name
+        assert result["data"]["kind"] == "ai"
 
 
 class TestMCPServerAppPermissionApplyCreateApi:
@@ -1232,19 +1241,20 @@ class TestGatewayBatchQueryApi:
     def test_batch_query_with_fields(self, request_view, fake_gateway):
         fake_gateway.status = GatewayStatusEnum.ACTIVE.value
         fake_gateway.is_public = True
+        fake_gateway.kind = GatewayKindEnum.AI.value
         fake_gateway.save()
 
         resp = request_view(
             method="POST",
             view_name="openapi.v2.open.gateway.batch_query",
             app=mock.MagicMock(app_code="test"),
-            data={"names": [fake_gateway.name], "fields": "name"},
+            data={"names": [fake_gateway.name], "fields": "name,kind"},
             content_type="application/json",
         )
         result = resp.json()
         assert resp.status_code == 200
         assert len(result["data"]) == 1
-        assert set(result["data"][0].keys()) == {"name"}
+        assert result["data"][0] == {"name": fake_gateway.name, "kind": "ai"}
 
     def test_batch_query_no_ids_or_names(self, request_view):
         resp = request_view(
@@ -1267,6 +1277,7 @@ class TestGatewayResourceRetrieveByNameApi:
             method="GET",
             path="/api/v1/users/",
             is_public=True,
+            kind=ResourceKindEnum.AI.value,
         )
 
         request = request_factory.get("")
@@ -1283,6 +1294,7 @@ class TestGatewayResourceRetrieveByNameApi:
         assert response.status_code == 200
         assert result["data"]["name"] == "get_user_info"
         assert result["data"]["id"] == resource.id
+        assert result["data"]["kind"] == ResourceKindEnum.AI.value
 
     def test_retrieve_nonexistent_resource(self, request_to_view, request_factory, fake_gateway):
         request = request_factory.get("")
@@ -1298,6 +1310,41 @@ class TestGatewayResourceRetrieveByNameApi:
         assert response.status_code == 404
 
 
+class TestGatewayResourceDetailApi:
+    def test_retrieve_returns_resource_kind(self, mocker, request_to_view, request_factory, fake_gateway):
+        resource_data = ReleasedResourceData(
+            id=1,
+            name="chat_completions",
+            method="POST",
+            path="/chat/completions",
+            is_public=True,
+            kind=ResourceKindEnum.AI.value,
+            contexts={"resource_auth": {"config": "{}"}},
+        )
+        mocker.patch(
+            "apigateway.apis.v2.open.views.Release.objects.get_released_resource_version_id",
+            return_value=1,
+        )
+        mocker.patch(
+            "apigateway.apis.v2.open.views.ReleasedResourceDocHandler.get_released_resource_doc_data",
+            return_value=(resource_data, None),
+        )
+        mocker.patch("apigateway.apis.v2.open.views.get_resource_schema", return_value={})
+
+        request = request_factory.get("", data={"stage_name": "prod"})
+        request.gateway = fake_gateway
+        request.app = mock.MagicMock(app_code="test")
+        response = request_to_view(
+            request,
+            view_name="openapi.v2.open.gateway.resources.detail",
+            path_params={"gateway_name": fake_gateway.name, "resource_name": resource_data.name},
+        )
+        result = get_response_json(response)
+
+        assert response.status_code == 200
+        assert result["data"]["kind"] == ResourceKindEnum.AI.value
+
+
 class TestGatewayReleasedResourceListApi:
     def test_list_by_stage(self, settings, mocker, request_to_view, request_factory, fake_gateway):
         settings.API_RESOURCE_URL_TMPL = "http://bkapi.example.com/{resource_path}"
@@ -1309,6 +1356,7 @@ class TestGatewayReleasedResourceListApi:
                 "description": "test",
                 "method": "GET",
                 "path": "/test/",
+                "kind": ResourceKindEnum.AI.value,
                 "match_subpath": False,
                 "enable_websocket": False,
                 "app_verified_required": True,
@@ -1334,6 +1382,7 @@ class TestGatewayReleasedResourceListApi:
         assert response.status_code == 200
         assert result["data"]["count"] == 1
         assert result["data"]["results"][0]["name"] == "test"
+        assert result["data"]["results"][0]["kind"] == ResourceKindEnum.AI.value
         get_released_public_resources_mock.assert_called_once_with(fake_gateway.id, stage_name="prod")
 
 
@@ -1351,6 +1400,7 @@ class TestGatewayReleasedResourceRetrieveApi:
                 "name": "test",
                 "method": "GET",
                 "path": "/test/",
+                "kind": ResourceKindEnum.AI.value,
             },
         )
         get_resource_schema_mock = mocker.patch(
@@ -1374,6 +1424,7 @@ class TestGatewayReleasedResourceRetrieveApi:
 
         assert response.status_code == 200
         assert result["data"]["name"] == "test"
+        assert result["data"]["kind"] == ResourceKindEnum.AI.value
         assert result["data"]["schema"] == {"parameters": []}
         get_released_resource_version_id_mock.assert_called_once_with(fake_gateway.id, "prod")
         get_released_resource_mock.assert_called_once_with(fake_gateway.id, 1, "test")
@@ -1541,9 +1592,10 @@ class TestGatewayResourceListApiFields:
             method="GET",
             path="/api/v1/users/",
             is_public=True,
+            kind=ResourceKindEnum.AI.value,
         )
 
-        request = request_factory.get("", data={"fields": "id,name,method"})
+        request = request_factory.get("", data={"fields": "id,name,method,kind"})
         request.gateway = fake_gateway
         request.app = mock.MagicMock(app_code="test")
 
@@ -1556,7 +1608,8 @@ class TestGatewayResourceListApiFields:
 
         assert response.status_code == 200
         assert len(result["data"]) == 1
-        assert set(result["data"][0].keys()) == {"id", "name", "method"}
+        assert set(result["data"][0].keys()) == {"id", "name", "method", "kind"}
+        assert result["data"][0]["kind"] == ResourceKindEnum.AI.value
 
     def test_list_without_fields_returns_default_id_name(self, request_to_view, request_factory, fake_gateway):
         G(

--- a/src/dashboard/apigateway/apigateway/tests/apis/v2/sync/test_views.py
+++ b/src/dashboard/apigateway/apigateway/tests/apis/v2/sync/test_views.py
@@ -350,6 +350,7 @@ class TestSyncApi:
         )
 
         assert response.status_code == 200, response.json()
+        assert response.json()["data"]["kind"] == "ai"
         assert Gateway.objects.get(name=unique_gateway_name).kind == GatewayKindEnum.AI.value
 
     def test_gateway_sync_ai_gateway_rejects_older_default_data_plane(

--- a/src/dashboard/apigateway/apigateway/tests/apis/web/docs/gateway/gateway/test_serializers.py
+++ b/src/dashboard/apigateway/apigateway/tests/apis/web/docs/gateway/gateway/test_serializers.py
@@ -17,11 +17,13 @@
 # to the current version of the project delivered to anyone in the future.
 #
 from apigateway.apis.web.docs.gateway.gateway.serializers import GatewayOutputSLZ
+from apigateway.core.constants import GatewayKindEnum
 
 
 class TestGatewayOutputSLZ:
     def test_to_representation(self, settings, fake_gateway):
         settings.BK_API_URL_TMPL = "http://{api_name}.example.com"
+        fake_gateway.kind = GatewayKindEnum.AI.value
 
         slz = GatewayOutputSLZ(
             fake_gateway,
@@ -32,6 +34,7 @@ class TestGatewayOutputSLZ:
         )
 
         assert slz.data["is_official"] is False
+        assert slz.data["kind"] == GatewayKindEnum.AI.value
         assert slz.data["api_url"] == f"http://{fake_gateway.name}.example.com"
         assert slz.data["doc_maintainers"] == {
             "type": "user",

--- a/src/dashboard/apigateway/apigateway/tests/apis/web/docs/gateway/resource/test_views.py
+++ b/src/dashboard/apigateway/apigateway/tests/apis/web/docs/gateway/resource/test_views.py
@@ -48,3 +48,4 @@ class TestResourceListApi:
 
         assert resp.status_code == 200
         assert len(result["data"]) > 0
+        assert result["data"][0]["kind"] == "standard"

--- a/src/dashboard/apigateway/apigateway/tests/apis/web/release/test_views.py
+++ b/src/dashboard/apigateway/apigateway/tests/apis/web/release/test_views.py
@@ -146,6 +146,7 @@ class TestReleaseAvailableResourceListApi:
                     "description": "test...",
                     "method": "get",
                     "path": "/test/",
+                    "kind": "standard",
                     "verified_user_required": False,
                     "verified_app_required": True,
                     "resource_perm_required": True,

--- a/src/dashboard/apigateway/apigateway/tests/apis/web/resource/test_views.py
+++ b/src/dashboard/apigateway/apigateway/tests/apis/web/resource/test_views.py
@@ -1295,7 +1295,7 @@ class TestBackendPathCheckApi:
 
 class TestResourcesWithVerifiedUserRequiredApi:
     def test_list(self, request_view, fake_gateway):
-        resource_1 = G(Resource, gateway=fake_gateway)
+        resource_1 = G(Resource, gateway=fake_gateway, kind=ResourceKindEnum.AI.value)
         resource_2 = G(Resource, gateway=fake_gateway)
 
         auth_config = ResourceHandler.get_default_auth_config()
@@ -1311,3 +1311,4 @@ class TestResourcesWithVerifiedUserRequiredApi:
 
         assert resp.status_code == 200
         assert len(result["data"]) == 1
+        assert result["data"][0]["kind"] == ResourceKindEnum.AI.value

--- a/src/dashboard/apigateway/apigateway/tests/apis/web/resource_doc/test_serializers.py
+++ b/src/dashboard/apigateway/apigateway/tests/apis/web/resource_doc/test_serializers.py
@@ -56,6 +56,7 @@ class TestDocArchiveParseOutputSLZ:
                     "resource": {
                         "id": 1,
                         "name": "get_user",
+                        "kind": "ai",
                         "method": "GET",
                         "path": "/user",
                         "description": "",
@@ -72,6 +73,7 @@ class TestDocArchiveParseOutputSLZ:
                     "resource": {
                         "id": 1,
                         "name": "get_user",
+                        "kind": "ai",
                         "method": "GET",
                         "path": "/user",
                         "description": "",


### PR DESCRIPTION
## Summary

- expose gateway kind from v1/v2 OpenAPI, inner, sync, and API-document responses
- expose resource kind from current, released, documentation, release, archive, and filtered-resource responses
- keep historical released snapshots compatible by defaulting missing resource kind to standard
- align gateway resource definitions and API reference pages with the runtime contract

## Verification

- uv run make lint-check
- uv run make test: 3328 passed
- uv run make check-openapi JSON=1: 0 errors; 42 unchanged baseline warnings
- focused red-green API contract tests