### PR TITLE
fix(sync): honor gateway name check whitelist

### DIFF
--- a/src/dashboard/apigateway/apigateway/apis/v2/sync/serializers.py
+++ b/src/dashboard/apigateway/apigateway/apis/v2/sync/serializers.py
@@ -170,6 +170,10 @@ class GatewaySyncInputSLZ(serializers.ModelSerializer):
         if api_type is None or api_type == GatewayTypeEnum.CLOUDS_API.value:
             return
 
+        # 场景：某些官方网关名不是 bk-开头，但是需要标记为官方网关
+        if name in settings.IGNORE_GATEWAY_NAME_CHECK_WHITELIST:
+            return
+
         for prefix in settings.OFFICIAL_GATEWAY_NAME_PREFIXES:
             if name.startswith(prefix):
                 return

--- a/src/dashboard/apigateway/apigateway/tests/apis/v2/sync/test_serializers.py
+++ b/src/dashboard/apigateway/apigateway/tests/apis/v2/sync/test_serializers.py
@@ -25,7 +25,7 @@ from apigateway.apis.v2.sync.serializers import (
     SDKGenerateInputSLZ,
     StageSyncInputSLZ,
 )
-from apigateway.core.constants import GatewayKindEnum
+from apigateway.core.constants import GatewayKindEnum, GatewayTypeEnum
 
 
 def _custom_instance(name):
@@ -92,6 +92,16 @@ def test_gateway_sync_input_maps_ai_kind():
     slz.is_valid(raise_exception=True)
 
     assert slz.validated_data["kind"] == GatewayKindEnum.AI.value
+
+
+class TestGatewaySyncInputSLZ:
+    def test_validate_name_allows_whitelisted_official_gateway(self, settings):
+        settings.IGNORE_GATEWAY_NAME_CHECK_WHITELIST = ["paasv3"]
+        settings.OFFICIAL_GATEWAY_NAME_PREFIXES = ["bk-"]
+
+        slz = GatewaySyncInputSLZ()
+
+        slz._validate_name("paasv3", GatewayTypeEnum.OFFICIAL_API.value)
 
 
 class TestSDKGenerateInputSLZ:


### PR DESCRIPTION
## Summary
- honor IGNORE_GATEWAY_NAME_CHECK_WHITELIST when validating v2 sync official gateway names
- add regression coverage for a whitelisted name without an official prefix
- carry the release/1.23 fix from #3056

## Verification
- focused pytest: 1 passed
- uv run make lint: includes OpenAPI check with 0 errors
- uv run make test: 3442 passed