### PR TITLE
feat(itsm): backfill actual approver from ITSM tickets

### DIFF
--- a/src/dashboard/apigateway/apigateway/apps/permission/management/commands/backfill_itsm_approver.py
+++ b/src/dashboard/apigateway/apigateway/apps/permission/management/commands/backfill_itsm_approver.py
@@ -1,0 +1,218 @@
+# -*- coding: utf-8 -*-
+#
+# TencentBlueKing is pleased to support the open source community by making
+# 蓝鲸智云 - API 网关(BlueKing - APIGateway) available.
+# Copyright (C) Tencent. All rights reserved.
+# Licensed under the MIT License (the "License"); you may not use this file except
+# in compliance with the License. You may obtain a copy of the License at
+#
+#     http://opensource.org/licenses/MIT
+#
+# Unless required by applicable law or agreed to in writing, software distributed under
+# the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+# either express or implied. See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# We undertake not to change the open source license (MIT license) applicable
+# to the current version of the project delivered to anyone in the future.
+#
+import logging
+
+from django.core.management.base import BaseCommand, CommandParser
+from pydantic import BaseModel, Field
+
+from apigateway.apps.mcp_server.models import MCPServerAppPermissionApply
+from apigateway.apps.permission.models import AppPermissionRecord
+from apigateway.apps.permission.tasks import (
+    async_fill_gateway_or_resource_itsm_approver,
+    async_fill_mcp_server_itsm_approver,
+)
+
+logger = logging.getLogger(__name__)
+
+TYPE_GATEWAY = "gateway"
+TYPE_MCP = "mcp"
+TYPE_ALL = "all"
+# Keep aligned with apigateway.biz.bk_itsm.bk_itsm.ITSM_PERMISSION_APPROVAL_HANDLER
+ITSM_HANDLED_BY_PLACEHOLDER = "itsm"
+
+
+class BackfillStats(BaseModel):
+    total: int = Field(default=0)
+    success: int = Field(default=0)
+    failed: int = Field(default=0)
+
+
+class Command(BaseCommand):
+    help = (
+        "Synchronously backfill actual ITSM approvers for historical records. "
+        "Gateway/resource uses AppPermissionRecord (--record-id); "
+        "MCP server uses MCPServerAppPermissionApply (--mcp-apply-id)."
+    )
+
+    def add_arguments(self, parser: CommandParser):
+        parser.add_argument("--dry-run", action="store_true", help="Preview candidates without backfilling")
+        parser.add_argument(
+            "--force",
+            action="store_true",
+            help=f'Include records whose handled_by is not "{ITSM_HANDLED_BY_PLACEHOLDER}"',
+        )
+        parser.add_argument(
+            "--type",
+            dest="record_type",
+            choices=[TYPE_ALL, TYPE_GATEWAY, TYPE_MCP],
+            default=TYPE_ALL,
+            help="Which records to scan: gateway=AppPermissionRecord, mcp=MCPServerAppPermissionApply",
+        )
+        parser.add_argument("--limit", type=int, default=0, help="Max records to process per type; 0 means no limit")
+        parser.add_argument(
+            "--record-id",
+            type=int,
+            help="Only process one gateway/resource AppPermissionRecord id",
+        )
+        parser.add_argument(
+            "--mcp-apply-id",
+            type=int,
+            help="Only process one MCPServerAppPermissionApply id",
+        )
+
+    def handle(self, *args, **options):
+        dry_run = options["dry_run"]
+        force = options["force"]
+        record_type = options["record_type"]
+        limit = options["limit"]
+        record_id = options.get("record_id")
+        mcp_apply_id = options.get("mcp_apply_id")
+
+        gateway_stats = BackfillStats()
+        mcp_stats = BackfillStats()
+
+        if record_type in (TYPE_ALL, TYPE_GATEWAY) and mcp_apply_id is None:
+            gateway_stats = self._backfill_gateway_or_resource(
+                dry_run=dry_run,
+                force=force,
+                limit=limit,
+                record_id=record_id,
+            )
+
+        if record_type in (TYPE_ALL, TYPE_MCP) and record_id is None:
+            mcp_stats = self._backfill_mcp(
+                dry_run=dry_run,
+                force=force,
+                limit=limit,
+                mcp_apply_id=mcp_apply_id,
+            )
+
+        mode = "dry-run" if dry_run else "backfill"
+        self.stdout.write(
+            f"mode={mode} "
+            f"gateway_total={gateway_stats.total} gateway_success={gateway_stats.success} "
+            f"gateway_failed={gateway_stats.failed} "
+            f"mcp_total={mcp_stats.total} mcp_success={mcp_stats.success} mcp_failed={mcp_stats.failed}"
+        )
+
+    def _build_queryset(self, model, force: bool, pk: int | None):
+        qs = model.objects.exclude(itsm_ticket_id="")
+        if pk is not None:
+            qs = qs.filter(id=pk)
+        elif not force:
+            qs = qs.filter(handled_by=ITSM_HANDLED_BY_PLACEHOLDER)
+        return qs.order_by("id")
+
+    @staticmethod
+    def _is_backfilled(handled_by: str) -> bool:
+        return bool(handled_by) and handled_by != ITSM_HANDLED_BY_PLACEHOLDER
+
+    def _backfill_gateway_or_resource(
+        self, dry_run: bool, force: bool, limit: int, record_id: int | None
+    ) -> BackfillStats:
+        qs = self._build_queryset(AppPermissionRecord, force=force, pk=record_id)
+        stats = BackfillStats()
+
+        for record in qs.iterator():
+            if limit > 0 and stats.total >= limit:
+                break
+            stats.total += 1
+            self.stdout.write(
+                f"gateway record_id={record.id} grant_dimension={record.grant_dimension} "
+                f"ticket_id={record.itsm_ticket_id} handled_by={record.handled_by}"
+            )
+            if dry_run:
+                continue
+            try:
+                # Call the shared task body synchronously; no Celery worker required.
+                async_fill_gateway_or_resource_itsm_approver(
+                    record.grant_dimension,
+                    record.id,
+                    record.itsm_ticket_id,
+                )
+            except Exception as err:  # pylint: disable=broad-except
+                stats.failed += 1
+                logger.exception(
+                    "backfill gateway itsm approver failed, record_id=%s, ticket_id=%s",
+                    record.id,
+                    record.itsm_ticket_id,
+                )
+                self.stderr.write(
+                    self.style.ERROR(
+                        f"gateway backfill failed record_id={record.id} ticket_id={record.itsm_ticket_id} err={err}"
+                    )
+                )
+                continue
+
+            record.refresh_from_db()
+            if self._is_backfilled(record.handled_by):
+                stats.success += 1
+                self.stdout.write(f"gateway record_id={record.id} handled_by={record.handled_by}")
+            else:
+                stats.failed += 1
+                self.stderr.write(
+                    self.style.ERROR(
+                        f"gateway backfill failed record_id={record.id} ticket_id={record.itsm_ticket_id} "
+                        "approver empty"
+                    )
+                )
+        return stats
+
+    def _backfill_mcp(self, dry_run: bool, force: bool, limit: int, mcp_apply_id: int | None) -> BackfillStats:
+        qs = self._build_queryset(MCPServerAppPermissionApply, force=force, pk=mcp_apply_id)
+        stats = BackfillStats()
+
+        for apply_obj in qs.iterator():
+            if limit > 0 and stats.total >= limit:
+                break
+            stats.total += 1
+            self.stdout.write(
+                f"mcp apply_id={apply_obj.id} ticket_id={apply_obj.itsm_ticket_id} handled_by={apply_obj.handled_by}"
+            )
+            if dry_run:
+                continue
+            try:
+                async_fill_mcp_server_itsm_approver(apply_obj.id, apply_obj.itsm_ticket_id)
+            except Exception as err:  # pylint: disable=broad-except
+                stats.failed += 1
+                logger.exception(
+                    "backfill mcp itsm approver failed, apply_id=%s, ticket_id=%s",
+                    apply_obj.id,
+                    apply_obj.itsm_ticket_id,
+                )
+                self.stderr.write(
+                    self.style.ERROR(
+                        f"mcp backfill failed apply_id={apply_obj.id} ticket_id={apply_obj.itsm_ticket_id} err={err}"
+                    )
+                )
+                continue
+
+            apply_obj.refresh_from_db()
+            if self._is_backfilled(apply_obj.handled_by):
+                stats.success += 1
+                self.stdout.write(f"mcp apply_id={apply_obj.id} handled_by={apply_obj.handled_by}")
+            else:
+                stats.failed += 1
+                self.stderr.write(
+                    self.style.ERROR(
+                        f"mcp backfill failed apply_id={apply_obj.id} ticket_id={apply_obj.itsm_ticket_id} "
+                        "approver empty"
+                    )
+                )
+        return stats

--- a/src/dashboard/apigateway/apigateway/apps/permission/tasks.py
+++ b/src/dashboard/apigateway/apigateway/apps/permission/tasks.py
@@ -46,7 +46,7 @@ from apigateway.apps.permission.models import (
 from apigateway.biz.permission import PermissionDimensionManager
 from apigateway.common.tenant.request import get_tenant_id_for_gateway_maintainers
 from apigateway.components.bkcmsi import cmsi_component
-from apigateway.components.bkitsm import ticket_search_full_text_search
+from apigateway.components.bkitsm import get_ticket_by_id
 from apigateway.components.bkpaas import get_app_maintainers, get_tenant_id_for_app_developers
 from apigateway.core.constants import ContextScopeTypeEnum, ContextTypeEnum, GatewayStatusEnum
 from apigateway.core.models import Context, Gateway, Resource
@@ -211,39 +211,33 @@ def renew_app_resource_permission():
 def _get_actual_approver_from_itsm(ticket_id: str) -> str:
     try:
         # /ticket/detail/ 暂无法返回 history_processors，先用工单搜索接口，修复后可切回详情接口。
-        ticket_search_result = ticket_search_full_text_search(ticket_id)
+        ticket_search_result = get_ticket_by_id(ticket_id)
     except Exception:
-        logger.warning("query or parse itsm ticket search result failed, ticket_id=%s", ticket_id, exc_info=True)
+        logger.warning("query or parse itsm ticket failed, ticket_id=%s", ticket_id, exc_info=True)
         return ""
 
     return ticket_search_result.actual_approver
 
 
-def _update_permission_handled_by(grant_dimension: str, apply_id: int, approver: str) -> None:
-    # MCP Server 权限申请人回填
-    if grant_dimension == FormattedGrantDimensionEnum.MCP_SERVER.value:
-        updated = MCPServerAppPermissionApply.objects.filter(id=apply_id).update(handled_by=approver)
-        if not updated:
-            logger.info("skip filling itsm approver because mcp apply not found, apply_id=%s", apply_id)
-        return
-
-    # 网关、资源维度权限申请人回填
-    record = AppPermissionRecord.objects.filter(id=apply_id).first()
+def _update_gateway_or_resource_permission_record_handled_by(
+    grant_dimension: str, record_id: int, approver: str
+) -> None:
+    record = AppPermissionRecord.objects.filter(id=record_id).first()
     if not record:
-        logger.info("skip filling itsm approver because permission record not found, record_id=%s", apply_id)
+        logger.info("skip filling itsm approver because permission record not found, record_id=%s", record_id)
         return
 
     record.handled_by = approver
     record.save(update_fields=["handled_by"])
 
-    if grant_dimension in [GrantDimensionEnum.API.value, FormattedGrantDimensionEnum.GATEWAY.value]:
+    if grant_dimension == GrantDimensionEnum.API.value:
         if record.status == ApplyStatusEnum.APPROVED.value:
             AppGatewayPermission.objects.filter(gateway=record.gateway, bk_app_code=record.bk_app_code).update(
                 handled_by=approver
             )
         return
 
-    if grant_dimension in [GrantDimensionEnum.RESOURCE.value, FormattedGrantDimensionEnum.RESOURCE.value]:
+    if grant_dimension == GrantDimensionEnum.RESOURCE.value:
         approved_resource_ids = record.handled_resource_ids.get(ApplyStatusEnum.APPROVED.value) or []
         if approved_resource_ids:
             AppResourcePermission.objects.filter(
@@ -258,22 +252,50 @@ def _update_permission_handled_by(grant_dimension: str, apply_id: int, approver:
     )
 
 
-@shared_task(name="apigateway.apps.permission.tasks.async_fill_itsm_approver", ignore_result=True)
-def async_fill_itsm_approver(grant_dimension: str, apply_id: int, ticket_id: str) -> None:
+def _get_itsm_approver_for_backfill(ticket_id: str, log_context: Dict[str, Any]) -> str:
     if not ticket_id:
         logger.warning(
-            "skip filling itsm approver because ticket_id is empty, grant_dimension=%s, apply_id=%s",
-            grant_dimension,
-            apply_id,
+            "skip filling itsm approver because ticket_id is empty, context=%s",
+            log_context,
         )
-        return
+        return ""
 
     approver = _get_actual_approver_from_itsm(ticket_id)
     if not approver:
         logger.info("skip filling itsm approver because approver is empty, ticket_id=%s", ticket_id)
+        return ""
+
+    return approver
+
+
+@shared_task(name="apigateway.apps.permission.tasks.async_fill_gateway_or_resource_itsm_approver", ignore_result=True)
+def async_fill_gateway_or_resource_itsm_approver(grant_dimension: str, record_id: int, ticket_id: str) -> None:
+    approver = _get_itsm_approver_for_backfill(
+        ticket_id,
+        log_context={"grant_dimension": grant_dimension, "record_id": record_id},
+    )
+    if not approver:
         return
 
-    _update_permission_handled_by(grant_dimension=grant_dimension, apply_id=apply_id, approver=approver)
+    _update_gateway_or_resource_permission_record_handled_by(
+        grant_dimension=grant_dimension,
+        record_id=record_id,
+        approver=approver,
+    )
+
+
+@shared_task(name="apigateway.apps.permission.tasks.async_fill_mcp_server_itsm_approver", ignore_result=True)
+def async_fill_mcp_server_itsm_approver(apply_id: int, ticket_id: str) -> None:
+    approver = _get_itsm_approver_for_backfill(
+        ticket_id,
+        log_context={"grant_dimension": FormattedGrantDimensionEnum.MCP_SERVER.value, "apply_id": apply_id},
+    )
+    if not approver:
+        return
+
+    updated = MCPServerAppPermissionApply.objects.filter(id=apply_id).update(handled_by=approver)
+    if not updated:
+        logger.info("skip filling itsm approver because mcp apply not found, apply_id=%s", apply_id)
 
 
 class AppPermissionExpiringSoonAlerter:

--- a/src/dashboard/apigateway/apigateway/apps/permission/tasks.py
+++ b/src/dashboard/apigateway/apigateway/apps/permission/tasks.py
@@ -33,7 +33,6 @@ from apigateway.apps.mcp_server.models import MCPServerAppPermissionApply
 from apigateway.apps.metrics.models import StatisticsAppRequestByDay
 from apigateway.apps.permission.constants import (
     ApplyStatusEnum,
-    FormattedGrantDimensionEnum,
     GrantDimensionEnum,
     GrantTypeEnum,
     PermissionApplyExpireDaysEnum,
@@ -208,17 +207,6 @@ def renew_app_resource_permission():
             )
 
 
-def _get_actual_approver_from_itsm(ticket_id: str) -> str:
-    try:
-        # /ticket/detail/ 暂无法返回 history_processors，先用工单搜索接口，修复后可切回详情接口。
-        ticket_search_result = get_ticket_by_id(ticket_id)
-    except Exception:
-        logger.warning("query or parse itsm ticket failed, ticket_id=%s", ticket_id, exc_info=True)
-        return ""
-
-    return ticket_search_result.actual_approver
-
-
 def _update_gateway_or_resource_permission_record_handled_by(
     grant_dimension: str, record_id: int, approver: str
 ) -> None:
@@ -252,15 +240,15 @@ def _update_gateway_or_resource_permission_record_handled_by(
     )
 
 
-def _get_itsm_approver_for_backfill(ticket_id: str, log_context: Dict[str, Any]) -> str:
-    if not ticket_id:
-        logger.warning(
-            "skip filling itsm approver because ticket_id is empty, context=%s",
-            log_context,
-        )
+def _get_itsm_approver_for_backfill(ticket_id: str) -> str:
+    try:
+        # /ticket/detail/ 暂无法返回 history_processors，先用工单搜索接口，修复后可切回详情接口。
+        ticket_search_result = get_ticket_by_id(ticket_id)
+    except Exception:
+        logger.warning("query or parse itsm ticket failed, ticket_id=%s", ticket_id, exc_info=True)
         return ""
 
-    approver = _get_actual_approver_from_itsm(ticket_id)
+    approver = ticket_search_result.actual_approver
     if not approver:
         logger.info("skip filling itsm approver because approver is empty, ticket_id=%s", ticket_id)
         return ""
@@ -270,10 +258,7 @@ def _get_itsm_approver_for_backfill(ticket_id: str, log_context: Dict[str, Any])
 
 @shared_task(name="apigateway.apps.permission.tasks.async_fill_gateway_or_resource_itsm_approver", ignore_result=True)
 def async_fill_gateway_or_resource_itsm_approver(grant_dimension: str, record_id: int, ticket_id: str) -> None:
-    approver = _get_itsm_approver_for_backfill(
-        ticket_id,
-        log_context={"grant_dimension": grant_dimension, "record_id": record_id},
-    )
+    approver = _get_itsm_approver_for_backfill(ticket_id)
     if not approver:
         return
 
@@ -286,10 +271,7 @@ def async_fill_gateway_or_resource_itsm_approver(grant_dimension: str, record_id
 
 @shared_task(name="apigateway.apps.permission.tasks.async_fill_mcp_server_itsm_approver", ignore_result=True)
 def async_fill_mcp_server_itsm_approver(apply_id: int, ticket_id: str) -> None:
-    approver = _get_itsm_approver_for_backfill(
-        ticket_id,
-        log_context={"grant_dimension": FormattedGrantDimensionEnum.MCP_SERVER.value, "apply_id": apply_id},
-    )
+    approver = _get_itsm_approver_for_backfill(ticket_id)
     if not approver:
         return
 

--- a/src/dashboard/apigateway/apigateway/apps/permission/tasks.py
+++ b/src/dashboard/apigateway/apigateway/apps/permission/tasks.py
@@ -29,9 +29,11 @@ from django.db.models import Exists, OuterRef
 from django.template.loader import render_to_string
 from django.utils import timezone
 
+from apigateway.apps.mcp_server.models import MCPServerAppPermissionApply
 from apigateway.apps.metrics.models import StatisticsAppRequestByDay
 from apigateway.apps.permission.constants import (
     ApplyStatusEnum,
+    FormattedGrantDimensionEnum,
     GrantDimensionEnum,
     GrantTypeEnum,
     PermissionApplyExpireDaysEnum,
@@ -44,6 +46,7 @@ from apigateway.apps.permission.models import (
 from apigateway.biz.permission import PermissionDimensionManager
 from apigateway.common.tenant.request import get_tenant_id_for_gateway_maintainers
 from apigateway.components.bkcmsi import cmsi_component
+from apigateway.components.bkitsm import ticket_search_full_text_search
 from apigateway.components.bkpaas import get_app_maintainers, get_tenant_id_for_app_developers
 from apigateway.core.constants import ContextScopeTypeEnum, ContextTypeEnum, GatewayStatusEnum
 from apigateway.core.models import Context, Gateway, Resource
@@ -203,6 +206,74 @@ def renew_app_resource_permission():
                 resource_ids=resource_ids,
                 grant_type=GrantTypeEnum.AUTO_RENEW.value,
             )
+
+
+def _get_actual_approver_from_itsm(ticket_id: str) -> str:
+    try:
+        # /ticket/detail/ 暂无法返回 history_processors，先用工单搜索接口，修复后可切回详情接口。
+        ticket_search_result = ticket_search_full_text_search(ticket_id)
+    except Exception:
+        logger.warning("query or parse itsm ticket search result failed, ticket_id=%s", ticket_id, exc_info=True)
+        return ""
+
+    return ticket_search_result.actual_approver
+
+
+def _update_permission_handled_by(grant_dimension: str, apply_id: int, approver: str) -> None:
+    # MCP Server 权限申请人回填
+    if grant_dimension == FormattedGrantDimensionEnum.MCP_SERVER.value:
+        updated = MCPServerAppPermissionApply.objects.filter(id=apply_id).update(handled_by=approver)
+        if not updated:
+            logger.info("skip filling itsm approver because mcp apply not found, apply_id=%s", apply_id)
+        return
+
+    # 网关、资源维度权限申请人回填
+    record = AppPermissionRecord.objects.filter(id=apply_id).first()
+    if not record:
+        logger.info("skip filling itsm approver because permission record not found, record_id=%s", apply_id)
+        return
+
+    record.handled_by = approver
+    record.save(update_fields=["handled_by"])
+
+    if grant_dimension in [GrantDimensionEnum.API.value, FormattedGrantDimensionEnum.GATEWAY.value]:
+        if record.status == ApplyStatusEnum.APPROVED.value:
+            AppGatewayPermission.objects.filter(gateway=record.gateway, bk_app_code=record.bk_app_code).update(
+                handled_by=approver
+            )
+        return
+
+    if grant_dimension in [GrantDimensionEnum.RESOURCE.value, FormattedGrantDimensionEnum.RESOURCE.value]:
+        approved_resource_ids = record.handled_resource_ids.get(ApplyStatusEnum.APPROVED.value) or []
+        if approved_resource_ids:
+            AppResourcePermission.objects.filter(
+                gateway=record.gateway,
+                bk_app_code=record.bk_app_code,
+                resource_id__in=approved_resource_ids,
+            ).update(handled_by=approver)
+        return
+
+    logger.warning(
+        "skip filling itsm approver because grant dimension is unsupported, grant_dimension=%s", grant_dimension
+    )
+
+
+@shared_task(name="apigateway.apps.permission.tasks.async_fill_itsm_approver", ignore_result=True)
+def async_fill_itsm_approver(grant_dimension: str, apply_id: int, ticket_id: str) -> None:
+    if not ticket_id:
+        logger.warning(
+            "skip filling itsm approver because ticket_id is empty, grant_dimension=%s, apply_id=%s",
+            grant_dimension,
+            apply_id,
+        )
+        return
+
+    approver = _get_actual_approver_from_itsm(ticket_id)
+    if not approver:
+        logger.info("skip filling itsm approver because approver is empty, ticket_id=%s", ticket_id)
+        return
+
+    _update_permission_handled_by(grant_dimension=grant_dimension, apply_id=apply_id, approver=approver)
 
 
 class AppPermissionExpiringSoonAlerter:

--- a/src/dashboard/apigateway/apigateway/biz/bk_itsm/bk_itsm.py
+++ b/src/dashboard/apigateway/apigateway/biz/bk_itsm/bk_itsm.py
@@ -28,6 +28,7 @@ from apigateway.apps.mcp_server.constants import (
 from apigateway.apps.mcp_server.models import MCPServerAppPermission, MCPServerAppPermissionApply
 from apigateway.apps.permission.constants import ApplyStatusEnum, FormattedGrantDimensionEnum
 from apigateway.apps.permission.models import AppPermissionApply
+from apigateway.apps.permission.tasks import async_fill_itsm_approver
 from apigateway.biz.mcp_server import MCPServerHandler
 from apigateway.biz.permission import PermissionDimensionManager
 from apigateway.common.error_codes import error_codes
@@ -105,6 +106,37 @@ class ItsmCallbackResultHandler:
             )
             raise error_codes.INVALID_ARGUMENT.format("ticket id mismatch")
 
+    @staticmethod
+    def _enqueue_approver_backfill_task(grant_dimension: str, apply_id: int, ticket_id: str):
+        task_kwargs = {
+            "grant_dimension": grant_dimension,
+            "apply_id": apply_id,
+            "ticket_id": ticket_id,
+        }
+
+        def _safe_apply_async():
+            try:
+                async_fill_itsm_approver.apply_async(kwargs=task_kwargs, ignore_result=True)
+            except Exception:
+                logger.warning(
+                    "enqueue itsm approver backfill task failed, grant_dimension=%s, apply_id=%s, ticket_id=%s",
+                    grant_dimension,
+                    apply_id,
+                    ticket_id,
+                    exc_info=True,
+                )
+
+        try:
+            transaction.on_commit(_safe_apply_async)
+        except Exception:
+            logger.warning(
+                "enqueue itsm approver backfill task failed, grant_dimension=%s, apply_id=%s, ticket_id=%s",
+                grant_dimension,
+                apply_id,
+                ticket_id,
+                exc_info=True,
+            )
+
     def _handle_gateway_approval(
         self, apply_record_id: int, approve_result: bool, ticket_id: str, callback_token: str
     ):
@@ -152,6 +184,11 @@ class ItsmCallbackResultHandler:
                 part_resource_ids=None,
             )
 
+            self._enqueue_approver_backfill_task(
+                grant_dimension=apply.grant_dimension,
+                apply_id=apply.apply_record_id,
+                ticket_id=ticket_id,
+            )
             apply.delete()
 
         logger.info(
@@ -211,6 +248,12 @@ class ItsmCallbackResultHandler:
                     expire_days=None,
                 )
                 MCPServerHandler.sync_permissions(apply.mcp_server_id)
+
+            self._enqueue_approver_backfill_task(
+                grant_dimension=FormattedGrantDimensionEnum.MCP_SERVER.value,
+                apply_id=apply.id,
+                ticket_id=ticket_id,
+            )
 
         logger.info(
             "ITSM mcp server approval result handled: apply_id=%s, approve_result=%s, ticket_id=%s",

--- a/src/dashboard/apigateway/apigateway/biz/bk_itsm/bk_itsm.py
+++ b/src/dashboard/apigateway/apigateway/biz/bk_itsm/bk_itsm.py
@@ -110,14 +110,22 @@ class ItsmCallbackResultHandler:
             raise error_codes.INVALID_ARGUMENT.format("ticket id mismatch")
 
     @staticmethod
-    def _enqueue_approver_backfill_task(celery_task, task_kwargs: Dict[str, Any], log_context: Dict[str, Any]):
+    def _enqueue_approver_backfill_task(celery_task, task_kwargs: Dict[str, Any]):
+        # ticket_id 为空时跳过入队
+        if not task_kwargs.get("ticket_id"):
+            logger.warning(
+                "skip enqueue itsm approver backfill task because ticket_id is empty, task_kwargs=%s",
+                task_kwargs,
+            )
+            return
+
         def _safe_apply_async():
             try:
                 celery_task.apply_async(kwargs=task_kwargs, ignore_result=True)
             except Exception:
                 logger.warning(
-                    "enqueue itsm approver backfill task failed, context=%s",
-                    log_context,
+                    "enqueue itsm approver backfill task failed, task_kwargs=%s",
+                    task_kwargs,
                     exc_info=True,
                 )
 
@@ -173,11 +181,6 @@ class ItsmCallbackResultHandler:
             self._enqueue_approver_backfill_task(
                 async_fill_gateway_or_resource_itsm_approver,
                 task_kwargs={
-                    "grant_dimension": apply.grant_dimension,
-                    "record_id": apply.apply_record_id,
-                    "ticket_id": ticket_id,
-                },
-                log_context={
                     "grant_dimension": apply.grant_dimension,
                     "record_id": apply.apply_record_id,
                     "ticket_id": ticket_id,
@@ -246,11 +249,6 @@ class ItsmCallbackResultHandler:
             self._enqueue_approver_backfill_task(
                 async_fill_mcp_server_itsm_approver,
                 task_kwargs={
-                    "apply_id": apply.id,
-                    "ticket_id": ticket_id,
-                },
-                log_context={
-                    "grant_dimension": FormattedGrantDimensionEnum.MCP_SERVER.value,
                     "apply_id": apply.id,
                     "ticket_id": ticket_id,
                 },

--- a/src/dashboard/apigateway/apigateway/biz/bk_itsm/bk_itsm.py
+++ b/src/dashboard/apigateway/apigateway/biz/bk_itsm/bk_itsm.py
@@ -28,7 +28,10 @@ from apigateway.apps.mcp_server.constants import (
 from apigateway.apps.mcp_server.models import MCPServerAppPermission, MCPServerAppPermissionApply
 from apigateway.apps.permission.constants import ApplyStatusEnum, FormattedGrantDimensionEnum
 from apigateway.apps.permission.models import AppPermissionApply
-from apigateway.apps.permission.tasks import async_fill_itsm_approver
+from apigateway.apps.permission.tasks import (
+    async_fill_gateway_or_resource_itsm_approver,
+    async_fill_mcp_server_itsm_approver,
+)
 from apigateway.biz.mcp_server import MCPServerHandler
 from apigateway.biz.permission import PermissionDimensionManager
 from apigateway.common.error_codes import error_codes
@@ -107,35 +110,18 @@ class ItsmCallbackResultHandler:
             raise error_codes.INVALID_ARGUMENT.format("ticket id mismatch")
 
     @staticmethod
-    def _enqueue_approver_backfill_task(grant_dimension: str, apply_id: int, ticket_id: str):
-        task_kwargs = {
-            "grant_dimension": grant_dimension,
-            "apply_id": apply_id,
-            "ticket_id": ticket_id,
-        }
-
+    def _enqueue_approver_backfill_task(celery_task, task_kwargs: Dict[str, Any], log_context: Dict[str, Any]):
         def _safe_apply_async():
             try:
-                async_fill_itsm_approver.apply_async(kwargs=task_kwargs, ignore_result=True)
+                celery_task.apply_async(kwargs=task_kwargs, ignore_result=True)
             except Exception:
                 logger.warning(
-                    "enqueue itsm approver backfill task failed, grant_dimension=%s, apply_id=%s, ticket_id=%s",
-                    grant_dimension,
-                    apply_id,
-                    ticket_id,
+                    "enqueue itsm approver backfill task failed, context=%s",
+                    log_context,
                     exc_info=True,
                 )
 
-        try:
-            transaction.on_commit(_safe_apply_async)
-        except Exception:
-            logger.warning(
-                "enqueue itsm approver backfill task failed, grant_dimension=%s, apply_id=%s, ticket_id=%s",
-                grant_dimension,
-                apply_id,
-                ticket_id,
-                exc_info=True,
-            )
+        transaction.on_commit(_safe_apply_async)
 
     def _handle_gateway_approval(
         self, apply_record_id: int, approve_result: bool, ticket_id: str, callback_token: str
@@ -185,9 +171,17 @@ class ItsmCallbackResultHandler:
             )
 
             self._enqueue_approver_backfill_task(
-                grant_dimension=apply.grant_dimension,
-                apply_id=apply.apply_record_id,
-                ticket_id=ticket_id,
+                async_fill_gateway_or_resource_itsm_approver,
+                task_kwargs={
+                    "grant_dimension": apply.grant_dimension,
+                    "record_id": apply.apply_record_id,
+                    "ticket_id": ticket_id,
+                },
+                log_context={
+                    "grant_dimension": apply.grant_dimension,
+                    "record_id": apply.apply_record_id,
+                    "ticket_id": ticket_id,
+                },
             )
             apply.delete()
 
@@ -250,9 +244,16 @@ class ItsmCallbackResultHandler:
                 MCPServerHandler.sync_permissions(apply.mcp_server_id)
 
             self._enqueue_approver_backfill_task(
-                grant_dimension=FormattedGrantDimensionEnum.MCP_SERVER.value,
-                apply_id=apply.id,
-                ticket_id=ticket_id,
+                async_fill_mcp_server_itsm_approver,
+                task_kwargs={
+                    "apply_id": apply.id,
+                    "ticket_id": ticket_id,
+                },
+                log_context={
+                    "grant_dimension": FormattedGrantDimensionEnum.MCP_SERVER.value,
+                    "apply_id": apply.id,
+                    "ticket_id": ticket_id,
+                },
             )
 
         logger.info(

--- a/src/dashboard/apigateway/apigateway/components/bkitsm.py
+++ b/src/dashboard/apigateway/apigateway/components/bkitsm.py
@@ -104,6 +104,106 @@ class ItsmFormModelUpdateResult:
         return cls(updated_field_keys=frozenset(updated_fields.keys()), raw=resp)
 
 
+@dataclass(frozen=True)
+class ItsmTicketProcessor:
+    user_id: str
+    processor_type: str
+    raw: Dict[str, Any]
+
+    @classmethod
+    def from_response_item(cls, item: Any) -> Optional["ItsmTicketProcessor"]:
+        if not isinstance(item, dict):
+            return None
+
+        processor_type = item.get("type")
+        if processor_type != "user":
+            return None
+
+        user_id = item.get("id")
+        if not isinstance(user_id, str) or not user_id.strip():
+            return None
+
+        return cls(user_id=user_id.strip(), processor_type=processor_type, raw=item)
+
+
+@dataclass(frozen=True)
+class ItsmTicketDetail:
+    history_processors: tuple[ItsmTicketProcessor, ...]
+    current_processors: tuple[ItsmTicketProcessor, ...]
+    raw: Dict[str, Any]
+
+    @classmethod
+    def from_response(cls, resp: Any):
+        if not isinstance(resp, dict):
+            raise TypeError("invalid ticket item response: response must be an object")
+
+        data = resp.get("data")
+        response_data = data if isinstance(data, dict) else resp
+        return cls(
+            history_processors=cls._extract_processors(response_data.get("history_processors"), "history_processors"),
+            current_processors=cls._extract_processors(response_data.get("current_processors"), "current_processors"),
+            raw=resp,
+        )
+
+    @staticmethod
+    def _extract_processors(processors: Any, field_name: str) -> tuple[ItsmTicketProcessor, ...]:
+        if processors is None:
+            return ()
+        if not isinstance(processors, list):
+            raise TypeError(f"invalid ticket item response: {field_name} must be a list")
+
+        return tuple(
+            processor
+            for processor in (ItsmTicketProcessor.from_response_item(item) for item in processors)
+            if processor is not None
+        )
+
+    @property
+    def actual_approver(self) -> str:
+        for processor in self.history_processors:
+            return processor.user_id
+
+        return ""
+
+
+@dataclass(frozen=True)
+class ItsmTicketSearchResult:
+    count: int
+    tickets: tuple[ItsmTicketDetail, ...]
+    raw: Dict[str, Any]
+
+    @classmethod
+    def from_response(cls, resp: Any):
+        if not isinstance(resp, dict):
+            raise TypeError("invalid ticket_search_full_text_search response: response must be an object")
+
+        response_data = resp.get("data")
+        if not isinstance(response_data, dict):
+            raise TypeError("invalid ticket_search_full_text_search response: data must be an object")
+
+        results = response_data.get("results")
+        if not isinstance(results, list):
+            raise TypeError("invalid ticket_search_full_text_search response: results must be a list")
+
+        count = response_data.get("count", len(results))
+        if not isinstance(count, int):
+            raise TypeError("invalid ticket_search_full_text_search response: count must be an integer")
+
+        return cls(
+            count=count,
+            tickets=tuple(ItsmTicketDetail.from_response(item) for item in results),
+            raw=resp,
+        )
+
+    @property
+    def actual_approver(self) -> str:
+        for ticket in self.tickets:
+            if ticket.actual_approver:
+                return ticket.actual_approver
+
+        return ""
+
+
 def _call_bkitsm_api(
     http_func,
     path: str,
@@ -264,3 +364,26 @@ def create_ticket(
         more_headers=more_headers,
         timeout=settings.BK_ITSM4_API_TIMEOUT,
     )
+
+
+def ticket_search_full_text_search(ticket_id: str, operator: Optional[str] = None) -> ItsmTicketSearchResult:
+    """
+    批量查询 ITSM 工单列表
+
+    调用接口: ticket_search_full_text_search (POST)
+    路径: /api/v1/ticket_search/full_text_search/
+    """
+    data = {
+        "page": 1,
+        "page_size": 10,
+        "id__in": ticket_id,
+        "operator": operator or settings.BK_ITSM4_QUERY_OPERATOR,
+        "group_key": "all",
+    }
+    resp = _call_bkitsm_api(
+        http_post,
+        "/api/v1/ticket_search/full_text_search/",
+        data,
+        timeout=settings.BK_ITSM4_API_TIMEOUT,
+    )
+    return ItsmTicketSearchResult.from_response(resp)

--- a/src/dashboard/apigateway/apigateway/components/bkitsm.py
+++ b/src/dashboard/apigateway/apigateway/components/bkitsm.py
@@ -18,10 +18,10 @@
 #
 import json
 import logging
-from dataclasses import dataclass
 from typing import Any, Dict, Optional
 
 from django.conf import settings
+from pydantic import BaseModel
 
 from apigateway.utils.url import url_join
 
@@ -31,177 +31,77 @@ from .utils import do_blueking_http_request, gen_gateway_headers
 logger = logging.getLogger(__name__)
 
 
-@dataclass(frozen=True)
-class ItsmWorkflow:
+class ItsmWorkflow(BaseModel):
     form_schema: Dict[str, Any]
-    raw: Dict[str, Any]
-
-    @classmethod
-    def from_response_item(cls, item: Any):
-        if not isinstance(item, dict):
-            raise TypeError("invalid system_workflow_list response: results items must be objects")
-
-        form_schema = item.get("form_schema") or {}
-        if not isinstance(form_schema, dict):
-            raise TypeError("invalid system_workflow_list response: form_schema must be an object")
-
-        return cls(form_schema=form_schema, raw=item)
 
 
-@dataclass(frozen=True)
-class ItsmWorkflowList:
+class ItsmWorkflowList(BaseModel):
     count: int
-    workflows: tuple[ItsmWorkflow, ...]
-    raw: Dict[str, Any]
+    results: list[ItsmWorkflow]
 
     @classmethod
-    def empty(cls):
-        return cls(count=0, workflows=(), raw={})
+    def empty(cls) -> "ItsmWorkflowList":
+        return cls(count=0, results=[])
 
     @classmethod
-    def from_response(cls, resp: Any):
-        if not isinstance(resp, dict):
-            raise TypeError("invalid system_workflow_list response: response must be an object")
+    def from_response(cls, resp: Any) -> "ItsmWorkflowList":
+        return cls.model_validate(resp)
 
-        count = resp.get("count", 0)
-        if not isinstance(count, int):
-            raise TypeError("invalid system_workflow_list response: count must be an integer")
-
-        results = resp.get("results")
-        if not isinstance(results, list):
-            raise TypeError("invalid system_workflow_list response: results must be a list")
-
-        return cls(
-            count=count,
-            workflows=tuple(ItsmWorkflow.from_response_item(item) for item in results),
-            raw=resp,
-        )
+    @property
+    def workflows(self) -> list[ItsmWorkflow]:
+        return self.results
 
     @property
     def is_registered(self) -> bool:
         return self.count > 0
 
 
-@dataclass(frozen=True)
-class ItsmFormModelUpdateResult:
-    updated_field_keys: frozenset[str]
-    raw: Any
+class ItsmFormModelMeta(BaseModel):
+    fields: Dict[str, Any]
+
+
+class ItsmFormModelUpdateResult(BaseModel):
+    meta: ItsmFormModelMeta
 
     @classmethod
-    def from_response(cls, resp: Any):
-        if isinstance(resp, dict) and resp.get("result") is False:
-            raise RuntimeError(f"update_form_model failed: {resp}")
+    def from_response(cls, resp: Any) -> "ItsmFormModelUpdateResult":
+        return cls.model_validate(resp)
 
-        response_data = resp.get("data") if isinstance(resp, dict) and isinstance(resp.get("data"), dict) else resp
-        updated_fields = (
-            ((response_data or {}).get("meta") or {}).get("fields", {}) if isinstance(response_data, dict) else {}
-        )
-        if not updated_fields:
-            raise RuntimeError(f"update_form_model response missing meta.fields: {resp}")
-        if not isinstance(updated_fields, dict):
-            raise TypeError("invalid update_form_model response: meta.fields must be an object")
-
-        return cls(updated_field_keys=frozenset(updated_fields.keys()), raw=resp)
+    @property
+    def updated_field_keys(self) -> frozenset[str]:
+        return frozenset(self.meta.fields.keys())
 
 
-@dataclass(frozen=True)
-class ItsmTicketProcessor:
-    user_id: str
-    processor_type: str
-    raw: Dict[str, Any]
-
-    @classmethod
-    def from_response_item(cls, item: Any) -> Optional["ItsmTicketProcessor"]:
-        if not isinstance(item, dict):
-            return None
-
-        processor_type = item.get("type")
-        if processor_type != "user":
-            return None
-
-        user_id = item.get("id")
-        if not isinstance(user_id, str) or not user_id.strip():
-            return None
-
-        return cls(user_id=user_id.strip(), processor_type=processor_type, raw=item)
+class ItsmTicketProcessor(BaseModel):
+    id: str
+    type: str
+    display: str = ""
 
 
-@dataclass(frozen=True)
-class ItsmTicketDetail:
-    history_processors: tuple[ItsmTicketProcessor, ...]
-    current_processors: tuple[ItsmTicketProcessor, ...]
-    raw: Dict[str, Any]
-
-    @classmethod
-    def from_response(cls, resp: Any):
-        if not isinstance(resp, dict):
-            raise TypeError("invalid ticket item response: response must be an object")
-
-        data = resp.get("data")
-        response_data = data if isinstance(data, dict) else resp
-        return cls(
-            history_processors=cls._extract_processors(response_data.get("history_processors"), "history_processors"),
-            current_processors=cls._extract_processors(response_data.get("current_processors"), "current_processors"),
-            raw=resp,
-        )
-
-    @staticmethod
-    def _extract_processors(processors: Any, field_name: str) -> tuple[ItsmTicketProcessor, ...]:
-        if processors is None:
-            return ()
-        if not isinstance(processors, list):
-            raise TypeError(f"invalid ticket item response: {field_name} must be a list")
-
-        return tuple(
-            processor
-            for processor in (ItsmTicketProcessor.from_response_item(item) for item in processors)
-            if processor is not None
-        )
+class ItsmTicketItem(BaseModel):
+    id: str
+    history_processors: Optional[list[ItsmTicketProcessor]] = None
 
     @property
     def actual_approver(self) -> str:
-        for processor in self.history_processors:
-            return processor.user_id
-
-        return ""
+        history_processors = [processor for processor in (self.history_processors or []) if processor.type == "user"]
+        return history_processors[0].id if history_processors else ""
 
 
-@dataclass(frozen=True)
-class ItsmTicketSearchResult:
+class ItsmTicketSearchResult(BaseModel):
+    results: list[ItsmTicketItem]
+    page: int = 1
+    page_size: int = 10
     count: int
-    tickets: tuple[ItsmTicketDetail, ...]
-    raw: Dict[str, Any]
 
     @classmethod
-    def from_response(cls, resp: Any):
-        if not isinstance(resp, dict):
-            raise TypeError("invalid ticket_search_full_text_search response: response must be an object")
-
-        response_data = resp.get("data")
-        if not isinstance(response_data, dict):
-            raise TypeError("invalid ticket_search_full_text_search response: data must be an object")
-
-        results = response_data.get("results")
-        if not isinstance(results, list):
-            raise TypeError("invalid ticket_search_full_text_search response: results must be a list")
-
-        count = response_data.get("count", len(results))
-        if not isinstance(count, int):
-            raise TypeError("invalid ticket_search_full_text_search response: count must be an integer")
-
-        return cls(
-            count=count,
-            tickets=tuple(ItsmTicketDetail.from_response(item) for item in results),
-            raw=resp,
-        )
+    def from_response(cls, resp: Any) -> "ItsmTicketSearchResult":
+        return cls.model_validate(resp)
 
     @property
     def actual_approver(self) -> str:
-        for ticket in self.tickets:
-            if ticket.actual_approver:
-                return ticket.actual_approver
-
-        return ""
+        approvers = [ticket.actual_approver for ticket in self.results if ticket.actual_approver]
+        return approvers[0] if approvers else ""
 
 
 def _call_bkitsm_api(
@@ -366,16 +266,18 @@ def create_ticket(
     )
 
 
-def ticket_search_full_text_search(ticket_id: str, operator: Optional[str] = None) -> ItsmTicketSearchResult:
+def get_ticket_by_id(ticket_id: str, operator: Optional[str] = None) -> ItsmTicketSearchResult:
     """
-    批量查询 ITSM 工单列表
+    按工单 ID 查询单条 ITSM 工单。
 
+    因 /ticket/detail/ 暂无法返回 history_processors，先走搜索接口按 id__in 精确查询。
     调用接口: ticket_search_full_text_search (POST)
     路径: /api/v1/ticket_search/full_text_search/
     """
     data = {
         "page": 1,
-        "page_size": 10,
+        # 按单个 ticket_id 查询，只需返回一条
+        "page_size": 1,
         "id__in": ticket_id,
         "operator": operator or settings.BK_ITSM4_QUERY_OPERATOR,
         "group_key": "all",

--- a/src/dashboard/apigateway/apigateway/conf/default.py
+++ b/src/dashboard/apigateway/apigateway/conf/default.py
@@ -579,6 +579,7 @@ BK_ITSM4_URL_PREFIX = (
 )
 BK_ITSM4_API_TIMEOUT = env.int("BK_ITSM4_API_TIMEOUT", 30)
 BK_ITSM4_SYSTEM_TOKEN = env.str("BK_ITSM4_SYSTEM_TOKEN", default="")
+BK_ITSM4_QUERY_OPERATOR = env.str("BK_ITSM4_QUERY_OPERATOR", default="admin")
 BK_ITSM4_CALLBACK_APP_CODE = env.str(
     "BK_ITSM4_CALLBACK_APP_CODE",
     default="bk-itsm4" if EDITION == "te" else "cw_aitsm",

--- a/src/dashboard/apigateway/apigateway/tests/apps/permission/management/commands/test_backfill_itsm_approver.py
+++ b/src/dashboard/apigateway/apigateway/tests/apps/permission/management/commands/test_backfill_itsm_approver.py
@@ -1,0 +1,198 @@
+#
+# TencentBlueKing is pleased to support the open source community by making
+# 蓝鲸智云 - API 网关(BlueKing - APIGateway) available.
+# Copyright (C) Tencent. All rights reserved.
+# Licensed under the MIT License (the "License"); you may not use this file except
+# in compliance with the License. You may obtain a copy of the License at
+#
+#     http://opensource.org/licenses/MIT
+#
+# Unless required by applicable law or agreed to in writing, software distributed under
+# the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+# either express or implied. See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# We undertake not to change the open source license (MIT license) applicable
+# to the current version of the project delivered to anyone in the future.
+#
+
+from io import StringIO
+
+import pytest
+from ddf import G
+from django.core.management import call_command
+
+from apigateway.apps.mcp_server.models import MCPServer, MCPServerAppPermissionApply
+from apigateway.apps.permission.constants import GrantDimensionEnum
+from apigateway.apps.permission.management.commands.backfill_itsm_approver import ITSM_HANDLED_BY_PLACEHOLDER
+from apigateway.apps.permission.models import AppPermissionRecord
+
+pytestmark = pytest.mark.django_db
+
+COMMAND_NAME = "backfill_itsm_approver"
+
+
+def test_dry_run_does_not_backfill(fake_gateway, unique_id, mocker):
+    record = G(
+        AppPermissionRecord,
+        gateway=fake_gateway,
+        bk_app_code=unique_id,
+        grant_dimension=GrantDimensionEnum.API.value,
+        handled_by=ITSM_HANDLED_BY_PLACEHOLDER,
+        itsm_ticket_id="ticket-001",
+    )
+    backfill = mocker.patch(
+        "apigateway.apps.permission.management.commands.backfill_itsm_approver."
+        "async_fill_gateway_or_resource_itsm_approver"
+    )
+
+    output = StringIO()
+    call_command(COMMAND_NAME, type="gateway", dry_run=True, stdout=output)
+
+    assert f"gateway record_id={record.id}" in output.getvalue()
+    assert (
+        "mode=dry-run gateway_total=1 gateway_success=0 gateway_failed=0 "
+        "mcp_total=0 mcp_success=0 mcp_failed=0" in output.getvalue()
+    )
+    backfill.assert_not_called()
+
+
+def test_default_backfills_gateway_and_mcp(fake_gateway, fake_stage, unique_id, mocker):
+    record = G(
+        AppPermissionRecord,
+        gateway=fake_gateway,
+        bk_app_code=unique_id,
+        grant_dimension=GrantDimensionEnum.RESOURCE.value,
+        handled_by=ITSM_HANDLED_BY_PLACEHOLDER,
+        itsm_ticket_id="ticket-gateway",
+    )
+    mcp_server = G(MCPServer, gateway=fake_gateway, stage=fake_stage)
+    apply = G(
+        MCPServerAppPermissionApply,
+        mcp_server=mcp_server,
+        bk_app_code=unique_id,
+        handled_by=ITSM_HANDLED_BY_PLACEHOLDER,
+        itsm_ticket_id="ticket-mcp",
+    )
+    # already backfilled, should be skipped without --force
+    G(
+        AppPermissionRecord,
+        gateway=fake_gateway,
+        bk_app_code=f"{unique_id}-done",
+        grant_dimension=GrantDimensionEnum.API.value,
+        handled_by="admin",
+        itsm_ticket_id="ticket-done",
+    )
+
+    def _fill_gateway(grant_dimension, record_id, ticket_id):
+        AppPermissionRecord.objects.filter(id=record_id).update(handled_by="admin")
+
+    def _fill_mcp(apply_id, ticket_id):
+        MCPServerAppPermissionApply.objects.filter(id=apply_id).update(handled_by="admin")
+
+    gateway_backfill = mocker.patch(
+        "apigateway.apps.permission.management.commands.backfill_itsm_approver."
+        "async_fill_gateway_or_resource_itsm_approver",
+        side_effect=_fill_gateway,
+    )
+    mcp_backfill = mocker.patch(
+        "apigateway.apps.permission.management.commands.backfill_itsm_approver.async_fill_mcp_server_itsm_approver",
+        side_effect=_fill_mcp,
+    )
+
+    output = StringIO()
+    call_command(COMMAND_NAME, stdout=output)
+
+    assert (
+        "mode=backfill gateway_total=1 gateway_success=1 gateway_failed=0 "
+        "mcp_total=1 mcp_success=1 mcp_failed=0" in output.getvalue()
+    )
+    gateway_backfill.assert_called_once_with(record.grant_dimension, record.id, "ticket-gateway")
+    mcp_backfill.assert_called_once_with(apply.id, "ticket-mcp")
+    record.refresh_from_db()
+    apply.refresh_from_db()
+    assert record.handled_by == "admin"
+    assert apply.handled_by == "admin"
+
+
+def test_mcp_apply_id_only_backfills_mcp(fake_gateway, fake_stage, unique_id, mocker):
+    G(
+        AppPermissionRecord,
+        gateway=fake_gateway,
+        bk_app_code=unique_id,
+        grant_dimension=GrantDimensionEnum.API.value,
+        handled_by=ITSM_HANDLED_BY_PLACEHOLDER,
+        itsm_ticket_id="ticket-gateway",
+    )
+    mcp_server = G(MCPServer, gateway=fake_gateway, stage=fake_stage)
+    apply = G(
+        MCPServerAppPermissionApply,
+        mcp_server=mcp_server,
+        bk_app_code=unique_id,
+        handled_by=ITSM_HANDLED_BY_PLACEHOLDER,
+        itsm_ticket_id="ticket-mcp",
+    )
+
+    gateway_backfill = mocker.patch(
+        "apigateway.apps.permission.management.commands.backfill_itsm_approver."
+        "async_fill_gateway_or_resource_itsm_approver"
+    )
+    mcp_backfill = mocker.patch(
+        "apigateway.apps.permission.management.commands.backfill_itsm_approver.async_fill_mcp_server_itsm_approver",
+        side_effect=lambda apply_id, ticket_id: MCPServerAppPermissionApply.objects.filter(id=apply_id).update(
+            handled_by="admin"
+        ),
+    )
+
+    output = StringIO()
+    call_command(COMMAND_NAME, mcp_apply_id=apply.id, stdout=output)
+
+    assert (
+        "mode=backfill gateway_total=0 gateway_success=0 gateway_failed=0 "
+        "mcp_total=1 mcp_success=1 mcp_failed=0" in output.getvalue()
+    )
+    gateway_backfill.assert_not_called()
+    mcp_backfill.assert_called_once_with(apply.id, "ticket-mcp")
+
+
+def test_backfill_failure_is_counted_and_continues(fake_gateway, unique_id, mocker):
+    record1 = G(
+        AppPermissionRecord,
+        gateway=fake_gateway,
+        bk_app_code=f"{unique_id}-1",
+        grant_dimension=GrantDimensionEnum.API.value,
+        handled_by=ITSM_HANDLED_BY_PLACEHOLDER,
+        itsm_ticket_id="ticket-1",
+    )
+    record2 = G(
+        AppPermissionRecord,
+        gateway=fake_gateway,
+        bk_app_code=f"{unique_id}-2",
+        grant_dimension=GrantDimensionEnum.API.value,
+        handled_by=ITSM_HANDLED_BY_PLACEHOLDER,
+        itsm_ticket_id="ticket-2",
+    )
+
+    def _side_effect(grant_dimension, record_id, ticket_id):
+        if record_id == record1.id:
+            raise RuntimeError("itsm down")
+        AppPermissionRecord.objects.filter(id=record_id).update(handled_by="admin")
+
+    backfill = mocker.patch(
+        "apigateway.apps.permission.management.commands.backfill_itsm_approver."
+        "async_fill_gateway_or_resource_itsm_approver",
+        side_effect=_side_effect,
+    )
+
+    output = StringIO()
+    err = StringIO()
+    call_command(COMMAND_NAME, type="gateway", stdout=output, stderr=err)
+
+    assert (
+        "mode=backfill gateway_total=2 gateway_success=1 gateway_failed=1 "
+        "mcp_total=0 mcp_success=0 mcp_failed=0" in output.getvalue()
+    )
+    assert f"gateway backfill failed record_id={record1.id}" in err.getvalue()
+    assert backfill.call_count == 2
+    record2.refresh_from_db()
+    assert record2.handled_by == "admin"

--- a/src/dashboard/apigateway/apigateway/tests/apps/permission/test_tasks.py
+++ b/src/dashboard/apigateway/apigateway/tests/apps/permission/test_tasks.py
@@ -29,7 +29,8 @@ from apigateway.apps.permission.models import AppGatewayPermission, AppPermissio
 from apigateway.apps.permission.tasks import (
     AppPermissionExpiringSoonAlerter,
     _get_actual_approver_from_itsm,
-    async_fill_itsm_approver,
+    async_fill_gateway_or_resource_itsm_approver,
+    async_fill_mcp_server_itsm_approver,
     renew_app_resource_permission,
 )
 from apigateway.utils.time import NeverExpiresTime, now_datetime, to_datetime_from_now
@@ -113,7 +114,7 @@ class TestRenewAppResourcePermission:
 class TestAsyncFillItsmApprover:
     def test_get_actual_approver_returns_structured_result(self, mocker):
         mocker.patch(
-            "apigateway.apps.permission.tasks.ticket_search_full_text_search",
+            "apigateway.apps.permission.tasks.get_ticket_by_id",
             return_value=mocker.Mock(actual_approver="admin"),
         )
 
@@ -121,16 +122,14 @@ class TestAsyncFillItsmApprover:
 
     def test_get_actual_approver_returns_empty_when_ticket_has_no_approver(self, mocker):
         mocker.patch(
-            "apigateway.apps.permission.tasks.ticket_search_full_text_search",
+            "apigateway.apps.permission.tasks.get_ticket_by_id",
             return_value=mocker.Mock(actual_approver=""),
         )
 
         assert _get_actual_approver_from_itsm("ticket-001") == ""
 
     def test_get_actual_approver_returns_empty_when_query_failed(self, mocker):
-        mocker.patch(
-            "apigateway.apps.permission.tasks.ticket_search_full_text_search", side_effect=Exception("remote error")
-        )
+        mocker.patch("apigateway.apps.permission.tasks.get_ticket_by_id", side_effect=Exception("remote error"))
 
         assert _get_actual_approver_from_itsm("ticket-001") == ""
 
@@ -152,7 +151,7 @@ class TestAsyncFillItsmApprover:
         )
         mocker.patch("apigateway.apps.permission.tasks._get_actual_approver_from_itsm", return_value="admin")
 
-        async_fill_itsm_approver(GrantDimensionEnum.API.value, record.id, "ticket-001")
+        async_fill_gateway_or_resource_itsm_approver(GrantDimensionEnum.API.value, record.id, "ticket-001")
 
         record.refresh_from_db()
         permission.refresh_from_db()
@@ -179,7 +178,7 @@ class TestAsyncFillItsmApprover:
         )
         mocker.patch("apigateway.apps.permission.tasks._get_actual_approver_from_itsm", return_value="admin")
 
-        async_fill_itsm_approver(GrantDimensionEnum.RESOURCE.value, record.id, "ticket-001")
+        async_fill_gateway_or_resource_itsm_approver(GrantDimensionEnum.RESOURCE.value, record.id, "ticket-001")
 
         record.refresh_from_db()
         permission.refresh_from_db()
@@ -197,7 +196,7 @@ class TestAsyncFillItsmApprover:
         )
         mocker.patch("apigateway.apps.permission.tasks._get_actual_approver_from_itsm", return_value="admin")
 
-        async_fill_itsm_approver("mcp_server", apply.id, "ticket-001")
+        async_fill_mcp_server_itsm_approver(apply.id, "ticket-001")
 
         apply.refresh_from_db()
         assert apply.handled_by == "admin"

--- a/src/dashboard/apigateway/apigateway/tests/apps/permission/test_tasks.py
+++ b/src/dashboard/apigateway/apigateway/tests/apps/permission/test_tasks.py
@@ -16,13 +16,22 @@
 # to the current version of the project delivered to anyone in the future.
 #
 import datetime
+import json
 
 from ddf import G
 from django.utils import timezone
 
+from apigateway.apps.mcp_server.constants import MCPServerAppPermissionApplyStatusEnum
+from apigateway.apps.mcp_server.models import MCPServer, MCPServerAppPermissionApply
 from apigateway.apps.metrics.models import StatisticsAppRequestByDay
-from apigateway.apps.permission.models import AppGatewayPermission, AppResourcePermission
-from apigateway.apps.permission.tasks import AppPermissionExpiringSoonAlerter, renew_app_resource_permission
+from apigateway.apps.permission.constants import ApplyStatusEnum, GrantDimensionEnum, GrantTypeEnum
+from apigateway.apps.permission.models import AppGatewayPermission, AppPermissionRecord, AppResourcePermission
+from apigateway.apps.permission.tasks import (
+    AppPermissionExpiringSoonAlerter,
+    _get_actual_approver_from_itsm,
+    async_fill_itsm_approver,
+    renew_app_resource_permission,
+)
 from apigateway.utils.time import NeverExpiresTime, now_datetime, to_datetime_from_now
 
 
@@ -99,6 +108,99 @@ class TestRenewAppResourcePermission:
         assert AppResourcePermission.objects.get(
             gateway_id=fake_gateway.id, bk_app_code=bk_app_code, resource_id=5
         ).expires > to_datetime_from_now(days=179)
+
+
+class TestAsyncFillItsmApprover:
+    def test_get_actual_approver_returns_structured_result(self, mocker):
+        mocker.patch(
+            "apigateway.apps.permission.tasks.ticket_search_full_text_search",
+            return_value=mocker.Mock(actual_approver="admin"),
+        )
+
+        assert _get_actual_approver_from_itsm("ticket-001") == "admin"
+
+    def test_get_actual_approver_returns_empty_when_ticket_has_no_approver(self, mocker):
+        mocker.patch(
+            "apigateway.apps.permission.tasks.ticket_search_full_text_search",
+            return_value=mocker.Mock(actual_approver=""),
+        )
+
+        assert _get_actual_approver_from_itsm("ticket-001") == ""
+
+    def test_get_actual_approver_returns_empty_when_query_failed(self, mocker):
+        mocker.patch(
+            "apigateway.apps.permission.tasks.ticket_search_full_text_search", side_effect=Exception("remote error")
+        )
+
+        assert _get_actual_approver_from_itsm("ticket-001") == ""
+
+    def test_fill_gateway_permission_approver(self, mocker, fake_gateway, unique_id):
+        record = G(
+            AppPermissionRecord,
+            gateway=fake_gateway,
+            bk_app_code=unique_id,
+            grant_dimension=GrantDimensionEnum.API.value,
+            status=ApplyStatusEnum.APPROVED.value,
+            handled_by="itsm",
+        )
+        permission = G(
+            AppGatewayPermission,
+            gateway=fake_gateway,
+            bk_app_code=unique_id,
+            grant_type=GrantTypeEnum.APPLY.value,
+            handled_by="itsm",
+        )
+        mocker.patch("apigateway.apps.permission.tasks._get_actual_approver_from_itsm", return_value="admin")
+
+        async_fill_itsm_approver(GrantDimensionEnum.API.value, record.id, "ticket-001")
+
+        record.refresh_from_db()
+        permission.refresh_from_db()
+        assert record.handled_by == "admin"
+        assert permission.handled_by == "admin"
+
+    def test_fill_resource_permission_approver(self, mocker, fake_gateway, unique_id):
+        record = G(
+            AppPermissionRecord,
+            gateway=fake_gateway,
+            bk_app_code=unique_id,
+            grant_dimension=GrantDimensionEnum.RESOURCE.value,
+            status=ApplyStatusEnum.APPROVED.value,
+            handled_by="itsm",
+            _handled_resource_ids=json.dumps({ApplyStatusEnum.APPROVED.value: [1]}),
+        )
+        permission = G(
+            AppResourcePermission,
+            gateway=fake_gateway,
+            bk_app_code=unique_id,
+            resource_id=1,
+            grant_type=GrantTypeEnum.APPLY.value,
+            handled_by="itsm",
+        )
+        mocker.patch("apigateway.apps.permission.tasks._get_actual_approver_from_itsm", return_value="admin")
+
+        async_fill_itsm_approver(GrantDimensionEnum.RESOURCE.value, record.id, "ticket-001")
+
+        record.refresh_from_db()
+        permission.refresh_from_db()
+        assert record.handled_by == "admin"
+        assert permission.handled_by == "admin"
+
+    def test_fill_mcp_permission_apply_approver(self, mocker, fake_gateway, fake_stage):
+        mcp_server = G(MCPServer, gateway=fake_gateway, stage=fake_stage)
+        apply = G(
+            MCPServerAppPermissionApply,
+            bk_app_code="test-app",
+            mcp_server=mcp_server,
+            status=MCPServerAppPermissionApplyStatusEnum.APPROVED.value,
+            handled_by="itsm",
+        )
+        mocker.patch("apigateway.apps.permission.tasks._get_actual_approver_from_itsm", return_value="admin")
+
+        async_fill_itsm_approver("mcp_server", apply.id, "ticket-001")
+
+        apply.refresh_from_db()
+        assert apply.handled_by == "admin"
 
 
 class TestAppPermissionExpiringSoonAlerter:

--- a/src/dashboard/apigateway/apigateway/tests/apps/permission/test_tasks.py
+++ b/src/dashboard/apigateway/apigateway/tests/apps/permission/test_tasks.py
@@ -28,7 +28,7 @@ from apigateway.apps.permission.constants import ApplyStatusEnum, GrantDimension
 from apigateway.apps.permission.models import AppGatewayPermission, AppPermissionRecord, AppResourcePermission
 from apigateway.apps.permission.tasks import (
     AppPermissionExpiringSoonAlerter,
-    _get_actual_approver_from_itsm,
+    _get_itsm_approver_for_backfill,
     async_fill_gateway_or_resource_itsm_approver,
     async_fill_mcp_server_itsm_approver,
     renew_app_resource_permission,
@@ -112,26 +112,26 @@ class TestRenewAppResourcePermission:
 
 
 class TestAsyncFillItsmApprover:
-    def test_get_actual_approver_returns_structured_result(self, mocker):
+    def test_get_itsm_approver_returns_structured_result(self, mocker):
         mocker.patch(
             "apigateway.apps.permission.tasks.get_ticket_by_id",
             return_value=mocker.Mock(actual_approver="admin"),
         )
 
-        assert _get_actual_approver_from_itsm("ticket-001") == "admin"
+        assert _get_itsm_approver_for_backfill("ticket-001") == "admin"
 
-    def test_get_actual_approver_returns_empty_when_ticket_has_no_approver(self, mocker):
+    def test_get_itsm_approver_returns_empty_when_ticket_has_no_approver(self, mocker):
         mocker.patch(
             "apigateway.apps.permission.tasks.get_ticket_by_id",
             return_value=mocker.Mock(actual_approver=""),
         )
 
-        assert _get_actual_approver_from_itsm("ticket-001") == ""
+        assert _get_itsm_approver_for_backfill("ticket-001") == ""
 
-    def test_get_actual_approver_returns_empty_when_query_failed(self, mocker):
+    def test_get_itsm_approver_returns_empty_when_query_failed(self, mocker):
         mocker.patch("apigateway.apps.permission.tasks.get_ticket_by_id", side_effect=Exception("remote error"))
 
-        assert _get_actual_approver_from_itsm("ticket-001") == ""
+        assert _get_itsm_approver_for_backfill("ticket-001") == ""
 
     def test_fill_gateway_permission_approver(self, mocker, fake_gateway, unique_id):
         record = G(
@@ -149,7 +149,10 @@ class TestAsyncFillItsmApprover:
             grant_type=GrantTypeEnum.APPLY.value,
             handled_by="itsm",
         )
-        mocker.patch("apigateway.apps.permission.tasks._get_actual_approver_from_itsm", return_value="admin")
+        mocker.patch(
+            "apigateway.apps.permission.tasks.get_ticket_by_id",
+            return_value=mocker.Mock(actual_approver="admin"),
+        )
 
         async_fill_gateway_or_resource_itsm_approver(GrantDimensionEnum.API.value, record.id, "ticket-001")
 
@@ -176,7 +179,10 @@ class TestAsyncFillItsmApprover:
             grant_type=GrantTypeEnum.APPLY.value,
             handled_by="itsm",
         )
-        mocker.patch("apigateway.apps.permission.tasks._get_actual_approver_from_itsm", return_value="admin")
+        mocker.patch(
+            "apigateway.apps.permission.tasks.get_ticket_by_id",
+            return_value=mocker.Mock(actual_approver="admin"),
+        )
 
         async_fill_gateway_or_resource_itsm_approver(GrantDimensionEnum.RESOURCE.value, record.id, "ticket-001")
 
@@ -194,7 +200,10 @@ class TestAsyncFillItsmApprover:
             status=MCPServerAppPermissionApplyStatusEnum.APPROVED.value,
             handled_by="itsm",
         )
-        mocker.patch("apigateway.apps.permission.tasks._get_actual_approver_from_itsm", return_value="admin")
+        mocker.patch(
+            "apigateway.apps.permission.tasks.get_ticket_by_id",
+            return_value=mocker.Mock(actual_approver="admin"),
+        )
 
         async_fill_mcp_server_itsm_approver(apply.id, "ticket-001")
 

--- a/src/dashboard/apigateway/apigateway/tests/biz/bk_itsm/test_bk_itsm.py
+++ b/src/dashboard/apigateway/apigateway/tests/biz/bk_itsm/test_bk_itsm.py
@@ -119,7 +119,7 @@ class TestItsmCallbackResultHandler:
         assert apply.status == ApplyStatusEnum.APPROVED.value
         mock_get_manager.assert_not_called()
 
-    def test_handle_gateway_callback_approved_grant_type_apply(self, fake_gateway):
+    def test_handle_gateway_callback_approved_grant_type_apply(self, mocker, fake_gateway):
         record = G(
             AppPermissionRecord,
             gateway=fake_gateway,
@@ -142,6 +142,8 @@ class TestItsmCallbackResultHandler:
             itsm_ticket_id="itsm-ticket-004",
             itsm_callback_token="cb-token-004",
         )
+        mocker.patch("apigateway.biz.bk_itsm.bk_itsm.transaction.on_commit", side_effect=lambda fn: fn())
+        mock_apply_async = mocker.patch("apigateway.biz.bk_itsm.bk_itsm.async_fill_itsm_approver.apply_async")
 
         ItsmCallbackResultHandler().handle(
             ticket={
@@ -158,6 +160,14 @@ class TestItsmCallbackResultHandler:
         permission = AppGatewayPermission.objects.get(gateway=fake_gateway, bk_app_code=apply.bk_app_code)
         assert permission.grant_type == GrantTypeEnum.APPLY.value
         assert not AppPermissionApply.objects.filter(id=apply.id).exists()
+        mock_apply_async.assert_called_once_with(
+            kwargs={
+                "grant_dimension": GrantDimensionEnum.API.value,
+                "apply_id": record.id,
+                "ticket_id": "itsm-ticket-004",
+            },
+            ignore_result=True,
+        )
 
     def test_handle_mcp_callback_approved_updates_apply_and_sync_permissions(self, mocker, fake_gateway, fake_stage):
         mcp_server = G(MCPServer, gateway=fake_gateway, stage=fake_stage)
@@ -176,6 +186,8 @@ class TestItsmCallbackResultHandler:
             "apigateway.biz.bk_itsm.bk_itsm.MCPServerAppPermission.objects.save_permission"
         )
         mock_sync_permissions = mocker.patch("apigateway.biz.bk_itsm.bk_itsm.MCPServerHandler.sync_permissions")
+        mocker.patch("apigateway.biz.bk_itsm.bk_itsm.transaction.on_commit", side_effect=lambda fn: fn())
+        mock_apply_async = mocker.patch("apigateway.biz.bk_itsm.bk_itsm.async_fill_itsm_approver.apply_async")
 
         ItsmCallbackResultHandler().handle(
             ticket={
@@ -200,3 +212,11 @@ class TestItsmCallbackResultHandler:
             expire_days=None,
         )
         mock_sync_permissions.assert_called_once_with(apply.mcp_server_id)
+        mock_apply_async.assert_called_once_with(
+            kwargs={
+                "grant_dimension": "mcp_server",
+                "apply_id": apply.id,
+                "ticket_id": "itsm-mcp-001",
+            },
+            ignore_result=True,
+        )

--- a/src/dashboard/apigateway/apigateway/tests/biz/bk_itsm/test_bk_itsm.py
+++ b/src/dashboard/apigateway/apigateway/tests/biz/bk_itsm/test_bk_itsm.py
@@ -223,3 +223,15 @@ class TestItsmCallbackResultHandler:
             },
             ignore_result=True,
         )
+
+    def test_enqueue_approver_backfill_task_skips_when_ticket_id_empty(self, mocker):
+        mock_on_commit = mocker.patch("apigateway.biz.bk_itsm.bk_itsm.transaction.on_commit")
+        celery_task = mocker.Mock()
+
+        ItsmCallbackResultHandler._enqueue_approver_backfill_task(
+            celery_task,
+            task_kwargs={"record_id": 1, "ticket_id": ""},
+        )
+
+        mock_on_commit.assert_not_called()
+        celery_task.apply_async.assert_not_called()

--- a/src/dashboard/apigateway/apigateway/tests/biz/bk_itsm/test_bk_itsm.py
+++ b/src/dashboard/apigateway/apigateway/tests/biz/bk_itsm/test_bk_itsm.py
@@ -143,7 +143,9 @@ class TestItsmCallbackResultHandler:
             itsm_callback_token="cb-token-004",
         )
         mocker.patch("apigateway.biz.bk_itsm.bk_itsm.transaction.on_commit", side_effect=lambda fn: fn())
-        mock_apply_async = mocker.patch("apigateway.biz.bk_itsm.bk_itsm.async_fill_itsm_approver.apply_async")
+        mock_apply_async = mocker.patch(
+            "apigateway.biz.bk_itsm.bk_itsm.async_fill_gateway_or_resource_itsm_approver.apply_async"
+        )
 
         ItsmCallbackResultHandler().handle(
             ticket={
@@ -163,7 +165,7 @@ class TestItsmCallbackResultHandler:
         mock_apply_async.assert_called_once_with(
             kwargs={
                 "grant_dimension": GrantDimensionEnum.API.value,
-                "apply_id": record.id,
+                "record_id": record.id,
                 "ticket_id": "itsm-ticket-004",
             },
             ignore_result=True,
@@ -187,7 +189,9 @@ class TestItsmCallbackResultHandler:
         )
         mock_sync_permissions = mocker.patch("apigateway.biz.bk_itsm.bk_itsm.MCPServerHandler.sync_permissions")
         mocker.patch("apigateway.biz.bk_itsm.bk_itsm.transaction.on_commit", side_effect=lambda fn: fn())
-        mock_apply_async = mocker.patch("apigateway.biz.bk_itsm.bk_itsm.async_fill_itsm_approver.apply_async")
+        mock_apply_async = mocker.patch(
+            "apigateway.biz.bk_itsm.bk_itsm.async_fill_mcp_server_itsm_approver.apply_async"
+        )
 
         ItsmCallbackResultHandler().handle(
             ticket={
@@ -214,7 +218,6 @@ class TestItsmCallbackResultHandler:
         mock_sync_permissions.assert_called_once_with(apply.mcp_server_id)
         mock_apply_async.assert_called_once_with(
             kwargs={
-                "grant_dimension": "mcp_server",
                 "apply_id": apply.id,
                 "ticket_id": "itsm-mcp-001",
             },

--- a/src/dashboard/apigateway/apigateway/tests/components/test_bkitsm.py
+++ b/src/dashboard/apigateway/apigateway/tests/components/test_bkitsm.py
@@ -21,9 +21,12 @@ import pytest
 
 from apigateway.components.bkitsm import (
     ItsmFormModelUpdateResult,
+    ItsmTicketDetail,
+    ItsmTicketSearchResult,
     ItsmWorkflowList,
     _call_bkitsm_api,
     create_ticket,
+    ticket_search_full_text_search,
     update_form_model,
 )
 
@@ -61,6 +64,67 @@ def test_itsm_form_model_update_result_extract_updated_fields():
     )
 
     assert result.updated_field_keys == frozenset({"apply_reason", "gateway_name"})
+
+
+def test_itsm_ticket_detail_prefers_first_history_user():
+    detail = ItsmTicketDetail.from_response(
+        {
+            "history_processors": [
+                {"id": "admin", "type": "user", "display": "管理员(admin)"},
+                {"id": "neoling", "type": "user", "display": "neoling"},
+            ],
+            "current_processors": [{"processor": "current-user", "processor_type": "user"}],
+        }
+    )
+
+    assert detail.actual_approver == "admin"
+
+
+def test_itsm_ticket_detail_returns_empty_without_history_user():
+    detail = ItsmTicketDetail.from_response(
+        {
+            "current_processors": [
+                {"id": "group-a", "type": "group", "display": "group-a"},
+                {"id": "admin", "type": "user", "display": "管理员(admin)"},
+            ]
+        }
+    )
+
+    assert detail.actual_approver == ""
+
+
+def test_itsm_ticket_detail_requires_processors_list():
+    with pytest.raises(TypeError, match="history_processors must be a list"):
+        ItsmTicketDetail.from_response({"history_processors": {"id": "admin", "type": "user"}})
+
+
+def test_itsm_ticket_search_result_extract_actual_approver():
+    result = ItsmTicketSearchResult.from_response(
+        {
+            "result": True,
+            "data": {
+                "results": [
+                    {
+                        "id": "t-001",
+                        "history_processors": [
+                            {"id": "admin", "type": "user", "display": "管理员(admin)"},
+                            {"id": "neoling", "type": "user", "display": "neoling"},
+                        ],
+                    }
+                ],
+                "page": 1,
+                "page_size": 10,
+                "count": 1,
+            },
+        }
+    )
+
+    assert result.actual_approver == "admin"
+
+
+def test_itsm_ticket_search_result_requires_results_list():
+    with pytest.raises(TypeError, match="results must be a list"):
+        ItsmTicketSearchResult.from_response({"data": {"results": {}, "count": 1}})
 
 
 def test_create_ticket_prefers_system_token(settings, mocker):
@@ -118,3 +182,34 @@ def test_update_form_model_fallback_to_global_token(settings, mocker):
     _, kwargs = mock_call.call_args
     assert kwargs["more_headers"] == {"SYSTEM-TOKEN": "fallback-token"}
     assert result.updated_field_keys == frozenset({"apply_reason"})
+
+
+def test_ticket_search_full_text_search(settings, mocker):
+    settings.BK_ITSM4_URL_PREFIX = "http://bk-itsm4.example.com/prod"
+    settings.BK_ITSM4_API_TIMEOUT = 30
+    settings.BK_ITSM4_QUERY_OPERATOR = "admin"
+
+    mock_call = mocker.patch(
+        "apigateway.components.bkitsm._call_bkitsm_api",
+        return_value={
+            "data": {
+                "results": [{"id": "t-001", "history_processors": [{"id": "admin", "type": "user"}]}],
+                "count": 1,
+            }
+        },
+    )
+
+    result = ticket_search_full_text_search("t-001")
+
+    args, kwargs = mock_call.call_args
+    assert args[1] == "/api/v1/ticket_search/full_text_search/"
+    assert args[2] == {
+        "page": 1,
+        "page_size": 10,
+        "id__in": "t-001",
+        "operator": "admin",
+        "group_key": "all",
+    }
+    assert kwargs["timeout"] == 30
+    assert result.actual_approver == "admin"
+    assert result.count == 1

--- a/src/dashboard/apigateway/apigateway/tests/components/test_bkitsm.py
+++ b/src/dashboard/apigateway/apigateway/tests/components/test_bkitsm.py
@@ -18,15 +18,16 @@
 #
 
 import pytest
+from pydantic import ValidationError
 
 from apigateway.components.bkitsm import (
     ItsmFormModelUpdateResult,
-    ItsmTicketDetail,
+    ItsmTicketItem,
     ItsmTicketSearchResult,
     ItsmWorkflowList,
     _call_bkitsm_api,
     create_ticket,
-    ticket_search_full_text_search,
+    get_ticket_by_id,
     update_form_model,
 )
 
@@ -51,71 +52,71 @@ def test_itsm_workflow_list_requires_results_shape():
 
     assert len(workflow_list.workflows) == 1
 
-    with pytest.raises(TypeError, match="results must be a list"):
+    with pytest.raises(ValidationError):
         ItsmWorkflowList.from_response({"count": 1, "data": []})
 
-    with pytest.raises(TypeError, match="results items must be objects"):
+    with pytest.raises(ValidationError):
         ItsmWorkflowList.from_response({"count": 1, "results": ["invalid"]})
 
 
 def test_itsm_form_model_update_result_extract_updated_fields():
-    result = ItsmFormModelUpdateResult.from_response(
-        {"data": {"meta": {"fields": {"apply_reason": {}, "gateway_name": {}}}}}
-    )
+    result = ItsmFormModelUpdateResult.from_response({"meta": {"fields": {"apply_reason": {}, "gateway_name": {}}}})
 
     assert result.updated_field_keys == frozenset({"apply_reason", "gateway_name"})
 
 
-def test_itsm_ticket_detail_prefers_first_history_user():
-    detail = ItsmTicketDetail.from_response(
+def test_itsm_ticket_item_prefers_first_history_user():
+    detail = ItsmTicketItem.model_validate(
         {
+            "id": "t-001",
             "history_processors": [
                 {"id": "admin", "type": "user", "display": "管理员(admin)"},
                 {"id": "neoling", "type": "user", "display": "neoling"},
             ],
-            "current_processors": [{"processor": "current-user", "processor_type": "user"}],
         }
     )
 
     assert detail.actual_approver == "admin"
 
 
-def test_itsm_ticket_detail_returns_empty_without_history_user():
-    detail = ItsmTicketDetail.from_response(
+def test_itsm_ticket_item_returns_empty_without_history_user():
+    detail = ItsmTicketItem.model_validate(
         {
-            "current_processors": [
+            "id": "t-001",
+            "history_processors": [
                 {"id": "group-a", "type": "group", "display": "group-a"},
-                {"id": "admin", "type": "user", "display": "管理员(admin)"},
-            ]
+            ],
         }
     )
 
     assert detail.actual_approver == ""
 
 
-def test_itsm_ticket_detail_requires_processors_list():
-    with pytest.raises(TypeError, match="history_processors must be a list"):
-        ItsmTicketDetail.from_response({"history_processors": {"id": "admin", "type": "user"}})
+def test_itsm_ticket_item_requires_processors_list():
+    with pytest.raises(ValidationError):
+        ItsmTicketItem.model_validate(
+            {
+                "id": "t-001",
+                "history_processors": {"id": "admin", "type": "user"},
+            }
+        )
 
 
 def test_itsm_ticket_search_result_extract_actual_approver():
     result = ItsmTicketSearchResult.from_response(
         {
-            "result": True,
-            "data": {
-                "results": [
-                    {
-                        "id": "t-001",
-                        "history_processors": [
-                            {"id": "admin", "type": "user", "display": "管理员(admin)"},
-                            {"id": "neoling", "type": "user", "display": "neoling"},
-                        ],
-                    }
-                ],
-                "page": 1,
-                "page_size": 10,
-                "count": 1,
-            },
+            "results": [
+                {
+                    "id": "t-001",
+                    "history_processors": [
+                        {"id": "admin", "type": "user", "display": "管理员(admin)"},
+                        {"id": "neoling", "type": "user", "display": "neoling"},
+                    ],
+                }
+            ],
+            "page": 1,
+            "page_size": 10,
+            "count": 1,
         }
     )
 
@@ -123,8 +124,8 @@ def test_itsm_ticket_search_result_extract_actual_approver():
 
 
 def test_itsm_ticket_search_result_requires_results_list():
-    with pytest.raises(TypeError, match="results must be a list"):
-        ItsmTicketSearchResult.from_response({"data": {"results": {}, "count": 1}})
+    with pytest.raises(ValidationError):
+        ItsmTicketSearchResult.from_response({"results": {}, "count": 1})
 
 
 def test_create_ticket_prefers_system_token(settings, mocker):
@@ -184,7 +185,7 @@ def test_update_form_model_fallback_to_global_token(settings, mocker):
     assert result.updated_field_keys == frozenset({"apply_reason"})
 
 
-def test_ticket_search_full_text_search(settings, mocker):
+def test_get_ticket_by_id(settings, mocker):
     settings.BK_ITSM4_URL_PREFIX = "http://bk-itsm4.example.com/prod"
     settings.BK_ITSM4_API_TIMEOUT = 30
     settings.BK_ITSM4_QUERY_OPERATOR = "admin"
@@ -192,20 +193,18 @@ def test_ticket_search_full_text_search(settings, mocker):
     mock_call = mocker.patch(
         "apigateway.components.bkitsm._call_bkitsm_api",
         return_value={
-            "data": {
-                "results": [{"id": "t-001", "history_processors": [{"id": "admin", "type": "user"}]}],
-                "count": 1,
-            }
+            "results": [{"id": "t-001", "history_processors": [{"id": "admin", "type": "user"}]}],
+            "count": 1,
         },
     )
 
-    result = ticket_search_full_text_search("t-001")
+    result = get_ticket_by_id("t-001")
 
     args, kwargs = mock_call.call_args
     assert args[1] == "/api/v1/ticket_search/full_text_search/"
     assert args[2] == {
         "page": 1,
-        "page_size": 10,
+        "page_size": 1,
         "id__in": "t-001",
         "operator": "admin",
         "group_key": "all",

--- a/src/dashboard/apigateway/apigateway/tests/service/test_bk_itsm.py
+++ b/src/dashboard/apigateway/apigateway/tests/service/test_bk_itsm.py
@@ -344,7 +344,7 @@ class TestItsmPermissionApplyHelper:
         mocker.patch.object(command, "_ensure_config_from_template")
         mock_update_form_model = mocker.patch(
             "apigateway.apps.bk_itsm.management.commands.register_to_itsm.update_form_model",
-            return_value=ItsmFormModelUpdateResult(updated_field_keys=frozenset(field_keys), raw={}),
+            return_value=ItsmFormModelUpdateResult(meta={"fields": {key: {} for key in field_keys}}),
         )
         mock_system_migrate = mocker.patch(
             "apigateway.apps.bk_itsm.management.commands.register_to_itsm.system_migrate"
@@ -381,7 +381,7 @@ class TestItsmPermissionApplyHelper:
         mock_ensure_config = mocker.patch.object(command, "_ensure_config_from_template")
         mocker.patch(
             "apigateway.apps.bk_itsm.management.commands.register_to_itsm.update_form_model",
-            return_value=ItsmFormModelUpdateResult(updated_field_keys=frozenset(field_keys), raw={}),
+            return_value=ItsmFormModelUpdateResult(meta={"fields": {key: {} for key in field_keys}}),
         )
         mock_system_migrate = mocker.patch(
             "apigateway.apps.bk_itsm.management.commands.register_to_itsm.system_migrate"


### PR DESCRIPTION
- 新增 ITSM 实际审批人回填能力：在 ITSM 审批回调处理完成后，异步查询工单历史处理人，并将实际审批人写回网关、资源和 MCP Server 权限申请相关记录，执行失败不会影响主审批流程。