### PR TITLE
fix(dashboard): align inner MCP API contracts for release/1.23

### DIFF
--- a/src/dashboard/apigateway/apigateway/apis/v2/inner/serializers.py
+++ b/src/dashboard/apigateway/apigateway/apis/v2/inner/serializers.py
@@ -730,8 +730,17 @@ class MCPServerListInputSLZ(serializers.Serializer):
     keyword = serializers.CharField(
         allow_blank=True, required=False, help_text="MCPServer 筛选条件，支持模糊匹配 MCPServer 名称或描述"
     )
-    order_by = serializers.CharField(
-        allow_blank=True,
+    order_by = serializers.ChoiceField(
+        choices=[
+            "id",
+            "-id",
+            "name",
+            "-name",
+            "updated_time",
+            "-updated_time",
+            "created_time",
+            "-created_time",
+        ],
         required=False,
         default="-updated_time",
         help_text="排序字段，支持 id, name, updated_time, created_time，前缀 - 表示降序，默认 -updated_time",
@@ -823,7 +832,8 @@ class MCPServerListOutputSLZ(_SelectableFieldsOutputSLZMixin, serializers.Serial
         return self.context["gateways"][obj.gateway.id]
 
     def get_url(self, obj) -> str:
-        return _get_mcp_server_url_from_context(self.context, obj)
+        least_privileges = self.context.get("least_privileges_by_server", {})
+        return MCPServerHandler.get_mcp_server_url(obj, least_privileges.get(obj.id, ""))
 
     def get_detail_url(self, obj) -> str:
         return build_mcp_server_detail_url(obj.id)

--- a/src/dashboard/apigateway/apigateway/apis/v2/inner/views.py
+++ b/src/dashboard/apigateway/apigateway/apis/v2/inner/views.py
@@ -96,6 +96,11 @@ class OAuth2ClientScopePagination(BoundedLimitOffsetPagination):
     max_limit = INNER_BOUNDED_LIST_MAX_LIMIT
 
 
+class MCPServerListPagination(BoundedLimitOffsetPagination):
+    default_limit = INNER_BOUNDED_LIST_DEFAULT_LIMIT
+    max_limit = INNER_BOUNDED_LIST_MAX_LIMIT
+
+
 @method_decorator(
     name="get",
     decorator=swagger_auto_schema(
@@ -1209,6 +1214,7 @@ class MCPServerListApi(generics.ListAPIView):
     """
 
     permission_classes = [OpenAPIV2Permission]
+    pagination_class = MCPServerListPagination
 
     def list(self, request, *args, **kwargs):
         slz = serializers.MCPServerListInputSLZ(data=request.query_params)
@@ -1241,7 +1247,7 @@ class MCPServerListApi(generics.ListAPIView):
             context["categories"] = MCPServerHandler.build_categories_map(mcp_server_ids)
 
         if include_all_fields or "url" in fields:
-            context["least_privileges"] = MCPServerHandler.get_least_privileges(page)
+            context["least_privileges_by_server"] = MCPServerHandler.get_least_privileges_by_server(page)
 
         output_slz = serializers.MCPServerListOutputSLZ(page, many=True, context=context, fields=fields)
         return self.get_paginated_response(output_slz.data)

--- a/src/dashboard/apigateway/apigateway/data/apidocs/zh/v2_inner_list_mcp_server.md
+++ b/src/dashboard/apigateway/apigateway/data/apidocs/zh/v2_inner_list_mcp_server.md
@@ -14,6 +14,8 @@
 | mcp_server_ids | string | 否  | MCPServer ID 列表，多个以逗号分割，最多 50 个。例如：1,2,3 |
 | mcp_server_names | string | 否  | MCPServer 名称列表，精确匹配，多个以逗号分割，最多 50 个。例如：server-1,server-2 |
 | fields | string | 否  | 指定返回的字段列表，多个以逗号分割，例如 `fields=name,title`；支持的字段见 `data.results`；不传时返回全部字段，包含不支持的字段时返回参数校验错误 |
+| limit | int | 否 | 每页数量，取值范围 1～20，默认 10 |
+| offset | int | 否 | 分页偏移量，必须大于或等于 0，默认 0 |
 
 
 ### 响应示例
@@ -22,8 +24,6 @@
 {
   "data": {
     "count": 2,
-    "has_next": false,
-    "has_previous": false,
     "results": [
       {
         "id": 1,
@@ -77,8 +77,6 @@
 | 参数名称       | 参数类型  | 描述         |
 |------------|-------|------------|
 | count      | int   | 总数         |
-| has_next   | bool  | 是否有下一页     |
-| has_previous | bool  | 是否有上一页     |
 | results    | array | MCPServer 列表 |
 
 #### data.results

--- a/src/dashboard/apigateway/apigateway/data/apigw-definitions/bk-apigateway-resources.yaml
+++ b/src/dashboard/apigateway/apigateway/data/apigw-definitions/bk-apigateway-resources.yaml
@@ -7149,6 +7149,8 @@ paths:
           in: query
           schema:
             type: string
+            enum: [id, -id, name, -name, updated_time, -updated_time, created_time, -created_time]
+            default: -updated_time
           description: 排序字段，支持 id, name, updated_time, created_time，前缀 - 表示降序，默认 -updated_time
           example: -updated_time
         - name: mcp_server_ids
@@ -7169,6 +7171,23 @@ paths:
             type: string
           description: 指定返回的字段列表，多个以逗号分割；不传时返回全部字段
           example: name,title
+        - name: limit
+          in: query
+          required: false
+          schema:
+            type: integer
+            minimum: 1
+            maximum: 20
+            default: 10
+          description: 每页 MCPServer 数量
+        - name: offset
+          in: query
+          required: false
+          schema:
+            type: integer
+            minimum: 0
+            default: 0
+          description: MCPServer 分页偏移量
       responses:
         default:
           description: ''
@@ -7242,7 +7261,50 @@ paths:
           description: ''
           content:
             application/json:
-              schema: {}
+              schema:
+                type: object
+                required: [data]
+                properties:
+                  data:
+                    type: object
+                    required: [count, results]
+                    properties:
+                      count:
+                        type: integer
+                        description: 网关总数
+                      results:
+                        type: array
+                        items:
+                          type: object
+                          required: [id, name, is_official, mcp_server_count, mcp_servers]
+                          properties:
+                            id:
+                              type: integer
+                              description: 网关 ID
+                            name:
+                              type: string
+                              description: 网关名称
+                            is_official:
+                              type: boolean
+                              description: 是否为官方网关
+                            mcp_server_count:
+                              type: integer
+                              description: 可选 MCPServer 数量
+                            mcp_servers:
+                              type: array
+                              items:
+                                type: object
+                                required: [id, name, title]
+                                properties:
+                                  id:
+                                    type: integer
+                                    description: MCPServer ID
+                                  name:
+                                    type: string
+                                    description: MCPServer 名称
+                                  title:
+                                    type: string
+                                    description: MCPServer 标题
       x-bk-apigateway-resource:
         isPublic: false
         allowApplyPermission: false
@@ -7310,7 +7372,50 @@ paths:
           description: ''
           content:
             application/json:
-              schema: {}
+              schema:
+                type: object
+                required: [data]
+                properties:
+                  data:
+                    type: object
+                    required: [count, results]
+                    properties:
+                      count:
+                        type: integer
+                        description: 网关总数
+                      results:
+                        type: array
+                        items:
+                          type: object
+                          required: [id, name, is_official, resource_count, resources]
+                          properties:
+                            id:
+                              type: integer
+                              description: 网关 ID
+                            name:
+                              type: string
+                              description: 网关名称
+                            is_official:
+                              type: boolean
+                              description: 是否为官方网关
+                            resource_count:
+                              type: integer
+                              description: 可选资源数量
+                            resources:
+                              type: array
+                              items:
+                                type: object
+                                required: [id, name, description]
+                                properties:
+                                  id:
+                                    type: integer
+                                    description: 资源 ID
+                                  name:
+                                    type: string
+                                    description: 资源名称
+                                  description:
+                                    type: string
+                                    description: 资源描述
       x-bk-apigateway-resource:
         isPublic: false
         allowApplyPermission: false

--- a/src/dashboard/apigateway/apigateway/tests/apis/v2/inner/test_views.py
+++ b/src/dashboard/apigateway/apigateway/tests/apis/v2/inner/test_views.py
@@ -33,6 +33,7 @@ from apigateway.apps.mcp_server.constants import (
     OFFICIAL_MCP_CATEGORY_NAME,
     MCPServerAppPermissionApplyStatusEnum,
     MCPServerAppPermissionGrantTypeEnum,
+    MCPServerLeastPrivilegeEnum,
     MCPServerPermissionStatusEnum,
     MCPServerProtocolTypeEnum,
     MCPServerStatusEnum,
@@ -1774,6 +1775,28 @@ class TestAppRequestLogListApi:
 class TestMCPServerListApi:
     """测试 MCPServerListApi - 获取全量的 MCPServer 列表"""
 
+    @pytest.mark.parametrize("order_by", ["unknown", "-unknown", "id,name"])
+    def test_list_rejects_invalid_order_by(self, request_view, order_by):
+        resp = request_view(
+            method="GET",
+            view_name="openapi.v2.inner.mcp_server.list",
+            data={"order_by": order_by},
+            app=mock.MagicMock(app_code="test"),
+        )
+
+        assert resp.status_code == 400
+
+    @pytest.mark.parametrize("limit", [0, 21, "invalid"])
+    def test_list_rejects_invalid_limit(self, request_view, limit):
+        resp = request_view(
+            method="GET",
+            view_name="openapi.v2.inner.mcp_server.list",
+            data={"limit": limit},
+            app=mock.MagicMock(app_code="test"),
+        )
+
+        assert resp.status_code == 400
+
     def test_list_rejects_unsupported_fields(self, request_view):
         resp = request_view(
             method="GET",
@@ -1810,9 +1833,9 @@ class TestMCPServerListApi:
             "build_categories_map",
             side_effect=AssertionError("unexpected context build"),
         )
-        get_least_privileges = mocker.patch.object(
+        get_least_privileges_by_server = mocker.patch.object(
             inner_views.MCPServerHandler,
-            "get_least_privileges",
+            "get_least_privileges_by_server",
             side_effect=AssertionError("unexpected context build"),
         )
 
@@ -1848,7 +1871,7 @@ class TestMCPServerListApi:
         build_list_context.assert_not_called()
         get_prompts_count_map.assert_not_called()
         build_categories_map.assert_not_called()
-        get_least_privileges.assert_not_called()
+        get_least_privileges_by_server.assert_not_called()
 
     @pytest.mark.parametrize(
         ("fields", "expected_helper"),
@@ -1856,7 +1879,7 @@ class TestMCPServerListApi:
             ("stage,gateway", "build_list_context"),
             ("prompts_count", "get_prompts_count_map"),
             ("categories", "build_categories_map"),
-            ("url", "get_least_privileges"),
+            ("url", "get_least_privileges_by_server"),
         ],
     )
     def test_list_with_dynamic_fields_builds_only_required_context(
@@ -1887,8 +1910,8 @@ class TestMCPServerListApi:
             "build_categories_map": mocker.patch.object(
                 inner_views.MCPServerHandler, "build_categories_map", return_value={mcp_server.id: []}
             ),
-            "get_least_privileges": mocker.patch.object(
-                inner_views.MCPServerHandler, "get_least_privileges", return_value={}
+            "get_least_privileges_by_server": mocker.patch.object(
+                inner_views.MCPServerHandler, "get_least_privileges_by_server", return_value={}
             ),
         }
 
@@ -1906,6 +1929,51 @@ class TestMCPServerListApi:
                 helper.assert_called_once()
             else:
                 helper.assert_not_called()
+
+    def test_list_uses_server_scoped_least_privileges_for_urls(self, request_view, fake_gateway, mocker):
+        fake_gateway.status = GatewayStatusEnum.ACTIVE.value
+        fake_gateway.save(update_fields=["status"])
+        stage = G(Stage, gateway=fake_gateway, status=StageStatusEnum.ACTIVE.value)
+        application_server = G(
+            MCPServer,
+            gateway=fake_gateway,
+            stage=stage,
+            name="application-server",
+            status=MCPServerStatusEnum.ACTIVE.value,
+            protocol_type=MCPServerProtocolTypeEnum.SSE.value,
+            oauth2_public_client_enabled=False,
+        )
+        user_server = G(
+            MCPServer,
+            gateway=fake_gateway,
+            stage=stage,
+            name="user-server",
+            status=MCPServerStatusEnum.ACTIVE.value,
+            protocol_type=MCPServerProtocolTypeEnum.SSE.value,
+            oauth2_public_client_enabled=False,
+        )
+        get_least_privileges_by_server = mocker.patch.object(
+            inner_views.MCPServerHandler,
+            "get_least_privileges_by_server",
+            return_value={
+                application_server.id: MCPServerLeastPrivilegeEnum.APPLICATION.value,
+                user_server.id: MCPServerLeastPrivilegeEnum.APPLICATION_AND_USER.value,
+            },
+        )
+
+        resp = request_view(
+            method="GET",
+            view_name="openapi.v2.inner.mcp_server.list",
+            data={"fields": "id,url", "order_by": "id"},
+            app=mock.MagicMock(app_code="test"),
+        )
+
+        assert resp.status_code == 200
+        results = {item["id"]: item["url"] for item in resp.json()["data"]["results"]}
+        assert results[application_server.id].endswith("/application/sse/")
+        assert results[user_server.id].endswith("/sse/")
+        assert "/application/" not in results[user_server.id]
+        get_least_privileges_by_server.assert_called_once()
 
     def test_list_public_active_mcp_servers(self, request_view, fake_gateway):
         """测试获取活跃的 MCPServer 列表"""


### PR DESCRIPTION
## Summary
- backport #3116 to `release/1.23`
- source PR: https://github.com/TencentBlueKing/blueking-apigateway/pull/3116

## Cherry-picked commits
- `cfd8af995` fix(dashboard): align inner MCP API contracts

## Verification
- focused MCP list tests: 26 passed
- `uv run make lint-check`: passed
- `uv run make check-openapi`: passed with 0 errors

Made with [Cursor](https://cursor.com)