### PR TITLE
fix(alert): handle null app_code in alarm record creation

### DIFF
--- a/src/dashboard/apigateway/apigateway/service/alert_flow/handlers/base.py
+++ b/src/dashboard/apigateway/apigateway/service/alert_flow/handlers/base.py
@@ -55,7 +55,7 @@ class AlarmRecordCreator(AlertHandler):
             return None
 
         record = AlarmRecord.objects.create(
-            app_code=event.event_dimensions.get("app_code", ""),
+            app_code=event.event_dimensions.get("app_code") or "",
             resource_id=self._get_resource_id(event.event_dimensions),
             stage=event.event_dimensions.get("stage", ""),
             alarm_type=event.alarm_type.value,

--- a/src/dashboard/apigateway/apigateway/tests/service/alert_flow/handlers/test_base.py
+++ b/src/dashboard/apigateway/apigateway/tests/service/alert_flow/handlers/test_base.py
@@ -38,6 +38,15 @@ class TestAlarmRecordCreator:
         assert record.stage == mock_event.event_dimensions["stage"]
         assert record.alarm_type == mock_event.alarm_type.value
 
+    def test_do_with_null_app_code(self, mock_event):
+        mock_event.event_dimensions["app_code"] = None
+
+        record_creator = base_handlers.AlarmRecordCreator()
+        result = record_creator._do(mock_event)
+
+        record = AlarmRecord.objects.get(id=result.alarm_record_id)
+        assert record.app_code == ""
+
 
 class TestAPIExistFilter:
     @pytest.fixture(autouse=True)


### PR DESCRIPTION
- 修复：当 event.event_dimensions.get("app_code") 为 None 时，转换为 "" 字符串