### PR TITLE
feat(plugin): add OAuth2 app code validation fixture

### DIFF
--- a/src/dashboard/apigateway/apigateway/fixtures/plugins.yaml
+++ b/src/dashboard/apigateway/apigateway/fixtures/plugins.yaml
@@ -416,6 +416,18 @@
     priority: 17678
     _tags: "认证,Authentication"
     schema: null
+- model: plugin.plugintype
+  fields:
+    code: bk-oauth2-appcode-validate
+    name: OAuth2 App Code 校验
+    name_en: OAuth2 App Code Validate
+    description: OAuth2 app code validate plugin
+    description_en: OAuth2 app code validate plugin
+    is_public: true
+    scope: resource
+    priority: 17677
+    _tags: "认证,Authentication"
+    schema: null
 - model: schema.schema
   fields:
     created_time: 2023-02-02 14:54:21.010753+00:00

--- a/src/dashboard/apigateway/apigateway/fixtures/plugins.yaml
+++ b/src/dashboard/apigateway/apigateway/fixtures/plugins.yaml
@@ -413,9 +413,33 @@
     description_en: OAuth2 audience validate plugin
     is_public: true
     scope: resource
-    priority: 17678
+    priority: 17677
     _tags: "认证,Authentication"
     schema: null
+- model: schema.schema
+  fields:
+    created_time: 2026-07-28 00:00:00.000000+00:00
+    updated_time: 2026-07-28 00:00:00.000000+00:00
+    name: bk-oauth2-appcode-validate
+    type: plugin
+    version: '0'
+    _schema: |-
+      {
+        "$comment": "this is a mark for our injected plugin schema",
+        "type": "object",
+        "properties": {
+          "support_public": {
+            "type": "boolean",
+            "default": false
+          },
+          "support_personal": {
+            "type": "boolean",
+            "default": false
+          }
+        }
+      }
+    description: '-'
+    example: '-'
 - model: plugin.plugintype
   fields:
     code: bk-oauth2-appcode-validate
@@ -425,9 +449,12 @@
     description_en: OAuth2 app code validate plugin
     is_public: true
     scope: resource
-    priority: 17677
+    priority: 17678
     _tags: "认证,Authentication"
-    schema: null
+    schema:
+    - bk-oauth2-appcode-validate
+    - plugin
+    - '0'
 - model: schema.schema
   fields:
     created_time: 2023-02-02 14:54:21.010753+00:00

--- a/src/dashboard/apigateway/apigateway/fixtures/plugins.yaml
+++ b/src/dashboard/apigateway/apigateway/fixtures/plugins.yaml
@@ -387,7 +387,7 @@
     name_en: OAuth2 Protected Resource
     description: OAuth2 protected resource plugin
     description_en: OAuth2 protected resource plugin
-    is_public: true
+    is_public: false
     scope: resource
     priority: 18740
     _tags: "认证,Authentication"
@@ -399,7 +399,7 @@
     name_en: OAuth2 Verify
     description: OAuth2 verify plugin
     description_en: OAuth2 verify plugin
-    is_public: true
+    is_public: false
     scope: resource
     priority: 18732
     _tags: "认证,Authentication"
@@ -411,7 +411,7 @@
     name_en: OAuth2 Audience Validate
     description: OAuth2 audience validate plugin
     description_en: OAuth2 audience validate plugin
-    is_public: true
+    is_public: false
     scope: resource
     priority: 17677
     _tags: "认证,Authentication"
@@ -447,7 +447,7 @@
     name_en: OAuth2 App Code Validate
     description: OAuth2 app code validate plugin
     description_en: OAuth2 app code validate plugin
-    is_public: true
+    is_public: false
     scope: resource
     priority: 17678
     _tags: "认证,Authentication"


### PR DESCRIPTION
## Summary
- add `bk-oauth2-appcode-validate` to the dashboard plugin fixture with its route schema
- expose `support_public` and `support_personal` as boolean options defaulting to `false`
- align OAuth2 plugin priorities with APISIX: app code `17678`, audience `17677`
- keep all four `bk-oauth2-*` plugins out of the public plugin catalog

## Verification
- fixture parse, schema assertion, APISIX priority comparison, and OAuth2 visibility assertion
- `uv run make edition-ee && uv run make lint-check`
- `uv run make edition-ee && uv run make test` (3446 passed)
- `git diff --check`