### PR TITLE
fix(dashboard): restore swagger schema generation

### DIFF
--- a/src/dashboard/apigateway/apigateway/apis/open/gateway/views.py
+++ b/src/dashboard/apigateway/apigateway/apis/open/gateway/views.py
@@ -190,7 +190,7 @@ class GatewayIdRetrieveApi(generics.RetrieveAPIView):
 class GatewayPublicKeyRetrieveApi(generics.RetrieveAPIView):
     permission_classes = [OpenAPIGatewayNamePermission]
 
-    @swagger_auto_schema(tags=["OpenAPI.V1"])
+    @swagger_auto_schema(responses={status.HTTP_200_OK: ""}, tags=["OpenAPI.V1"])
     def get(self, request, gateway_name: str, *args, **kwargs):
         jwt = JWT.objects.get(gateway=request.gateway)
         return V1OKJsonResponse(

--- a/src/dashboard/apigateway/apigateway/apis/open/resource_version/views.py
+++ b/src/dashboard/apigateway/apigateway/apis/open/resource_version/views.py
@@ -124,7 +124,7 @@ class ResourceVersionReleaseApi(generics.CreateAPIView):
 class ResourceVersionGetLatestApi(generics.RetrieveAPIView):
     permission_classes = [OpenAPIGatewayRelatedAppPermission]
 
-    @swagger_auto_schema(tags=["OpenAPI.V1"])
+    @swagger_auto_schema(responses={status.HTTP_200_OK: ""}, tags=["OpenAPI.V1"])
     def get(self, request, gateway_name: str, *args, **kwargs):
         resource_version = ResourceVersion.objects.get_latest_version(request.gateway.id)
 

--- a/src/dashboard/apigateway/apigateway/apis/open/stage/serializers.py
+++ b/src/dashboard/apigateway/apigateway/apis/open/stage/serializers.py
@@ -276,10 +276,16 @@ class AIBackendConfigSLZ(serializers.Serializer):
     def to_internal_value(self, data):
         return validate_ai_backend_config(data)
 
+    class Meta:
+        ref_name = "apis.open.stage.AIBackendConfigSLZ"
+
 
 class AIBackendSLZ(serializers.Serializer):
     name = serializers.CharField(help_text="模型服务名称")
     config = AIBackendConfigSLZ()
+
+    class Meta:
+        ref_name = "apis.open.stage.AIBackendSLZ"
 
 
 class PluginConfigSLZ(serializers.Serializer):

--- a/src/dashboard/apigateway/apigateway/apis/v2/inner/serializers.py
+++ b/src/dashboard/apigateway/apigateway/apis/v2/inner/serializers.py
@@ -798,15 +798,6 @@ class AppAlarmRecordListInputSLZ(serializers.Serializer):
     )
     time_start = TimestampField(required=True, help_text="开始时间")
     time_end = TimestampField(required=True, help_text="结束时间")
-    offset = serializers.IntegerField(label="偏移量", required=False, min_value=0, default=0, help_text="偏移量")
-    limit = serializers.IntegerField(
-        label="限制条数",
-        required=False,
-        min_value=1,
-        max_value=100,
-        default=10,
-        help_text="限制条数",
-    )
 
     class Meta:
         ref_name = "apigateway.apis.v2.inner.serializers.AppAlarmRecordListInputSLZ"

--- a/src/dashboard/apigateway/apigateway/apis/v2/inner/views.py
+++ b/src/dashboard/apigateway/apigateway/apis/v2/inner/views.py
@@ -605,6 +605,7 @@ class AppAlarmRecordListApi(generics.ListAPIView):
 class AppRequestLogListApi(generics.ListAPIView):
     permission_classes = [OpenAPIV2Permission]
     serializer_class = serializers.AppRequestLogListInputSLZ
+    pagination_class = None
 
     _output_fields = [
         "request_id",

--- a/src/dashboard/apigateway/apigateway/apis/v2/sync/serializers.py
+++ b/src/dashboard/apigateway/apigateway/apis/v2/sync/serializers.py
@@ -385,10 +385,16 @@ class AIBackendConfigSLZ(serializers.Serializer):
     def to_internal_value(self, data):
         return validate_ai_backend_config(data)
 
+    class Meta:
+        ref_name = "apigateway.apis.v2.sync.serializers.AIBackendConfigSLZ"
+
 
 class AIBackendSLZ(serializers.Serializer):
     name = serializers.CharField(help_text="模型服务名称")
     config = AIBackendConfigSLZ()
+
+    class Meta:
+        ref_name = "apigateway.apis.v2.sync.serializers.AIBackendSLZ"
 
 
 class PluginConfigSLZ(serializers.Serializer):

--- a/src/dashboard/apigateway/apigateway/apis/web/personal_workbench/serializers.py
+++ b/src/dashboard/apigateway/apigateway/apis/web/personal_workbench/serializers.py
@@ -23,13 +23,11 @@ from rest_framework import serializers
 from apigateway.apps.mcp_server.constants import MCPServerAppPermissionApplyStatusEnum
 from apigateway.apps.mcp_server.models import MCPServer, MCPServerAppPermissionApply
 from apigateway.apps.permission.constants import (
-    ApplyStatusEnum,
     GrantDimensionEnum,
     PermissionApplyExpireDaysEnum,
 )
 from apigateway.apps.permission.models import AppPermissionApply, AppPermissionRecord
 from apigateway.biz.permission import ResourcePermissionHandler
-from apigateway.common.fields import TimestampField
 from apigateway.core.models import Gateway, Resource
 from apigateway.service.bk_itsm import ItsmPermissionApplyHelper
 
@@ -86,67 +84,6 @@ class WorkbenchMCPServerFilterOptionSLZ(serializers.ModelSerializer):
 
     def get_gateway_name(self, obj) -> str:
         return obj.gateway.name
-
-
-# ========== 查询输入序列化器 ==========
-# NOTE: 以下 Input SLZ 仅用于 swagger 文档生成，实际查询过滤由 filters.py 中的 FilterSet 生效。
-# 修改查询参数时需同步修改对应的 FilterSet 以保持一致性。
-
-
-class WorkbenchGatewayPendingPermissionQueryInputSLZ(serializers.Serializer):
-    """个人工作台 - API 网关待办权限查询输入（仅用于文档生成，实际过滤由 FilterSet 处理）"""
-
-    bk_app_code = serializers.CharField(required=False, allow_blank=True, help_text="蓝鲸应用 ID")
-    applied_by = serializers.CharField(required=False, allow_blank=True, help_text="申请人")
-    gateway_id = serializers.IntegerField(required=False, help_text="网关 ID")
-    grant_dimension = serializers.ChoiceField(
-        choices=GrantDimensionEnum.get_choices(), required=False, help_text="授权维度"
-    )
-    time_start = TimestampField(allow_null=True, required=False, help_text="申请时间开始")
-    time_end = TimestampField(allow_null=True, required=False, help_text="申请时间结束")
-    keyword = serializers.CharField(
-        required=False, allow_blank=True, help_text="搜索关键字（模糊匹配网关名称或应用ID）"
-    )
-
-    class Meta:
-        ref_name = "apigateway.apis.web.personal_workbench.serializers.WorkbenchGatewayPendingPermissionQueryInputSLZ"
-
-
-class WorkbenchGatewayPermissionQueryInputSLZ(WorkbenchGatewayPendingPermissionQueryInputSLZ):
-    """个人工作台 - API 网关权限查询输入（仅用于文档生成，实际过滤由 FilterSet 处理）"""
-
-    status = serializers.ChoiceField(choices=ApplyStatusEnum.get_choices(), required=False, help_text="审批状态")
-
-    class Meta:
-        ref_name = "apigateway.apis.web.personal_workbench.serializers.WorkbenchGatewayPermissionQueryInputSLZ"
-
-
-class WorkbenchMCPPendingPermissionQueryInputSLZ(serializers.Serializer):
-    """个人工作台 - MCP Server 待办权限查询输入（仅用于文档生成，实际过滤由 FilterSet 处理）"""
-
-    bk_app_code = serializers.CharField(required=False, allow_blank=True, help_text="蓝鲸应用 ID")
-    applied_by = serializers.CharField(required=False, allow_blank=True, help_text="申请人")
-    gateway_id = serializers.IntegerField(required=False, help_text="网关 ID")
-    mcp_server_id = serializers.IntegerField(required=False, help_text="MCP Server ID")
-    time_start = TimestampField(allow_null=True, required=False, help_text="申请时间开始")
-    time_end = TimestampField(allow_null=True, required=False, help_text="申请时间结束")
-    keyword = serializers.CharField(
-        required=False, allow_blank=True, help_text="搜索关键字（模糊匹配 MCP Server 名称、展示名称或应用ID）"
-    )
-
-    class Meta:
-        ref_name = "apigateway.apis.web.personal_workbench.serializers.WorkbenchMCPPendingPermissionQueryInputSLZ"
-
-
-class WorkbenchMCPPermissionQueryInputSLZ(WorkbenchMCPPendingPermissionQueryInputSLZ):
-    """个人工作台 - MCP Server 权限查询输入（仅用于文档生成，实际过滤由 FilterSet 处理）"""
-
-    status = serializers.ChoiceField(
-        choices=MCPServerAppPermissionApplyStatusEnum.get_choices(), required=False, help_text="审批状态"
-    )
-
-    class Meta:
-        ref_name = "apigateway.apis.web.personal_workbench.serializers.WorkbenchMCPPermissionQueryInputSLZ"
 
 
 # ========== API 网关 输出序列化器 ==========

--- a/src/dashboard/apigateway/apigateway/apis/web/personal_workbench/views.py
+++ b/src/dashboard/apigateway/apigateway/apis/web/personal_workbench/views.py
@@ -50,14 +50,10 @@ from .filters import (
 from .serializers import (
     WorkbenchFilterOptionQueryInputSLZ,
     WorkbenchGatewayFilterOptionSLZ,
-    WorkbenchGatewayPendingPermissionQueryInputSLZ,
     WorkbenchGatewayPermissionApplyOutputSLZ,
-    WorkbenchGatewayPermissionQueryInputSLZ,
     WorkbenchGatewayPermissionRecordOutputSLZ,
-    WorkbenchMCPPendingPermissionQueryInputSLZ,
     WorkbenchMCPPermissionApplyOutputSLZ,
     WorkbenchMCPPermissionHandledOutputSLZ,
-    WorkbenchMCPPermissionQueryInputSLZ,
     WorkbenchMCPServerFilterOptionSLZ,
 )
 
@@ -300,7 +296,6 @@ class WorkbenchMCPGatewayFilterOptionListApi(WorkbenchPermissionMixin, generics.
     name="get",
     decorator=swagger_auto_schema(
         operation_description="个人工作台 - 我的待办 - API 网关权限申请列表",
-        query_serializer=WorkbenchGatewayPendingPermissionQueryInputSLZ,
         responses={status.HTTP_200_OK: WorkbenchGatewayPermissionApplyOutputSLZ(many=True)},
         tags=["WebAPI.PersonalWorkbench"],
     ),
@@ -322,7 +317,6 @@ class WorkbenchPendingGatewayPermissionListApi(ResourcePrefetchMixin, WorkbenchP
     name="get",
     decorator=swagger_auto_schema(
         operation_description="个人工作台 - 我的待办 - MCP Server 权限申请列表",
-        query_serializer=WorkbenchMCPPendingPermissionQueryInputSLZ,
         responses={status.HTTP_200_OK: WorkbenchMCPPermissionApplyOutputSLZ(many=True)},
         tags=["WebAPI.PersonalWorkbench"],
     ),
@@ -351,7 +345,6 @@ class WorkbenchPendingMCPPermissionListApi(WorkbenchPermissionMixin, generics.Li
     name="get",
     decorator=swagger_auto_schema(
         operation_description="个人工作台 - 我的申请 - API 网关权限申请列表",
-        query_serializer=WorkbenchGatewayPermissionQueryInputSLZ,
         responses={status.HTTP_200_OK: WorkbenchGatewayPermissionApplyOutputSLZ(many=True)},
         tags=["WebAPI.PersonalWorkbench"],
     ),
@@ -376,7 +369,6 @@ class WorkbenchMyApplyGatewayPermissionListApi(ResourcePrefetchMixin, WorkbenchP
     name="get",
     decorator=swagger_auto_schema(
         operation_description="个人工作台 - 我的申请 - MCP Server 权限申请列表",
-        query_serializer=WorkbenchMCPPermissionQueryInputSLZ,
         responses={status.HTTP_200_OK: WorkbenchMCPPermissionApplyOutputSLZ(many=True)},
         tags=["WebAPI.PersonalWorkbench"],
     ),
@@ -408,7 +400,6 @@ class WorkbenchMyApplyMCPPermissionListApi(WorkbenchPermissionMixin, generics.Li
     name="get",
     decorator=swagger_auto_schema(
         operation_description="个人工作台 - 我的已办 - API 网关权限申请列表",
-        query_serializer=WorkbenchGatewayPermissionQueryInputSLZ,
         responses={status.HTTP_200_OK: WorkbenchGatewayPermissionRecordOutputSLZ(many=True)},
         tags=["WebAPI.PersonalWorkbench"],
     ),
@@ -437,7 +428,6 @@ class WorkbenchHandledGatewayPermissionListApi(ResourcePrefetchMixin, WorkbenchP
     name="get",
     decorator=swagger_auto_schema(
         operation_description="个人工作台 - 我的已办 - MCP Server 权限申请列表",
-        query_serializer=WorkbenchMCPPermissionQueryInputSLZ,
         responses={status.HTTP_200_OK: WorkbenchMCPPermissionHandledOutputSLZ(many=True)},
         tags=["WebAPI.PersonalWorkbench"],
     ),

--- a/src/dashboard/apigateway/apigateway/tests/drf_yasg/test_urls.py
+++ b/src/dashboard/apigateway/apigateway/tests/drf_yasg/test_urls.py
@@ -22,9 +22,65 @@ from django.test import override_settings
 from django.urls import NoReverseMatch, clear_url_caches, reverse, set_urlconf
 
 import apigateway.urls
+from apigateway.apis.v2.inner import serializers, views
 
 
 class TestUrls:
+    def test_inner_monitor_apis_own_pagination_parameters_once(self):
+        assert "offset" not in serializers.AppAlarmRecordListInputSLZ().fields
+        assert "limit" not in serializers.AppAlarmRecordListInputSLZ().fields
+        assert views.AppRequestLogListApi.pagination_class is None
+
+    def test_schema_generation_succeeds_with_explicit_query_parameters(self, caplog, client):
+        try:
+            with override_settings(DEBUG=True):
+                clear_url_caches()
+                importlib.reload(apigateway.urls)
+                set_urlconf(None)
+
+                response = client.get("/backend/docs/auto/swagger/?format=openapi")
+
+                assert response.status_code == 200
+                schema = response.json()
+                alarm_record_parameters = schema["paths"]["/api/v2/inner/apps/{app_code}/monitor/alarm-records/"][
+                    "get"
+                ]["parameters"]
+                alarm_record_parameter_names = [parameter["name"] for parameter in alarm_record_parameters]
+                assert set(alarm_record_parameter_names) == {
+                    "status",
+                    "gateway_name",
+                    "resource_name",
+                    "time_start",
+                    "time_end",
+                    "offset",
+                    "limit",
+                }
+                assert len(alarm_record_parameter_names) == len(set(alarm_record_parameter_names))
+
+                workbench_parameters = schema["paths"]["/me/workbench/permissions/gateway/applied/"]["get"][
+                    "parameters"
+                ]
+                workbench_parameter_names = [parameter["name"] for parameter in workbench_parameters]
+                assert set(workbench_parameter_names) == {
+                    "limit",
+                    "offset",
+                    "bk_app_code",
+                    "applied_by",
+                    "gateway_id",
+                    "grant_dimension",
+                    "time_start",
+                    "time_end",
+                    "keyword",
+                    "status",
+                }
+                assert len(workbench_parameter_names) == len(set(workbench_parameter_names))
+                assert "GatewayPublicKeyRetrieveApi.get_serializer raised exception" not in caplog.text
+                assert "ResourceVersionGetLatestApi.get_serializer raised exception" not in caplog.text
+        finally:
+            importlib.reload(apigateway.urls)
+            clear_url_caches()
+            set_urlconf(None)
+
     def test_schema_json_url_uses_non_compat_format(self):
         try:
             with override_settings(DEBUG=True):


### PR DESCRIPTION
## Summary
- follow the existing endpoint-level Swagger convention instead of changing `BkStandardResponseSwaggerAutoSchema`
- let `AppAlarmRecordListApi` use DRF pagination-owned `limit`/`offset` parameters
- mark `AppRequestLogListApi` as manually paginated so its query serializer owns `limit`/`offset`
- remove personal-workbench documentation-only query serializers that duplicated FilterSet parameters
- keep explicit schema names for duplicated v1/v2 AI backend serializers and explicit responses for legacy retrieve endpoints
- add regression coverage for Swagger generation and duplicate query-parameter ownership

## Verification
- `apigateway/tests/drf_yasg/test_urls.py` (`4 passed`)
- related focused tests for personal workbench and inner monitor APIs (`92 passed`)
- `make lint`
- `make test` (`3380 passed`)
- `git diff --check`
