### PR TITLE
fix(resource-version): support AI resource diffs

### DIFF
--- a/src/dashboard/apigateway/apigateway/biz/resource_version/diff.py
+++ b/src/dashboard/apigateway/apigateway/biz/resource_version/diff.py
@@ -18,7 +18,9 @@
 #
 from typing import Any, Dict, List, Literal, Optional, Text, Tuple, Union
 
-from pydantic import BaseModel, Field, Json, field_validator
+from pydantic import BaseModel, Field, Json, ValidationInfo, field_validator
+
+from apigateway.core.constants import ResourceKindEnum
 
 
 class DiffMixin:
@@ -96,6 +98,15 @@ class ResourceMockProxy(BaseModel, DiffMixin):
         return self.config.diff(target.config)
 
 
+class ResourceAIProxy(BaseModel, DiffMixin):
+    type: Literal["http"]
+    config: Json[Dict[Text, Any]]
+    backend_id: Optional[int] = 0
+
+    def diff_config(self, target: BaseModel) -> Tuple[Optional[dict], Optional[dict]]:
+        return self._diff_with_field_value(target, "config")
+
+
 class ResourceAuthConfig(BaseModel, DiffMixin):
     auth_verified_required: bool
     app_verified_required: bool
@@ -125,6 +136,7 @@ class ResourcePluginConfig(BaseModel, DiffMixin):
 
 class ResourceDifferHandler(BaseModel, DiffMixin):
     id: int
+    kind: Literal["standard", "ai"] = ResourceKindEnum.STANDARD.value
     name: Text
     description: Optional[Text] = ""
     method: Text
@@ -133,13 +145,23 @@ class ResourceDifferHandler(BaseModel, DiffMixin):
     enable_websocket: bool = False
     is_public: bool = True
     allow_apply_permission: bool = True
-    proxy: Union[ResourceHTTPProxy, ResourceMockProxy]
+    proxy: Union[ResourceHTTPProxy, ResourceMockProxy, ResourceAIProxy]
     api_labels: List[int] = Field(default_factory=list)
     contexts: ResourceContexts
     disabled_stages: List[Text] = Field(default_factory=list)
     plugins: List[ResourcePluginConfig] = Field(default_factory=list)
     openapi_schema: Dict[str, Any] = Field(default_factory=dict)
     doc_updated_time: Dict[str, str]
+
+    @field_validator("proxy", mode="before")
+    @classmethod
+    def validate_proxy(cls, value, info: ValidationInfo):
+        if info.data.get("kind", ResourceKindEnum.STANDARD.value) == ResourceKindEnum.AI.value:
+            return ResourceAIProxy.model_validate(value)
+
+        if value.get("type") == "http":
+            return ResourceHTTPProxy.model_validate(value)
+        return ResourceMockProxy.model_validate(value)
 
     def diff_proxy(self, target: BaseModel) -> Tuple[Optional[dict], Optional[dict]]:
         if not isinstance(self.proxy, type(target.proxy)):

--- a/src/dashboard/apigateway/apigateway/tests/apis/web/resource_version/test_views.py
+++ b/src/dashboard/apigateway/apigateway/tests/apis/web/resource_version/test_views.py
@@ -489,6 +489,7 @@ class TestResourceVersionDiffApi:
                 "add": [
                     {
                         "id": fake_resource.id,
+                        "kind": ResourceKindEnum.STANDARD.value,
                         "name": fake_resource.name,
                         "description": fake_resource.description,
                         "method": fake_resource.method,
@@ -529,6 +530,40 @@ class TestResourceVersionDiffApi:
                 "update": [],
             }
         }
+
+    def test_resource_version_diff_with_ai_resource(
+        self,
+        request_view,
+        fake_backend,
+        fake_gateway,
+        fake_resource,
+    ):
+        fake_gateway.kind = GatewayKindEnum.AI.value
+        fake_gateway.save(update_fields=["kind"])
+        fake_backend.kind = BackendKindEnum.AI.value
+        fake_backend.save(update_fields=["kind"])
+        fake_resource.kind = ResourceKindEnum.AI.value
+        fake_resource.method = "POST"
+        fake_resource.match_subpath = False
+        fake_resource.enable_websocket = False
+        fake_resource.save(update_fields=["kind", "method", "match_subpath", "enable_websocket"])
+        proxy = Proxy.objects.get(resource=fake_resource)
+        Proxy.objects.filter(id=proxy.id).update(_config="{}")
+
+        resp = request_view(
+            method="GET",
+            view_name="gateway.resource_version.diff",
+            gateway=fake_gateway,
+            path_params={"gateway_id": fake_gateway.id},
+            data={"source_resource_version_id": "", "target_resource_version_id": ""},
+        )
+
+        assert resp.status_code == 200
+        resource = resp.json()["data"]["add"][0]
+        assert resource["id"] == fake_resource.id
+        assert resource["kind"] == ResourceKindEnum.AI.value
+        assert resource["proxy"]["backend_id"] == fake_backend.id
+        assert resource["proxy"]["config"] == {}
 
     def test_resource_version_diff_with_resource_version(
         self,


### PR DESCRIPTION
## Summary

- validate resource-version proxy snapshots according to resource kind
- support the intentionally empty proxy config used by AI resources without relaxing standard HTTP validation
- preserve resource kind in diff output
- add Web API regression coverage for AI resource diffs

## Background

Creating a resource version after adding an AI resource called the resource-version diff endpoint. AI resource snapshots use an HTTP proxy with an empty config, while the diff model required the standard HTTP fields `method`, `path`, and `timeout`, causing a Pydantic validation error and an HTTP 500 response.

## Verification

- regression test reproduced the original HTTP 500 before the fix and passed afterward
- focused resource-version diff tests: 21 passed
- `uv run make edition-ee && uv run make lint-check`
- `uv run make edition-ee && uv run make test`: 3448 passed
