### PR TITLE
fix(dashboard): reject AI resources from MCP tools

### DIFF
--- a/src/dashboard/apigateway/apigateway/apis/web/mcp_server/serializers.py
+++ b/src/dashboard/apigateway/apigateway/apis/web/mcp_server/serializers.py
@@ -43,7 +43,8 @@ from apigateway.biz.permission import ResourcePermissionHandler
 from apigateway.biz.validators import BKAppCodeValidator, MCPServerHandler, MCPServerValidator
 from apigateway.common.constants import LanguageCodeEnum
 from apigateway.common.django.translation import get_current_language_code
-from apigateway.core.constants import GatewayStatusEnum, StageStatusEnum
+from apigateway.core.constants import GatewayStatusEnum, ResourceKindEnum, StageStatusEnum
+from apigateway.core.models import Release
 from apigateway.service.bk_itsm import ItsmPermissionApplyHelper
 
 logger = logging.getLogger(__name__)
@@ -267,12 +268,35 @@ class MCPServerCreateInputSLZ(serializers.ModelSerializer):
         if len(resource_names) != len(set(resource_names)):
             raise serializers.ValidationError(_("资源名称列表中不能存在重复的资源名称"))
 
-        for resource_name in resource_names:
-            if resource_name not in valid_resource_names:
-                raise serializers.ValidationError(
-                    _("资源名称列表非法，请检查当前环境发布的最新版本中对应资源名称是否存在")
-                    + f"resource_name={resource_name}"
+        invalid_resource_names = [name for name in resource_names if name not in valid_resource_names]
+        if invalid_resource_names:
+            release = (
+                Release.objects.filter(
+                    gateway_id=self.context["gateway"].id,
+                    stage_id=self.initial_data["stage_id"],
                 )
+                .select_related("resource_version")
+                .first()
+            )
+            ai_resource_names = (
+                {
+                    resource["name"]
+                    for resource in release.resource_version.data
+                    if resource.get("kind") == ResourceKindEnum.AI.value
+                }
+                if release
+                else set()
+            )
+            for resource_name in invalid_resource_names:
+                if resource_name in ai_resource_names:
+                    raise serializers.ValidationError(
+                        _("模型代理 API 不能作为 MCP Tool") + f": resource_name={resource_name}"
+                    )
+
+            raise serializers.ValidationError(
+                _("资源名称列表非法，请检查当前环境发布的最新版本中对应资源名称是否存在")
+                + f"resource_name={invalid_resource_names[0]}"
+            )
         return resource_names
 
     def validate_tool_names(self, tool_names):
@@ -476,12 +500,35 @@ class MCPServerUpdateInputSLZ(serializers.ModelSerializer):
         if len(resource_names) != len(set(resource_names)):
             raise serializers.ValidationError(_("资源名称列表中不能存在重复的资源名称"))
 
-        for resource_name in resource_names:
-            if resource_name not in valid_resource_names:
-                raise serializers.ValidationError(
-                    _("资源名称列表非法，请检查当前环境发布的最新版本中对应资源名称是否存在")
-                    + f"resource_name={resource_name}"
+        invalid_resource_names = [name for name in resource_names if name not in valid_resource_names]
+        if invalid_resource_names:
+            release = (
+                Release.objects.filter(
+                    gateway_id=self.instance.gateway_id,
+                    stage_id=self.instance.stage_id,
                 )
+                .select_related("resource_version")
+                .first()
+            )
+            ai_resource_names = (
+                {
+                    resource["name"]
+                    for resource in release.resource_version.data
+                    if resource.get("kind") == ResourceKindEnum.AI.value
+                }
+                if release
+                else set()
+            )
+            for resource_name in invalid_resource_names:
+                if resource_name in ai_resource_names:
+                    raise serializers.ValidationError(
+                        _("模型代理 API 不能作为 MCP Tool") + f": resource_name={resource_name}"
+                    )
+
+            raise serializers.ValidationError(
+                _("资源名称列表非法，请检查当前环境发布的最新版本中对应资源名称是否存在")
+                + f"resource_name={invalid_resource_names[0]}"
+            )
         return resource_names
 
     def validate_tool_names(self, tool_names):

--- a/src/dashboard/apigateway/apigateway/apis/web/mcp_server/serializers.py
+++ b/src/dashboard/apigateway/apigateway/apis/web/mcp_server/serializers.py
@@ -50,6 +50,43 @@ from apigateway.service.bk_itsm import ItsmPermissionApplyHelper
 logger = logging.getLogger(__name__)
 
 
+def _validate_mcp_tool_resource_names(
+    resource_names: List[str], valid_resource_names: set[str], gateway_id: int, stage_id: int
+) -> None:
+    release = (
+        Release.objects.filter(
+            gateway_id=gateway_id,
+            stage_id=stage_id,
+            stage__status=StageStatusEnum.ACTIVE.value,
+        )
+        .select_related("resource_version")
+        .first()
+    )
+    ai_resource_names = (
+        {
+            resource["name"]
+            for resource in release.resource_version.data
+            if resource.get("kind") == ResourceKindEnum.AI.value
+        }
+        if release
+        else set()
+    )
+
+    # 必须遍历所有提交的资源检查 AI 类型，不能依赖 valid_resource_names 只包含普通 API 这一上游约定。
+    # 即使调用方错误地将 AI 资源放入 valid_resource_names，后端防御校验仍然需要拒绝保存。
+    for resource_name in resource_names:
+        if resource_name in ai_resource_names:
+            raise serializers.ValidationError(_("模型代理 API 不能作为 MCP Tool") + f": resource_name={resource_name}")
+
+    # 排除 AI 资源后，其余不在普通资源集合中的名称沿用原有“不存在或已失效”错误。
+    for resource_name in resource_names:
+        if resource_name not in valid_resource_names:
+            raise serializers.ValidationError(
+                _("资源名称列表非法，请检查当前环境发布的最新版本中对应资源名称是否存在")
+                + f"resource_name={resource_name}"
+            )
+
+
 class MCPServerCategoryOutputSLZ(serializers.Serializer):
     """MCPServer 分类输出序列化器"""
 
@@ -268,35 +305,12 @@ class MCPServerCreateInputSLZ(serializers.ModelSerializer):
         if len(resource_names) != len(set(resource_names)):
             raise serializers.ValidationError(_("资源名称列表中不能存在重复的资源名称"))
 
-        invalid_resource_names = [name for name in resource_names if name not in valid_resource_names]
-        if invalid_resource_names:
-            release = (
-                Release.objects.filter(
-                    gateway_id=self.context["gateway"].id,
-                    stage_id=self.initial_data["stage_id"],
-                )
-                .select_related("resource_version")
-                .first()
-            )
-            ai_resource_names = (
-                {
-                    resource["name"]
-                    for resource in release.resource_version.data
-                    if resource.get("kind") == ResourceKindEnum.AI.value
-                }
-                if release
-                else set()
-            )
-            for resource_name in invalid_resource_names:
-                if resource_name in ai_resource_names:
-                    raise serializers.ValidationError(
-                        _("模型代理 API 不能作为 MCP Tool") + f": resource_name={resource_name}"
-                    )
-
-            raise serializers.ValidationError(
-                _("资源名称列表非法，请检查当前环境发布的最新版本中对应资源名称是否存在")
-                + f"resource_name={invalid_resource_names[0]}"
-            )
+        _validate_mcp_tool_resource_names(
+            resource_names,
+            valid_resource_names,
+            gateway_id=self.context["gateway"].id,
+            stage_id=self.initial_data["stage_id"],
+        )
         return resource_names
 
     def validate_tool_names(self, tool_names):
@@ -500,35 +514,12 @@ class MCPServerUpdateInputSLZ(serializers.ModelSerializer):
         if len(resource_names) != len(set(resource_names)):
             raise serializers.ValidationError(_("资源名称列表中不能存在重复的资源名称"))
 
-        invalid_resource_names = [name for name in resource_names if name not in valid_resource_names]
-        if invalid_resource_names:
-            release = (
-                Release.objects.filter(
-                    gateway_id=self.instance.gateway_id,
-                    stage_id=self.instance.stage_id,
-                )
-                .select_related("resource_version")
-                .first()
-            )
-            ai_resource_names = (
-                {
-                    resource["name"]
-                    for resource in release.resource_version.data
-                    if resource.get("kind") == ResourceKindEnum.AI.value
-                }
-                if release
-                else set()
-            )
-            for resource_name in invalid_resource_names:
-                if resource_name in ai_resource_names:
-                    raise serializers.ValidationError(
-                        _("模型代理 API 不能作为 MCP Tool") + f": resource_name={resource_name}"
-                    )
-
-            raise serializers.ValidationError(
-                _("资源名称列表非法，请检查当前环境发布的最新版本中对应资源名称是否存在")
-                + f"resource_name={invalid_resource_names[0]}"
-            )
+        _validate_mcp_tool_resource_names(
+            resource_names,
+            valid_resource_names,
+            gateway_id=self.instance.gateway_id,
+            stage_id=self.instance.stage_id,
+        )
         return resource_names
 
     def validate_tool_names(self, tool_names):

--- a/src/dashboard/apigateway/apigateway/apis/web/resource_version/views.py
+++ b/src/dashboard/apigateway/apigateway/apis/web/resource_version/views.py
@@ -43,7 +43,7 @@ from apigateway.biz.resource_version import (
 )
 from apigateway.biz.sdk import GatewaySDKHandler
 from apigateway.common.error_codes import error_codes
-from apigateway.core.constants import PublishSourceEnum
+from apigateway.core.constants import PublishSourceEnum, ResourceKindEnum
 from apigateway.core.models import Release, Resource, ResourceVersion
 from apigateway.service.backend import get_backend_id_to_instance
 from apigateway.service.resource_version import OpenAPIExportManager, get_resource_id_to_schema_by_resource_version
@@ -195,7 +195,9 @@ class ResourceVersionRetrieveDestroyApi(generics.RetrieveDestroyAPIView):
         source = self.request.query_params.get("source")
         # sort the resources by has_openapi_schema, for mcp server to show the options of tools
         if source == "mcp_server":
-            resources = data["resources"]
+            resources = [
+                resource for resource in data["resources"] if resource["kind"] == ResourceKindEnum.STANDARD.value
+            ]
             resources.sort(key=lambda x: x["has_openapi_schema"], reverse=True)
             data["resources"] = resources
 

--- a/src/dashboard/apigateway/apigateway/tests/apis/web/mcp_server/test_serializers.py
+++ b/src/dashboard/apigateway/apigateway/tests/apis/web/mcp_server/test_serializers.py
@@ -44,6 +44,8 @@ from apigateway.apps.mcp_server.models import (
     MCPServerCategory,
 )
 from apigateway.common.constants import CallSourceTypeEnum, LanguageCodeEnum
+from apigateway.core.constants import ResourceKindEnum
+from apigateway.core.models import Release
 
 pytestmark = pytest.mark.django_db
 
@@ -102,6 +104,29 @@ class TestMCPServerCreateInputSLZ:
         slz = MCPServerCreateInputSLZ(data=data, context=context)
         assert not slz.is_valid()
         assert "resource_names" in slz.errors
+
+    def test_validate_resource_names_rejects_ai_resource(self, fake_gateway, fake_stage, fake_resource_version):
+        fake_resource_version.data = [{"name": "ai-resource", "kind": ResourceKindEnum.AI.value}]
+        fake_resource_version.save()
+        G(Release, gateway=fake_gateway, stage=fake_stage, resource_version=fake_resource_version)
+        data = {
+            "name": "test-mcp-server",
+            "description": "Test description",
+            "stage_id": fake_stage.id,
+            "is_public": True,
+            "resource_names": ["ai-resource"],
+            "tool_names": ["ai-resource"],
+        }
+        context = {
+            "gateway": fake_gateway,
+            "source": CallSourceTypeEnum.Web,
+            "valid_resource_names": set(),
+        }
+
+        slz = MCPServerCreateInputSLZ(data=data, context=context)
+
+        assert not slz.is_valid()
+        assert "模型代理 API 不能作为 MCP Tool" in str(slz.errors["resource_names"])
 
     @patch("apigateway.biz.validators.MCPServerHandler.get_valid_resource_names")
     def test_validate_resource_names_with_tool_name(self, mock_get_valid, fake_gateway, fake_stage):
@@ -226,6 +251,25 @@ class TestMCPServerUpdateInputSLZ:
         )
         assert not slz.is_valid()
         assert "resource_names" in slz.errors
+
+    def test_validate_resource_names_rejects_ai_resource(self, fake_gateway, fake_stage, fake_resource_version):
+        fake_resource_version.data = [{"name": "ai-resource", "kind": ResourceKindEnum.AI.value}]
+        fake_resource_version.save()
+        G(Release, gateway=fake_gateway, stage=fake_stage, resource_version=fake_resource_version)
+        mcp_server = G(MCPServer, gateway=fake_gateway, stage=fake_stage, status=MCPServerStatusEnum.ACTIVE.value)
+        data = {
+            "description": "Updated description",
+            "resource_names": ["ai-resource"],
+            "tool_names": ["ai-resource"],
+        }
+        slz = MCPServerUpdateInputSLZ(
+            instance=mcp_server,
+            data=data,
+            context={"valid_resource_names": set()},
+        )
+
+        assert not slz.is_valid()
+        assert "模型代理 API 不能作为 MCP Tool" in str(slz.errors["resource_names"])
 
     def test_validate_resource_names_with_tool_name(self, fake_gateway, fake_stage):
         """测试带 tool_name 的资源名称列表"""

--- a/src/dashboard/apigateway/apigateway/tests/apis/web/mcp_server/test_serializers.py
+++ b/src/dashboard/apigateway/apigateway/tests/apis/web/mcp_server/test_serializers.py
@@ -120,7 +120,7 @@ class TestMCPServerCreateInputSLZ:
         context = {
             "gateway": fake_gateway,
             "source": CallSourceTypeEnum.Web,
-            "valid_resource_names": set(),
+            "valid_resource_names": {"ai-resource"},
         }
 
         slz = MCPServerCreateInputSLZ(data=data, context=context)
@@ -265,7 +265,7 @@ class TestMCPServerUpdateInputSLZ:
         slz = MCPServerUpdateInputSLZ(
             instance=mcp_server,
             data=data,
-            context={"valid_resource_names": set()},
+            context={"valid_resource_names": {"ai-resource"}},
         )
 
         assert not slz.is_valid()

--- a/src/dashboard/apigateway/apigateway/tests/apis/web/resource_version/test_views.py
+++ b/src/dashboard/apigateway/apigateway/tests/apis/web/resource_version/test_views.py
@@ -19,6 +19,7 @@
 import datetime
 import json
 import operator
+from copy import deepcopy
 
 from django_dynamic_fixture import G
 
@@ -204,6 +205,52 @@ class TestResourceVersionRetrieveDestroyApi:
             "created_time": fake_resource_version_v2.created_time,
             "created_by": fake_resource_version_v2.created_by,
         }
+
+    def test_retrieve_for_mcp_server_filters_ai_resources(self, request_view, fake_gateway, fake_resource_version_v2):
+        standard_resource = fake_resource_version_v2.data[0]
+        legacy_resource = deepcopy(standard_resource)
+        legacy_resource["id"] += 1
+        legacy_resource["name"] = "legacy-resource"
+        legacy_resource.pop("kind", None)
+        ai_resource = deepcopy(standard_resource)
+        ai_resource["id"] += 2
+        ai_resource["name"] = "ai-resource"
+        ai_resource["kind"] = ResourceKindEnum.AI.value
+        fake_resource_version_v2.data = [ai_resource, legacy_resource, standard_resource]
+        fake_resource_version_v2.save()
+
+        resp = request_view(
+            method="GET",
+            view_name="gateway.resource_version.retrieve_destroy",
+            gateway=fake_gateway,
+            path_params={"gateway_id": fake_gateway.id, "id": fake_resource_version_v2.id},
+            data={"source": "mcp_server"},
+        )
+
+        assert resp.status_code == 200
+        assert [resource["name"] for resource in resp.json()["data"]["resources"]] == [
+            "legacy-resource",
+            standard_resource["name"],
+        ]
+
+    def test_retrieve_for_mcp_server_returns_empty_when_only_ai_resources(
+        self, request_view, fake_gateway, fake_resource_version_v2
+    ):
+        ai_resource = fake_resource_version_v2.data[0]
+        ai_resource["kind"] = ResourceKindEnum.AI.value
+        fake_resource_version_v2.data = [ai_resource]
+        fake_resource_version_v2.save()
+
+        resp = request_view(
+            method="GET",
+            view_name="gateway.resource_version.retrieve_destroy",
+            gateway=fake_gateway,
+            path_params={"gateway_id": fake_gateway.id, "id": fake_resource_version_v2.id},
+            data={"source": "mcp_server"},
+        )
+
+        assert resp.status_code == 200
+        assert resp.json()["data"]["resources"] == []
 
     def test_retrieve_with_stage_masks_ai_backend_config(
         self, request_view, fake_backend, fake_stage, fake_gateway, fake_resource_version_v2


### PR DESCRIPTION
### Description

- Filter model proxy APIs from the resource-version response used by the MCP Server tool selector.
- Return an empty resource list when the released version contains no standard APIs.
- Reject model proxy APIs during MCP Server create and update with an explicit error message while preserving the existing error for missing resources.
- Treat legacy resource-version entries without `kind` as standard APIs.

### Verification

- `uv run ruff format --check` on the four changed files
- Focused resource-version and MCP serializer tests: 75 passed
- `uv run make lint-check`
- `uv run make test`: 3401 passed

### Checklist

- [x] 填写 PR 描述及相关 issue (write PR description and related issue)
- [x] 代码风格检查通过 (code style check passed)
- [x] PR 中包含单元测试 (include unit test)
- [x] 单元测试通过 (unit test passed)
- [ ] 本地开发联调环境验证通过 (local development environment verification passed)