### PR TITLE
fix(mcp): avoid oversized release lookup queries

### DIFF
--- a/src/dashboard/apigateway/apigateway/biz/mcp_server/mcp_server.py
+++ b/src/dashboard/apigateway/apigateway/biz/mcp_server/mcp_server.py
@@ -469,15 +469,11 @@ class MCPServerHandler:
         Returns:
             {(gateway_id, stage_id): Release} 映射
         """
-        gateway_stage_pairs = {(mcp_server.gateway_id, mcp_server.stage_id) for mcp_server in mcp_servers}
-        if not gateway_stage_pairs:
+        stage_ids = {mcp_server.stage_id for mcp_server in mcp_servers}
+        if not stage_ids:
             return {}
 
-        release_filters = Q()
-        for gateway_id, stage_id in gateway_stage_pairs:
-            release_filters |= Q(gateway_id=gateway_id, stage_id=stage_id)
-
-        releases = Release.objects.filter(release_filters).select_related("resource_version")
+        releases = Release.objects.filter(stage_id__in=stage_ids).select_related("resource_version")
         return {(r.gateway_id, r.stage_id): r for r in releases}
 
     @staticmethod

--- a/src/dashboard/apigateway/apigateway/tests/biz/mcp_server/test_mcp_server.py
+++ b/src/dashboard/apigateway/apigateway/tests/biz/mcp_server/test_mcp_server.py
@@ -20,6 +20,8 @@ from unittest.mock import patch
 
 import pytest
 from ddf import G
+from django.db import connection
+from django.test.utils import CaptureQueriesContext
 
 from apigateway.apps.mcp_server.constants import (
     OFFICIAL_MCP_CATEGORY_NAME,
@@ -964,6 +966,26 @@ class TestMCPServerHandler:
 
         assert (fake_gateway.id, fake_stage.id) in result
         assert result[(fake_gateway.id, fake_stage.id)].id == release.id
+
+    def test_get_releases_for_mcp_servers_uses_stage_id_in_query(self, fake_gateway, fake_stage):
+        """批量查询 Release 时应使用 stage_id IN，避免按网关环境组合生成大量 OR 条件"""
+        another_stage = G(Stage, gateway=fake_gateway)
+        rv = self._make_resource_version_with_data(fake_gateway, [{"name": "tool_a"}])
+        releases = [
+            G(Release, gateway=fake_gateway, stage=stage, resource_version=rv) for stage in [fake_stage, another_stage]
+        ]
+        mcp_servers = [
+            G(MCPServer, gateway=fake_gateway, stage=stage, _resource_names="tool_a")
+            for stage in [fake_stage, another_stage]
+        ]
+
+        with CaptureQueriesContext(connection) as queries:
+            result = MCPServerHandler._get_releases_for_mcp_servers(mcp_servers)
+
+        assert set(result) == {(release.gateway_id, release.stage_id) for release in releases}
+        assert len(queries) == 1
+        assert '"core_release"."stage_id" IN (' in queries[0]["sql"]
+        assert " OR " not in queries[0]["sql"]
 
     def test_get_releases_for_mcp_servers_empty(self):
         """空列表应返回空字典"""


### PR DESCRIPTION
## Summary
- query MCP server releases by their unique stage IDs instead of expanding every gateway-stage pair into OR predicates
- keep the existing release mapping and resource version eager loading behavior
- add a regression test that verifies the batch query uses stage_id IN without OR predicates

## Verification
- focused MCP handler tests: 110 passed
- uv run ruff format --check: passed
- uv run make lint-check: passed (OpenAPI check retained 41 existing warnings, 0 errors)
- uv run make test: 3652 passed
- git diff --check: passed