### PR TITLE
feat(dashboard): filter inner MCP servers by name for release/1.23

### DIFF
--- a/src/dashboard/apigateway/apigateway/apis/v2/inner/serializers.py
+++ b/src/dashboard/apigateway/apigateway/apis/v2/inner/serializers.py
@@ -644,6 +644,9 @@ class MCPServerListInputSLZ(serializers.Serializer):
     mcp_server_ids = serializers.CharField(
         allow_blank=True, required=False, help_text="MCPServer ID 列表，多个以逗号 , 分割"
     )
+    mcp_server_names = serializers.CharField(
+        allow_blank=True, required=False, help_text="MCPServer 名称列表，多个以逗号 , 分割"
+    )
 
     class Meta:
         ref_name = "apigateway.apis.v2.inner.serializers.MCPServerListInputSLZ"
@@ -658,6 +661,14 @@ class MCPServerListInputSLZ(serializers.Serializer):
         if len(ids) > 50:
             raise serializers.ValidationError(_("MCPServer ID 列表最多支持 50 个"))
         return ids
+
+    def validate_mcp_server_names(self, value):
+        if not value:
+            return []
+        names = [x.strip() for x in value.split(",")]
+        if len(names) > 50:
+            raise serializers.ValidationError(_("MCPServer 名称列表最多支持 50 个"))
+        return names
 
 
 class MCPServerListOutputSLZ(serializers.Serializer):

--- a/src/dashboard/apigateway/apigateway/apis/v2/inner/views.py
+++ b/src/dashboard/apigateway/apigateway/apis/v2/inner/views.py
@@ -1156,6 +1156,7 @@ class MCPServerListApi(generics.ListAPIView):
             keyword=slz.validated_data.get("keyword"),
             order_by=slz.validated_data.get("order_by", "-updated_time"),
             ids=slz.validated_data.get("mcp_server_ids") or None,
+            names=slz.validated_data.get("mcp_server_names") or None,
         )
 
         page = self.paginate_queryset(queryset)

--- a/src/dashboard/apigateway/apigateway/biz/mcp_server/mcp_server.py
+++ b/src/dashboard/apigateway/apigateway/biz/mcp_server/mcp_server.py
@@ -703,6 +703,7 @@ class MCPServerHandler:
         is_public: Optional[bool] = None,
         order_by: str = "-updated_time",
         ids: Optional[List[int]] = None,
+        names: Optional[List[str]] = None,
     ) -> QuerySet:
         """构建 MCPServer 列表的通用 queryset
 
@@ -715,6 +716,7 @@ class MCPServerHandler:
             is_public: 是否公开
             order_by: 排序字段
             ids: MCPServer ID 列表，用于批量筛选
+            names: MCPServer 名称列表，用于批量精确筛选
 
         Returns:
             构建好的 queryset
@@ -725,6 +727,9 @@ class MCPServerHandler:
 
         if ids:
             queryset = queryset.filter(id__in=ids)
+
+        if names:
+            queryset = queryset.filter(name__in=names)
 
         if is_public is not None:
             queryset = queryset.filter(is_public=is_public)

--- a/src/dashboard/apigateway/apigateway/data/apidocs/zh/v2_inner_list_mcp_server.md
+++ b/src/dashboard/apigateway/apigateway/data/apidocs/zh/v2_inner_list_mcp_server.md
@@ -12,6 +12,7 @@
 | keyword | string | 否  | MCPServer 筛选条件，支持模糊匹配 MCPServer 名称或描述 |
 | order_by | string | 否  | 排序字段，支持 id, name, updated_time, created_time，前缀 - 表示降序，默认 -updated_time |
 | mcp_server_ids | string | 否  | MCPServer ID 列表，多个以逗号分割，最多 50 个。例如：1,2,3 |
+| mcp_server_names | string | 否  | MCPServer 名称列表，精确匹配，多个以逗号分割，最多 50 个。例如：server-1,server-2 |
 
 
 ### 响应示例

--- a/src/dashboard/apigateway/apigateway/data/apigw-definitions/bk-apigateway-definition.yaml
+++ b/src/dashboard/apigateway/apigateway/data/apigw-definitions/bk-apigateway-definition.yaml
@@ -130,6 +130,7 @@ grant_permissions:
   - bk_app_code: bk_auth
     grant_dimension: "resource"
     resource_names:
+      - v2_inner_list_mcp_server
       - v2_open_batch_query_mcp_servers
       - v2_open_list_gateways
       - v2_open_list_gateway_resources

--- a/src/dashboard/apigateway/apigateway/data/apigw-definitions/bk-apigateway-resources.yaml
+++ b/src/dashboard/apigateway/apigateway/data/apigw-definitions/bk-apigateway-resources.yaml
@@ -6987,6 +6987,12 @@ paths:
             type: string
           description: MCPServer ID 列表，多个以逗号分割，最多 50 个
           example: "1,2,3"
+        - name: mcp_server_names
+          in: query
+          schema:
+            type: string
+          description: MCPServer 名称列表，精确匹配，多个以逗号分割，最多 50 个
+          example: "server-1,server-2"
       responses:
         default:
           description: ''

--- a/src/dashboard/apigateway/apigateway/tests/apis/v2/inner/test_views.py
+++ b/src/dashboard/apigateway/apigateway/tests/apis/v2/inner/test_views.py
@@ -2040,6 +2040,42 @@ class TestMCPServerListApi:
         assert mcp_server3.id in result_ids
         assert mcp_server2.id not in result_ids
 
+    def test_list_with_mcp_server_names_filter(self, request_view, fake_gateway):
+        """测试使用 mcp_server_names 精确筛选 MCPServer，未命中的名称被忽略"""
+        fake_gateway.status = GatewayStatusEnum.ACTIVE.value
+        fake_gateway.save()
+
+        stage = G(Stage, gateway=fake_gateway, status=StageStatusEnum.ACTIVE.value)
+        private_mcp_server = G(
+            MCPServer,
+            gateway=fake_gateway,
+            stage=stage,
+            name="private-server",
+            title="Private Server",
+            is_public=False,
+            status=MCPServerStatusEnum.ACTIVE.value,
+        )
+        G(
+            MCPServer,
+            gateway=fake_gateway,
+            stage=stage,
+            name="unrequested-server",
+            is_public=True,
+            status=MCPServerStatusEnum.ACTIVE.value,
+        )
+
+        resp = request_view(
+            method="GET",
+            view_name="openapi.v2.inner.mcp_server.list",
+            data={"mcp_server_names": "private-server,missing-server"},
+            app=mock.MagicMock(app_code="test"),
+        )
+
+        assert resp.status_code == 200
+        results = resp.json()["data"]["results"]
+        assert [item["id"] for item in results] == [private_mcp_server.id]
+        assert results[0]["title"] == "Private Server"
+
     def test_list_with_mcp_server_ids_empty(self, request_view, fake_gateway):
         """测试 mcp_server_ids 为空时返回所有"""
         fake_gateway.status = GatewayStatusEnum.ACTIVE.value

--- a/src/dashboard/apigateway/apigateway/tests/biz/mcp_server/test_mcp_server.py
+++ b/src/dashboard/apigateway/apigateway/tests/biz/mcp_server/test_mcp_server.py
@@ -1523,6 +1523,32 @@ class TestMCPServerHandler:
         assert server.id in result_ids
         assert 999999 not in result_ids
 
+    def test_build_list_queryset_with_names(self, fake_gateway, fake_stage):
+        """按名称列表精确筛选，忽略不存在的名称"""
+        fake_gateway.status = GatewayStatusEnum.ACTIVE.value
+        fake_gateway.save()
+        fake_stage.status = StageStatusEnum.ACTIVE.value
+        fake_stage.save()
+
+        server = G(
+            MCPServer,
+            gateway=fake_gateway,
+            stage=fake_stage,
+            name="requested-server",
+            status=MCPServerStatusEnum.ACTIVE.value,
+        )
+        G(
+            MCPServer,
+            gateway=fake_gateway,
+            stage=fake_stage,
+            name="unrequested-server",
+            status=MCPServerStatusEnum.ACTIVE.value,
+        )
+
+        result = MCPServerHandler.build_list_queryset(names=[server.name, "missing-server"])
+
+        assert list(result.values_list("id", flat=True)) == [server.id]
+
     # ========== build_list_context 测试 ==========
 
     def test_build_list_context_basic(self, fake_gateway, fake_stage):


### PR DESCRIPTION
## Summary
- backport #3095 to release/1.23
- add exact `mcp_server_names` filtering to `GET /api/v2/inner/mcp-servers/`
- support private MCP server lookup and silently omit missing names
- keep `v2_open_batch_query_mcp_servers` unchanged

## Cherry-picked commits
- 39781f162 feat(dashboard): filter inner MCP servers by name

## Verification
- focused pytest: 2 passed
- `uv run make check-openapi`: 0 errors
- `uv run make edition-ee && uv run make lint-check`: passed
- changed-file `ruff format --check`: passed
- `uv run make edition-ee && uv run make test`: 3250 passed
- `git diff --check upstream/release/1.23...HEAD`: passed

Source PR: https://github.com/TencentBlueKing/blueking-apigateway/pull/3095