### PR TITLE
fix(dashboard): align AI backend config contract

### DIFF
--- a/docs/ai-gateway-models.md
+++ b/docs/ai-gateway-models.md
@@ -115,12 +115,11 @@ unique(gateway, backend, stage)
 
 ```json
 {
-  "timeout": 30000,
+  "timeout": 30,
   "instances": [
     {
       "name": "primary",
       "provider": "openai",
-      "weight": 1,
       "auth": {
         "header": {
           "Authorization": "Bearer <secret>"
@@ -135,7 +134,7 @@ unique(gateway, backend, stage)
 }
 ```
 
-`instances[]` 直接采用 [APISIX `ai-proxy-multi.instances`](https://apisix.apache.org/docs/apisix/plugins/ai-proxy-multi/) 的字段结构，不增加 `ModelInstance` 数据表，也不定义一套产品中间字段再转换。
+`instances[]` 以 [APISIX `ai-proxy-multi.instances`](https://apisix.apache.org/docs/apisix/plugins/ai-proxy-multi/) 的字段结构为基础，不增加 `ModelInstance` 数据表。dashboard 额外保存 `model_endpoint` 用于编辑和连接测试，controller 发布时移除该字段。
 
 第一期约束：
 
@@ -143,7 +142,7 @@ unique(gateway, backend, stage)
 - `instances` 必须存在。
 - `len(instances) == 1`。
 - `instances[0].provider` 只允许 `openai`、`deepseek`、`openai-compatible`。
-- `instances[0].options` 必须是 JSON 对象，其中 `model` 必须是非空字符串，并允许配置其他合法 JSON 键值对。
+- `instances[0].options` 必须是 JSON 对象；`model` 可选，提供时必须是非空字符串，并允许配置其他合法 JSON 键值对。
 - 不允许接受无法转换为单实例 `ai-proxy` 语义的多实例策略，不得静默丢弃用户配置。
 
 第一期 provider 允许列表由 dashboard 代码显式维护，不直接等同于 APISIX 当前支持的全部 provider。APISIX 后续新增 provider 或升级版本时不能自动进入产品 API，必须同步增加 Pydantic 类型、凭证处理和发布转换测试后才能开放。
@@ -154,10 +153,11 @@ unique(gateway, backend, stage)
 | --- | --- |
 | `name` | 必填，非空字符串；作为未来开放多 instance 时的稳定标识 |
 | `provider` | 必填，只允许第一期 provider 允许列表 |
-| `weight` | 必填且固定为 `1` |
+| `weight` | 可选，未提供时默认 `0`；提供时必须是非负整数 |
 | `auth.header` | 允许配置字符串 Header 映射；Web 展示时对 Header value 脱敏 |
-| `options` | 必填 JSON 对象；`model` 必填且为非空字符串；允许配置其他合法 JSON 键值对 |
+| `options` | 必填 JSON 对象；`model` 可选，提供时必须为非空字符串；允许配置其他合法 JSON 键值对 |
 | `override.endpoint` | 仅 `openai-compatible` 允许且必须提供 |
+| `model_endpoint` | 可选；dashboard 编辑和连接测试使用，controller 发布时移除 |
 
 `options` 的 key 必须是合法 JSON 字符串，value 可以是字符串、数字、布尔值、`null`、对象或数组。Pydantic `options` 类型允许额外字段；dashboard 必须完整保存，controller 必须原样透传，不能丢弃除 `model` 外的配置。
 
@@ -170,8 +170,9 @@ unique(gateway, backend, stage)
 
 Model BackendConfig 顶层只开放 `timeout`：
 
-- `timeout` 使用 APISIX 语义，单位为毫秒，必须是正整数。
-- `AIBackendConfig` 在用户未提供时显式写入默认值 `30000`。
+- `timeout` 使用 dashboard 语义，单位为秒，必须是正整数。
+- `AIBackendConfig` 在用户未提供时显式写入默认值 `30`。
+- controller 发布时将 `timeout` 转换为 APISIX 使用的毫秒值。
 - `ssl_verify` 固定为 `true`，不允许通过 Model BackendConfig 关闭。
 - `keepalive`、`keepalive_timeout`、`keepalive_pool` 使用 APISIX 默认值，第一期不对用户开放。
 - `logging` 不属于用户 BackendConfig，由 controller 固定生成 `summaries=true`、`payloads=false`。

--- a/src/dashboard/apigateway/apigateway/apis/web/backend/serializers.py
+++ b/src/dashboard/apigateway/apigateway/apis/web/backend/serializers.py
@@ -68,9 +68,11 @@ class AIBackendConnectivityInputSLZ(serializers.Serializer):
         config = config_slz.validated_data
         if (
             config["instances"][0]["provider"] == AIBackendProviderEnum.OPENAI_COMPATIBLE.value
-            and "model_endpoint" not in config
+            and "model_endpoint" not in config["instances"][0]
         ):
-            raise serializers.ValidationError({"config": {"model_endpoint": _("必须提供模型列表地址。")}})
+            raise serializers.ValidationError(
+                {"config": {"instances": [{"model_endpoint": _("必须提供模型列表地址。")}]}}
+            )
 
         backend_id = attrs.get("backend_id")
         if backend_id is not None:
@@ -146,7 +148,7 @@ def _get_ai_backend_destination_identity(config):
     return (
         provider,
         _get_url_origin(instance.get("override", {}).get("endpoint")),
-        _get_url_origin(config.get("model_endpoint")),
+        _get_url_origin(instance.get("model_endpoint")),
     )
 
 

--- a/src/dashboard/apigateway/apigateway/biz/backend/connectivity.py
+++ b/src/dashboard/apigateway/apigateway/biz/backend/connectivity.py
@@ -29,7 +29,7 @@ def get_ai_backend_model_ids(config: dict) -> list[str]:
     provider = instance["provider"]
     endpoint = AI_PROVIDER_MODELS_ENDPOINTS.get(provider)
     if endpoint is None:
-        endpoint = config["model_endpoint"]
+        endpoint = instance["model_endpoint"]
         _resolve_endpoint(endpoint)
 
     headers = {

--- a/src/dashboard/apigateway/apigateway/controller/convertor/service.py
+++ b/src/dashboard/apigateway/apigateway/controller/convertor/service.py
@@ -62,12 +62,14 @@ logger = logging.getLogger(__name__)
 
 def _build_ai_proxy_plugins(config: Dict[str, Any]) -> Dict[str, Plugin]:
     common_config = {
-        "timeout": config.get("timeout", 30000),
+        "timeout": config.get("timeout", 30) * 1000,
         "ssl_verify": True,
         "logging": {"summaries": True, "payloads": False},
     }
 
-    instances = config["instances"]
+    instances = [
+        {key: value for key, value in instance.items() if key != "model_endpoint"} for instance in config["instances"]
+    ]
     if len(instances) > 1:
         plugin_config: Dict[str, Any] = {"instances": instances, **common_config}
         for key in ("balancer", "fallback_strategy"):

--- a/src/dashboard/apigateway/apigateway/core/backend_config.py
+++ b/src/dashboard/apigateway/apigateway/core/backend_config.py
@@ -79,8 +79,7 @@ class StandardBackendConfig(BaseModel):
 class AIBackendConfig(BaseModel):
     model_config = ConfigDict(extra="forbid", strict=True)
 
-    timeout: int = Field(default=30000, gt=0)
-    model_endpoint: str | None = None
+    timeout: int = Field(default=30, gt=0)
     instances: list[dict[str, Any]] = Field(min_length=1, max_length=1)
 
     @model_validator(mode="before")
@@ -93,24 +92,30 @@ class AIBackendConfig(BaseModel):
     @field_validator("instances")
     @classmethod
     def validate_instances(cls, instances: list[dict[str, Any]]) -> list[dict[str, Any]]:
-        instance = instances[0]
+        instance = dict(instances[0])
         path = "$.instances[0]"
         _validate_object_keys(
             instance,
-            allowed={"name", "provider", "weight", "auth", "options", "override"},
-            required={"name", "provider", "weight", "options"},
+            allowed={"name", "provider", "weight", "auth", "options", "override", "model_endpoint"},
+            required={"name", "provider", "options"},
             path=path,
         )
         if not isinstance(instance["name"], str) or not instance["name"]:
             raise ValueError(f"{path}.name: must be a non-empty string")
         if instance["provider"] not in AIBackendProviderEnum.get_values():
             raise ValueError(f"{path}.provider: unsupported provider")
-        if type(instance["weight"]) is not int or instance["weight"] != 1:
-            raise ValueError(f"{path}.weight: must be 1")
+        instance.setdefault("weight", 0)
+        if type(instance["weight"]) is not int or instance["weight"] < 0:
+            raise ValueError(f"{path}.weight: must be a non-negative integer")
         cls._validate_auth(instance.get("auth"), provided="auth" in instance)
         cls._validate_options(instance["options"])
         cls._validate_override(instance.get("override"), provided="override" in instance)
-        return instances
+        if "model_endpoint" in instance:
+            model_endpoint = instance["model_endpoint"]
+            if not isinstance(model_endpoint, str) or not model_endpoint:
+                raise ValueError(f"{path}.model_endpoint: must be a non-empty string")
+            cls._validate_endpoint(model_endpoint, f"{path}.model_endpoint")
+        return [instance]
 
     @staticmethod
     def _validate_auth(auth: Any, *, provided: bool) -> None:
@@ -141,9 +146,7 @@ class AIBackendConfig(BaseModel):
         path = "$.instances[0].options"
         if not isinstance(options, dict):
             raise ValueError(f"{path}: must be an object")  # noqa: TRY004
-        if "model" not in options:
-            raise ValueError(f"{path}: missing required field: model")
-        if not isinstance(options["model"], str) or not options["model"]:
+        if "model" in options and (not isinstance(options["model"], str) or not options["model"]):
             raise ValueError(f"{path}.model: must be a non-empty string")
 
     @staticmethod
@@ -153,19 +156,13 @@ class AIBackendConfig(BaseModel):
             return
         if not isinstance(override, dict):
             raise ValueError(f"{path}: must be an object")  # noqa: TRY004
-        _validate_object_keys(override, allowed={"endpoint"}, required={"endpoint"}, path=path)
+        _validate_object_keys(override, allowed={"endpoint"}, required=set(), path=path)
+        if "endpoint" not in override:
+            return
         if not isinstance(override["endpoint"], str) or not override["endpoint"]:
             raise ValueError(f"{path}.endpoint: must be a non-empty string")
 
         AIBackendConfig._validate_endpoint(override["endpoint"], f"{path}.endpoint")
-
-    @field_validator("model_endpoint")
-    @classmethod
-    def validate_model_endpoint(cls, endpoint: str | None) -> str | None:
-        if endpoint is None:
-            return endpoint
-        cls._validate_endpoint(endpoint, "$.model_endpoint")
-        return endpoint
 
     @staticmethod
     def _validate_endpoint(endpoint: str, path: str) -> None:
@@ -199,9 +196,9 @@ class AIBackendConfig(BaseModel):
                 raise ValueError("$.instances[0].auth.header: Authorization header is required")
             if "override" in instance:
                 raise ValueError("$.instances[0].override: override is not allowed")
-            if self.model_endpoint is not None:
-                raise ValueError("$.model_endpoint: model_endpoint is not allowed")
-        elif "override" not in instance:
+            if "model_endpoint" in instance:
+                raise ValueError("$.instances[0].model_endpoint: model_endpoint is not allowed")
+        elif "endpoint" not in instance.get("override", {}):
             raise ValueError("$.instances[0].override: override.endpoint is required")
         return self
 

--- a/src/dashboard/apigateway/apigateway/data/apidocs/zh/v2_sync_stages.md
+++ b/src/dashboard/apigateway/apigateway/data/apidocs/zh/v2_sync_stages.md
@@ -59,7 +59,7 @@ ai_backends.config 参数说明
 
 | 参数名称 | 参数类型 | 必选 | 描述 |
 | -------- | -------- | ---- | ---- |
-| `timeout` | integer | 否 | 超时时间，单位毫秒，默认 `30000` |
+| `timeout` | integer | 否 | 超时时间，单位秒，默认 `30` |
 | `instances` | array[object] | 是 | 模型实例列表；第一期必须且只能配置 1 个实例 |
 
 instances 参数说明
@@ -68,10 +68,11 @@ instances 参数说明
 | -------- | -------- | ---- | ---- |
 | `name` | string | 是 | 实例名称 |
 | `provider` | string | 是 | `openai`、`deepseek` 或 `openai-compatible` |
-| `weight` | integer | 是 | 第一期固定为 `1` |
+| `weight` | integer | 否 | 实例权重，默认 `0` |
 | `auth.header` | object | 否 | 发往模型服务的认证 Header；凭证入库时加密 |
-| `options.model` | string | 是 | 模型名称 |
-| `override.endpoint` | string | 否 | 自定义模型服务地址 |
+| `options.model` | string | 否 | 模型名称 |
+| `override.endpoint` | string | 否 | 自定义模型服务地址；`provider=openai-compatible` 时必填 |
+| `model_endpoint` | string | 否 | dashboard 编辑及连接测试使用的模型列表地址，不下发到网关 |
 
 plugin_configs 参数说明
 每个插件配置对象包含：
@@ -110,12 +111,11 @@ plugin_configs 参数说明
     {
       "name": "openai-primary",
       "config": {
-        "timeout": 30000,
+        "timeout": 30,
         "instances": [
           {
             "name": "primary",
             "provider": "openai-compatible",
-            "weight": 1,
             "auth": {
               "header": {
                 "Authorization": "Bearer <token>"
@@ -126,7 +126,8 @@ plugin_configs 参数说明
             },
             "override": {
               "endpoint": "https://llm.example.com/v1/chat/completions"
-            }
+            },
+            "model_endpoint": "https://llm.example.com/v1/models"
           }
         ]
       }

--- a/src/dashboard/apigateway/apigateway/data/apigw-definitions/bk-apigateway-resources.yaml
+++ b/src/dashboard/apigateway/apigateway/data/apigw-definitions/bk-apigateway-resources.yaml
@@ -1884,8 +1884,8 @@ paths:
                           timeout:
                             type: integer
                             minimum: 1
-                            default: 30000
-                            description: 超时时间，单位毫秒
+                            default: 30
+                            description: 超时时间，单位秒
                           instances:
                             type: array
                             minItems: 1
@@ -1895,7 +1895,6 @@ paths:
                               required:
                                 - name
                                 - provider
-                                - weight
                                 - options
                               properties:
                                 name:
@@ -1908,8 +1907,8 @@ paths:
                                     - openai-compatible
                                 weight:
                                   type: integer
-                                  minimum: 1
-                                  maximum: 1
+                                  minimum: 0
+                                  default: 0
                                 auth:
                                   type: object
                                   properties:
@@ -1919,18 +1918,18 @@ paths:
                                         type: string
                                 options:
                                   type: object
-                                  required:
-                                    - model
                                   properties:
                                     model:
                                       type: string
                                 override:
                                   type: object
-                                  required:
-                                    - endpoint
+                                  description: provider 为 openai-compatible 时必须提供 endpoint
                                   properties:
                                     endpoint:
                                       type: string
+                                model_endpoint:
+                                  type: string
+                                  description: dashboard 编辑及连接测试使用，不下发到网关
                 plugin_configs:
                   type: array
                   nullable: true
@@ -4965,8 +4964,8 @@ paths:
                           timeout:
                             type: integer
                             minimum: 1
-                            default: 30000
-                            description: 超时时间（单位：毫秒）
+                            default: 30
+                            description: 超时时间（单位：秒）
                           instances:
                             type: array
                             minItems: 1
@@ -4976,7 +4975,6 @@ paths:
                               required:
                                 - name
                                 - provider
-                                - weight
                                 - options
                               properties:
                                 name:
@@ -4990,8 +4988,8 @@ paths:
                                     - openai-compatible
                                 weight:
                                   type: integer
-                                  minimum: 1
-                                  maximum: 1
+                                  minimum: 0
+                                  default: 0
                                 auth:
                                   type: object
                                   properties:
@@ -5001,18 +4999,18 @@ paths:
                                         type: string
                                 options:
                                   type: object
-                                  required:
-                                    - model
                                   properties:
                                     model:
                                       type: string
                                 override:
                                   type: object
-                                  required:
-                                    - endpoint
+                                  description: provider 为 openai-compatible 时必须提供 endpoint
                                   properties:
                                     endpoint:
                                       type: string
+                                model_endpoint:
+                                  type: string
+                                  description: dashboard 编辑及连接测试使用，不下发到网关
                 plugin_configs:
                   type: array
                   nullable: true

--- a/src/dashboard/apigateway/apigateway/tests/apis/web/backend/test_views.py
+++ b/src/dashboard/apigateway/apigateway/tests/apis/web/backend/test_views.py
@@ -179,7 +179,7 @@ class TestBackendApi:
         stored_instance["provider"] = "openai-compatible"
         stored_instance["auth"]["header"] = {"X-Api-Key": "secret"}
         stored_instance["override"] = {"endpoint": "https://example.com/v1"}
-        stored_config["model_endpoint"] = "https://example.com/models"
+        stored_instance["model_endpoint"] = "https://example.com/models"
         BackendConfig.objects.create(
             gateway=fake_stage.gateway,
             backend=backend,
@@ -191,7 +191,7 @@ class TestBackendApi:
         instance["provider"] = "openai-compatible"
         instance.pop("auth")
         instance["override"] = {"endpoint": "https://example.com/v1"}
-        config["model_endpoint"] = "https://example.com/models"
+        instance["model_endpoint"] = "https://example.com/models"
 
         response = request_view(
             "PUT",
@@ -422,7 +422,7 @@ class TestBackendConnectivityApi:
         )
         http_get = _mock_model_response(mocker, {"data": [{"id": "custom-model"}]})
         model_endpoint = "https://catalog.example.com/custom/models?api-version=2026-01-01"
-        config["model_endpoint"] = model_endpoint
+        instance["model_endpoint"] = model_endpoint
 
         response = request_view(
             "POST",
@@ -468,7 +468,7 @@ class TestBackendConnectivityApi:
         instance = config["instances"][0]
         instance["provider"] = "openai-compatible"
         instance["override"] = {"endpoint": "https://models.example.com/v1/chat/completions"}
-        config["model_endpoint"] = "https://models.example.com/v1/models"
+        instance["model_endpoint"] = "https://models.example.com/v1/models"
         mocker.patch(
             "socket.getaddrinfo",
             return_value=[(2, 1, 6, "", ("169.254.169.254", 443))],
@@ -493,7 +493,7 @@ class TestBackendConnectivityApi:
         instance = config["instances"][0]
         instance["provider"] = "openai-compatible"
         instance["override"] = {"endpoint": "https://models.internal.example/v1/chat/completions"}
-        config["model_endpoint"] = "https://models.internal.example/v1/models"
+        instance["model_endpoint"] = "https://models.internal.example/v1/models"
         mocker.patch(
             "socket.getaddrinfo",
             return_value=[(2, 1, 6, "", ("10.0.0.1", 443))],
@@ -518,7 +518,7 @@ class TestBackendConnectivityApi:
         instance = config["instances"][0]
         instance["provider"] = "openai-compatible"
         instance["override"] = {"endpoint": "https://models.example.com/v1/chat/completions"}
-        config["model_endpoint"] = "https://models.example.com/v1/models"
+        instance["model_endpoint"] = "https://models.example.com/v1/models"
         mocker.patch(
             "socket.getaddrinfo",
             return_value=[(10, 1, 6, "", ("2001:4860:4860::abcd", 443, 0, 0))],
@@ -604,7 +604,7 @@ class TestBackendConnectivityApi:
         instance["provider"] = "openai-compatible"
         instance["auth"]["header"]["Authorization"] = "Be****et"
         instance["override"] = {"endpoint": "https://attacker.example.com/v1"}
-        config["model_endpoint"] = "https://attacker.example.com/models"
+        instance["model_endpoint"] = "https://attacker.example.com/models"
         http_get = _mock_model_response(mocker, {"data": []})
 
         response = request_view(

--- a/src/dashboard/apigateway/apigateway/tests/controller/convertor/test_service.py
+++ b/src/dashboard/apigateway/apigateway/tests/controller/convertor/test_service.py
@@ -50,6 +50,7 @@ def _ai_backend_config(
     auth=None,
     options=None,
     override=None,
+    model_endpoint=None,
 ):
     instance = {
         "name": "primary",
@@ -61,12 +62,14 @@ def _ai_backend_config(
         instance["auth"] = auth
     if override is not None:
         instance["override"] = override
+    if model_endpoint is not None:
+        instance["model_endpoint"] = model_endpoint
     return StageBackendConfig(
         backend_id=backend_id,
         backend_name="model-service",
         backend_kind=BackendKindEnum.AI.value,
         backend_type=BackendTypeEnum.HTTP.value,
-        config={"timeout": 45000, "instances": [instance]},
+        config={"timeout": 45, "instances": [instance]},
     )
 
 
@@ -245,6 +248,7 @@ class TestServiceConvertor:
             10: _ai_backend_config(
                 auth={"header": {"Authorization": "Bearer must-not-log"}},
                 override={"endpoint": "https://models.example.com/v1/chat/completions"},
+                model_endpoint="https://models.example.com/v1/models",
             )
         }
         mock_release_data.get_stage_plugins.return_value = []
@@ -325,6 +329,7 @@ class TestServiceConvertor:
                 "auth": {"header": {"Authorization": "Bearer fallback"}},
                 "options": {"model": "fallback-model"},
                 "override": {"endpoint": "https://models.example.com/v1/chat/completions"},
+                "model_endpoint": "https://models.example.com/v1/models",
             },
         ]
         mock_release_data.stage_backend_configs = {
@@ -334,7 +339,7 @@ class TestServiceConvertor:
                 backend_kind=BackendKindEnum.AI.value,
                 backend_type=BackendTypeEnum.HTTP.value,
                 config={
-                    "timeout": 60000,
+                    "timeout": 60,
                     "instances": instances,
                     "balancer": {"algorithm": "roundrobin"},
                     "fallback_strategy": ["http_429", "http_5xx"],
@@ -349,8 +354,10 @@ class TestServiceConvertor:
         ).convert()[0]
 
         assert "ai-proxy" not in service.plugins
+        expected_instances = [dict(instance) for instance in instances]
+        expected_instances[1].pop("model_endpoint")
         assert service.plugins["ai-proxy-multi"].model_dump(exclude_none=True) == {
-            "instances": instances,
+            "instances": expected_instances,
             "balancer": {"algorithm": "roundrobin"},
             "fallback_strategy": ["http_429", "http_5xx"],
             "timeout": 60000,

--- a/src/dashboard/apigateway/apigateway/tests/core/test_backend_config.py
+++ b/src/dashboard/apigateway/apigateway/tests/core/test_backend_config.py
@@ -188,7 +188,7 @@ def test_ai_backend_config_rejects_forbidden_headers(ai_backend_config, header):
 @pytest.mark.parametrize(
     ("path", "value"),
     [
-        (("model_endpoint",), "https://{{env.host}}/models"),
+        (("instances", 0, "model_endpoint"), "https://{{env.host}}/models"),
         (("instances", 0, "name"), "{env.instance_name}"),
         (("instances", 0, "auth", "header", "Authorization"), "Bearer {{env.token}}"),
         (("instances", 0, "options", "model"), "{env.model}"),
@@ -228,6 +228,19 @@ def test_ai_backend_config_preserves_additional_json_options(ai_backend_config):
     assert config.to_config() == ai_backend_config
 
 
+def test_ai_backend_config_defaults_optional_instance_fields(ai_backend_config):
+    ai_backend_config.pop("timeout")
+    instance = ai_backend_config["instances"][0]
+    instance.pop("weight")
+    instance["options"] = {}
+
+    stored = AIBackendConfig.model_validate(ai_backend_config).to_config()
+
+    assert stored["timeout"] == 30
+    assert stored["instances"][0]["weight"] == 0
+    assert stored["instances"][0]["options"] == {}
+
+
 def test_backend_config_optional_fields_reject_explicit_null(ai_backend_config):
     ai_backend_config["instances"][0]["auth"] = None
     standard_backend_config = {
@@ -255,7 +268,7 @@ def test_ai_backend_config_preserves_empty_auth_shape(ai_backend_config, auth, e
     instance = ai_backend_config["instances"][0]
     instance["provider"] = "openai-compatible"
     instance["override"] = {"endpoint": "https://example.com/v1"}
-    ai_backend_config["model_endpoint"] = "https://example.com/models"
+    instance["model_endpoint"] = "https://example.com/models"
     if auth is None:
         instance.pop("auth")
     else:
@@ -327,7 +340,7 @@ def test_ai_backend_config_validates_override_endpoint(ai_backend_config, endpoi
     instance = ai_backend_config["instances"][0]
     instance["provider"] = "openai-compatible"
     instance["override"] = {"endpoint": endpoint}
-    ai_backend_config["model_endpoint"] = "https://example.com/models"
+    instance["model_endpoint"] = "https://example.com/models"
 
     with pytest.raises(ValueError, match=error):
         AIBackendConfig.model_validate(ai_backend_config)
@@ -338,7 +351,7 @@ def test_ai_backend_config_rejects_forbidden_override_endpoint_port(ai_backend_c
     instance = ai_backend_config["instances"][0]
     instance["provider"] = "openai-compatible"
     instance["override"] = {"endpoint": "https://example.com:22/v1"}
-    ai_backend_config["model_endpoint"] = "https://example.com/models"
+    instance["model_endpoint"] = "https://example.com/models"
 
     with pytest.raises(ValueError, match="port is forbidden"):
         AIBackendConfig.model_validate(ai_backend_config)
@@ -351,7 +364,7 @@ def test_ai_backend_config_accepts_legacy_openai_compatible_without_model_endpoi
 
     stored = AIBackendConfig.model_validate(ai_backend_config).to_config()
 
-    assert "model_endpoint" not in stored
+    assert "model_endpoint" not in stored["instances"][0]
 
 
 def test_ai_backend_config_rejects_forbidden_model_endpoint_port(ai_backend_config, settings):
@@ -359,7 +372,7 @@ def test_ai_backend_config_rejects_forbidden_model_endpoint_port(ai_backend_conf
     instance = ai_backend_config["instances"][0]
     instance["provider"] = "openai-compatible"
     instance["override"] = {"endpoint": "https://example.com/v1"}
-    ai_backend_config["model_endpoint"] = "https://example.com:22/models"
+    instance["model_endpoint"] = "https://example.com:22/models"
 
     with pytest.raises(ValueError, match="port is forbidden"):
         AIBackendConfig.model_validate(ai_backend_config)

--- a/src/dashboard/apigateway/apigateway/tests/service/release/test_validation.py
+++ b/src/dashboard/apigateway/apigateway/tests/service/release/test_validation.py
@@ -162,7 +162,7 @@ class TestPublishBackendKindValidation:
 
     def test_invalid_ai_backend_config_does_not_expose_credentials(self, fake_gateway, fake_stage):
         invalid_config = _ai_backend_config()
-        invalid_config["instances"][0]["options"] = {}
+        invalid_config["instances"][0]["options"] = {"model": ""}
         backend, _ = _create_backend_config(
             fake_gateway,
             fake_stage,


### PR DESCRIPTION
## Summary

- make AI backend instance `weight` optional with a default of `0`
- allow `options` without a `model`, and require `override.endpoint` only for OpenAI-compatible providers
- treat dashboard timeout values as seconds and convert them to milliseconds when building APISIX service plugins
- move `model_endpoint` into each instance for dashboard editing and connectivity checks, while removing it from controller output
- synchronize the v2 sync schema, API documentation, model documentation, and regression coverage
- preserve the forbidden-header and environment-variable validation added by upstream #3032

## Verification

- focused dashboard tests: 119 passed
- full dashboard test suite: 3411 passed
- dashboard lint gate: ruff, mypy, import contracts, and API consistency passed
- formatting and `git diff --check` passed
