### PR TITLE
docs(agents): refresh dashboard workflow guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,6 +2,10 @@
 
 ## Overview
 
+This is a multi-component API Gateway repository. The root guidance applies to
+the whole checkout; each component's nearest `AGENTS.md` defines its local
+runtime, architecture, and verification commands.
+
 ## Project Structure
 
 ```
@@ -26,14 +30,36 @@
 │   ├── Dockerfile
 │   ├── README.md
 │   └── sync
-└── test-bdd                # BDD test suite (new)
+└── test-bdd                # Playwright BDD test suite
     ├── .gitignore          # Ignores runtime artifacts
     ├── AGENTS.md           # Business context, module classification, domain gotchas
-    ├── cases/              # BDD test cases (Chinese markdown, ~87 scenarios)
-    ├── scripts/            # Playwright test scripts (.spec.js only, no deps)
-    └── runtime/            # Test runner (package.json, helpers, setup, teardown, config)
-        └── reports/        # Timestamped test reports (gitignored)
+    ├── cases/              # BDD test cases in Chinese markdown
+    ├── scripts/            # Generated Playwright test scripts
+    ├── runtime/            # Runner helpers, setup, teardown, and config
+    ├── package.json
+    └── package-lock.json
 ```
+
+## Working In This Repository
+
+- Read this file and the nearest nested `AGENTS.md` for every target path. Run
+  commands from the component root documented there; do not assume one runtime
+  or top-level gate covers all projects.
+- Keep component-local work inside that component unless the request or a
+  verified producer/consumer path requires a cross-component change.
+- Start investigations from the exact log, path, URL, endpoint, commit, PR, or
+  report named by the user, then verify it against the current checkout before
+  generalizing.
+- Before editing, testing, reviewing, or publishing from a repository with
+  multiple worktrees, verify the active root, branch, and commit with
+  `git rev-parse --show-toplevel`, `git status --short --branch`, and
+  `git rev-parse HEAD`. When a PR or worktree is named, match its explicit head
+  to `git worktree list --porcelain`; do not let a helper infer a PR from an
+  unrelated checkout.
+- For review findings, answer two questions separately: whether the issue is
+  real in the inspected code and whether the selected diff introduced it.
+- Follow the target component's verification contract. Markdown-only changes
+  require diff and reference checks, not unrelated component lint or test runs.
 
 ## Project Relationship
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -36,6 +36,7 @@ runtime, architecture, and verification commands.
     ├── cases/              # BDD test cases in Chinese markdown
     ├── scripts/            # Generated Playwright test scripts
     ├── runtime/            # Runner helpers, setup, teardown, and config
+    │   └── package-lock.json # Additional tracked runtime lockfile
     ├── package.json
     └── package-lock.json
 ```

--- a/src/dashboard/AGENTS.md
+++ b/src/dashboard/AGENTS.md
@@ -147,7 +147,7 @@ its surface-specific rules into another layer.
 Use `uv`, `pyproject.toml`, and `uv.lock` as the environment source of truth:
 
 ```bash
-cd src/dashboard
+cd "$DASHBOARD_ROOT"
 make init
 uv sync --locked --all-extras --dev
 uv run python --version
@@ -157,7 +157,7 @@ Refresh a stale `.venv` with `uv sync` before trusting lint or test results.
 After dependency changes, run:
 
 ```bash
-cd src/dashboard
+cd "$DASHBOARD_ROOT"
 make uv.lock
 uv lock --check
 ```
@@ -168,7 +168,7 @@ Edition-specific code lives under `apigateway/apigateway/editions/`. CI uses
 the enterprise edition before lint and tests:
 
 ```bash
-cd src/dashboard
+cd "$DASHBOARD_ROOT"
 uv run make edition-ee
 ```
 
@@ -181,7 +181,7 @@ requires another edition or an edition reset.
 in `pyproject.toml` and the Makefile.
 
 ```bash
-cd src/dashboard
+cd "$DASHBOARD_ROOT"
 uv run make lint-check
 uv run make lint
 ```
@@ -196,7 +196,7 @@ explicit non-mutating Ruff format check when formatting evidence is required.
 The full test gate is:
 
 ```bash
-cd src/dashboard
+cd "$DASHBOARD_ROOT"
 uv run make edition-ee
 uv run make test
 ```
@@ -204,7 +204,7 @@ uv run make test
 For a focused Django pytest target:
 
 ```bash
-cd src/dashboard
+cd "$DASHBOARD_ROOT"
 uv run bash -lc 'cd apigateway && set -a && . apigateway/conf/unittest_env && set +a && python -m pytest --nomigrations --ds apigateway.settings -q --tb=short apigateway/tests/path/to/test_file.py::TestClass::test_method'
 ```
 

--- a/src/dashboard/AGENTS.md
+++ b/src/dashboard/AGENTS.md
@@ -1,31 +1,28 @@
 # AGENTS.md
 
-Guidance for coding agents working in `src/dashboard`. Treat this file as the
-local contract for dashboard changes; the repository-root AGENTS.md still
-applies.
+Guidance for coding agents working in `src/dashboard`. The repository-root
+`AGENTS.md` also applies. Read the nearest nested `AGENTS.md` before changing a
+directory that has one.
 
 ## Scope
 
-- Read this file through **Post-Implementation Requirements** before running
-  commands; the runtime and final gates are documented after the architecture.
 - Work from `src/dashboard` unless a command says otherwise.
-- Do not touch sibling projects (`src/dashboard-front`, `src/core-api`,
-  `src/mcp-proxy`, `src/esb`) for dashboard-only requests.
-- Start from the exact path, endpoint, traceback, SQL, commit, PR, or report named
-  by the user and verify it against the active checkout.
-- Before changing code, read the target file and, as applicable, its immediate
-  caller or URL route, serializer/form, and nearest tests.
+- Do not touch sibling projects for dashboard-only requests.
+- Start from the exact path, endpoint, traceback, SQL, commit, PR, or report
+  named by the user and verify it against the active checkout.
+- Before changing code, read the target file, its relevant caller or route, its
+  serializer or form, and the nearest tests.
 - Keep changes surgical. Do not reformat or refactor adjacent code unless the
   requested change requires it.
 - During refactors, preserve useful comments and keep unchanged control flow in
   contiguous blocks when that makes the diff easier to review.
-- This subproject is Python-only. Frontend code lives in `src/dashboard-front`.
+- This subproject is Python-only. Frontend code lives in
+  `src/dashboard-front`.
 
 ## Command Roots And Runtime
 
-Follow the repository-root checkout/worktree rules before selecting a branch or
-PR. Do not hard-code workspace prefixes such as `/root/workspace` or
-`/data/workspace`; derive the dashboard root from the active checkout:
+Follow the repository-root checkout and worktree rules before selecting a
+branch or PR. Derive paths from the active checkout:
 
 ```bash
 REPO_ROOT="$(git rev-parse --show-toplevel)"
@@ -35,55 +32,47 @@ cd "$DASHBOARD_ROOT"
 
 Run repository-level `git`, `gh`, and worktree commands from `REPO_ROOT`. Run
 dashboard `make`, `uv`, lint, test, and management commands from
-`DASHBOARD_ROOT`. Use `uv run` for Python-backed Make targets so a global pyenv,
-stale `.venv`, or missing shell executable is not mistaken for a code failure.
+`DASHBOARD_ROOT`. Use `uv run` for Python-backed Make targets so a global pyenv
+or stale `.venv` is not mistaken for a code failure.
 
-For direct Django pytest, use the wrapper in **Testing**; plain pytest does not
-load `apigateway/conf/unittest_env` or the required Django settings. If a command
-reports a missing executable, wrong Python version, unconfigured Django settings,
-or an unrelated PR, stop and re-check the worktree, command root, and runtime
-before interpreting the result as a product failure.
+For direct Django pytest, use the wrapper in **Testing**. If a command reports a
+missing executable, wrong Python version, unconfigured Django settings, or an
+unrelated PR, re-check the worktree, command root, and runtime before treating
+it as a product failure.
 
 ## Project Overview
 
-BlueKing API Gateway Dashboard is the Django control plane for managing gateway
+BlueKing API Gateway Dashboard is the Django control plane for gateway
 definitions, stages, resources, releases, permissions, plugins, SDK generation,
-MCP servers, and data-plane publication. Apache APISIX is the data plane; this
-service stores and validates gateway state, then turns releases into controller
-configuration that is published through `controller -> etcd -> operator -> APISIX`.
+MCP servers, and data-plane publication. It stores and validates gateway state,
+then publishes controller configuration through
+`controller -> etcd -> operator -> APISIX`.
 
-Current stack, from the checked-in files:
-
-- Python `>=3.14,<3.15` in `pyproject.toml`; CI uses Python `3.14.6`.
-- Django `5.2.15`, Django REST Framework `3.17.1`.
-- Dependencies are managed by `uv` with `pyproject.toml` and `uv.lock`.
-- The Django project root is `apigateway/` and contains `manage.py`.
-- The importable Django package is `apigateway/apigateway/`.
+The current Python, Django, tooling, and dependency versions are defined by
+`pyproject.toml` and `uv.lock`. The Django project root is `apigateway/`; the
+importable package is `apigateway/apigateway/`.
 
 ## Important Paths
 
-- `Makefile` - setup, lint, tests, edition switching, Docker image build, OpenAPI consistency lint.
-- `pyproject.toml` - dependencies, ruff, mypy, pytest, import-linter contracts.
-- `uv.lock` - dependency lockfile; keep it in sync with `pyproject.toml`.
-- `Dockerfile` - production image, currently based on `hub.bktencent.com/blueking/python:3.14-tencentos4`.
-- `bin/start.sh` - Gunicorn entrypoint; keeps Prometheus multiprocess metrics in `/tmp/`.
-- `bin/start_celery.sh` and `bin/start_beat.sh` - Celery entrypoints; worker concurrency defaults to `12` and can be overridden with `BK_APIGW_CELERY_WORKER_CONCURRENCY`.
-- `scripts/check_api_consistency.py` - deterministic OpenAPI consistency lint for API code, YAML definitions, and docs.
-- `scripts/config.yaml` - OpenAPI consistency lint allowlists and special-case config.
-- `apigateway/manage.py` - Django management command entrypoint.
+- `Makefile` - supported setup, lint, test, edition, fixture, and image targets.
+- `pyproject.toml` and `uv.lock` - dependencies, tool configuration, and lockfile.
 - `apigateway/apigateway/urls.py` - top-level URL routing.
-- `apigateway/apigateway/conf/default.py` - base settings.
-- `apigateway/apigateway/conf/settings_dev.py` and `settings_prod.py` - environment-specific settings.
-- `apigateway/apigateway/conf/unittest_env` - default test environment, SQLite databases.
-- `apigateway/apigateway/data/apigw-definitions/` - gateway resource YAML definitions.
-- `apigateway/apigateway/data/apidocs/zh/` - markdown API docs used by OpenAPI consistency checks.
-- `apigateway/apigateway/fixtures/plugins.yaml` - plugin type, schema, and form fixtures.
-- `apigateway/apigateway/apis/web/plugin/AGENTS.md` - local plugin subsystem guide; read it before changing plugins.
+- `apigateway/apigateway/conf/` - settings and test environment.
+- `apigateway/apigateway/data/apigw-definitions/` - gateway resource YAML.
+- `apigateway/apigateway/data/apidocs/zh/` - OpenAPI markdown documentation.
+- `scripts/check_api_consistency.py` and `scripts/config.yaml` - deterministic
+  API/YAML/documentation consistency checks.
 - `apigateway/apigateway/tests/` - pytest suite, mirroring source structure.
-- Repository root `docs/ai-gateway-models.md` - AI Gateway domain contract.
-- Repository root
+- `apigateway/apigateway/core/AGENTS.md` - core model, manager, kind, and backend
+  configuration rules.
+- `apigateway/apigateway/service/AGENTS.md` - service placement, packaging, and
+  public API rules.
+- `apigateway/apigateway/apis/web/plugin/AGENTS.md` - plugin fixtures,
+  conversion, compatibility, and focused verification.
+- Repository-root `docs/ai-gateway-models.md` - AI Gateway domain contract.
+- Repository-root
   `docs/superpowers/specs/2026-07-21-ai-backend-web-protocol-decoupling-design.md`
-  describes the current AI Backend Web/storage/publish protocol design.
+  - AI Backend Web/storage/publish protocol design.
 
 ## Architecture
 
@@ -93,234 +82,102 @@ Current stack, from the checked-in files:
 apis -> biz -> controller -> service -> components -> apps -> core -> common -> utils
 ```
 
-Higher layers may import lower layers only. If you need to cross this boundary,
-put shared logic in the lower appropriate layer instead of adding an import
-exception.
+Higher layers may import lower layers only. Put shared logic in the lowest
+appropriate layer instead of adding an import exception.
 
-Important call rules:
+Layer ownership:
 
-- `apis/` view and serializer code may call `biz/` and `service/` directly.
-- `biz/` may call `service/`. Package-local `biz` imports are allowed inside
-  one domain or subpackage, but do not add peer-domain imports covered by the
-  `biz-domain-independence` contract. That contract currently covers
-  `biz.gateway`, `biz.resource`, `biz.permission`, and `biz.mcp_server`.
-- `service/` modules may call each other and may contain cross-model operations
-  when the operation is focused and reusable.
-- `service/` is not a dumping ground for code moved only to avoid `biz`-to-`biz`
-  imports. Cross-domain workflow orchestration belongs in a neutral use-case
-  `biz` module or in `controller/`, not in `service/`. Keep `service/` to leaf
-  capabilities with stable inputs and outputs, clear reuse, direct tests, and no
-  permission, audit, lifecycle, or workflow decisions.
-- Historical exception: `apigateway.service.release.PublishValidator` currently
-  lives under `service/` because it was moved there during the 2026-05
-  `biz-domain-independence` refactor to break an import-boundary issue. Treat
-  that location as compatibility debt, not as placement precedent. Release
-  gating, lifecycle, and publish workflow decisions should prefer
-  `biz/release/`; keep only the smallest reusable leaf checks in `service/`.
-- Direct model or queryset use from views and serializers is limited to simple
-  local reads or writes that are already idiomatic in Django.
+- `apis/` owns HTTP surfaces, serializers, boundary validation, parameter
+  shaping, and response assembly. Views should stay thin and avoid N+1 queries.
+- `biz/` owns use-case workflows, permission-aware decisions, lifecycle
+  branching, audit or side-effect orchestration, transactions, and sequencing.
+- `controller/` owns release compilation, APISIX conversion, distribution, and
+  publisher tasks.
+- `service/` owns focused reusable leaf capabilities over domain data. It must
+  not absorb workflow decisions merely to bypass a `biz` import boundary. Read
+  `apigateway/apigateway/service/AGENTS.md` before changing it.
+- `components/` owns clients for external BlueKing systems.
+- `apps/` owns Django app models, admin, migrations, commands, and Celery tasks.
+- `core/` owns the central gateway domain models and normalized configuration.
+  Read `apigateway/apigateway/core/AGENTS.md` before changing it.
+- `common/` owns reusable middleware, permissions, fields, mixins, tenant
+  helpers, and factories. `utils/` owns low-level utilities.
 
-Function placement guide:
+When placing a function:
 
-Use this order when deciding where a new function belongs:
+1. Keep module-local or single-domain behavior where it is.
+2. Keep API-surface shaping in the owning view or serializer.
+3. Put workflows and decisions in `biz/` or release compilation in
+   `controller/`.
+4. Put only the smallest focused, reusable relation, query, or data operation
+   in `service/`.
+5. Keep reusable single-model queryset logic in managers; do not put
+   multi-model business queries there.
 
-1. Keep it where it is if it is only used inside one module or one `biz`
-   domain, especially when moving it would only create a proxy wrapper.
-2. Keep view-specific parameter shaping, response assembly, or API-surface
-   branching in the owning view or serializer.
-3. Put it in `biz/` when it owns use-case flow: what should happen,
-   permission-aware decisions, lifecycle branching, audit or side-effect
-   orchestration, transactions, or sequencing multiple lower-level operations.
-4. Put it in `service/` only when it is a focused reusable leaf operation over
-   model relationships or domain data: snapshots, schema lookup, cleanup,
-   reusable cross-model queries, relation normalization, or data shaping.
-5. When both `biz` and `service` seem possible, keep orchestration in `biz` and
-   extract only the smallest reusable relation or data operation to `service`.
-
-Service organization guide:
-
-- Name `service` modules by domain plus capability, not by vague technical
-  buckets. Prefer names like `resource_snapshot.py`, `resource_cleanup.py`,
-  `resource_version_schema.py`, or `openapi_export.py`; avoid adding new
-  behavior to generic modules such as `utils.py` unless the code is truly
-  domain-neutral.
-- Keep a small capability as a top-level module. Convert a domain into a package
-  only after several related service modules exist or a file starts mixing
-  unrelated capabilities, for example `service/resource/snapshot.py`,
-  `service/resource/cleanup.py`, and `service/resource/labels.py`.
-- For `service/<domain>/` packages, external callers must import public symbols from
-  `apigateway.service.<domain>`, not from leaf modules such as
-  `apigateway.service.<domain>.<capability>`. The package `__init__.py` owns the
-  public API and `__all__`; leaf modules must not define `__all__`.
-- For `biz/<domain>/` packages covered by the public API contract, callers from
-  `apis/` and `apps/` must import public symbols from
-  `apigateway.biz.<domain>`, not from leaf modules that import-linter forbids.
-- Service package internals may use single-dot relative imports for local
-  leaf modules, but should not use parent relative imports such as `..` inside
-  `service/`. When reaching outside the current package, use absolute imports
-  rooted at `apigateway.service`.
-- Function names should describe the action, domain, and output shape or side
-  effect. Use `get_*` for reads, `delete_*` or `clear_*` for destructive writes,
-  `build_*` for construction, `format_*` or `normalize_*` for shape changes,
-  `snapshot_*` for snapshot creation, and `ensure_*` for idempotent creation or
-  backfill.
-- Prefer free functions for stateless leaf operations. Use classes only when
-  the service needs state, strategy selection, validation objects, factories, or
-  polymorphic behavior.
-- Each non-trivial service module should expose a small public surface: add a
-  module docstring that states what the module owns, keep public helpers
-  discoverable, and prefix module-private helpers with `_`.
-
-Package `__init__.py` export guide:
-
-- For `biz/` and `service/` package `__init__.py` files that define `__all__`,
-  keep exports grouped in this fixed order: `# constant`, `# Enum`, `# class`,
-  `# functions`, `# others`.
-- Keep every section comment in place even when that section is empty, so later
-  additions have an obvious slot.
-- Keep names grouped under the matching section. Put module re-exports or other
-  uncategorized names under `# others`.
-
-Layer intent:
-
-- `apis/` - HTTP API surfaces and serializers. Serializers own input
-  validation and output definitions, and must not introduce N+1 queries for
-  computed fields. Views stay thin: simple control flow, parameter building,
-  lower-layer calls, and response assembly. Call `biz/` for workflows,
-  decisions, permission-aware orchestration, and multi-model operations. Call
-  `service/` for focused reusable domain operations, snapshots, cleanup
-  helpers, schema lookup, and pure or query helpers. Keep view-level logic
-  inside its own API module even when another API surface has the same or
-  similar logic.
-- `biz/` - workflow and decision logic, including permission-aware
-  orchestration and multi-model operations. Keep peer model domains such as
-  gateway, resource, resource version, permission, and MCP server independent;
-  move shared coordination or reusable domain operations into `service/` when
-  needed. Internal helpers within the same `biz` domain may stay inside that
-  domain.
-- `controller/` - release pipeline, APISIX config conversion, transformers, distributors, publisher tasks.
-- `service/` - focused reusable domain operations, snapshots, cleanup helpers,
-  schema lookup, and pure or query helpers. `service` modules may import each
-  other and may perform cross-model work when the operation is reusable outside
-  one view or `biz` workflow.
-- `components/` - external BlueKing system clients.
-- `apps/` - Django app model layer plus admin, migrations, management commands,
-  and Celery tasks. Keep `models.py` rich for single-model properties and
-  methods. Keep `managers.py` to reusable single-model queryset logic. Do not
-  put multiple-model business queries in managers.
-- `core/` - central gateway domain model layer such as `Gateway`, `Stage`,
-  `Resource`, `ResourceVersion`, `Release`, `Backend`, `Context`. Follow the
-  same model-layer rule as `apps/`: rich single-model methods in `models.py`,
-  reusable single-model queryset logic in `managers.py`, and no multiple-model
-  business queries in managers.
-- `common/` - reusable middleware, permissions, fields, mixins, tenant helpers, factories.
-- `utils/` - low-level utility functions.
-- Top-level packages such as `account/`, `healthz/`, `schema/`, and `tracing/`
-  are outside the main `global-layers` stack. Follow the nearest caller,
-  settings, or middleware pattern instead of forcing them into a layer.
+For `biz/<domain>/` packages covered by the public API contract, callers from
+`apis/` and `apps/` must import public symbols from
+`apigateway.biz.<domain>`, not forbidden leaf modules. Keep `__all__` sections
+in the established `constant`, `Enum`, `class`, `functions`, `others` order.
 
 The API surfaces are intentionally independent:
 
-- `apigateway.apis.web` - dashboard backend APIs consumed by `dashboard-front`.
-- `apigateway.apis.open` - legacy open APIs with compatibility response formats.
+- `apigateway.apis.web` - dashboard APIs consumed by `dashboard-front`.
+- `apigateway.apis.open` - legacy open APIs with compatibility formats.
 - `apigateway.apis.v2.open` - public open APIs.
-- `apigateway.apis.v2.inner` - internal APIs, mainly for BlueKing internal callers.
-- `apigateway.apis.v2.sync` - sync APIs for SDK or automation clients that manage gateways.
+- `apigateway.apis.v2.inner` - BlueKing internal APIs.
+- `apigateway.apis.v2.sync` - gateway automation and SDK sync APIs.
 
-Do not share view or serializer code across API surfaces by importing from one
-surface into another. Keep view-level logic in the owning API module
-(`apis.open`, `apis.web`, `apis.v2.open`, and other `apis.v2.*` modules), even
-when the logic is the same or nearly the same. Duplicate small view logic when
-that keeps the surfaces independent, especially because `apis.web` behavior
-changes frequently. Move common behavior down into `biz`, `service`, `common`,
-or `utils` only when it is true lower-layer business, service, or utility logic
-instead of surface-specific view flow.
+Do not import view or serializer code across API surfaces. Duplicate small
+surface-specific logic when necessary; move code down only when it is genuinely
+shared business, service, or utility behavior.
 
 ## Domain Notes
 
-- The main model chain is `Gateway -> Stage -> Resource -> ResourceVersion -> Release -> ReleaseHistory`.
-- `Gateway` is the current domain name. Legacy DB columns and some payloads still
-  use `api`, `api_id`, or `api_name`; do not introduce new API naming unless you
-  are touching an existing compatibility boundary.
-- Stage/resource plugins use `PluginBinding`.
-- Auth and other scoped configuration live in `Context` records.
+- The main model chain is
+  `Gateway -> Stage -> Resource -> ResourceVersion -> Release -> ReleaseHistory`.
+- `Gateway` is the current domain name. Legacy DB columns and payloads may still
+  use `api`, `api_id`, or `api_name`; do not expand legacy naming.
+- Stage and resource plugins use `PluginBinding`.
+- Scoped authentication and configuration live in `Context` records.
 - Backends are gateway-scoped, with stage-specific `BackendConfig` records.
-- Multi-tenant behavior is controlled by `ENABLE_MULTI_TENANT_MODE`; non-tenant
-  mode still mounts ESB routes and apps.
-- Settings are selected by `BKPAAS_ENVIRONMENT`, loading
-  `apigateway.conf.settings_<environment>`; default is `dev`.
+- Multi-tenant behavior is controlled by `ENABLE_MULTI_TENANT_MODE`.
+- `BKPAAS_ENVIRONMENT` selects the settings module; the default is `dev`.
 
 ## AI Gateway And Backend Configuration
 
-Read both AI Gateway documents listed in **Important Paths** before changing AI
+Read both AI Gateway documents in **Important Paths** before changing AI
 models, APIs, connectivity checks, plugin compatibility, or publishing. Current
-code and tests take precedence when an older plan or review report disagrees.
+code and tests take precedence over older plans or review reports.
 
-- `Gateway.kind` is stored as the numeric `GatewayKindEnum`; API names use
-  `GatewayKindNameEnum` conversion. `Backend.kind` and `Resource.kind` use the
-  string values `standard` and `ai`. Do not repurpose transport `type` fields as
-  kind discriminators.
-- Keep three representations separate: the flat Web DTO and
-  `AIBackendWebConfigAdapter`, the normalized stored `AIBackendConfig`, and the
-  APISIX plugin config compiled by `ServiceConvertor`. Open/v2 automation APIs
-  intentionally accept the stored protocol rather than the Web DTO.
-- `core/ai_backend.py` is the runtime-critical built-in provider registry used
-  by Web conversion, connectivity tests, and publishing. A provider change must
-  update choices, registry entries, adapter rules, tests, and API documentation.
-- Store built-in providers as their product identity. Convert compatible built-ins
-  to APISIX `openai-compatible`, add `override.endpoint`, strip
-  `model_endpoint`, and convert timeout seconds to milliseconds only at the
-  publish boundary.
-- Web and automation inputs are single-instance in the first phase, while the
-  core config and converter support multiple instances. Keep that external
-  restriction out of the core model.
-- `BackendConfig.config` transparently encrypts AI config at the ORM persistence
-  boundary. Web and audit outputs must mask credentials; API responses, logs,
-  exceptions, and publish history must not expose plaintext or encrypted
-  payloads. Generated APISIX/etcd runtime config is a credential trust boundary.
-- Resource plugin compatibility is enforced across list, bind/update, and
-  import paths. Stage configuration stays permissive; AI Service publishing
-  filters incompatible Stage plugins. `ai-proxy` and `ai-proxy-multi` are
-  controller-managed and must not be user-bound.
-- In controller convertor changes, preserve the standard Service/Route blocks
-  and their comments; isolate AI-specific behavior in narrow branches unless a
-  behavior change requires a broader refactor.
+Keep these representations separate:
+
+1. The flat Web DTO and `AIBackendWebConfigAdapter`.
+2. The normalized stored `AIBackendConfig` owned by `core/`.
+3. The APISIX plugin configuration compiled by `ServiceConvertor`.
+
+Open and v2 automation APIs intentionally use the stored protocol rather than
+the Web DTO. Provider identity plus configuration persistence and encryption
+rules live in `core/AGENTS.md`. APISIX-specific provider conversion and timeout
+conversion happen only at the controller publish boundary.
+
+Plugin compatibility is enforced at several entry points; follow the plugin
+guide rather than changing only one path. In controller convertor changes,
+preserve the standard Service and Route blocks and their comments, and isolate
+AI-specific behavior in narrow branches.
 
 ## Runtime Setup
 
-Use `uv` as the source of truth for the environment.
+Use `uv`, `pyproject.toml`, and `uv.lock` as the environment source of truth:
 
 ```bash
 cd src/dashboard
 make init
-```
-
-`make init` installs `uv==0.11.26`, runs `uv sync`, installs pre-commit, and
-installs mypy stub packages. The Docker image copies `uv==0.11.26`; use the
-checked-in lockfile rather than relying on either version detail.
-
-For a local install with CI's locked dependency set:
-
-```bash
-cd src/dashboard
 uv sync --locked --all-extras --dev
-```
-
-In GitHub Actions, the workflow also sets `UV_PROJECT_ENVIRONMENT` to the
-action-provided Python location before running the same `uv sync` flags.
-
-Before running Python tools, verify the interpreter matches `pyproject.toml`:
-
-```bash
-cd src/dashboard
 uv run python --version
 ```
 
-If an existing `.venv` reports Python 3.10 or old tool versions, refresh it with
-`uv sync` before trusting lint or test results. Do not assume a pre-existing
-`.venv` is current.
-
-After dependency changes:
+Refresh a stale `.venv` with `uv sync` before trusting lint or test results.
+After dependency changes, run:
 
 ```bash
 cd src/dashboard
@@ -328,77 +185,23 @@ make uv.lock
 uv lock --check
 ```
 
-## Local Development
-
-Prepare MySQL databases for a real local server:
-
-```sql
-CREATE DATABASE IF NOT EXISTS `bk_apigateway` DEFAULT CHARACTER SET utf8 COLLATE utf8_general_ci;
-CREATE DATABASE IF NOT EXISTS `bk_esb` DEFAULT CHARACTER SET utf8 COLLATE utf8_general_ci;
-```
-
-Then configure and run Django:
-
-```bash
-cd src/dashboard
-uv sync
-cp apigateway/apigateway/conf/.env.tpl apigateway/apigateway/conf/.env
-uv run python apigateway/manage.py migrate
-uv run python apigateway/manage.py migrate --database bkcore
-uv run python apigateway/manage.py runserver
-```
-
-The frontend is developed separately in `src/dashboard-front`. A local nginx
-reverse proxy usually sends `/backend/` to the dashboard server and other paths
-to the frontend dev server.
-
-## Plugin Fixtures
-
-Before changing plugin behavior, read
-`apigateway/apigateway/apis/web/plugin/AGENTS.md`.
-
-For plugin type/schema/form maintenance:
-
-```bash
-cd src/dashboard
-uv run make load_fixtures
-# edit through Django admin or update fixtures intentionally
-uv run make dump_fixtures
-```
-
-New APISIX plugins should normally store APISIX-native YAML and should not add
-API-layer or service-layer convertors unless the plugin guide says the legacy
-compatibility path applies.
-
 ## Edition System
 
-Edition-specific code lives under `apigateway/apigateway/editions/` and is
-activated through `editionctl`.
+Edition-specific code lives under `apigateway/apigateway/editions/`. CI uses
+the enterprise edition before lint and tests:
 
 ```bash
 cd src/dashboard
-uv run make edition
 uv run make edition-ee
-uv run make edition-te
-uv run make edition-develop
-uv run make edition-reset
-uv run make edition-modules
 ```
 
-CI runs lint and tests after the `edition-ee` target. Run
-`uv run make edition-ee` before local lint or test gates unless you are
-intentionally checking a different edition.
+Use the other edition targets in the Makefile only when the task explicitly
+requires another edition or an edition reset.
 
 ## Linting
 
-Configured in `pyproject.toml`:
-
-- `ruff` handles formatting and linting.
-- `mypy` runs with strict optional checks; migrations, conf, and editions are
-  excluded or error-suppressed as configured.
-- `lint-imports` enforces the layer and API-surface contracts from `pyproject.toml`.
-
-Commands:
+`ruff`, `mypy`, `lint-imports`, and the API consistency checker are configured
+in `pyproject.toml` and the Makefile.
 
 ```bash
 cd src/dashboard
@@ -406,15 +209,14 @@ uv run make lint-check
 uv run make lint
 ```
 
-Use `uv run make lint-check` as the default agent gate because it is
-non-mutating. `uv run make lint` formats and fixes files; run it only when those
-edits are intended, then inspect the resulting diff. `lint-check` does not run
-`ruff format --check`, so use pre-commit or an explicit non-mutating Ruff format
-check when formatting evidence is required.
+Use `uv run make lint-check` as the default non-mutating agent gate. Run the
+mutating `uv run make lint` only when formatting or fixes are intended, then
+inspect its diff. `lint-check` does not run `ruff format --check`; use an
+explicit non-mutating Ruff format check when formatting evidence is required.
 
 ## Testing
 
-The normal full test gate is:
+The full test gate is:
 
 ```bash
 cd src/dashboard
@@ -422,125 +224,73 @@ uv run make edition-ee
 uv run make test
 ```
 
-`make test` runs pytest with `--reuse-db`, `-n auto`, and `--dist loadscope`.
-
-Useful variants:
-
-```bash
-cd src/dashboard
-uv run make test-lf
-uv run make test-cov
-uv run make test-pdb
-```
-
-Focused pytest pattern for agents:
+For a focused Django pytest target:
 
 ```bash
 cd src/dashboard
 uv run bash -lc 'cd apigateway && set -a && . apigateway/conf/unittest_env && set +a && python -m pytest --nomigrations --ds apigateway.settings -q --tb=short apigateway/tests/path/to/test_file.py::TestClass::test_method'
 ```
 
-Notes:
-
-- Tests live under `apigateway/apigateway/tests/` and mirror source paths.
-- `apigateway/conf/unittest_env` uses SQLite for both `default` and `bkcore`.
-- Always pass `--ds apigateway.settings` for direct pytest runs.
-- Add `--nomigrations` for focused runs when branch migration conflicts block DB setup.
-- Use `request_view`, `request_to_view`, `fake_gateway`, `fake_stage`, `fake_backend`,
-  `fake_resource`, and related fixtures from `tests/conftest.py`.
-- Model setup commonly uses `ddf` / `django_dynamic_fixture` `G()`.
-- API tests usually call the URL by `view_name` and assert through `resp.json()`.
-- When adding `service/<domain>/` packages or package exports, keep
-  `tests/service/test_public_api_contract.py` passing.
+- Tests mirror source paths under `apigateway/apigateway/tests/`.
+- Direct pytest must load `apigateway/conf/unittest_env` and pass
+  `--ds apigateway.settings`.
+- Use `--nomigrations` for focused tests when branch migration conflicts block
+  database setup.
+- Reuse fixtures from `tests/conftest.py`; model setup commonly uses `G()` from
+  `django_dynamic_fixture`.
+- API tests usually call URLs by `view_name` and assert through `resp.json()`.
 
 ## OpenAPI And API Docs
 
-When changing an open API, keep these three surfaces aligned:
+When changing an open API, keep these surfaces aligned:
 
-- API implementation: views and serializers under `apigateway/apigateway/apis/`.
-- Gateway YAML definitions: `apigateway/apigateway/data/apigw-definitions/`.
-- Markdown docs: `apigateway/apigateway/data/apidocs/zh/`.
+- Views and serializers under `apigateway/apigateway/apis/`.
+- Gateway YAML under `apigateway/apigateway/data/apigw-definitions/`.
+- Markdown docs under `apigateway/apigateway/data/apidocs/zh/`.
 
-The consistency checker is a deterministic dashboard lint script at
-`scripts/check_api_consistency.py`. Both `make lint` and `make lint-check` run
-it by default. Use the dedicated target below when you want to rerun only this
-gate.
-
-Available commands:
+Both lint targets run the consistency checker. For a focused rerun:
 
 ```bash
 cd src/dashboard
 uv run make lint-openapi
 uv run make lint-openapi-help
-uv run make lint-openapi SCOPE=v2_open
-uv run make lint-openapi SCOPE=v2_inner
-uv run make lint-openapi SCOPE=v2_sync
-uv run make lint-openapi API=v2_sync_gateway
-uv run make lint-openapi JSON=1
-uv run make lint-openapi FIX=1
 ```
 
-For changed or new endpoints, update the matching markdown doc with method,
-path, parameters or request body, response fields, status codes, and error
-examples. The frontend team uses these docs for integration. CI runs
-the same check through `make lint-check`, so keep API, YAML, serializer, and
-docs aligned before push.
+The help target documents supported scope, API, JSON, and intentional fix
+options. Keep method, path, request, response, status, and error documentation
+aligned before push.
 
 ## Response And Validation Patterns
 
-- Prefer serializer validation at the API boundary; do not duplicate it in views
-  unless the rule depends on already-loaded domain state.
-- Web and v2 APIs commonly return `OKJsonResponse` / `FailJsonResponse` from
-  `apigateway.utils.responses`.
-- Legacy open APIs may use `V1OKJsonResponse` / `V1FailJsonResponse`; do not
-  switch formats unless the compatibility contract changes.
-- For health or security-sensitive errors, keep client messages sanitized and
-  log original exceptions with `logger.exception(...)`.
-- For drf-yasg docs, serializers commonly define unique `Meta.ref_name` values;
-  preserve that pattern when adding serializers.
-
-## Build And Runtime Entrypoints
-
-Image build targets copy a clean build tree and remove tests, edition metadata,
-and local artifacts before building.
-
-```bash
-cd src/dashboard
-uv run make image-ee
-uv run make image-te
-uv run make dev-ee-image
-```
-
-Runtime scripts source `${BK_HOME}/etc/bk_apigateway/bk_apigateway.env` when it
-exists. `bin/start.sh` runs Gunicorn with gevent workers and Prometheus
-multiprocess mode. Keep `/metrics` compatibility in mind when changing URL
-routing, middleware, or process startup.
+- Prefer serializer validation at the API boundary.
+- Web and v2 APIs commonly use `OKJsonResponse` / `FailJsonResponse`; legacy
+  open APIs may require `V1OKJsonResponse` / `V1FailJsonResponse`.
+- Sanitize client-visible security errors and log original exceptions with
+  `logger.exception(...)`.
+- Preserve unique drf-yasg `Meta.ref_name` values when adding serializers.
 
 ## Security And Secrets
 
-- Do not commit real `.env` values, app secrets, database credentials, tokens, or
+- Do not commit `.env` values, app secrets, database credentials, tokens, or
   generated certificates.
-- `apigateway/apigateway/conf/.env` is local-only; copy from `.env.tpl`.
-- Check permission classes, middleware, serializer validation, and tenant checks
-  before accepting or rejecting a security report.
-- When a report points at a sink, trace the route, serializer, permission class,
-  and downstream handler before deciding whether the issue is real.
+- Copy local configuration from `apigateway/apigateway/conf/.env.tpl`.
+- Verify routes, serializers, permissions, tenant checks, and downstream
+  handlers before accepting or rejecting a security report.
+- API responses, logs, exceptions, audit events, and publish history must not
+  expose plaintext or encrypted credential payloads.
 
 ## Post-Implementation Requirements
 
 For markdown-only documentation changes, do not run `make lint` or `make test`;
-verify the diff instead.
+verify the diff and referenced paths instead.
 
 For code changes:
 
 1. Add or update focused tests under `apigateway/apigateway/tests/`.
-2. Update API docs and gateway YAML definitions when an API contract changes.
+2. Update API docs and gateway YAML when an API contract changes.
 3. Run the narrow relevant pytest target first.
 4. Run `uv run make edition-ee && uv run make lint-check` for the CI-style lint
-   gate. Use `uv run make lint` only when auto-format/fix changes are intended.
-   This lint gate includes the OpenAPI consistency check; use
-   `uv run make lint-openapi` only when you need a focused rerun of that checker.
-5. Run `uv run make edition-ee && uv run make test` for broad code changes or
-   when shared behavior is touched.
+   gate. Use `uv run make lint` only when auto-fix changes are intended.
+5. Run `uv run make edition-ee && uv run make test` for broad or shared changes.
 
 If a required verification command is skipped, say exactly why.

--- a/src/dashboard/AGENTS.md
+++ b/src/dashboard/AGENTS.md
@@ -63,10 +63,9 @@ importable package is `apigateway/apigateway/`.
 - `scripts/check_api_consistency.py` and `scripts/config.yaml` - deterministic
   API/YAML/documentation consistency checks.
 - `apigateway/apigateway/tests/` - pytest suite, mirroring source structure.
-- `apigateway/apigateway/core/AGENTS.md` - core model, manager, kind, and backend
-  configuration rules.
-- `apigateway/apigateway/service/AGENTS.md` - service placement, packaging, and
-  public API rules.
+- `apigateway/apigateway/` layer guides: `apis/AGENTS.md`, `biz/AGENTS.md`,
+  `controller/AGENTS.md`, `service/AGENTS.md`, and `core/AGENTS.md`; read the
+  guide under the directory being changed.
 - `apigateway/apigateway/apis/web/plugin/AGENTS.md` - plugin fixtures,
   conversion, compatibility, and focused verification.
 - Repository-root `docs/ai-gateway-models.md` - AI Gateway domain contract.
@@ -88,11 +87,12 @@ appropriate layer instead of adding an import exception.
 Layer ownership:
 
 - `apis/` owns HTTP surfaces, serializers, boundary validation, parameter
-  shaping, and response assembly. Views should stay thin and avoid N+1 queries.
+  shaping, and response assembly. Read `apigateway/apigateway/apis/AGENTS.md`.
 - `biz/` owns use-case workflows, permission-aware decisions, lifecycle
   branching, audit or side-effect orchestration, transactions, and sequencing.
+  Read `apigateway/apigateway/biz/AGENTS.md`.
 - `controller/` owns release compilation, APISIX conversion, distribution, and
-  publisher tasks.
+  publisher tasks. Read `apigateway/apigateway/controller/AGENTS.md`.
 - `service/` owns focused reusable leaf capabilities over domain data. It must
   not absorb workflow decisions merely to bypass a `biz` import boundary. Read
   `apigateway/apigateway/service/AGENTS.md` before changing it.
@@ -114,23 +114,6 @@ When placing a function:
 5. Keep reusable single-model queryset logic in managers; do not put
    multi-model business queries there.
 
-For `biz/<domain>/` packages covered by the public API contract, callers from
-`apis/` and `apps/` must import public symbols from
-`apigateway.biz.<domain>`, not forbidden leaf modules. Keep `__all__` sections
-in the established `constant`, `Enum`, `class`, `functions`, `others` order.
-
-The API surfaces are intentionally independent:
-
-- `apigateway.apis.web` - dashboard APIs consumed by `dashboard-front`.
-- `apigateway.apis.open` - legacy open APIs with compatibility formats.
-- `apigateway.apis.v2.open` - public open APIs.
-- `apigateway.apis.v2.inner` - BlueKing internal APIs.
-- `apigateway.apis.v2.sync` - gateway automation and SDK sync APIs.
-
-Do not import view or serializer code across API surfaces. Duplicate small
-surface-specific logic when necessary; move code down only when it is genuinely
-shared business, service, or utility behavior.
-
 ## Domain Notes
 
 - The main model chain is
@@ -140,8 +123,8 @@ shared business, service, or utility behavior.
 - Stage and resource plugins use `PluginBinding`.
 - Scoped authentication and configuration live in `Context` records.
 - Backends are gateway-scoped, with stage-specific `BackendConfig` records.
-- Multi-tenant behavior is controlled by `ENABLE_MULTI_TENANT_MODE`.
-- `BKPAAS_ENVIRONMENT` selects the settings module; the default is `dev`.
+- `ENABLE_MULTI_TENANT_MODE` controls tenancy; `BKPAAS_ENVIRONMENT` selects the
+  settings module and defaults to `dev`.
 
 ## AI Gateway And Backend Configuration
 
@@ -151,19 +134,13 @@ code and tests take precedence over older plans or review reports.
 
 Keep these representations separate:
 
-1. The flat Web DTO and `AIBackendWebConfigAdapter`.
+1. The flat Web DTO and `AIBackendWebConfigAdapter`, owned by `apis/`.
 2. The normalized stored `AIBackendConfig` owned by `core/`.
-3. The APISIX plugin configuration compiled by `ServiceConvertor`.
+3. The APISIX plugin configuration compiled by `controller/`.
 
-Open and v2 automation APIs intentionally use the stored protocol rather than
-the Web DTO. Provider identity plus configuration persistence and encryption
-rules live in `core/AGENTS.md`. APISIX-specific provider conversion and timeout
-conversion happen only at the controller publish boundary.
-
-Plugin compatibility is enforced at several entry points; follow the plugin
-guide rather than changing only one path. In controller convertor changes,
-preserve the standard Service and Route blocks and their comments, and isolate
-AI-specific behavior in narrow branches.
+Follow the owning API, core, controller, and plugin guides when changing a
+representation or its transition. Do not repair one representation by leaking
+its surface-specific rules into another layer.
 
 ## Runtime Setup
 
@@ -238,36 +215,6 @@ uv run bash -lc 'cd apigateway && set -a && . apigateway/conf/unittest_env && se
   database setup.
 - Reuse fixtures from `tests/conftest.py`; model setup commonly uses `G()` from
   `django_dynamic_fixture`.
-- API tests usually call URLs by `view_name` and assert through `resp.json()`.
-
-## OpenAPI And API Docs
-
-When changing an open API, keep these surfaces aligned:
-
-- Views and serializers under `apigateway/apigateway/apis/`.
-- Gateway YAML under `apigateway/apigateway/data/apigw-definitions/`.
-- Markdown docs under `apigateway/apigateway/data/apidocs/zh/`.
-
-Both lint targets run the consistency checker. For a focused rerun:
-
-```bash
-cd src/dashboard
-uv run make lint-openapi
-uv run make lint-openapi-help
-```
-
-The help target documents supported scope, API, JSON, and intentional fix
-options. Keep method, path, request, response, status, and error documentation
-aligned before push.
-
-## Response And Validation Patterns
-
-- Prefer serializer validation at the API boundary.
-- Web and v2 APIs commonly use `OKJsonResponse` / `FailJsonResponse`; legacy
-  open APIs may require `V1OKJsonResponse` / `V1FailJsonResponse`.
-- Sanitize client-visible security errors and log original exceptions with
-  `logger.exception(...)`.
-- Preserve unique drf-yasg `Meta.ref_name` values when adding serializers.
 
 ## Security And Secrets
 

--- a/src/dashboard/AGENTS.md
+++ b/src/dashboard/AGENTS.md
@@ -6,14 +6,43 @@ applies.
 
 ## Scope
 
+- Read this file through **Post-Implementation Requirements** before running
+  commands; the runtime and final gates are documented after the architecture.
 - Work from `src/dashboard` unless a command says otherwise.
 - Do not touch sibling projects (`src/dashboard-front`, `src/core-api`,
   `src/mcp-proxy`, `src/esb`) for dashboard-only requests.
-- Before changing code, read the target file, its immediate caller or URL route,
-  the serializer/form it depends on, and the nearest tests.
+- Start from the exact path, endpoint, traceback, SQL, commit, PR, or report named
+  by the user and verify it against the active checkout.
+- Before changing code, read the target file and, as applicable, its immediate
+  caller or URL route, serializer/form, and nearest tests.
 - Keep changes surgical. Do not reformat or refactor adjacent code unless the
   requested change requires it.
+- During refactors, preserve useful comments and keep unchanged control flow in
+  contiguous blocks when that makes the diff easier to review.
 - This subproject is Python-only. Frontend code lives in `src/dashboard-front`.
+
+## Command Roots And Runtime
+
+Follow the repository-root checkout/worktree rules before selecting a branch or
+PR. Do not hard-code workspace prefixes such as `/root/workspace` or
+`/data/workspace`; derive the dashboard root from the active checkout:
+
+```bash
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+DASHBOARD_ROOT="$REPO_ROOT/src/dashboard"
+cd "$DASHBOARD_ROOT"
+```
+
+Run repository-level `git`, `gh`, and worktree commands from `REPO_ROOT`. Run
+dashboard `make`, `uv`, lint, test, and management commands from
+`DASHBOARD_ROOT`. Use `uv run` for Python-backed Make targets so a global pyenv,
+stale `.venv`, or missing shell executable is not mistaken for a code failure.
+
+For direct Django pytest, use the wrapper in **Testing**; plain pytest does not
+load `apigateway/conf/unittest_env` or the required Django settings. If a command
+reports a missing executable, wrong Python version, unconfigured Django settings,
+or an unrelated PR, stop and re-check the worktree, command root, and runtime
+before interpreting the result as a product failure.
 
 ## Project Overview
 
@@ -51,6 +80,10 @@ Current stack, from the checked-in files:
 - `apigateway/apigateway/fixtures/plugins.yaml` - plugin type, schema, and form fixtures.
 - `apigateway/apigateway/apis/web/plugin/AGENTS.md` - local plugin subsystem guide; read it before changing plugins.
 - `apigateway/apigateway/tests/` - pytest suite, mirroring source structure.
+- Repository root `docs/ai-gateway-models.md` - AI Gateway domain contract.
+- Repository root
+  `docs/superpowers/specs/2026-07-21-ai-backend-web-protocol-decoupling-design.md`
+  describes the current AI Backend Web/storage/publish protocol design.
 
 ## Architecture
 
@@ -217,6 +250,42 @@ instead of surface-specific view flow.
 - Settings are selected by `BKPAAS_ENVIRONMENT`, loading
   `apigateway.conf.settings_<environment>`; default is `dev`.
 
+## AI Gateway And Backend Configuration
+
+Read both AI Gateway documents listed in **Important Paths** before changing AI
+models, APIs, connectivity checks, plugin compatibility, or publishing. Current
+code and tests take precedence when an older plan or review report disagrees.
+
+- `Gateway.kind` is stored as the numeric `GatewayKindEnum`; API names use
+  `GatewayKindNameEnum` conversion. `Backend.kind` and `Resource.kind` use the
+  string values `standard` and `ai`. Do not repurpose transport `type` fields as
+  kind discriminators.
+- Keep three representations separate: the flat Web DTO and
+  `AIBackendWebConfigAdapter`, the normalized stored `AIBackendConfig`, and the
+  APISIX plugin config compiled by `ServiceConvertor`. Open/v2 automation APIs
+  intentionally accept the stored protocol rather than the Web DTO.
+- `core/ai_backend.py` is the runtime-critical built-in provider registry used
+  by Web conversion, connectivity tests, and publishing. A provider change must
+  update choices, registry entries, adapter rules, tests, and API documentation.
+- Store built-in providers as their product identity. Convert compatible built-ins
+  to APISIX `openai-compatible`, add `override.endpoint`, strip
+  `model_endpoint`, and convert timeout seconds to milliseconds only at the
+  publish boundary.
+- Web and automation inputs are single-instance in the first phase, while the
+  core config and converter support multiple instances. Keep that external
+  restriction out of the core model.
+- `BackendConfig.config` transparently encrypts AI config at the ORM persistence
+  boundary. Web and audit outputs must mask credentials; API responses, logs,
+  exceptions, and publish history must not expose plaintext or encrypted
+  payloads. Generated APISIX/etcd runtime config is a credential trust boundary.
+- Resource plugin compatibility is enforced across list, bind/update, and
+  import paths. Stage configuration stays permissive; AI Service publishing
+  filters incompatible Stage plugins. `ai-proxy` and `ai-proxy-multi` are
+  controller-managed and must not be user-bound.
+- In controller convertor changes, preserve the standard Service/Route blocks
+  and their comments; isolate AI-specific behavior in narrow branches unless a
+  behavior change requires a broader refactor.
+
 ## Runtime Setup
 
 Use `uv` as the source of truth for the environment.
@@ -292,9 +361,9 @@ For plugin type/schema/form maintenance:
 
 ```bash
 cd src/dashboard
-make load_fixtures
+uv run make load_fixtures
 # edit through Django admin or update fixtures intentionally
-make dump_fixtures
+uv run make dump_fixtures
 ```
 
 New APISIX plugins should normally store APISIX-native YAML and should not add
@@ -308,17 +377,17 @@ activated through `editionctl`.
 
 ```bash
 cd src/dashboard
-make edition
-make edition-ee
-make edition-te
-make edition-develop
-make edition-reset
-make edition-modules
+uv run make edition
+uv run make edition-ee
+uv run make edition-te
+uv run make edition-develop
+uv run make edition-reset
+uv run make edition-modules
 ```
 
-CI runs lint and tests after `make edition-ee`. Run `make edition-ee` before
-local lint or test gates unless you are intentionally checking a different
-edition.
+CI runs lint and tests after the `edition-ee` target. Run
+`uv run make edition-ee` before local lint or test gates unless you are
+intentionally checking a different edition.
 
 ## Linting
 
@@ -333,14 +402,15 @@ Commands:
 
 ```bash
 cd src/dashboard
-make lint
-make lint-check
+uv run make lint-check
+uv run make lint
 ```
 
-Use `make lint` for local code edits because it auto-formats and fixes what it
-can. Use `make lint-check` when you need the CI-style non-mutating check; note
-that `lint-check` does not run `ruff format --check`, so formatting is enforced
-locally by `make lint` or pre-commit rather than by this CI step.
+Use `uv run make lint-check` as the default agent gate because it is
+non-mutating. `uv run make lint` formats and fixes files; run it only when those
+edits are intended, then inspect the resulting diff. `lint-check` does not run
+`ruff format --check`, so use pre-commit or an explicit non-mutating Ruff format
+check when formatting evidence is required.
 
 ## Testing
 
@@ -348,8 +418,8 @@ The normal full test gate is:
 
 ```bash
 cd src/dashboard
-make edition-ee
-make test
+uv run make edition-ee
+uv run make test
 ```
 
 `make test` runs pytest with `--reuse-db`, `-n auto`, and `--dist loadscope`.
@@ -358,9 +428,9 @@ Useful variants:
 
 ```bash
 cd src/dashboard
-make test-lf
-make test-cov
-make test-pdb
+uv run make test-lf
+uv run make test-cov
+uv run make test-pdb
 ```
 
 Focused pytest pattern for agents:
@@ -400,14 +470,14 @@ Available commands:
 
 ```bash
 cd src/dashboard
-make lint-openapi
-make lint-openapi-help
-make lint-openapi SCOPE=v2_open
-make lint-openapi SCOPE=v2_inner
-make lint-openapi SCOPE=v2_sync
-make lint-openapi API=v2_sync_gateway
-make lint-openapi JSON=1
-make lint-openapi FIX=1
+uv run make lint-openapi
+uv run make lint-openapi-help
+uv run make lint-openapi SCOPE=v2_open
+uv run make lint-openapi SCOPE=v2_inner
+uv run make lint-openapi SCOPE=v2_sync
+uv run make lint-openapi API=v2_sync_gateway
+uv run make lint-openapi JSON=1
+uv run make lint-openapi FIX=1
 ```
 
 For changed or new endpoints, update the matching markdown doc with method,
@@ -436,9 +506,9 @@ and local artifacts before building.
 
 ```bash
 cd src/dashboard
-make image-ee
-make image-te
-make dev-ee-image
+uv run make image-ee
+uv run make image-te
+uv run make dev-ee-image
 ```
 
 Runtime scripts source `${BK_HOME}/etc/bk_apigateway/bk_apigateway.env` when it
@@ -466,11 +536,11 @@ For code changes:
 1. Add or update focused tests under `apigateway/apigateway/tests/`.
 2. Update API docs and gateway YAML definitions when an API contract changes.
 3. Run the narrow relevant pytest target first.
-4. Run `make edition-ee && make lint-check` for the CI-style lint gate, or
-   `make edition-ee && make lint` first if you want auto-format/fix behavior.
+4. Run `uv run make edition-ee && uv run make lint-check` for the CI-style lint
+   gate. Use `uv run make lint` only when auto-format/fix changes are intended.
    This lint gate includes the OpenAPI consistency check; use
-   `make lint-openapi` only when you need a focused rerun of that checker.
-5. Run `make edition-ee && make test` for broad code changes or when shared
-   behavior is touched.
+   `uv run make lint-openapi` only when you need a focused rerun of that checker.
+5. Run `uv run make edition-ee && uv run make test` for broad code changes or
+   when shared behavior is touched.
 
 If a required verification command is skipped, say exactly why.

--- a/src/dashboard/apigateway/apigateway/apis/AGENTS.md
+++ b/src/dashboard/apigateway/apigateway/apis/AGENTS.md
@@ -1,0 +1,74 @@
+# API Layer Guide
+
+This guide applies under `apigateway/apigateway/apis/`. The dashboard and
+repository-root `AGENTS.md` files also apply. Read a deeper guide when present,
+including `apis/web/plugin/AGENTS.md` for plugin work.
+
+## Surface Ownership
+
+The API surfaces are intentionally independent and enforced by the
+`api-layers` import-linter contract in `pyproject.toml`:
+
+- `apis.web` serves `dashboard-front` and may use Web-specific DTOs.
+- `apis.open` is the legacy open API with compatibility response formats.
+- `apis.v2.open` is the public v2 open API.
+- `apis.v2.inner` serves BlueKing internal callers.
+- `apis.v2.sync` serves gateway automation and SDK sync clients.
+
+- Do not import views, serializers, or helpers from one API surface into
+  another.
+- Keep small surface-specific parameter shaping, response assembly, and
+  compatibility behavior in the owning surface, even when similar code exists
+  elsewhere.
+- Move behavior down only when it is genuinely shared workflow, domain,
+  service, or utility logic. Do not create a shared API helper that couples
+  otherwise independent surfaces.
+
+## Boundary Responsibilities
+
+- Serializers own transport validation and input/output definitions. Views own
+  request context, thin control flow, lower-layer calls, and response assembly.
+- Avoid per-row model lookups from serializer methods or response filters; use
+  query shaping, annotations, or lower-layer batching to prevent N+1 behavior.
+- Verify gateway/resource ownership, permission classes, tenant context, and
+  object scope before accepting identifiers from a request. Do not confuse an
+  input-validation gap with proof of an authorization bypass.
+- Web and v2 APIs normally use `OKJsonResponse` / `FailJsonResponse`. Preserve
+  `V1OKJsonResponse` / `V1FailJsonResponse` where the legacy open contract
+  requires them.
+- Keep client-visible security errors sanitized and log the original exception
+  with `logger.exception(...)`.
+- Preserve unique drf-yasg `Meta.ref_name` values when adding serializers.
+
+Web AI backend payloads use the flat `AIBackendWebConfigAdapter` contract.
+Open and v2 automation surfaces use the normalized stored protocol instead.
+Masked-secret restoration is a Web update-boundary behavior; do not apply it to
+Open or Sync input, where submitted stored-protocol values are literal.
+
+## OpenAPI Contract
+
+When changing an open API, keep these representations aligned:
+
+- Views and serializers under `apigateway/apigateway/apis/`.
+- Gateway YAML under `apigateway/apigateway/data/apigw-definitions/`.
+- Markdown docs under `apigateway/apigateway/data/apidocs/zh/`.
+
+Both dashboard lint targets run the consistency checker. For a focused rerun:
+
+```bash
+cd src/dashboard
+uv run make lint-openapi
+uv run make lint-openapi-help
+```
+
+The help target documents scope, API, JSON, and intentional fix options. Keep
+method, path, request, response, status, and error documentation synchronized.
+
+## Testing
+
+- Mirror tests under `apigateway/apigateway/tests/apis/<surface>/`.
+- API tests normally call URLs by `view_name` and assert through `resp.json()`.
+- When a contract exists on several surfaces, test every surface intended to
+  change and preserve tests for surfaces that intentionally differ.
+- Follow the dashboard guide for the exact pytest wrapper and final lint/test
+  gates.

--- a/src/dashboard/apigateway/apigateway/apis/web/plugin/AGENTS.md
+++ b/src/dashboard/apigateway/apigateway/apis/web/plugin/AGENTS.md
@@ -87,15 +87,18 @@ current boundaries aligned with `service/plugin/compatibility.py` and its tests:
 
 - `AI_ONLY_PLUGIN_CODES` are exposed only for AI resources.
 - `CONTROLLER_MANAGED_PLUGIN_CODES` such as `ai-proxy` and `ai-proxy-multi`
-  cannot be user-bound; the controller generates them during publication.
+  cannot be user-bound to Resources; the controller generates them when
+  compiling AI Services for publication.
 - An AI resource accepts only `AI_COMPATIBLE_PLUGIN_CODES`. Keep list filtering
   aligned with those policy sets, and reuse
   `is_plugin_compatible_with_resource_kind()` at create, update, and
   resource-import validation boundaries so one entrypoint cannot bypass the
   policy.
-- Stage plugin configuration remains permissive. When publishing an AI Service,
-  `ServiceConvertor` filters incompatible Stage plugins and logs the skipped
-  type codes without configs or credentials.
+- Stage plugin configuration remains permissive, including for
+  controller-managed plugin codes. When publishing an AI Service,
+  `ServiceConvertor` filters Stage plugins against `AI_COMPATIBLE_PLUGIN_CODES`,
+  the same policy set used by `is_plugin_compatible_with_resource_kind()` for
+  AI resources, and logs the skipped type codes without configs or credentials.
 
 When adding a plugin, decide explicitly whether it is AI-only, AI-compatible,
 or standard-only. Update the policy set and

--- a/src/dashboard/apigateway/apigateway/apis/web/plugin/AGENTS.md
+++ b/src/dashboard/apigateway/apigateway/apis/web/plugin/AGENTS.md
@@ -36,6 +36,7 @@ DB storage ──publish──▶ PluginConvertorFactory convertor ──▶ API
 | **Checker** | `service/plugin/checker.py` (`PluginConfigYamlChecker`) | Plugin-specific validation with human-readable error messages |
 | **Validator** | `service/plugin/validator.py` (`PluginConfigYamlValidator`) | Orchestrates checker + JSON Schema validation |
 | **Service-layer convertor** | `service/plugin/convertor.py` (`PluginConvertorFactory`) | Converts DB storage format to APISIX-native config for publishing. New plugins use `DefaultPluginConvertor` (identity) automatically |
+| **Compatibility policy** | `service/plugin/compatibility.py` | Defines AI-only, controller-managed, and AI-compatible plugin sets plus resource-kind compatibility |
 | **API-layer convertor (LEGACY)** | `apis/web/plugin/convertor.py` (`PluginConfigYamlConvertor`) | **Legacy only** — used by `bk-rate-limit` and `bk-ip-restriction`. Do NOT add new plugins here |
 | **Release mapping** | `controller/release_data.py` (`PluginData`) | Maps plugin type_code to APISIX plugin name (only needed when they differ) |
 
@@ -78,6 +79,28 @@ There are two independent convertor layers.
 > The form data = DB storage = APISIX config. `DefaultPluginConvertor` (identity) handles it automatically.
 >
 > `PluginConfigYamlConvertor` is frozen — it only serves 2 legacy plugins and must not be extended.
+
+### AI Gateway Compatibility Boundaries
+
+Plugin compatibility is not determined by fixture visibility alone. Keep these
+current boundaries aligned with `service/plugin/compatibility.py` and its tests:
+
+- `AI_ONLY_PLUGIN_CODES` are exposed only for AI resources.
+- `CONTROLLER_MANAGED_PLUGIN_CODES` such as `ai-proxy` and `ai-proxy-multi`
+  cannot be user-bound; the controller generates them during publication.
+- An AI resource accepts only `AI_COMPATIBLE_PLUGIN_CODES`. Keep list filtering
+  aligned with those policy sets, and reuse
+  `is_plugin_compatible_with_resource_kind()` at create, update, and
+  resource-import validation boundaries so one entrypoint cannot bypass the
+  policy.
+- Stage plugin configuration remains permissive. When publishing an AI Service,
+  `ServiceConvertor` filters incompatible Stage plugins and logs the skipped
+  type codes without configs or credentials.
+
+When adding a plugin, decide explicitly whether it is AI-only, AI-compatible,
+or standard-only. Update the policy set and
+`tests/service/plugin/test_compatibility.py` only when that classification is
+part of the requested product contract.
 
 ## How to Add a New Plugin
 
@@ -180,10 +203,8 @@ class TestMyPluginChecker:
 
 Run tests:
 ```bash
-cd src/dashboard/apigateway && \
-  set -a; . apigateway/conf/unittest_env; set +a; \
-  python3 -m pytest --nomigrations --ds apigateway.settings -x -q --tb=short \
-  apigateway/tests/service/plugin/test_checkers.py
+cd src/dashboard
+uv run bash -lc 'cd apigateway && set -a && . apigateway/conf/unittest_env && set +a && python -m pytest --nomigrations --ds apigateway.settings -x -q --tb=short apigateway/tests/service/plugin/test_checkers.py'
 ```
 
 ### Checklist
@@ -193,6 +214,8 @@ cd src/dashboard/apigateway && \
 - [ ] Add `plugin.plugintype` entry in `fixtures/plugins.yaml`
 - [ ] Add checker in `service/plugin/checker.py` and register in `type_code_to_checker`
 - [ ] Add tests for the checker in `tests/service/plugin/test_checkers.py`
+- [ ] Classify AI compatibility when the product contract requires it; update
+  `service/plugin/compatibility.py` and its tests together
 - [ ] Verify: no API-layer convertor needed (new plugin rule)
 - [ ] Verify: no service-layer convertor needed (store APISIX-native format)
 - [ ] Verify: no `release_data.py` mapping needed (plugin name = APISIX name)

--- a/src/dashboard/apigateway/apigateway/biz/AGENTS.md
+++ b/src/dashboard/apigateway/apigateway/biz/AGENTS.md
@@ -1,0 +1,51 @@
+# Business Layer Guide
+
+This guide applies under `apigateway/apigateway/biz/`. The dashboard and
+repository-root `AGENTS.md` files also apply.
+
+## Layer Boundary
+
+`biz/` owns use-case decisions and orchestration: permission-aware behavior,
+lifecycle branching, audit and side effects, transaction boundaries, and the
+sequence of lower-layer operations.
+
+- Keep transport validation, response shaping, and API-surface branching in
+  `apis/`.
+- Keep APISIX resource compilation and publication in `controller/`.
+- Extract only focused reusable queries, relationship operations, snapshots,
+  cleanup, or data shaping into `service/`.
+- Do not add a `biz` wrapper that merely delegates to a service or another
+  domain. Keep local behavior local, or move the real ownership boundary.
+- Place transactions around the complete use case that must commit or roll
+  back together; do not hide a partial transaction inside an unrelated helper.
+
+## Domain Independence And Public APIs
+
+`pyproject.toml` is authoritative for the `biz-domain-independence` and
+`biz-package-public-api` contracts.
+
+- `biz.gateway`, `biz.resource`, `biz.permission`, and `biz.mcp_server` must
+  remain independent peer domains. Package-local imports within one domain are
+  allowed.
+- Put cross-domain workflow coordination in a neutral use-case module or in
+  `controller/` when it is part of publication. Put only reusable leaf
+  capabilities in `service/`.
+- Callers from `apis/` and `apps/` must import contracted public symbols from
+  `apigateway.biz.<domain>`, not forbidden leaf modules.
+- A package `__init__.py` owns its public API. Keep `__all__` grouped in the
+  established `constant`, `Enum`, `class`, `functions`, `others` order,
+  retaining empty section comments.
+- Before moving, renaming, or deleting a public symbol, search production and
+  test call sites. Remove proxy-only wrappers unless a documented compatibility
+  boundary requires them.
+
+## Testing
+
+- Mirror tests under `apigateway/apigateway/tests/biz/<domain>/`.
+- Test observable workflow decisions, transaction behavior, permissions,
+  lifecycle transitions, audit records, and side effects rather than private
+  helper structure.
+- When logic moves between `biz/` and `service/`, run focused tests for both
+  owners and the callers whose behavior must remain unchanged.
+- Follow the dashboard guide for the exact pytest wrapper and final lint/test
+  gates.

--- a/src/dashboard/apigateway/apigateway/controller/AGENTS.md
+++ b/src/dashboard/apigateway/apigateway/controller/AGENTS.md
@@ -1,0 +1,67 @@
+# Controller Layer Guide
+
+This guide applies under `apigateway/apigateway/controller/`. The dashboard and
+repository-root `AGENTS.md` files also apply.
+
+## Publish Pipeline
+
+The normal gateway publication path is:
+
+```text
+biz/release -> controller/tasks -> GatewayResourceDistributor
+            -> GatewayApisixResourceTransformer
+            -> ServiceConvertor + RouteConvertor -> EtcdRegistry
+```
+
+- `release_data.py` materializes the release input consumed by conversion.
+- `transformer.py` coordinates APISIX resource conversion.
+- `convertor/` owns APISIX-native Service, Route, SSL, proto, and release
+  resource construction.
+- `distributor/` owns registry selection and synchronization.
+- `tasks/` and `publisher/` own asynchronous publication, revoke, and lifecycle
+  entrypoints.
+
+Controller code consumes domain state and emits data-plane configuration. It
+does not own Web DTOs, API response compatibility, normalized persistence
+models, or general-purpose domain workflows.
+
+## Conversion Rules
+
+- Preserve existing standard Service and Route blocks, ordering, and useful
+  comments when their behavior is unchanged. Add AI behavior through narrow,
+  explicit branches rather than refactoring the standard path for symmetry.
+- Convert stored provider identity to APISIX provider configuration only here:
+  apply built-in endpoint overrides, remove storage-only fields, and convert
+  timeout seconds to milliseconds at the publish boundary.
+- `ai-proxy` and `ai-proxy-multi` are controller-managed plugins. Generate them
+  here; never source them from user bindings.
+- Stage plugin configuration remains permissive. When generating an AI Service,
+  filter incompatible Stage plugins at publication without changing standard
+  Service behavior.
+- Use the shared data-plane compatibility helper for AI Gateway version checks.
+  Preserve revoke paths that intentionally bypass publish-only compatibility
+  checks, and propagate `revoke_flag` through transformer and convertors.
+- Do not log plugin configs, backend credentials, plaintext secrets, encrypted
+  payloads, or generated APISIX credential material. Warning logs may identify
+  skipped plugin type codes without their configuration.
+
+## Distribution And Failure Handling
+
+- Conversion completes in the intermediate transformer registry before the
+  target registry is synchronized. Do not write partially converted resources
+  directly to the target registry.
+- Preserve publish-event transitions and failure reporting when changing task,
+  distributor, or publisher control flow.
+- Do not swallow conversion or synchronization exceptions. Record the sanitized
+  failure through the existing publish-event and procedure-logger paths, then
+  preserve the caller-visible failure behavior.
+
+## Testing
+
+- Mirror tests under `apigateway/apigateway/tests/controller/`.
+- For convertor changes, cover the unchanged standard path plus each affected
+  AI, version, plugin, and revoke branch.
+- For distributor or task changes, cover resource synchronization, publish
+  events, failure propagation, and data-plane selection as applicable.
+- Follow the dashboard guide for the exact pytest wrapper and final lint/test
+  gates.

--- a/src/dashboard/apigateway/apigateway/core/AGENTS.md
+++ b/src/dashboard/apigateway/apigateway/core/AGENTS.md
@@ -1,0 +1,57 @@
+# Core Module Guide
+
+This guide applies under `apigateway/apigateway/core/`. The dashboard and
+repository-root `AGENTS.md` files also apply.
+
+## Module Ownership
+
+`core/` owns the central gateway domain model and normalized configuration:
+`Gateway`, `Stage`, `Resource`, `ResourceVersion`, `Release`, `Backend`,
+`BackendConfig`, and `Context`-related domain types.
+
+- Keep rich behavior that concerns one model in `models.py`.
+- Keep reusable single-model queryset logic in `managers.py`.
+- Put multi-model queries or workflows in the appropriate `service/`, `biz/`,
+  or `controller/` layer; do not grow managers into business services.
+- Keep constants and stored enum values backward compatible with existing rows
+  and public payloads.
+- Do not import API serializers, Web DTOs, or controller models into `core/`.
+
+## Domain Names And Kinds
+
+- `Gateway.kind` stores numeric `GatewayKindEnum` values. API names use
+  `GatewayKindNameEnum` conversion.
+- `Backend.kind` and `Resource.kind` store the string values `standard` and
+  `ai`.
+- Transport fields named `type` are not kind discriminators. Do not repurpose
+  them to select gateway, backend, or resource behavior.
+
+## AI Backend Configuration
+
+Read the repository-root AI Gateway model and Web/storage/publish protocol
+documents listed in the dashboard guide before changing AI configuration.
+
+`core/backend_config.py` owns the normalized Pydantic storage contract.
+`core/ai_backend.py` owns the built-in provider registry used by Web adaptation,
+connectivity tests, and publishing.
+
+- Store built-in providers by product identity. APISIX-specific
+  `openai-compatible` conversion, endpoint overrides, and timeout conversion
+  belong at the controller publish boundary.
+- Keep Web-only input limits out of the core model. The normalized core config
+  may support shapes that a particular API surface does not expose.
+- A provider change must account for enum choices, registry entries, Web
+  adapter rules, connectivity behavior, publish conversion, tests, and API
+  documentation. Change each representation at its owning layer.
+- `BackendConfig.config` encrypts AI configuration at the ORM persistence
+  boundary. Do not bypass its model field or persistence helpers with raw
+  plaintext writes.
+
+## Verification
+
+- Add focused tests under `apigateway/apigateway/tests/core/` for model,
+  manager, kind, serialization, encryption, or masking behavior.
+- When a core contract changes, also run the focused tests for every API,
+  service, or controller consumer identified by call-site search.
+- Follow the dashboard guide for the exact pytest wrapper and final lint/test
+  gates.

--- a/src/dashboard/apigateway/apigateway/service/AGENTS.md
+++ b/src/dashboard/apigateway/apigateway/service/AGENTS.md
@@ -1,0 +1,74 @@
+# Service Layer Guide
+
+This guide applies under `apigateway/apigateway/service/`. The dashboard and
+repository-root `AGENTS.md` files also apply.
+
+## Layer Boundary
+
+`service/` owns focused, reusable leaf capabilities over model relationships or
+domain data: snapshots, schema lookup, cleanup, reusable cross-model queries,
+relation normalization, and data shaping.
+
+- Keep permission decisions, lifecycle branching, audit orchestration,
+  transactions, and multi-step workflows in `biz/` or `controller/`.
+- Do not move code into `service/` only to bypass a `biz`-to-`biz` import
+  boundary. Extract only the smallest stable operation with clear inputs,
+  outputs, reuse, and direct tests.
+- Service modules may call each other and may perform cross-model work when the
+  operation remains a reusable leaf capability.
+- Historical exception: `service.release.PublishValidator` was moved during
+  the `biz-domain-independence` refactor. Treat its location as compatibility
+  debt, not placement precedent; new release workflow decisions belong in
+  `biz/release/`.
+
+## Module And Package Organization
+
+- Name modules by domain plus capability, such as `resource_snapshot.py`,
+  `resource_cleanup.py`, `resource_version_schema.py`, or `openapi_export.py`.
+  Avoid generic buckets such as `utils.py` unless the behavior is domain-neutral.
+- Keep a small capability as a top-level module. Create `service/<domain>/`
+  only when several related capabilities exist or one file mixes unrelated
+  responsibilities.
+- External callers import package symbols from `apigateway.service.<domain>`,
+  not `apigateway.service.<domain>.<capability>`. The package `__init__.py` owns
+  its public API and `__all__`; leaf modules do not define `__all__`.
+- Package internals may use single-dot relative imports for local leaf modules.
+  Use absolute `apigateway.service...` imports outside the current package; do
+  not add parent-relative `..` imports.
+- Prefer free functions for stateless operations. Use classes when state,
+  strategy selection, validation objects, factories, or polymorphism requires
+  them.
+- Name functions for their action and result: `get_*` for reads, `delete_*` or
+  `clear_*` for destructive writes, `build_*` for construction, `format_*` or
+  `normalize_*` for shape changes, `snapshot_*` for snapshots, and `ensure_*`
+  for idempotent creation or backfill.
+- Give non-trivial modules a docstring stating their ownership, keep the public
+  surface small, and prefix private helpers with `_`.
+
+## Package Exports
+
+For package `__init__.py` files with `__all__`, keep every section comment in
+this fixed order, including empty sections:
+
+```python
+# constant
+# Enum
+# class
+# functions
+# others
+```
+
+Group every export under its matching section. Put module re-exports or other
+uncategorized names under `# others`.
+
+## Verification
+
+- Mirror service tests under `apigateway/apigateway/tests/service/`.
+- When adding or changing a service package or export, run
+  `apigateway/tests/service/test_public_api_contract.py` through the dashboard
+  pytest wrapper, as well as focused behavior tests.
+- Search production and test call sites before moving, renaming, or deleting a
+  public service symbol; remove proxy-only compatibility wrappers unless a
+  documented boundary requires them.
+- Follow the dashboard guide for the exact pytest wrapper and final lint/test
+  gates.


### PR DESCRIPTION
## Summary
- refresh root monorepo and worktree guidance and remove stale BDD layout and count assumptions
- reduce src/dashboard/AGENTS.md from 546 to 243 lines by removing volatile setup detail and moving layer-specific rules to their owning directories
- add directory-scoped guides for the APIs, biz, controller, core, and service hot paths
- keep the plugin guide as the leaf authority for plugin fixtures, conversion, compatibility, and focused verification

## Ownership split
- dashboard parent: cross-dashboard architecture, runtime, security, representation boundaries, and final gates
- APIs guide: independent API surfaces, serializers and views, response compatibility, permissions, OpenAPI mirrors, and API tests
- biz guide: workflows, lifecycle and permission decisions, transactions, audit, public package contracts, and dependency rules
- controller guide: release-data compilation, APISIX conversion, distribution, registry synchronization, publish events, and revoke paths
- core guide: models, managers, kinds, normalized AI backend configuration, and persistence encryption
- service guide: leaf-operation boundaries, package layout, exports, naming, and public API verification
- plugin guide: plugin compatibility and legacy conversion boundaries

## Evidence reviewed
- 30 days of relevant Codex workflow history and exact dashboard correction sessions
- AGENTS.md history, dashboard commit history, and current upstream/master at 051ad47c1
- current dashboard Makefile, import-linter contracts, API surfaces, AI Backend adapters, controller publish pipeline, provider registry, and plugin compatibility code

## Verification
- post-commit tree: exactly 8 Markdown files over upstream/master; clean worktree
- git diff upstream/master --check passed
- all referenced paths exist and all documented Make targets resolve with make -n
- layer-contract symbols and import-linter rules were checked against the current source
- exact duplicated prose blocks across dashboard guides: 0
- the previously documented focused plugin pytest command passed 101 tests; that plugin guide did not change in this follow-up commit
- make lint and make test were not run because this PR changes Markdown only, per repository guidance