### PR TITLE
fix(dashboard): migrate MCP user routes to authConfig OAuth2 flags

### DIFF
--- a/src/dashboard/apigateway/apigateway/data/apigw-definitions/bk-apigateway-resources.yaml
+++ b/src/dashboard/apigateway/apigateway/data/apigw-definitions/bk-apigateway-resources.yaml
@@ -418,17 +418,13 @@ paths:
           path: /{mcp_server_name}/sse
           matchSubpath: false
           timeout: 0
-        pluginConfigs:
-        - type: bk-oauth2-protected-resource
-          yaml: '{}'
-        - type: bk-oauth2-verify
-          yaml: '{}'
-        - type: bk-oauth2-audience-validate
-          yaml: '{}'
+        pluginConfigs: [ ]
         authConfig:
           userVerifiedRequired: true
           appVerifiedRequired: true
           resourcePermissionRequired: false
+          oauth2PublicClientEnabled: true
+          oauth2PersonalClientEnabled: true
         descriptionEn: None
     post:
       operationId: mcp_proxy_sse_post
@@ -452,17 +448,13 @@ paths:
           path: /{mcp_server_name}/sse
           matchSubpath: false
           timeout: 0
-        pluginConfigs:
-        - type: bk-oauth2-protected-resource
-          yaml: '{}'
-        - type: bk-oauth2-verify
-          yaml: '{}'
-        - type: bk-oauth2-audience-validate
-          yaml: '{}'
+        pluginConfigs: [ ]
         authConfig:
           userVerifiedRequired: true
           appVerifiedRequired: true
           resourcePermissionRequired: false
+          oauth2PublicClientEnabled: true
+          oauth2PersonalClientEnabled: true
         descriptionEn: None
   /api/v2/mcp-servers/{mcp_server_name}/sse/message:
     post:
@@ -487,17 +479,13 @@ paths:
           path: /{mcp_server_name}/sse/message
           matchSubpath: false
           timeout: 0
-        pluginConfigs:
-        - type: bk-oauth2-protected-resource
-          yaml: '{}'
-        - type: bk-oauth2-verify
-          yaml: '{}'
-        - type: bk-oauth2-audience-validate
-          yaml: '{}'
+        pluginConfigs: [ ]
         authConfig:
           userVerifiedRequired: true
           appVerifiedRequired: true
           resourcePermissionRequired: false
+          oauth2PublicClientEnabled: true
+          oauth2PersonalClientEnabled: true
   /api/v2/mcp-servers/{mcp_server_name}/application/sse:
     get:
       operationId: mcp_proxy_application_sse
@@ -606,17 +594,13 @@ paths:
           path: /{mcp_server_name}/mcp
           matchSubpath: false
           timeout: 0
-        pluginConfigs:
-        - type: bk-oauth2-protected-resource
-          yaml: '{}'
-        - type: bk-oauth2-verify
-          yaml: '{}'
-        - type: bk-oauth2-audience-validate
-          yaml: '{}'
+        pluginConfigs: [ ]
         authConfig:
           userVerifiedRequired: true
           appVerifiedRequired: true
           resourcePermissionRequired: false
+          oauth2PublicClientEnabled: true
+          oauth2PersonalClientEnabled: true
         descriptionEn: None
     post:
       operationId: mcp_proxy_user_streamable_http_post
@@ -640,17 +624,13 @@ paths:
           path: /{mcp_server_name}/mcp
           matchSubpath: false
           timeout: 0
-        pluginConfigs:
-        - type: bk-oauth2-protected-resource
-          yaml: '{}'
-        - type: bk-oauth2-verify
-          yaml: '{}'
-        - type: bk-oauth2-audience-validate
-          yaml: '{}'
+        pluginConfigs: [ ]
         authConfig:
           userVerifiedRequired: true
           appVerifiedRequired: true
           resourcePermissionRequired: false
+          oauth2PublicClientEnabled: true
+          oauth2PersonalClientEnabled: true
         descriptionEn: None
   /api/v2/mcp-servers/{mcp_server_name}/application/mcp:
     post:


### PR DESCRIPTION
## Summary

- Remove manually bound OAuth2 plugins from 5 user-mode MCP proxy resources in `bk-apigateway-resources.yaml`
- Enable `oauth2PublicClientEnabled` and `oauth2PersonalClientEnabled` in `authConfig` instead
- OAuth2 plugins are controller-managed (#3070) and are injected automatically during publish when these flags are set

Fixes `post_migrate` validation error:
```
资源绑定了与资源类型不兼容的插件，插件类型：bk-oauth2-protected-resource, bk-oauth2-verify, bk-oauth2-audience-validate
```

Affected resources:
- `mcp_proxy_sse` / `mcp_proxy_sse_post` / `mcp_proxy_message`
- `mcp_proxy_user_streamable_http_get` / `mcp_proxy_user_streamable_http_post`

Backport of #3119 for release/1.23.

## Test plan

- [ ] Run `bin/post_migrate` and confirm validation passes
- [ ] Publish bk-apigateway and verify user-mode MCP routes still receive OAuth2 plugin chain
- [ ] Verify OAuth2 public/personal client access to MCP user-mode endpoints still works


Made with [Cursor](https://cursor.com)