### PR TITLE
perf(dashboard): reduce repeated ORM queries

### DIFF
--- a/src/dashboard/apigateway/apigateway/apis/web/stage/views.py
+++ b/src/dashboard/apigateway/apigateway/apis/web/stage/views.py
@@ -86,7 +86,7 @@ class StageQuerySetMixin:
     ),
 )
 class StageListCreateApi(StageQuerySetMixin, generics.ListCreateAPIView):
-    queryset = Stage.objects.order_by("id")
+    queryset = Stage.objects.select_related("gateway").order_by("id")
 
     def list(self, request, *args, **kwargs):
         queryset = self.get_queryset()

--- a/src/dashboard/apigateway/apigateway/biz/release/release_handler.py
+++ b/src/dashboard/apigateway/apigateway/biz/release/release_handler.py
@@ -21,7 +21,7 @@ from datetime import datetime
 from typing import Any, Dict, List, Optional, Tuple
 
 from django.conf import settings
-from django.db.models import Q
+from django.db.models import OuterRef, Q, Subquery
 
 from apigateway.core.constants import (
     EVENT_FAIL_INTERVAL_TIME,
@@ -74,8 +74,7 @@ class ReleaseHandler:
         if order_by:
             queryset = queryset.order_by(order_by)
 
-        # Select related data_plane for ReleaseHistory to avoid N+1 queries.
-        return queryset.select_related("data_plane").distinct()
+        return queryset.select_related("data_plane", "resource_version", "stage").distinct()
 
     @staticmethod
     def get_released_stage_ids(gateway_ids: List[int]) -> List[int]:
@@ -180,14 +179,16 @@ class ReleaseHandler:
 
         # 获取多个 stage_id 对应的最新的 ReleaseHistory 记录
         # FIXME: 每个对应的 release 如果直接关联了对应的 release_history 就不需要通过这种方式去查了
-        latest_release_histories = []
-        latest_release_history_ids = []
-        for stage_id in stage_ids:
-            latest_release_history = ReleaseHistory.objects.filter(stage_id=stage_id).order_by("-id").first()
-            if not latest_release_history:
-                continue
-            latest_release_histories.append(latest_release_history)
-            latest_release_history_ids.append(latest_release_history.id)
+        latest_release_history_id = (
+            ReleaseHistory.objects.filter(stage_id=OuterRef("stage_id")).order_by("-id").values("id")[:1]
+        )
+        latest_release_histories = list(
+            ReleaseHistory.objects.filter(
+                stage_id__in=stage_ids,
+                id=Subquery(latest_release_history_id),
+            ).select_related("resource_version")
+        )
+        latest_release_history_ids = [release_history.id for release_history in latest_release_histories]
 
         # 查询发布历史对应的最新发布事件
         publish_id_to_latest_event_map = PublishEvent.objects.get_release_history_id_to_latest_publish_event_map(

--- a/src/dashboard/apigateway/apigateway/biz/released_resource/released_resource.py
+++ b/src/dashboard/apigateway/apigateway/biz/released_resource/released_resource.py
@@ -140,8 +140,10 @@ class ReleasedResourceHandler:
         released_stage_names = Release.objects.get_resource_version_released_stage_names(resource_version_ids)
 
         # 按照资源版本从小到大排序，可使最新版本数据覆盖前面版本的数据
-        released_resources = ReleasedResource.objects.filter(resource_id__in=resource_ids).order_by(
-            "resource_id", "resource_version_id"
+        released_resources = (
+            ReleasedResource.objects.filter(resource_id__in=resource_ids)
+            .select_related("gateway")
+            .order_by("resource_id", "resource_version_id")
         )
 
         doc_links = {}

--- a/src/dashboard/apigateway/apigateway/service/release/validation.py
+++ b/src/dashboard/apigateway/apigateway/service/release/validation.py
@@ -221,14 +221,23 @@ class PublishValidator:
         )
         stage_plugin_type_set = set()
         for stage_plugin in stage_plugins:
-            if stage_plugin.config.type.code in stage_plugin_type_set:
+            plugin_config = stage_plugin.config
+            if plugin_config is None or plugin_config.type is None:
+                raise ReleaseValidationError(
+                    _("网关环境【{stage_name}】存在插件配置或插件类型为空的插件绑定，不允许发布。").format(
+                        stage_name=self.stage.name,
+                    )
+                )
+
+            plugin_code = plugin_config.type.code
+            if plugin_code in stage_plugin_type_set:
                 raise ReleaseValidationError(
                     _("网关环境【{stage_name}】存在绑定多个相同类型[{plugin_code}]的插件。").format(
                         stage_name=self.stage.name,
-                        plugin_code=stage_plugin.config.type.code,
+                        plugin_code=plugin_code,
                     )
                 )
-            stage_plugin_type_set.add(stage_plugin.config.type.code)
+            stage_plugin_type_set.add(plugin_code)
 
     def _validate_stage_vars(self, stage: Stage, resource_version_id: int):
         validator = StageVarsValuesValidator()

--- a/src/dashboard/apigateway/apigateway/service/release/validation.py
+++ b/src/dashboard/apigateway/apigateway/service/release/validation.py
@@ -216,7 +216,7 @@ class PublishValidator:
                 scope_id=self.stage.id,
                 scope_type=PluginBindingScopeEnum.STAGE.value,
             )
-            .prefetch_related("config")
+            .select_related("config__type")
             .all()
         )
         stage_plugin_type_set = set()

--- a/src/dashboard/apigateway/apigateway/tests/apis/web/release/test_views.py
+++ b/src/dashboard/apigateway/apigateway/tests/apis/web/release/test_views.py
@@ -243,6 +243,23 @@ class TestReleaseHistoryListApi:
             result = resp.json()
             assert result["data"]["count"] == test["expected"]["count"]
 
+    def test_list_selects_stage_and_resource_version(self, request_view, django_assert_num_queries, fake_gateway):
+        for index in range(3):
+            stage = G(Stage, gateway=fake_gateway, name=f"stage-{index}")
+            resource_version = G(ResourceVersion, gateway=fake_gateway, version=f"1.0.{index}")
+            G(ReleaseHistory, gateway=fake_gateway, stage=stage, resource_version=resource_version)
+
+        with django_assert_num_queries(4):
+            resp = request_view(
+                method="GET",
+                view_name="gateway.release_histories.list",
+                path_params={"gateway_id": fake_gateway.id},
+            )
+            result = resp.json()
+
+        assert resp.status_code == 200
+        assert result["data"]["count"] == 3
+
 
 class TestReleaseHistoryEventsRetrieveAPI:
     def test_retrieve(self, request_view, fake_gateway):

--- a/src/dashboard/apigateway/apigateway/tests/apis/web/stage/test_views.py
+++ b/src/dashboard/apigateway/apigateway/tests/apis/web/stage/test_views.py
@@ -86,6 +86,42 @@ class TestStageApi:
         data = response.json()
         assert len(data["data"]) == 1
 
+    def test_list_selects_gateway(
+        self,
+        request_view,
+        django_assert_num_queries,
+        fake_gateway,
+        mocker,
+    ):
+        for index in range(3):
+            G(Stage, gateway=fake_gateway, name=f"stage-{index}")
+
+        mocker.patch(
+            "apigateway.apis.web.stage.views.ReleasedResourceHandler.get_stage_release",
+            return_value={},
+        )
+        mocker.patch(
+            "apigateway.apis.web.stage.views.ReleaseHandler.batch_get_stage_release_status",
+            return_value={},
+        )
+        mocker.patch(
+            "apigateway.apis.web.stage.views.ResourceVersionHandler.get_latest_version_by_gateway",
+            return_value="",
+        )
+        mocker.patch("apigateway.apis.web.stage.serializers.PublishValidator.__call__", return_value=None)
+
+        with django_assert_num_queries(2):
+            response = request_view(
+                "GET",
+                "stage.list-create",
+                path_params={"gateway_id": fake_gateway.id},
+                gateway=fake_gateway,
+            )
+            data = response.json()
+
+        assert response.status_code == 200
+        assert len(data["data"]) == 3
+
     def test_create(self, request_view, fake_gateway, fake_default_backend):
         data = {
             "name": "stage-test",

--- a/src/dashboard/apigateway/apigateway/tests/biz/release/test_release.py
+++ b/src/dashboard/apigateway/apigateway/tests/biz/release/test_release.py
@@ -259,3 +259,16 @@ class TestReleaseHandler:
             ReleaseHandler.batch_get_stage_release_status([fake_stage.id])[fake_stage.id]["status"]
             == PublishEventStatusTypeEnum.SUCCESS.value
         )
+
+    def test_batch_get_stage_release_status_uses_constant_queries(self, django_assert_num_queries, fake_gateway):
+        stage_ids = []
+        for index in range(3):
+            stage = G(Stage, gateway=fake_gateway, name=f"stage-{index}")
+            resource_version = G(ResourceVersion, gateway=fake_gateway, version=f"1.0.{index}")
+            G(ReleaseHistory, gateway=fake_gateway, stage=stage, resource_version=resource_version)
+            stage_ids.append(stage.id)
+
+        with django_assert_num_queries(2):
+            result = ReleaseHandler.batch_get_stage_release_status(stage_ids)
+
+        assert set(result) == set(stage_ids)

--- a/src/dashboard/apigateway/apigateway/tests/biz/release/test_release.py
+++ b/src/dashboard/apigateway/apigateway/tests/biz/release/test_release.py
@@ -272,3 +272,21 @@ class TestReleaseHandler:
             result = ReleaseHandler.batch_get_stage_release_status(stage_ids)
 
         assert set(result) == set(stage_ids)
+
+    def test_batch_get_stage_release_status_uses_latest_release_history(self, fake_gateway):
+        stage = G(Stage, gateway=fake_gateway)
+        old_resource_version = G(ResourceVersion, gateway=fake_gateway, version="1.0.0")
+        latest_resource_version = G(ResourceVersion, gateway=fake_gateway, version="2.0.0")
+        G(ReleaseHistory, gateway=fake_gateway, stage=stage, resource_version=old_resource_version)
+        latest_release_history = G(
+            ReleaseHistory,
+            gateway=fake_gateway,
+            stage=stage,
+            resource_version=latest_resource_version,
+        )
+
+        result = ReleaseHandler.batch_get_stage_release_status([stage.id])[stage.id]
+
+        assert result["publish_id"] == latest_release_history.id
+        assert result["resource_version_id"] == latest_resource_version.id
+        assert result["resource_version_display"] == latest_resource_version.object_display

--- a/src/dashboard/apigateway/apigateway/tests/biz/released_resource/test_released_resource.py
+++ b/src/dashboard/apigateway/apigateway/tests/biz/released_resource/test_released_resource.py
@@ -140,6 +140,30 @@ class TestReleasedResourceHandler:
             result = ReleasedResourceHandler.get_stage_release(fake_gateway, test["stage_ids"])
             assert result == test["expected"]
 
+    def test_get_latest_doc_link_selects_gateway(self, django_assert_num_queries, fake_gateway):
+        stage = G(Stage, gateway=fake_gateway, name="prod", status=1)
+        resource_version = G(ResourceVersion, gateway=fake_gateway)
+        G(Release, gateway=fake_gateway, stage=stage, resource_version=resource_version)
+        resource_ids = []
+        for index in range(3):
+            resource_id = index + 1
+            G(
+                ReleasedResource,
+                gateway=fake_gateway,
+                resource_version_id=resource_version.id,
+                resource_id=resource_id,
+                resource_name=f"resource-{index}",
+                resource_method="GET",
+                resource_path=f"/resource-{index}/",
+                data={},
+            )
+            resource_ids.append(resource_id)
+
+        with django_assert_num_queries(3):
+            result = ReleasedResourceHandler.get_latest_doc_link(resource_ids)
+
+        assert set(result) == set(resource_ids)
+
     def test_get_public_released_resource_data_list(self, fake_gateway, fake_stage, fake_release):
         result = ReleasedResourceHandler.get_public_released_resource_data_list(fake_gateway.id, fake_stage.name)
         assert len(result) >= 1

--- a/src/dashboard/apigateway/apigateway/tests/biz/test_validators.py
+++ b/src/dashboard/apigateway/apigateway/tests/biz/test_validators.py
@@ -318,6 +318,7 @@ class TestPublishValidator:
         echo_plugin_type,
         echo_plugin_stage_binding,
         faker,
+        django_assert_num_queries,
     ):
         echo_plugin2 = G(
             PluginConfig,
@@ -338,7 +339,7 @@ class TestPublishValidator:
             scope_id=fake_stage.pk,
         )
         publish_validator = PublishValidator(fake_gateway, fake_stage, fake_resource_version)
-        with pytest.raises(ReleaseValidationError):
+        with django_assert_num_queries(1), pytest.raises(ReleaseValidationError):
             publish_validator._validate_stage_plugins()
 
     def test_validate_stage_backends(self, fake_stage, fake_gateway):

--- a/src/dashboard/apigateway/apigateway/tests/biz/test_validators.py
+++ b/src/dashboard/apigateway/apigateway/tests/biz/test_validators.py
@@ -342,6 +342,30 @@ class TestPublishValidator:
         with django_assert_num_queries(1), pytest.raises(ReleaseValidationError):
             publish_validator._validate_stage_plugins()
 
+    @pytest.mark.parametrize("missing_relation", ["config", "type"])
+    def test_validate_stage_plugins_rejects_missing_config_relation(
+        self,
+        fake_stage,
+        fake_gateway,
+        fake_resource_version,
+        missing_relation,
+    ):
+        plugin_config = None
+        if missing_relation == "type":
+            plugin_config = G(PluginConfig, gateway=fake_gateway, type=None)
+
+        G(
+            PluginBinding,
+            gateway=fake_gateway,
+            config=plugin_config,
+            scope_type=PluginBindingScopeEnum.STAGE.value,
+            scope_id=fake_stage.pk,
+        )
+        publish_validator = PublishValidator(fake_gateway, fake_stage, fake_resource_version)
+
+        with pytest.raises(ReleaseValidationError, match="插件配置或插件类型为空"):
+            publish_validator._validate_stage_plugins()
+
     def test_validate_stage_backends(self, fake_stage, fake_gateway):
         backend = G(
             Backend,


### PR DESCRIPTION
## Summary

- batch latest release-history lookup instead of querying once per stage
- preload stage, resource-version, gateway, and plugin type relations used during response serialization and publish validation
- add query-count regression tests for each optimized path

## Query reductions covered by tests

- latest stage release status for three stages: 7 queries to 2
- release-history list for three rows: 10 queries to 4
- released-resource document links for three resources: 6 queries to 3
- stage list gateway hydration for three stages: 5 queries to 2
- plugin validation for two bindings: 4 queries to 1

## Verification

- `uv run make edition-ee && uv run make lint-check`
- `uv run make edition-ee && uv run make test` — 3,469 passed
- commit hooks: Ruff formatter, Ruff, mypy, import-linter, and sensitive-info checks

## Scope note

The ESB component query candidate is intentionally left unchanged. The broader per-stage publish-validation batching redesign is also left for a separate change.
