### PR TITLE
fix(sync): honor gateway name check whitelist

### DIFF
--- a/src/dashboard/apigateway/apigateway/apis/v2/sync/serializers.py
+++ b/src/dashboard/apigateway/apigateway/apis/v2/sync/serializers.py
@@ -161,6 +161,10 @@ class GatewaySyncInputSLZ(serializers.ModelSerializer):
         if api_type is None or api_type == GatewayTypeEnum.CLOUDS_API.value:
             return
 
+        # 场景：某些官方网关名不是 bk-开头，但是需要标记为官方网关
+        if name in settings.IGNORE_GATEWAY_NAME_CHECK_WHITELIST:
+            return
+
         for prefix in settings.OFFICIAL_GATEWAY_NAME_PREFIXES:
             if name.startswith(prefix):
                 return

--- a/src/dashboard/apigateway/apigateway/tests/apis/v2/sync/test_serializers.py
+++ b/src/dashboard/apigateway/apigateway/tests/apis/v2/sync/test_serializers.py
@@ -18,7 +18,18 @@
 #
 import pytest
 
-from apigateway.apis.v2.sync.serializers import SDKGenerateInputSLZ, StageSyncInputSLZ
+from apigateway.apis.v2.sync.serializers import GatewaySyncInputSLZ, SDKGenerateInputSLZ, StageSyncInputSLZ
+from apigateway.core.constants import GatewayTypeEnum
+
+
+class TestGatewaySyncInputSLZ:
+    def test_validate_name_allows_whitelisted_official_gateway(self, settings):
+        settings.IGNORE_GATEWAY_NAME_CHECK_WHITELIST = ["paasv3"]
+        settings.OFFICIAL_GATEWAY_NAME_PREFIXES = ["bk-"]
+
+        slz = GatewaySyncInputSLZ()
+
+        slz._validate_name("paasv3", GatewayTypeEnum.OFFICIAL_API.value)
 
 
 class TestSDKGenerateInputSLZ:


### PR DESCRIPTION
## Summary
- honor IGNORE_GATEWAY_NAME_CHECK_WHITELIST when validating v2 sync official gateway names
- add regression coverage for a whitelisted name without an official prefix

## Verification
- focused pytest: 1 passed
- uv run make lint
- uv run make check-openapi: 0 errors
- uv run make test: 3074 passed