### PR TITLE
feat(dashboard): add MCP OAuth2 personal client feature flag

### DIFF
--- a/src/dashboard/apigateway/apigateway/conf/utils.py
+++ b/src/dashboard/apigateway/apigateway/conf/utils.py
@@ -218,6 +218,10 @@ def get_default_feature_flags(
         "ENABLE_MCP_SERVER_OAUTH2_PUBLIC_CLIENT": env.bool(
             "FEATURE_FLAG_ENABLE_MCP_SERVER_OAUTH2_PUBLIC_CLIENT", True
         ),
+        # 是否开启 MCP Server OAuth2 个人客户端模式
+        "ENABLE_MCP_SERVER_OAUTH2_PERSONAL_CLIENT": env.bool(
+            "FEATURE_FLAG_ENABLE_MCP_SERVER_OAUTH2_PERSONAL_CLIENT", True
+        ),
         # 是否开启 BK CLI 展示
         "ENABLE_BK_CLI": env.bool("FEATURE_FLAG_ENABLE_BK_CLI", False),
         # 是否开启 ITSM 权限申请

--- a/src/dashboard/apigateway/apigateway/tests/conf/test_utils.py
+++ b/src/dashboard/apigateway/apigateway/tests/conf/test_utils.py
@@ -19,7 +19,26 @@
 
 from environ import Env
 
-from apigateway.conf.utils import get_frontend_env_vars
+from apigateway.conf.utils import get_default_feature_flags, get_frontend_env_vars
+
+
+def test_get_default_feature_flags_mcp_server_oauth2_personal_client(monkeypatch):
+    env = Env()
+    kwargs = {
+        "enable_bk_notice": False,
+        "enable_multi_tenant_mode": False,
+        "ai_open_api_base_url": "",
+        "enable_gateway_operation_status": False,
+        "enable_run_data_metrics": False,
+        "enable_itsm4_permission_apply": False,
+    }
+
+    flags = get_default_feature_flags(env, **kwargs)
+    assert flags["ENABLE_MCP_SERVER_OAUTH2_PERSONAL_CLIENT"] is True
+
+    monkeypatch.setenv("FEATURE_FLAG_ENABLE_MCP_SERVER_OAUTH2_PERSONAL_CLIENT", "false")
+    flags = get_default_feature_flags(env, **kwargs)
+    assert flags["ENABLE_MCP_SERVER_OAUTH2_PERSONAL_CLIENT"] is False
 
 
 def test_get_frontend_env_vars_includes_paas_developer_center_link(monkeypatch):


### PR DESCRIPTION
## Summary
- expose `ENABLE_MCP_SERVER_OAUTH2_PERSONAL_CLIENT` in the default frontend feature flags
- read `FEATURE_FLAG_ENABLE_MCP_SERVER_OAUTH2_PERSONAL_CLIENT`, enabled by default to mirror the public-client flag
- cover the default and environment override behavior

## Verification
- `uv run bash -lc 'cd apigateway && set -a && . apigateway/conf/unittest_env && set +a && python -m pytest --nomigrations --ds apigateway.settings -q --tb=short apigateway/tests/conf/test_utils.py'` (2 passed)\n- `uv run make edition-ee && uv run make lint-check` (passed; API consistency: 0 errors, 41 existing warnings)\n- `uv run make edition-ee && uv run make test` (3640 passed)