### PR TITLE
fix(mcp): protect builtin client permissions from deletion

### DIFF
--- a/src/dashboard/apigateway/apigateway/apis/web/mcp_server/views.py
+++ b/src/dashboard/apigateway/apigateway/apis/web/mcp_server/views.py
@@ -20,6 +20,7 @@
 import csv
 from io import StringIO
 
+from django.conf import settings
 from django.db import transaction
 from django.db.models import Case, DateTimeField, F, OuterRef, Q, Subquery, When
 from django.db.models.functions import Coalesce
@@ -829,6 +830,14 @@ class MCPServerAppPermissionDestroyApi(MCPServerAppPermissionQuerySetMixin, gene
 
     def destroy(self, request, *args, **kwargs):
         instance = self.get_object()
+        if instance.bk_app_code in {
+            settings.MCP_SERVER_OAUTH2_PUBLIC_CLIENT_APP_CODE,
+            settings.MCP_SERVER_OAUTH2_PERSONAL_CLIENT_APP_CODE,
+        }:
+            raise error_codes.FAILED_PRECONDITION.format(
+                _("OAuth2 内置客户端的 MCPServer 应用权限不允许删除。"), replace=True
+            )
+
         data_before = get_model_dict(instance)
         instance_id = instance.id
         bk_app_code = instance.bk_app_code

--- a/src/dashboard/apigateway/apigateway/conf/default.py
+++ b/src/dashboard/apigateway/apigateway/conf/default.py
@@ -570,8 +570,9 @@ BKAIDEV_USE_MOCK = env.bool("BKAIDEV_USE_MOCK", False)
 # AIDEV 平台配置（配置了 AIDEV_AGENT_CREATE_URL 则启用 AIDev）
 AIDEV_AGENT_CREATE_URL = env.str("AIDEV_AGENT_CREATE_URL", "")
 
-# MCP Server OAuth2 公开客户端模式开启后自动授权的 bk_app_code
+# MCP Server OAuth2 内置客户端的 bk_app_code
 MCP_SERVER_OAUTH2_PUBLIC_CLIENT_APP_CODE = env.str("MCP_SERVER_OAUTH2_PUBLIC_CLIENT_APP_CODE", "public")
+MCP_SERVER_OAUTH2_PERSONAL_CLIENT_APP_CODE = env.str("MCP_SERVER_OAUTH2_PERSONAL_CLIENT_APP_CODE", "personal")
 
 # ==============================================================================
 # ITSM v4 配置

--- a/src/dashboard/apigateway/apigateway/tests/apis/web/mcp_server/test_views.py
+++ b/src/dashboard/apigateway/apigateway/tests/apis/web/mcp_server/test_views.py
@@ -1358,6 +1358,50 @@ class TestMCPServerAppPermissionDestroyApi:
         )
         assert audit_log.op_type == "delete"
 
+    @pytest.mark.parametrize(
+        ("setting_name", "bk_app_code"),
+        [
+            ("MCP_SERVER_OAUTH2_PUBLIC_CLIENT_APP_CODE", "public-client"),
+            ("MCP_SERVER_OAUTH2_PERSONAL_CLIENT_APP_CODE", "personal-client"),
+        ],
+    )
+    def test_destroy_oauth2_builtin_client_permission_is_forbidden(
+        self,
+        mocker,
+        request_view,
+        fake_gateway,
+        fake_mcp_server,
+        settings,
+        setting_name,
+        bk_app_code,
+    ):
+        setattr(settings, setting_name, bk_app_code)
+        mock_sync_permissions = mocker.patch(
+            "apigateway.biz.mcp_server.MCPServerHandler.sync_permissions",
+            return_value=None,
+        )
+        permission = G(
+            MCPServerAppPermission,
+            mcp_server=fake_mcp_server,
+            bk_app_code=bk_app_code,
+            grant_type=MCPServerAppPermissionGrantTypeEnum.GRANT.value,
+        )
+
+        resp = request_view(
+            method="DELETE",
+            view_name="mcp_server.app-permission.destroy",
+            path_params={
+                "gateway_id": fake_gateway.id,
+                "mcp_server_id": fake_mcp_server.id,
+                "id": permission.id,
+            },
+            gateway=fake_gateway,
+        )
+
+        assert resp.status_code == 400
+        assert MCPServerAppPermission.objects.filter(id=permission.id).exists()
+        mock_sync_permissions.assert_not_called()
+
 
 class TestMCPServerAppPermissionApplyListApi:
     def test_list_pending_with_mcp_server_id(self, request_view, fake_gateway, fake_mcp_server, settings):


### PR DESCRIPTION
## Summary
- prevent manual deletion of the built-in OAuth2 public and personal MCP client permissions
- add the personal client app-code setting with a default of `personal`
- cover both configurable built-in app codes with regression tests
- cherry-pick source commit `34f853c60c596cf34ee16e0b59300f95bb2e5a26`

## Verification
- focused MCP permission destroy tests: 4 passed
- `uv run make lint-check`: passed
- `uv run make test`: 3076 passed
