### PR TITLE
feat(mcp): support OAuth2 personal client

### DIFF
--- a/src/dashboard/apigateway/apigateway/apis/v2/inner/serializers.py
+++ b/src/dashboard/apigateway/apigateway/apis/v2/inner/serializers.py
@@ -414,6 +414,9 @@ class MCPServerBaseSLZ(serializers.Serializer):
     oauth2_public_client_enabled = serializers.BooleanField(
         read_only=True, help_text="是否开启 OAuth2 公开客户端模式，开启后将会对 bk_app_code=public 的应用进行授权"
     )
+    oauth2_personal_client_enabled = serializers.BooleanField(
+        read_only=True, help_text="是否开启 OAuth2 个人客户端模式，开启后将会对 bk_app_code=personal 的应用进行授权"
+    )
 
     def get_title(self, obj) -> str:
         return obj.title if obj.title else obj.name
@@ -654,6 +657,9 @@ class MCPServerListOutputSLZ(serializers.Serializer):
 
     oauth2_public_client_enabled = serializers.BooleanField(
         read_only=True, help_text="是否开启 OAuth2 公开客户端模式，开启后将会对 bk_app_code=public 的应用进行授权"
+    )
+    oauth2_personal_client_enabled = serializers.BooleanField(
+        read_only=True, help_text="是否开启 OAuth2 个人客户端模式，开启后将会对 bk_app_code=personal 的应用进行授权"
     )
 
     categories = serializers.SerializerMethodField(help_text="MCPServer 分类列表")

--- a/src/dashboard/apigateway/apigateway/apis/v2/open/serializers.py
+++ b/src/dashboard/apigateway/apigateway/apis/v2/open/serializers.py
@@ -293,6 +293,9 @@ class MCPServerBaseOutputSLZ(serializers.Serializer):
     oauth2_public_client_enabled = serializers.BooleanField(
         read_only=True, help_text="是否开启 OAuth2 公开客户端模式，开启后将会对 bk_app_code=public 的应用进行授权"
     )
+    oauth2_personal_client_enabled = serializers.BooleanField(
+        read_only=True, help_text="是否开启 OAuth2 个人客户端模式，开启后将会对 bk_app_code=personal 的应用进行授权"
+    )
 
     categories = serializers.SerializerMethodField(help_text="MCPServer 分类列表")
 
@@ -630,6 +633,9 @@ class MCPServerRetrieveOutputSLZ(serializers.Serializer):
     )
     oauth2_public_client_enabled = serializers.BooleanField(
         read_only=True, help_text="是否开启 OAuth2 公开客户端模式，开启后将会对 bk_app_code=public 的应用进行授权"
+    )
+    oauth2_personal_client_enabled = serializers.BooleanField(
+        read_only=True, help_text="是否开启 OAuth2 个人客户端模式，开启后将会对 bk_app_code=personal 的应用进行授权"
     )
     url = serializers.SerializerMethodField(help_text="MCPServer 访问 URL")
     guideline = serializers.CharField(read_only=True, help_text="MCPServer 使用指南")

--- a/src/dashboard/apigateway/apigateway/apis/v2/sync/serializers.py
+++ b/src/dashboard/apigateway/apigateway/apis/v2/sync/serializers.py
@@ -810,6 +810,11 @@ class MCPServerSLZ(ExtensibleFieldMixin, serializers.ModelSerializer):
         default=False,
         help_text="是否开启 OAuth2 公开客户端模式，开启后将会对 bk_app_code=public 的应用进行授权",
     )
+    oauth2_personal_client_enabled = serializers.BooleanField(
+        required=False,
+        default=False,
+        help_text="是否开启 OAuth2 个人客户端模式，开启后将会对 bk_app_code=personal 的应用进行授权",
+    )
     raw_response_enabled = serializers.BooleanField(
         required=False,
         default=False,
@@ -837,6 +842,7 @@ class MCPServerSLZ(ExtensibleFieldMixin, serializers.ModelSerializer):
             "protocol_type",
             "target_app_codes",
             "oauth2_public_client_enabled",
+            "oauth2_personal_client_enabled",
             "raw_response_enabled",
             "category_names",
         )

--- a/src/dashboard/apigateway/apigateway/apis/web/mcp_marketplace/serializers.py
+++ b/src/dashboard/apigateway/apigateway/apis/web/mcp_marketplace/serializers.py
@@ -153,6 +153,9 @@ class MCPServerBaseOutputSLZ(serializers.Serializer):
     created_time = serializers.DateTimeField(read_only=True, help_text="MCPServer 创建时间")
 
     oauth2_public_client_enabled = serializers.BooleanField(read_only=True, help_text="是否开启 OAuth2 公开客户端模式")
+    oauth2_personal_client_enabled = serializers.BooleanField(
+        read_only=True, help_text="是否开启 OAuth2 个人客户端模式"
+    )
 
     # 分类信息
     categories = serializers.SerializerMethodField(help_text="MCPServer 分类列表")

--- a/src/dashboard/apigateway/apigateway/apis/web/mcp_server/serializers.py
+++ b/src/dashboard/apigateway/apigateway/apis/web/mcp_server/serializers.py
@@ -269,6 +269,11 @@ class MCPServerCreateInputSLZ(serializers.ModelSerializer):
         default=False,
         help_text="是否开启 OAuth2 公开客户端模式，开启后将会对 bk_app_code=public 的应用进行授权",
     )
+    oauth2_personal_client_enabled = serializers.BooleanField(
+        required=False,
+        default=False,
+        help_text="是否开启 OAuth2 个人客户端模式，开启后将会对 bk_app_code=personal 的应用进行授权",
+    )
     raw_response_enabled = serializers.BooleanField(
         required=False,
         default=False,
@@ -291,6 +296,7 @@ class MCPServerCreateInputSLZ(serializers.ModelSerializer):
             "protocol_type",
             "category_ids",
             "oauth2_public_client_enabled",
+            "oauth2_personal_client_enabled",
             "raw_response_enabled",
         )
         lookup_field = "id"
@@ -396,6 +402,9 @@ class MCPServerBaseOutputSLZ(serializers.Serializer):
     oauth2_public_client_enabled = serializers.BooleanField(
         read_only=True, help_text="是否开启 OAuth2 公开客户端模式，开启后将会对 bk_app_code=public 的应用进行授权"
     )
+    oauth2_personal_client_enabled = serializers.BooleanField(
+        read_only=True, help_text="是否开启 OAuth2 个人客户端模式，开启后将会对 bk_app_code=personal 的应用进行授权"
+    )
 
     raw_response_enabled = serializers.BooleanField(
         read_only=True,
@@ -500,6 +509,10 @@ class MCPServerUpdateInputSLZ(serializers.ModelSerializer):
         required=False,
         help_text="是否开启 OAuth2 公开客户端模式，开启后将会对 bk_app_code=public 的应用进行授权",
     )
+    oauth2_personal_client_enabled = serializers.BooleanField(
+        required=False,
+        help_text="是否开启 OAuth2 个人客户端模式，开启后将会对 bk_app_code=personal 的应用进行授权",
+    )
     raw_response_enabled = serializers.BooleanField(
         required=False,
         help_text="是否返回原始响应，开启后 mcp-proxy 将直接返回 API 响应结果，不添加 request_id 等额外信息",
@@ -553,6 +566,7 @@ class MCPServerUpdateInputSLZ(serializers.ModelSerializer):
             "protocol_type",
             "category_ids",
             "oauth2_public_client_enabled",
+            "oauth2_personal_client_enabled",
             "raw_response_enabled",
         )
         lookup_field = "id"

--- a/src/dashboard/apigateway/apigateway/apis/web/mcp_server/views.py
+++ b/src/dashboard/apigateway/apigateway/apis/web/mcp_server/views.py
@@ -216,7 +216,7 @@ class MCPServerListCreateApi(generics.ListCreateAPIView):
 
         slz.save()
 
-        # sync permissions (includes oauth2 public app permission based on oauth2_public_client_enabled)
+        # sync permissions (including OAuth2 built-in client permissions)
         MCPServerHandler.sync_permissions(slz.instance.id)
 
         # record audit log
@@ -323,7 +323,7 @@ class MCPServerRetrieveUpdateDestroyApi(MCPServerQuerySetMixin, generics.Retriev
         slz.is_valid(raise_exception=True)
         slz.save(updated_by=request.user.username)
 
-        # sync permissions (includes oauth2 public app permission based on oauth2_public_client_enabled)
+        # sync permissions (including OAuth2 built-in client permissions)
         MCPServerHandler.sync_permissions(instance.id)
 
         Auditor.record_mcp_server_op_success(

--- a/src/dashboard/apigateway/apigateway/apps/mcp_server/admin.py
+++ b/src/dashboard/apigateway/apigateway/apps/mcp_server/admin.py
@@ -77,6 +77,7 @@ class MCPServerAdmin(AuditFieldsDisplayAdminMixin, DjangoQLSearchMixin, admin.Mo
         "stage",
         "is_public",
         "oauth2_public_client_enabled",
+        "oauth2_personal_client_enabled",
         "status",
         "get_categories_display",
         "created_by",
@@ -84,12 +85,30 @@ class MCPServerAdmin(AuditFieldsDisplayAdminMixin, DjangoQLSearchMixin, admin.Mo
         "updated_time",
     ]
     search_fields = ["id", "name", "title", "gateway__name", "_labels"]
-    list_filter = ["gateway", "is_public", "status", "oauth2_public_client_enabled", "categories"]
+    list_filter = [
+        "gateway",
+        "is_public",
+        "status",
+        "oauth2_public_client_enabled",
+        "oauth2_personal_client_enabled",
+        "categories",
+    ]
     filter_horizontal = ["categories"]
 
     fieldsets = (
         (None, {"fields": ("name", "title", "description", "gateway", "stage")}),
-        ("状态和权限", {"fields": ("status", "is_public", "oauth2_public_client_enabled", "protocol_type")}),
+        (
+            "状态和权限",
+            {
+                "fields": (
+                    "status",
+                    "is_public",
+                    "oauth2_public_client_enabled",
+                    "oauth2_personal_client_enabled",
+                    "protocol_type",
+                )
+            },
+        ),
         ("分类", {"fields": ("categories",)}),
         ("资源配置", {"fields": ("_labels", "_resource_names"), "classes": ("collapse",)}),
     )

--- a/src/dashboard/apigateway/apigateway/apps/mcp_server/migrations/0015_mcpserver_oauth2_personal_client_enabled.py
+++ b/src/dashboard/apigateway/apigateway/apps/mcp_server/migrations/0015_mcpserver_oauth2_personal_client_enabled.py
@@ -1,0 +1,18 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("mcp_server", "0014_add_itsm_ticket_id"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="mcpserver",
+            name="oauth2_personal_client_enabled",
+            field=models.BooleanField(
+                default=False,
+                help_text="是否开启 OAuth2 个人客户端模式，开启后将会对 bk_app_code=personal 的应用进行授权",
+            ),
+        ),
+    ]

--- a/src/dashboard/apigateway/apigateway/apps/mcp_server/models.py
+++ b/src/dashboard/apigateway/apigateway/apps/mcp_server/models.py
@@ -107,6 +107,11 @@ class MCPServer(TimestampedModelMixin, OperatorModelMixin):
         help_text=_("是否开启 OAuth2 公开客户端模式，开启后将会对 bk_app_code=public 的应用进行授权"),
     )
 
+    oauth2_personal_client_enabled = models.BooleanField(
+        default=False,
+        help_text=_("是否开启 OAuth2 个人客户端模式，开启后将会对 bk_app_code=personal 的应用进行授权"),
+    )
+
     raw_response_enabled = models.BooleanField(
         default=False,
         help_text=_("是否返回原始响应，开启后 mcp-proxy 将直接返回 API 响应结果，不添加 request_id 等额外信息"),

--- a/src/dashboard/apigateway/apigateway/biz/mcp_server/mcp_server.py
+++ b/src/dashboard/apigateway/apigateway/biz/mcp_server/mcp_server.py
@@ -325,40 +325,52 @@ class MCPServerHandler:
         ).delete()
 
     @staticmethod
-    @transaction.atomic
-    def sync_permissions(mcp_server_id: int) -> None:
-        """同步 MCPServer 的权限，包括 OAuth2 权限（bk_app_code=public）
-        Args:
-            mcp_server_id (int): mcp_server 的 id
-        """
-        mcp_server = MCPServer.objects.get(id=mcp_server_id)
-
-        # 同步 OAuth2 权限：根据 oauth2_public_client_enabled 开启/关闭 public app 权限
-        public_app_code = settings.MCP_SERVER_OAUTH2_PUBLIC_CLIENT_APP_CODE
-        if mcp_server.oauth2_public_client_enabled:
+    def _sync_oauth2_client_permission(mcp_server_id: int, app_code: str, enabled: bool) -> None:
+        if enabled:
             MCPServerAppPermission.objects.save_permission(
                 mcp_server_id=mcp_server_id,
-                bk_app_code=public_app_code,
+                bk_app_code=app_code,
                 grant_type=MCPServerAppPermissionGrantTypeEnum.GRANT.value,
                 expire_days=None,
             )
             logger.info(
                 "sync oauth2 permissions for mcp_server %d, granted bk_app_code=%s",
                 mcp_server_id,
-                public_app_code,
+                app_code,
             )
-        else:
-            deleted_count, _ = MCPServerAppPermission.objects.filter(
-                mcp_server_id=mcp_server_id,
-                bk_app_code=public_app_code,
-            ).delete()
-            if deleted_count:
-                logger.info(
-                    "sync oauth2 permissions for mcp_server %d, revoked bk_app_code=%s, deleted %d",
-                    mcp_server_id,
-                    public_app_code,
-                    deleted_count,
-                )
+            return
+
+        deleted_count, _ = MCPServerAppPermission.objects.filter(
+            mcp_server_id=mcp_server_id,
+            bk_app_code=app_code,
+        ).delete()
+        if deleted_count:
+            logger.info(
+                "sync oauth2 permissions for mcp_server %d, revoked bk_app_code=%s, deleted %d",
+                mcp_server_id,
+                app_code,
+                deleted_count,
+            )
+
+    @staticmethod
+    @transaction.atomic
+    def sync_permissions(mcp_server_id: int) -> None:
+        """同步 MCPServer 的权限，包括 OAuth2 内置客户端权限
+        Args:
+            mcp_server_id (int): mcp_server 的 id
+        """
+        mcp_server = MCPServer.objects.get(id=mcp_server_id)
+
+        MCPServerHandler._sync_oauth2_client_permission(
+            mcp_server_id,
+            settings.MCP_SERVER_OAUTH2_PUBLIC_CLIENT_APP_CODE,
+            mcp_server.oauth2_public_client_enabled,
+        )
+        MCPServerHandler._sync_oauth2_client_permission(
+            mcp_server_id,
+            settings.MCP_SERVER_OAUTH2_PERSONAL_CLIENT_APP_CODE,
+            mcp_server.oauth2_personal_client_enabled,
+        )
 
         # 1. fetch the app codes in mcp_server_app_permission
         app_codes = MCPServerAppPermission.objects.filter(mcp_server=mcp_server).values_list("bk_app_code", flat=True)

--- a/src/dashboard/apigateway/apigateway/data/apidocs/zh/v2_inner_list_mcp_server.md
+++ b/src/dashboard/apigateway/apigateway/data/apidocs/zh/v2_inner_list_mcp_server.md
@@ -35,6 +35,7 @@
         "status": "active",
         "protocol_type": "sse",
         "oauth2_public_client_enabled": false,
+        "oauth2_personal_client_enabled": false,
         "categories": [
           {"name": "official", "display_name": "官方"},
           {"name": "ai", "display_name": "AI"}
@@ -93,6 +94,7 @@
 | status       | string | MCPServer 状态          |
 | protocol_type | string | MCPServer 协议类型        |
 | oauth2_public_client_enabled | bool   | 是否开启 OAuth2 公开客户端模式，开启后将会对 bk_app_code=public 的应用进行授权       |
+| oauth2_personal_client_enabled | bool   | 是否开启 OAuth2 个人客户端模式，开启后将会对 bk_app_code=personal 的应用进行授权       |
 | categories   | array  | MCPServer 分类列表，每项包含 name（英文标识）和 display_name（显示名称） |
 | stage        | object | MCPServer 环境信息        |
 | gateway      | object | MCPServer 网关信息        |

--- a/src/dashboard/apigateway/apigateway/data/apidocs/zh/v2_inner_list_mcp_server_app_permissions.md
+++ b/src/dashboard/apigateway/apigateway/data/apidocs/zh/v2_inner_list_mcp_server_app_permissions.md
@@ -31,7 +31,8 @@ mcp_server 已申请权限列表
           {"name": "ai", "display_name": "AI"}
         ],
         "is_official": true,
-        "oauth2_public_client_enabled": false
+        "oauth2_public_client_enabled": false,
+        "oauth2_personal_client_enabled": false
       },
       "permission": {
         "status": "owned",
@@ -74,6 +75,7 @@ mcp_server 已申请权限列表
 | categories      | array  | mcp_server 分类列表，每项包含 name（英文标识）和 display_name（显示名称） |
 | is_official     | bool   | 是否为官方 MCPServer |
 | oauth2_public_client_enabled | bool | 是否开启 OAuth2 公开客户端模式，开启后将会对 bk_app_code=public 的应用进行授权 |
+| oauth2_personal_client_enabled | bool | 是否开启 OAuth2 个人客户端模式，开启后将会对 bk_app_code=personal 的应用进行授权 |
 
 #### data.permission
 

--- a/src/dashboard/apigateway/apigateway/data/apidocs/zh/v2_inner_list_mcp_server_permission_apply_records.md
+++ b/src/dashboard/apigateway/apigateway/data/apidocs/zh/v2_inner_list_mcp_server_permission_apply_records.md
@@ -36,7 +36,8 @@ mcp_server 申请记录列表
           {"name": "ai", "display_name": "AI"}
         ],
         "is_official": true,
-        "oauth2_public_client_enabled": false
+        "oauth2_public_client_enabled": false,
+        "oauth2_personal_client_enabled": false
       },
       "record": {
         "id": 1,
@@ -86,6 +87,7 @@ mcp_server 申请记录列表
 | categories      | array  | mcp_server 分类列表，每项包含 name（英文标识）和 display_name（显示名称） |
 | is_official     | bool   | 是否为官方 MCPServer |
 | oauth2_public_client_enabled | bool | 是否开启 OAuth2 公开客户端模式，开启后将会对 bk_app_code=public 的应用进行授权 |
+| oauth2_personal_client_enabled | bool | 是否开启 OAuth2 个人客户端模式，开启后将会对 bk_app_code=personal 的应用进行授权 |
 
 #### data.record
 

--- a/src/dashboard/apigateway/apigateway/data/apidocs/zh/v2_inner_list_mcp_server_permissions.md
+++ b/src/dashboard/apigateway/apigateway/data/apidocs/zh/v2_inner_list_mcp_server_permissions.md
@@ -32,7 +32,8 @@ mcp_server 申请权限列表
           {"name": "ai", "display_name": "AI"}
         ],
         "is_official": true,
-        "oauth2_public_client_enabled": false
+        "oauth2_public_client_enabled": false,
+        "oauth2_personal_client_enabled": false
       },
       "permission": {
         "status": "pending",
@@ -55,7 +56,8 @@ mcp_server 申请权限列表
         "doc_link": "",
         "categories": [],
         "is_official": false,
-        "oauth2_public_client_enabled": false
+        "oauth2_public_client_enabled": false,
+        "oauth2_personal_client_enabled": false
       },
       "permission": {
         "status": "need_apply",
@@ -98,6 +100,7 @@ mcp_server 申请权限列表
 | categories      | array  | mcp_server 分类列表，每项包含 name（英文标识）和 display_name（显示名称） |
 | is_official     | bool   | 是否为官方 MCPServer |
 | oauth2_public_client_enabled | bool | 是否开启 OAuth2 公开客户端模式，开启后将会对 bk_app_code=public 的应用进行授权 |
+| oauth2_personal_client_enabled | bool | 是否开启 OAuth2 个人客户端模式，开启后将会对 bk_app_code=personal 的应用进行授权 |
 
 #### data.permission
 

--- a/src/dashboard/apigateway/apigateway/data/apidocs/zh/v2_inner_retrieve_mcp_server_permission_apply_record.md
+++ b/src/dashboard/apigateway/apigateway/data/apidocs/zh/v2_inner_retrieve_mcp_server_permission_apply_record.md
@@ -33,7 +33,8 @@ mcp_server 申请记录详情
         {"name": "ai", "display_name": "AI"}
       ],
       "is_official": true,
-      "oauth2_public_client_enabled": false
+      "oauth2_public_client_enabled": false,
+      "oauth2_personal_client_enabled": false
     },
     "record": {
       "id": 1,
@@ -81,6 +82,7 @@ mcp_server 申请记录详情
 | categories | array | mcp_server 分类列表，每项包含 name（英文标识）和 display_name（显示名称） |
 | is_official | bool | 是否为官方 MCPServer |
 | oauth2_public_client_enabled | bool | 是否开启 OAuth2 公开客户端模式，开启后将会对 bk_app_code=public 的应用进行授权 |
+| oauth2_personal_client_enabled | bool | 是否开启 OAuth2 个人客户端模式，开启后将会对 bk_app_code=personal 的应用进行授权 |
 
 #### data.record
 

--- a/src/dashboard/apigateway/apigateway/data/apidocs/zh/v2_open_list_mcp_server.md
+++ b/src/dashboard/apigateway/apigateway/data/apidocs/zh/v2_open_list_mcp_server.md
@@ -32,6 +32,7 @@
         "status": 1,
         "protocol_type": "sse",
         "oauth2_public_client_enabled": false,
+        "oauth2_personal_client_enabled": false,
         "categories": [
           {"name": "official", "display_name": "官方"},
           {"name": "ai", "display_name": "AI"}
@@ -82,6 +83,7 @@
 | status           | int     | mcp_server 状态（0：已停用，1：启用中）                             |
 | protocol_type    | string  | MCP 协议类型（sse：SSE 协议，streamable_http：Streamable HTTP 协议） |
 | oauth2_public_client_enabled   | boolean | 是否开启 OAuth2 公开客户端模式，开启后将会对 bk_app_code=public 的应用进行授权                                         |
+| oauth2_personal_client_enabled   | boolean | 是否开启 OAuth2 个人客户端模式，开启后将会对 bk_app_code=personal 的应用进行授权                                         |
 | categories      | array  | mcp_server 分类列表，每项包含 name（英文标识）和 display_name（显示名称） |
 | tools_count      | int     | mcp_server 工具数量                                        |
 | url              | string  | mcp_server 访问 URL，根据最低权限级别自适应返回普通 URL 或应用态 URL |

--- a/src/dashboard/apigateway/apigateway/data/apidocs/zh/v2_open_list_user_mcp_server.md
+++ b/src/dashboard/apigateway/apigateway/data/apidocs/zh/v2_open_list_user_mcp_server.md
@@ -32,6 +32,7 @@
         "status": 1,
         "protocol_type": "sse",
         "oauth2_public_client_enabled": false,
+        "oauth2_personal_client_enabled": false,
         "categories": [
           {"name": "official", "display_name": "官方"},
           {"name": "ai", "display_name": "AI"}
@@ -84,6 +85,7 @@
 | status              | int     | mcp_server 状态（0：已停用，1：启用中）                             |
 | protocol_type       | string  | MCP 协议类型（sse：SSE 协议，streamable_http：Streamable HTTP 协议） |
 | oauth2_public_client_enabled      | boolean | 是否开启 OAuth2 公开客户端模式，开启后将会对 bk_app_code=public 的应用进行授权                                         |
+| oauth2_personal_client_enabled      | boolean | 是否开启 OAuth2 个人客户端模式，开启后将会对 bk_app_code=personal 的应用进行授权                                         |
 | categories          | array  | mcp_server 分类列表，每项包含 name（英文标识）和 display_name（显示名称） |
 | tools_count         | int     | mcp_server 工具数量                                        |
 | url                 | string  | mcp_server 访问 URL，根据最低权限级别自适应返回普通 URL 或应用态 URL |

--- a/src/dashboard/apigateway/apigateway/data/apidocs/zh/v2_open_retrieve_mcp_server.md
+++ b/src/dashboard/apigateway/apigateway/data/apidocs/zh/v2_open_retrieve_mcp_server.md
@@ -29,6 +29,7 @@
     "status": 1,
     "protocol_type": "sse",
     "oauth2_public_client_enabled": false,
+    "oauth2_personal_client_enabled": false,
     "url": "https://test.com/api/bk-apigateway/prod/api/v2/mcp-servers/test/sse",
     "guideline": "## 使用指南\n...",
     "tools": [
@@ -104,6 +105,7 @@
 | status           | int      | mcp_server 状态（0：已停用，1：启用中）                      |
 | protocol_type    | string   | MCP 协议类型（sse：SSE 协议，streamable_http：Streamable HTTP 协议） |
 | oauth2_public_client_enabled   | boolean  | 是否开启 OAuth2 公开客户端模式，开启后将会对 bk_app_code=public 的应用进行授权                                         |
+| oauth2_personal_client_enabled   | boolean  | 是否开启 OAuth2 个人客户端模式，开启后将会对 bk_app_code=personal 的应用进行授权                                         |
 | url              | string   | mcp_server 访问 URL，根据最低权限级别自适应返回普通 URL 或应用态 URL |
 | guideline        | string   | mcp_server 使用指南                                          |
 | tools            | array    | mcp_server 工具列表                                          |

--- a/src/dashboard/apigateway/apigateway/data/apidocs/zh/v2_sync_stage_mcp_servers.md
+++ b/src/dashboard/apigateway/apigateway/data/apidocs/zh/v2_sync_stage_mcp_servers.md
@@ -35,6 +35,7 @@ mcp_servers 参数说明
 | `protocol_type` | string       | 否  | MCP 协议类型：sse（默认）、streamable_http                                       |
 | `target_app_codes`   | array[string]          | 否  | 主动授权的应用列表                                                              |
 | `oauth2_public_client_enabled`     | bool                   | 否  | 是否开启 OAuth2 公开客户端模式，开启后将会对 bk_app_code=public 的应用进行授权，默认不开启                     |
+| `oauth2_personal_client_enabled`     | bool                   | 否  | 是否开启 OAuth2 个人客户端模式，开启后将会对 bk_app_code=personal 的应用进行授权，默认不开启                     |
 | `raw_response_enabled`     | bool                   | 否  | 是否返回原始响应，开启后 mcp-proxy 将直接返回 API 响应结果，不添加 request_id 等额外信息，默认不开启                     |
 | `category_names`   | array[string]          | 否  | MCP Server 分类名称列表，不传则不更新分类。当前支持的分类：`Uncategorized`（未分类）、`Official`（官方资源）、`Featured`（精选推荐）、`Monitoring`（监控告警）、`ConfigManagement`（配置管理）、`DevOps`（持续交付）、`Emergency`（故障管理）、`Database`（数据服务）、`Automation`（运维自动化）、`Observability`（可观测性）、`Security`（安全合规）、`ResourceOptimize`（资源优化）、`ChaosEngineering`（混沌工程）、`Network`（网络管理）                                                              |
 
@@ -68,6 +69,7 @@ mcp_servers 参数说明
         "app2"
       ],
       "oauth2_public_client_enabled": false,
+      "oauth2_personal_client_enabled": false,
       "raw_response_enabled": false,
       "category_names": [
         "Official"

--- a/src/dashboard/apigateway/apigateway/data/apigw-definitions/bk-apigateway-resources.yaml
+++ b/src/dashboard/apigateway/apigateway/data/apigw-definitions/bk-apigateway-resources.yaml
@@ -3457,6 +3457,9 @@ paths:
                       oauth2_public_client_enabled:
                         type: boolean
                         description: 是否开启 OAuth2 公开客户端模式
+                      oauth2_personal_client_enabled:
+                        type: boolean
+                        description: 是否开启 OAuth2 个人客户端模式
                       url:
                         type: string
                         description: MCPServer 访问地址
@@ -5158,6 +5161,10 @@ paths:
                       oauth2_public_client_enabled:
                         type: boolean
                         description: 是否开启 OAuth2 公开客户端模式，开启后将会对 bk_app_code=public 的应用进行授权，默认不开启
+                        example: false
+                      oauth2_personal_client_enabled:
+                        type: boolean
+                        description: 是否开启 OAuth2 个人客户端模式，开启后将会对 bk_app_code=personal 的应用进行授权，默认不开启
                         example: false
                       category_names:
                         type: array

--- a/src/dashboard/apigateway/apigateway/tests/apis/v2/inner/test_views.py
+++ b/src/dashboard/apigateway/apigateway/tests/apis/v2/inner/test_views.py
@@ -2229,6 +2229,7 @@ class TestMCPServerListApi:
             status=MCPServerStatusEnum.ACTIVE.value,
             protocol_type=MCPServerProtocolTypeEnum.SSE.value,
             oauth2_public_client_enabled=True,
+            oauth2_personal_client_enabled=True,
         )
 
         resp = request_view(
@@ -2245,6 +2246,7 @@ class TestMCPServerListApi:
         )
         assert mcp_data is not None
         assert mcp_data["oauth2_public_client_enabled"] is True
+        assert mcp_data["oauth2_personal_client_enabled"] is True
 
     def test_list_returns_oauth2_public_client_enabled_false(self, request_view, fake_gateway):
         """测试 MCPServer 列表接口返回 oauth2_public_client_enabled=False"""
@@ -2263,6 +2265,7 @@ class TestMCPServerListApi:
             status=MCPServerStatusEnum.ACTIVE.value,
             protocol_type=MCPServerProtocolTypeEnum.SSE.value,
             oauth2_public_client_enabled=False,
+            oauth2_personal_client_enabled=False,
         )
 
         resp = request_view(
@@ -2279,6 +2282,7 @@ class TestMCPServerListApi:
         )
         assert mcp_data is not None
         assert mcp_data["oauth2_public_client_enabled"] is False
+        assert mcp_data["oauth2_personal_client_enabled"] is False
 
     def test_list_returns_tool_names(self, request_view, fake_gateway):
         """测试 MCPServer 列表接口返回 tool_names（含重命名场景）"""

--- a/src/dashboard/apigateway/apigateway/tests/apis/v2/open/test_views.py
+++ b/src/dashboard/apigateway/apigateway/tests/apis/v2/open/test_views.py
@@ -544,6 +544,7 @@ class TestMCPServerListApiOAuth2:
             status=MCPServerStatusEnum.ACTIVE.value,
             is_public=True,
             oauth2_public_client_enabled=True,
+            oauth2_personal_client_enabled=True,
         )
 
         resp = request_view(
@@ -560,6 +561,7 @@ class TestMCPServerListApiOAuth2:
         )
         assert mcp_data is not None
         assert mcp_data["oauth2_public_client_enabled"] is True
+        assert mcp_data["oauth2_personal_client_enabled"] is True
 
     def test_list_returns_oauth2_disabled(self, request_view, fake_gateway, settings):
         """测试 MCPServer 列表接口返回 oauth2_public_client_enabled=False"""
@@ -571,6 +573,7 @@ class TestMCPServerListApiOAuth2:
             status=MCPServerStatusEnum.ACTIVE.value,
             is_public=True,
             oauth2_public_client_enabled=False,
+            oauth2_personal_client_enabled=False,
         )
 
         resp = request_view(
@@ -587,6 +590,7 @@ class TestMCPServerListApiOAuth2:
         )
         assert mcp_data is not None
         assert mcp_data["oauth2_public_client_enabled"] is False
+        assert mcp_data["oauth2_personal_client_enabled"] is False
 
 
 class TestOAuthProtectedResourceApi:
@@ -790,6 +794,7 @@ class TestMCPServerRetrieveApi:
             status=MCPServerStatusEnum.ACTIVE.value,
             protocol_type=MCPServerProtocolTypeEnum.SSE.value,
             oauth2_public_client_enabled=True,
+            oauth2_personal_client_enabled=True,
         )
 
         mocker.patch(
@@ -820,6 +825,7 @@ class TestMCPServerRetrieveApi:
         assert resp.status_code == 200
         result = resp.json()
         assert result["data"]["oauth2_public_client_enabled"] is True
+        assert result["data"]["oauth2_personal_client_enabled"] is True
 
     def test_retrieve_returns_oauth2_public_client_enabled_false(self, request_view, fake_gateway, mocker):
         """测试 MCPServer 详情接口返回 oauth2_public_client_enabled=False"""
@@ -837,6 +843,7 @@ class TestMCPServerRetrieveApi:
             status=MCPServerStatusEnum.ACTIVE.value,
             protocol_type=MCPServerProtocolTypeEnum.SSE.value,
             oauth2_public_client_enabled=False,
+            oauth2_personal_client_enabled=False,
         )
 
         mocker.patch(
@@ -867,6 +874,7 @@ class TestMCPServerRetrieveApi:
         assert resp.status_code == 200
         result = resp.json()
         assert result["data"]["oauth2_public_client_enabled"] is False
+        assert result["data"]["oauth2_personal_client_enabled"] is False
 
     def test_retrieve_private_mcp_server_by_maintainer(self, request_view, fake_gateway, mocker):
         """测试网关维护者获取私有的 MCPServer 详情"""

--- a/src/dashboard/apigateway/apigateway/tests/apis/v2/sync/test_views.py
+++ b/src/dashboard/apigateway/apigateway/tests/apis/v2/sync/test_views.py
@@ -940,6 +940,52 @@ class TestSyncApi:
 class TestSyncApiOAuth2:
     """测试 MCPServer 同步接口的 OAuth2 功能"""
 
+    def test_mcp_server_sync_create_with_oauth2_personal_client_enabled(
+        self,
+        request_view,
+        fake_gateway,
+        fake_stage,
+        fake_resource,
+        fake_resource_schema_with_body,
+        fake_release_v2,
+        disable_app_permission,
+    ):
+        make_resource_schema_version(fake_release_v2.resource_version)
+        fake_gateway.name = "test"
+        fake_stage.name = "test"
+        fake_gateway.save()
+        fake_stage.save()
+
+        data = {
+            "mcp_servers": [
+                {
+                    "labels": ["tag1"],
+                    "name": "oauth2-personal-server",
+                    "resource_names": [fake_resource.name],
+                    "tool_names": [fake_resource.name],
+                    "is_public": True,
+                    "description": "oauth2 personal test server",
+                    "status": 1,
+                    "oauth2_personal_client_enabled": True,
+                }
+            ]
+        }
+        resp = request_view(
+            method="POST",
+            gateway=fake_gateway,
+            view_name="openapi.v2.sync.gateway.stages.mcp_servers.sync",
+            path_params={"gateway_name": fake_gateway.name, "stage_name": fake_stage.name},
+            data=data,
+        )
+        assert resp.status_code == 200
+        mcp_server_id = resp.json()["data"][0]["id"]
+        mcp_server = MCPServer.objects.get(id=mcp_server_id)
+        assert mcp_server.oauth2_personal_client_enabled is True
+        assert MCPServerAppPermission.objects.filter(
+            mcp_server_id=mcp_server_id,
+            bk_app_code=settings.MCP_SERVER_OAUTH2_PERSONAL_CLIENT_APP_CODE,
+        ).exists()
+
     def test_mcp_server_sync_create_with_oauth2_public_client_enabled(
         self,
         request_view,

--- a/src/dashboard/apigateway/apigateway/tests/apis/web/mcp_marketplace/test_views.py
+++ b/src/dashboard/apigateway/apigateway/tests/apis/web/mcp_marketplace/test_views.py
@@ -132,6 +132,7 @@ class TestMCPMarketplaceServerListApi:
     def test_list_with_oauth2_public_client_enabled(self, request_view, fake_public_mcp_server):
         """测试列表接口返回 oauth2_public_client_enabled 字段"""
         fake_public_mcp_server.oauth2_public_client_enabled = True
+        fake_public_mcp_server.oauth2_personal_client_enabled = True
         fake_public_mcp_server.save()
 
         resp = request_view(
@@ -147,6 +148,7 @@ class TestMCPMarketplaceServerListApi:
         )
         assert mcp_server_data is not None
         assert mcp_server_data["oauth2_public_client_enabled"] is True
+        assert mcp_server_data["oauth2_personal_client_enabled"] is True
 
     def test_list_with_categories(self, request_view, fake_public_mcp_server, fake_categories):
         """测试列表接口返回分类信息"""
@@ -491,6 +493,7 @@ class TestMCPMarketplaceServerRetrieveApi:
         )
 
         fake_public_mcp_server.oauth2_public_client_enabled = True
+        fake_public_mcp_server.oauth2_personal_client_enabled = True
         fake_public_mcp_server.save()
 
         resp = request_view(
@@ -502,6 +505,7 @@ class TestMCPMarketplaceServerRetrieveApi:
 
         assert resp.status_code == 200
         assert result["data"]["oauth2_public_client_enabled"] is True
+        assert result["data"]["oauth2_personal_client_enabled"] is True
 
     def test_retrieve_with_prompts(self, mocker, request_view, fake_public_mcp_server):
         """测试详情接口返回 prompts 列表（私有 prompt 的 content 为空）"""

--- a/src/dashboard/apigateway/apigateway/tests/apis/web/mcp_server/test_serializers.py
+++ b/src/dashboard/apigateway/apigateway/tests/apis/web/mcp_server/test_serializers.py
@@ -431,6 +431,29 @@ class TestMCPServerCreateInputSLZOAuth2:
     """测试 MCPServerCreateInputSLZ 序列化器的 OAuth2 相关功能"""
 
     @patch("apigateway.biz.validators.MCPServerHandler.get_valid_resource_names")
+    def test_create_with_oauth2_personal_client_enabled(self, mock_get_valid, fake_gateway, fake_stage):
+        mock_get_valid.return_value = {"resource1", "resource2"}
+
+        data = {
+            "name": "test-mcp-personal-oauth2",
+            "description": "Test description",
+            "stage_id": fake_stage.id,
+            "is_public": True,
+            "resource_names": ["resource1", "resource2"],
+            "tool_names": ["resource1", "resource2"],
+            "oauth2_personal_client_enabled": True,
+        }
+        context = {
+            "gateway": fake_gateway,
+            "source": CallSourceTypeEnum.Web,
+            "valid_resource_names": {"resource1", "resource2"},
+        }
+
+        slz = MCPServerCreateInputSLZ(data=data, context=context)
+        assert slz.is_valid(), slz.errors
+        assert slz.validated_data["oauth2_personal_client_enabled"] is True
+
+    @patch("apigateway.biz.validators.MCPServerHandler.get_valid_resource_names")
     def test_create_with_oauth2_public_client_enabled(self, mock_get_valid, fake_gateway, fake_stage):
         """测试创建时 oauth2_public_client_enabled=True"""
         mock_get_valid.return_value = {"resource1", "resource2"}
@@ -504,6 +527,21 @@ class TestMCPServerCreateInputSLZOAuth2:
 
 class TestMCPServerUpdateInputSLZOAuth2:
     """测试 MCPServerUpdateInputSLZ 序列化器的 OAuth2 相关功能"""
+
+    def test_update_with_oauth2_personal_client_enabled(self, fake_gateway, fake_stage):
+        mcp_server = G(MCPServer, gateway=fake_gateway, stage=fake_stage, status=MCPServerStatusEnum.ACTIVE.value)
+        data = {
+            "description": "Updated description",
+            "oauth2_personal_client_enabled": True,
+        }
+        slz = MCPServerUpdateInputSLZ(
+            instance=mcp_server,
+            data=data,
+            partial=True,
+            context={"valid_resource_names": {"resource1", "resource2"}},
+        )
+        assert slz.is_valid(), slz.errors
+        assert slz.validated_data["oauth2_personal_client_enabled"] is True
 
     def test_update_with_oauth2_public_client_enabled(self, fake_gateway, fake_stage):
         """测试更新时设置 oauth2_public_client_enabled=True"""

--- a/src/dashboard/apigateway/apigateway/tests/apis/web/mcp_server/test_views.py
+++ b/src/dashboard/apigateway/apigateway/tests/apis/web/mcp_server/test_views.py
@@ -3054,6 +3054,7 @@ class TestMCPServerOAuth2Enabled:
     def test_list_returns_oauth2_public_client_enabled(self, request_view, fake_gateway, fake_mcp_server):
         """测试列表接口返回 oauth2_public_client_enabled 字段"""
         fake_mcp_server.oauth2_public_client_enabled = True
+        fake_mcp_server.oauth2_personal_client_enabled = True
         fake_mcp_server.save()
 
         resp = request_view(
@@ -3071,6 +3072,7 @@ class TestMCPServerOAuth2Enabled:
         )
         assert mcp_server_data is not None
         assert mcp_server_data["oauth2_public_client_enabled"] is True
+        assert mcp_server_data["oauth2_personal_client_enabled"] is True
 
     def test_list_returns_oauth2_disabled(self, request_view, fake_gateway, fake_mcp_server):
         """测试列表接口返回 oauth2_public_client_enabled=False"""
@@ -3096,6 +3098,7 @@ class TestMCPServerOAuth2Enabled:
     def test_retrieve_returns_oauth2_public_client_enabled(self, request_view, fake_gateway, fake_mcp_server):
         """测试详情接口返回 oauth2_public_client_enabled 字段"""
         fake_mcp_server.oauth2_public_client_enabled = True
+        fake_mcp_server.oauth2_personal_client_enabled = True
         fake_mcp_server.save()
 
         resp = request_view(
@@ -3108,6 +3111,7 @@ class TestMCPServerOAuth2Enabled:
 
         assert resp.status_code == 200
         assert result["data"]["oauth2_public_client_enabled"] is True
+        assert result["data"]["oauth2_personal_client_enabled"] is True
 
     def test_retrieve_returns_oauth2_disabled(self, request_view, fake_gateway, fake_mcp_server):
         """测试详情接口返回 oauth2_public_client_enabled=False"""

--- a/src/dashboard/apigateway/apigateway/tests/biz/mcp_server/test_mcp_server.py
+++ b/src/dashboard/apigateway/apigateway/tests/biz/mcp_server/test_mcp_server.py
@@ -228,6 +228,44 @@ class TestMCPServerHandler:
             assert permission.expires == NeverExpiresTime.time
             assert permission.grant_type == GrantTypeEnum.SYNC.value
 
+    def test_sync_permissions_grants_and_revokes_oauth2_personal_client(self, fake_gateway, fake_stage, settings):
+        resource = G(Resource, gateway=fake_gateway, name="resource1")
+        mcp_server = G(
+            MCPServer,
+            gateway=fake_gateway,
+            stage=fake_stage,
+            _resource_names=resource.name,
+            oauth2_personal_client_enabled=True,
+        )
+        personal_app_code = settings.MCP_SERVER_OAUTH2_PERSONAL_CLIENT_APP_CODE
+        virtual_app_code = f"v_mcp_{mcp_server.id}_{personal_app_code}"
+
+        MCPServerHandler.sync_permissions(mcp_server.id)
+
+        assert MCPServerAppPermission.objects.filter(
+            mcp_server=mcp_server,
+            bk_app_code=personal_app_code,
+        ).exists()
+        assert AppResourcePermission.objects.filter(
+            gateway=fake_gateway,
+            bk_app_code=virtual_app_code,
+            resource_id=resource.id,
+        ).exists()
+
+        mcp_server.oauth2_personal_client_enabled = False
+        mcp_server.save(update_fields=["oauth2_personal_client_enabled"])
+        MCPServerHandler.sync_permissions(mcp_server.id)
+
+        assert not MCPServerAppPermission.objects.filter(
+            mcp_server=mcp_server,
+            bk_app_code=personal_app_code,
+        ).exists()
+        assert not AppResourcePermission.objects.filter(
+            gateway=fake_gateway,
+            bk_app_code=virtual_app_code,
+            resource_id=resource.id,
+        ).exists()
+
     def test_sync_permissions_excludes_ai_resources_from_release_snapshot(self, fake_gateway, fake_stage):
         standard_resource = G(
             Resource,


### PR DESCRIPTION
## Summary

- add `oauth2_personal_client_enabled` to MCP Server persistence, admin, APIs, schemas, and documentation
- grant or revoke the configured personal OAuth2 client permission during MCP permission synchronization
- synchronize the matching virtual resource permission and cover write/read behavior with regression tests

## Verification

- `uv run make edition-ee && uv run make lint-check` — passed
- Ruff format check for the 17 changed Python files — passed
- `uv run make edition-ee && uv run make test` — passed
- focused tests for the touched modules — 502 passed
- `git diff --cached --check` — passed before commit

## Review

- staged diff review completed with no remaining findings
- refactor call-site and dead-code audit completed
