### PR TITLE
fix(dashboard): reject unsafe AI backend config

### DIFF
--- a/src/dashboard/apigateway/apigateway/core/backend_config.py
+++ b/src/dashboard/apigateway/apigateway/core/backend_config.py
@@ -6,9 +6,12 @@ from pydantic import BaseModel, ConfigDict, Field, field_validator, model_valida
 from apigateway.common.security import is_forbidden_host
 from apigateway.core.constants import (
     AI_BACKEND_BUILTIN_PROVIDERS,
+    STAGE_VAR_PATTERN,
     AIBackendProviderEnum,
     BackendKindEnum,
 )
+
+_FORBIDDEN_AI_BACKEND_HEADERS = frozenset({"host", "content-length", "transfer-encoding", "connection"})
 
 
 def mask_header_value(value: str) -> str:
@@ -20,6 +23,16 @@ def _validate_object_keys(data: dict[str, Any], *, allowed: set[str], required: 
         raise ValueError(f"{path}: missing required field: {min(missing)}")
     if unknown := data.keys() - allowed:
         raise ValueError(f"{path}: unknown field: {min(unknown)}")
+
+
+def _contains_stage_var(value: Any) -> bool:
+    if isinstance(value, str):
+        return STAGE_VAR_PATTERN.search(value) is not None
+    if isinstance(value, dict):
+        return any(_contains_stage_var(key) or _contains_stage_var(item) for key, item in value.items())
+    if isinstance(value, list):
+        return any(_contains_stage_var(item) for item in value)
+    return False
 
 
 class StandardBackendConfig(BaseModel):
@@ -70,6 +83,13 @@ class AIBackendConfig(BaseModel):
     model_endpoint: str | None = None
     instances: list[dict[str, Any]] = Field(min_length=1, max_length=1)
 
+    @model_validator(mode="before")
+    @classmethod
+    def reject_stage_vars(cls, data: Any) -> Any:
+        if _contains_stage_var(data):
+            raise ValueError("AI backend config must not contain environment variables")
+        return data
+
     @field_validator("instances")
     @classmethod
     def validate_instances(cls, instances: list[dict[str, Any]]) -> list[dict[str, Any]]:
@@ -110,6 +130,8 @@ class AIBackendConfig(BaseModel):
         normalized: set[str] = set()
         for key in headers:
             normalized_key = key.casefold()
+            if normalized_key in _FORBIDDEN_AI_BACKEND_HEADERS:
+                raise ValueError(f"{path}.header: header is forbidden: {key}")
             if normalized_key in normalized:
                 raise ValueError(f"{path}.header: duplicate header: {key}")
             normalized.add(normalized_key)

--- a/src/dashboard/apigateway/apigateway/tests/apis/web/backend/test_views.py
+++ b/src/dashboard/apigateway/apigateway/tests/apis/web/backend/test_views.py
@@ -414,11 +414,7 @@ class TestBackendConnectivityApi:
         config = _ai_config(fake_stage.id)
         instance = config["instances"][0]
         instance["provider"] = "openai-compatible"
-        instance["auth"]["header"] = {
-            "X-Api-Key": "secret",
-            "Host": "internal.example",
-            "Content-Length": "999",
-        }
+        instance["auth"]["header"] = {"X-Api-Key": "secret"}
         instance["override"] = {"endpoint": "https://models.example.com/v1/chat/completions?api-version=2026-01-01"}
         resolver = mocker.patch(
             "socket.getaddrinfo",

--- a/src/dashboard/apigateway/apigateway/tests/core/test_backend_config.py
+++ b/src/dashboard/apigateway/apigateway/tests/core/test_backend_config.py
@@ -177,6 +177,41 @@ def test_model_rejects_case_insensitive_duplicate_headers(ai_backend_config):
         AIBackendConfig.model_validate(ai_backend_config)
 
 
+@pytest.mark.parametrize("header", ["Host", "content-length", "TRANSFER-ENCODING", "Connection"])
+def test_ai_backend_config_rejects_forbidden_headers(ai_backend_config, header):
+    ai_backend_config["instances"][0]["auth"]["header"][header] = "value"
+
+    with pytest.raises(ValueError, match=f"header is forbidden: {header}"):
+        AIBackendConfig.model_validate(ai_backend_config)
+
+
+@pytest.mark.parametrize(
+    ("path", "value"),
+    [
+        (("model_endpoint",), "https://{{env.host}}/models"),
+        (("instances", 0, "name"), "{env.instance_name}"),
+        (("instances", 0, "auth", "header", "Authorization"), "Bearer {{env.token}}"),
+        (("instances", 0, "options", "model"), "{env.model}"),
+        (("instances", 0, "options", "metadata"), {"region": "{{env.region}}"}),
+    ],
+)
+def test_ai_backend_config_rejects_environment_variables(ai_backend_config, path, value):
+    target = ai_backend_config
+    for key in path[:-1]:
+        target = target[key]
+    target[path[-1]] = value
+
+    with pytest.raises(ValueError, match="must not contain environment variables"):
+        AIBackendConfig.model_validate(ai_backend_config)
+
+
+def test_ai_backend_config_rejects_environment_variables_in_header_names(ai_backend_config):
+    ai_backend_config["instances"][0]["auth"]["header"]["{{env.header_name}}"] = "value"
+
+    with pytest.raises(ValueError, match="must not contain environment variables"):
+        AIBackendConfig.model_validate(ai_backend_config)
+
+
 @pytest.mark.parametrize("patch", [{"instances": []}, {"unknown": True}, {"timeout": 0}])
 def test_ai_backend_config_rejects_invalid_top_level(ai_backend_config, patch):
     with pytest.raises(ValueError):


### PR DESCRIPTION
## Summary
- reject stage environment variable placeholders anywhere in AI backend config
- reject `Host`, `Content-Length`, `Transfer-Encoding`, and `Connection` auth headers case-insensitively
- update connectivity coverage to use only permitted custom headers

## Verification
- `make lint-check`
- `make test` (3410 passed)