### PR TITLE
perf(mcp): support selective fields in inner server list

### DIFF
--- a/src/dashboard/apigateway/apigateway/apis/v2/inner/serializers.py
+++ b/src/dashboard/apigateway/apigateway/apis/v2/inner/serializers.py
@@ -16,6 +16,7 @@
 # We undertake not to change the open source license (MIT license) applicable
 # to the current version of the project delivered to anyone in the future.
 #
+import copy
 import logging
 import math
 from typing import Dict, List
@@ -627,6 +628,11 @@ class MCPServerListInputSLZ(serializers.Serializer):
     mcp_server_names = serializers.CharField(
         allow_blank=True, required=False, help_text="MCPServer 名称列表，多个以逗号 , 分割"
     )
+    fields = serializers.CharField(
+        allow_blank=True,
+        required=False,
+        help_text="指定返回的字段列表，多个以逗号分割；不传时返回全部字段",
+    )
 
     class Meta:
         ref_name = "apigateway.apis.v2.inner.serializers.MCPServerListInputSLZ"
@@ -692,6 +698,16 @@ class MCPServerListOutputSLZ(serializers.Serializer):
     created_by = serializers.CharField(read_only=True, help_text="创建人")
     updated_time = serializers.DateTimeField(read_only=True, help_text="更新时间")
     created_time = serializers.DateTimeField(read_only=True, help_text="创建时间")
+
+    def __init__(self, *args, fields=None, **kwargs):
+        self._output_fields = fields
+        super().__init__(*args, **kwargs)
+
+    def get_fields(self):
+        fields = self._declared_fields
+        if self._output_fields is not None:
+            fields = {name: field for name, field in fields.items() if name in self._output_fields}
+        return copy.deepcopy(fields)
 
     def get_title(self, obj) -> str:
         return obj.title if obj.title else obj.name

--- a/src/dashboard/apigateway/apigateway/apis/v2/inner/views.py
+++ b/src/dashboard/apigateway/apigateway/apis/v2/inner/views.py
@@ -1175,18 +1175,29 @@ class MCPServerListApi(generics.ListAPIView):
         )
 
         page = self.paginate_queryset(queryset)
-        context = MCPServerHandler.build_list_context(page)
+        fields_str = slz.validated_data.get("fields")
+        fields = {field.strip() for field in fields_str.split(",") if field.strip()} if fields_str else None
+        include_all_fields = fields is None
 
-        mcp_server_ids = [mcp_server.id for mcp_server in page]
-        context["prompts_count_map"] = MCPServerHandler.get_prompts_count_map(mcp_server_ids)
+        context = {}
+        if include_all_fields or fields & {"stage", "gateway"}:
+            context.update(MCPServerHandler.build_list_context(page))
 
-        # Add categories map
-        context["categories"] = MCPServerHandler.build_categories_map([mcp_server.id for mcp_server in page])
+        mcp_server_ids = (
+            [mcp_server.id for mcp_server in page]
+            if include_all_fields or fields & {"prompts_count", "categories"}
+            else []
+        )
+        if include_all_fields or "prompts_count" in fields:
+            context["prompts_count_map"] = MCPServerHandler.get_prompts_count_map(mcp_server_ids)
 
-        # 计算最低权限级别，用于判断是否展示应用态 URL
-        context["least_privileges"] = MCPServerHandler.get_least_privileges(page)
+        if include_all_fields or "categories" in fields:
+            context["categories"] = MCPServerHandler.build_categories_map(mcp_server_ids)
 
-        output_slz = serializers.MCPServerListOutputSLZ(page, many=True, context=context)
+        if include_all_fields or "url" in fields:
+            context["least_privileges"] = MCPServerHandler.get_least_privileges(page)
+
+        output_slz = serializers.MCPServerListOutputSLZ(page, many=True, context=context, fields=fields)
         return self.get_paginated_response(output_slz.data)
 
 

--- a/src/dashboard/apigateway/apigateway/data/apidocs/zh/v2_inner_list_mcp_server.md
+++ b/src/dashboard/apigateway/apigateway/data/apidocs/zh/v2_inner_list_mcp_server.md
@@ -13,6 +13,7 @@
 | order_by | string | 否  | 排序字段，支持 id, name, updated_time, created_time，前缀 - 表示降序，默认 -updated_time |
 | mcp_server_ids | string | 否  | MCPServer ID 列表，多个以逗号分割，最多 50 个。例如：1,2,3 |
 | mcp_server_names | string | 否  | MCPServer 名称列表，精确匹配，多个以逗号分割，最多 50 个。例如：server-1,server-2 |
+| fields | string | 否  | 指定返回的字段列表，多个以逗号分割，例如 `fields=name,title`；不传时返回全部字段 |
 
 
 ### 响应示例

--- a/src/dashboard/apigateway/apigateway/data/apigw-definitions/bk-apigateway-resources.yaml
+++ b/src/dashboard/apigateway/apigateway/data/apigw-definitions/bk-apigateway-resources.yaml
@@ -7346,6 +7346,12 @@ paths:
             type: string
           description: MCPServer 名称列表，精确匹配，多个以逗号分割，最多 50 个
           example: "server-1,server-2"
+        - name: fields
+          in: query
+          schema:
+            type: string
+          description: 指定返回的字段列表，多个以逗号分割；不传时返回全部字段
+          example: name,title
       responses:
         default:
           description: ''

--- a/src/dashboard/apigateway/apigateway/tests/apis/v2/inner/test_views.py
+++ b/src/dashboard/apigateway/apigateway/tests/apis/v2/inner/test_views.py
@@ -1901,6 +1901,129 @@ class TestAppRequestLogListApi:
 class TestMCPServerListApi:
     """测试 MCPServerListApi - 获取全量的 MCPServer 列表"""
 
+    def test_list_with_dynamic_fields_skips_unneeded_context_building(self, request_view, fake_gateway, mocker):
+        fake_gateway.status = GatewayStatusEnum.ACTIVE.value
+        fake_gateway.save(update_fields=["status"])
+        stage = G(Stage, gateway=fake_gateway, status=StageStatusEnum.ACTIVE.value)
+        mcp_server = G(
+            MCPServer,
+            gateway=fake_gateway,
+            stage=stage,
+            name="test-mcp-server",
+            title="Test MCP Server",
+            status=MCPServerStatusEnum.ACTIVE.value,
+            protocol_type=MCPServerProtocolTypeEnum.SSE.value,
+        )
+        build_list_context = mocker.patch.object(
+            inner_views.MCPServerHandler, "build_list_context", side_effect=AssertionError("unexpected context build")
+        )
+        get_prompts_count_map = mocker.patch.object(
+            inner_views.MCPServerHandler,
+            "get_prompts_count_map",
+            side_effect=AssertionError("unexpected context build"),
+        )
+        build_categories_map = mocker.patch.object(
+            inner_views.MCPServerHandler,
+            "build_categories_map",
+            side_effect=AssertionError("unexpected context build"),
+        )
+        get_least_privileges = mocker.patch.object(
+            inner_views.MCPServerHandler,
+            "get_least_privileges",
+            side_effect=AssertionError("unexpected context build"),
+        )
+
+        resp = request_view(
+            method="GET",
+            view_name="openapi.v2.inner.mcp_server.list",
+            data={"fields": "name,title"},
+            app=mock.MagicMock(app_code="test"),
+        )
+
+        assert resp.status_code == 200
+        assert resp.json()["data"]["results"] == [
+            {
+                "name": "test-mcp-server",
+                "title": "Test MCP Server",
+            }
+        ]
+
+        resp = request_view(
+            method="GET",
+            view_name="openapi.v2.inner.mcp_server.list",
+            data={"fields": "id,protocol_type"},
+            app=mock.MagicMock(app_code="test"),
+        )
+
+        assert resp.status_code == 200
+        assert resp.json()["data"]["results"] == [
+            {
+                "id": mcp_server.id,
+                "protocol_type": MCPServerProtocolTypeEnum.SSE.value,
+            }
+        ]
+        build_list_context.assert_not_called()
+        get_prompts_count_map.assert_not_called()
+        build_categories_map.assert_not_called()
+        get_least_privileges.assert_not_called()
+
+    @pytest.mark.parametrize(
+        ("fields", "expected_helper"),
+        [
+            ("stage,gateway", "build_list_context"),
+            ("prompts_count", "get_prompts_count_map"),
+            ("categories", "build_categories_map"),
+            ("url", "get_least_privileges"),
+        ],
+    )
+    def test_list_with_dynamic_fields_builds_only_required_context(
+        self, request_view, fake_gateway, mocker, fields, expected_helper
+    ):
+        fake_gateway.status = GatewayStatusEnum.ACTIVE.value
+        fake_gateway.save(update_fields=["status"])
+        stage = G(Stage, gateway=fake_gateway, status=StageStatusEnum.ACTIVE.value)
+        mcp_server = G(
+            MCPServer,
+            gateway=fake_gateway,
+            stage=stage,
+            status=MCPServerStatusEnum.ACTIVE.value,
+            protocol_type=MCPServerProtocolTypeEnum.SSE.value,
+        )
+        helpers = {
+            "build_list_context": mocker.patch.object(
+                inner_views.MCPServerHandler,
+                "build_list_context",
+                return_value={
+                    "stages": {stage.id: {"id": stage.id, "name": stage.name}},
+                    "gateways": {fake_gateway.id: {"id": fake_gateway.id, "name": fake_gateway.name}},
+                },
+            ),
+            "get_prompts_count_map": mocker.patch.object(
+                inner_views.MCPServerHandler, "get_prompts_count_map", return_value={mcp_server.id: 1}
+            ),
+            "build_categories_map": mocker.patch.object(
+                inner_views.MCPServerHandler, "build_categories_map", return_value={mcp_server.id: []}
+            ),
+            "get_least_privileges": mocker.patch.object(
+                inner_views.MCPServerHandler, "get_least_privileges", return_value={}
+            ),
+        }
+
+        resp = request_view(
+            method="GET",
+            view_name="openapi.v2.inner.mcp_server.list",
+            data={"fields": fields},
+            app=mock.MagicMock(app_code="test"),
+        )
+
+        assert resp.status_code == 200
+        assert set(resp.json()["data"]["results"][0]) == set(fields.split(","))
+        for helper_name, helper in helpers.items():
+            if helper_name == expected_helper:
+                helper.assert_called_once()
+            else:
+                helper.assert_not_called()
+
     def test_list_public_active_mcp_servers(self, request_view, fake_gateway):
         """测试获取活跃的 MCPServer 列表"""
         fake_gateway.status = GatewayStatusEnum.ACTIVE.value


### PR DESCRIPTION
## Summary

- support comma-separated dynamic fields for the inner MCP server list API
- bind and serialize only requested output fields
- build gateway, stage, prompt, category, and URL context only when selected fields require it
- keep the default full response compatible and synchronize API docs and gateway YAML
- cover helper-free and context-dependent field selections

## Verification

- focused MCPServerListApi tests: 18 passed
- uv run make lint-check
- uv run make test: 3645 passed
