### PR TITLE
fix(dashboard): remove stale maintainer imports

### DIFF
--- a/src/dashboard/apigateway/apigateway/apis/v2/inner/serializers.py
+++ b/src/dashboard/apigateway/apigateway/apis/v2/inner/serializers.py
@@ -45,8 +45,6 @@ from apigateway.biz.permission import ResourcePermissionHandler
 from apigateway.biz.validators import BKAppCodeValidator
 from apigateway.common.fields import TimestampField
 from apigateway.common.i18n.field import SerializerTranslatedField
-from apigateway.common.tenant.request import get_tenant_id_for_gateway_maintainers
-from apigateway.components.bkuser import query_display_names_for_readonly
 from apigateway.core.constants import GatewayKindNameEnum, GatewayStatusEnum, convert_gateway_kind_to_name
 from apigateway.service.bk_itsm import ItsmPermissionApplyHelper
 from apigateway.service.mcp import (


### PR DESCRIPTION
### Description

Fix the dashboard CI Ruff F401 failures reported in PR #3003 after master was merged into ft_ai_gateway.

The serializer now delegates maintainer display-name conversion to ResourcePermissionHandler, but the previous helper imports remained. This PR removes only those two unused imports; runtime behavior is unchanged.

Failing job: https://github.com/TencentBlueKing/blueking-apigateway/actions/runs/29567399559/job/87843012976

### Verification

- Focused inner gateway API and serializer tests: 7 passed
- uv run make edition-ee && uv run make lint-check
- uv run make edition-ee && uv run make test: 3378 passed

### Checklist

- [x] 填写 PR 描述及相关 issue (write PR description and related issue)
- [x] 代码风格检查通过 (code style check passed)
- [ ] PR 中包含单元测试 (include unit test) — no behavior change; existing focused and full tests cover the path
- [x] 单元测试通过 (unit test passed)
- [ ] 本地开发联调环境验证通过 (local development environment verification passed) — not applicable to an import-only CI fix
