### PR TITLE
fix(dashboard): align AI backend stage output

### DIFF
--- a/docs/ai-gateway-models.md
+++ b/docs/ai-gateway-models.md
@@ -235,7 +235,7 @@ flowchart LR
     Convertor --> Multi[多 instances: ai-proxy-multi]
 ```
 
-Web 输入和输出保持同一字段集合：`provider`、`endpoint`、`model_endpoint`、`api_key`、`auth_header`、`model`、`model_options`、`timeout`，backend 配置列表额外包含 `stage_id`。Web 不接收 `instances`、`auth`、`override`、`balancer`、`fallback_strategy` 等存储/APISIX 字段。
+Web 输入和输出的 AI 配置字段保持一致：`provider`、`endpoint`、`model_endpoint`、`api_key`、`auth_header`、`model`、`model_options`、`timeout`。backend 配置列表输入使用 `stage_id`，输出与普通 backend 一致，使用 `stage: {id, name}`。Web 不接收 `instances`、`auth`、`override`、`balancer`、`fallback_strategy` 等存储/APISIX 字段。
 
 内置 provider 的 Web `endpoint`、`model_endpoint` 可省略；如果前端回传只读值，必须与 registry 完全一致。自定义 `openai-compatible` 必须提供完整 Chat Completions endpoint；`model_endpoint` 可选且只保存在 instance 内供编辑和连接测试使用。
 

--- a/docs/superpowers/specs/2026-07-21-ai-backend-web-protocol-decoupling-design.md
+++ b/docs/superpowers/specs/2026-07-21-ai-backend-web-protocol-decoupling-design.md
@@ -90,7 +90,8 @@ Each stage configuration uses the following product-facing fields:
 
 | Field | Input rule | Output rule |
 | --- | --- | --- |
-| `stage_id` | Required stage identifier | Returned unchanged |
+| `stage_id` | Required stage identifier | Not returned |
+| `stage` | Not accepted | Returned as `{id, name}` |
 | `provider` | Required; `openai`, `deepseek`, or `openai-compatible` | Returned as the product provider stored in the database |
 | `endpoint` | Full Chat Completions URL; conditional rules below | Always returned |
 | `model_endpoint` | Optional only for `openai-compatible` | Registry value for built-ins; explicit stored value or `null` for custom providers |

--- a/src/dashboard/apigateway/apigateway/apis/web/backend/serializers.py
+++ b/src/dashboard/apigateway/apigateway/apis/web/backend/serializers.py
@@ -257,14 +257,12 @@ class BackendRetrieveOutputSLZ(serializers.Serializer):
         for backend_config in backend_configs:
             if obj.kind == BackendKindEnum.AI.value:
                 config = serialize_ai_backend_config_for_web(backend_config, error_field="configs")
-                data.append({"stage_id": backend_config.stage_id, **config})
-                continue
-            config = backend_config.get_config_for_display()
+            else:
+                config = backend_config.get_config_for_display()
             config["stage"] = {
                 "id": backend_config.stage.id,
                 "name": backend_config.stage.name,
             }
-
             data.append(config)
 
         return data

--- a/src/dashboard/apigateway/apigateway/tests/apis/web/backend/test_views.py
+++ b/src/dashboard/apigateway/apigateway/tests/apis/web/backend/test_views.py
@@ -113,7 +113,8 @@ class TestBackendApi:
         )
         assert response.json()["data"]["kind"] == BackendKindEnum.AI.value
         output = response.json()["data"]["configs"][0]
-        assert output["stage_id"] == fake_stage.id
+        assert output["stage"] == {"id": fake_stage.id, "name": fake_stage.name}
+        assert "stage_id" not in output
         assert output["api_key"] == "se****et"
         assert output["model"] == "gpt-4o"
         assert output["model_options"] == {"temperature": 0.7}


### PR DESCRIPTION
## Summary

- return `stage: {id, name}` for AI backend detail configs, matching standard backends
- keep `stage_id` as the create/update input contract
- update regression coverage and AI backend contract documentation

## Verification

- backend serializer/view tests: 36 passed
- dashboard full test suite: 3440 passed
- `uv run make edition-ee && uv run make lint-check`
- `uv run ruff format --check apigateway/apigateway/apis/web/backend/serializers.py apigateway/apigateway/tests/apis/web/backend/test_views.py`
