### PR TITLE
fix(dashboard): sync MCP permissions from released resource ids

### DIFF
--- a/src/dashboard/apigateway/apigateway/biz/mcp_server/mcp_server.py
+++ b/src/dashboard/apigateway/apigateway/biz/mcp_server/mcp_server.py
@@ -64,7 +64,7 @@ from apigateway.common.django.translation import get_current_language_code
 from apigateway.common.error_codes import error_codes
 from apigateway.components import bkaidev
 from apigateway.core.constants import GatewayStatusEnum, ResourceKindEnum, StageStatusEnum
-from apigateway.core.models import Gateway, Release, Resource, Stage
+from apigateway.core.models import Gateway, Release, Stage
 from apigateway.service.mcp import build_mcp_server_application_url, build_mcp_server_url
 from apigateway.service.resource import get_resource_id_to_labels_by_label_ids
 from apigateway.service.resource_version import (
@@ -388,20 +388,28 @@ class MCPServerHandler:
             )
             return
 
-        # 2. check the resource names, and get the resource_ids
+        # 2. resolve resource_ids from the stage's published resource_version snapshot
+        # core-api permission checks also use resource_id from the released version, not live Resource
         resource_names = mcp_server.resource_names
         if not resource_names:
             logger.debug("no resource_names, skip sync the permissions of the mcp_server %d", mcp_server_id)
             return
-        release = Release.objects.filter(gateway_id=mcp_server.gateway_id, stage_id=mcp_server.stage_id).first()
-        if release:
-            valid_resource_names = get_standard_resource_names_set(release.resource_version.id)
-            resource_names = [name for name in resource_names if name in valid_resource_names]
-        resource_ids = Resource.objects.filter(
-            gateway_id=mcp_server.gateway_id,
-            name__in=resource_names,
-            kind=ResourceKindEnum.STANDARD.value,
-        ).values_list("id", flat=True)
+        release = (
+            Release.objects.filter(gateway_id=mcp_server.gateway_id, stage_id=mcp_server.stage_id)
+            .select_related("resource_version")
+            .first()
+        )
+        if not release:
+            logger.debug("no release, skip sync the permissions of the mcp_server %d", mcp_server_id)
+            return
+
+        resource_name_set = set(resource_names)
+        resource_ids = [
+            resource["id"]
+            for resource in release.resource_version.data
+            if resource["name"] in resource_name_set
+            and (resource.get("kind") or ResourceKindEnum.STANDARD.value) == ResourceKindEnum.STANDARD.value
+        ]
 
         # 3. sync the permission
         newest_virtual_app_code_resource_id_set = {

--- a/src/dashboard/apigateway/apigateway/tests/biz/mcp_server/test_mcp_server.py
+++ b/src/dashboard/apigateway/apigateway/tests/biz/mcp_server/test_mcp_server.py
@@ -57,6 +57,20 @@ class TestMCPServerHandler:
         yield
         get_standard_resource_names_set.cache_clear()
 
+    @staticmethod
+    def _release_resources(gateway, stage, resources):
+        resource_version = G(ResourceVersion, gateway=gateway)
+        resource_version.data = [
+            {
+                "id": resource.id,
+                "name": resource.name,
+                "kind": getattr(resource, "kind", None) or ResourceKindEnum.STANDARD.value,
+            }
+            for resource in resources
+        ]
+        resource_version.save()
+        return G(Release, gateway=gateway, stage=stage, resource_version=resource_version)
+
     def test_virtual_app_code_prefix(self):
         assert MCPServerHandler._virtual_app_code_prefix(1) == "v_mcp_1_"
 
@@ -148,6 +162,7 @@ class TestMCPServerHandler:
         # Create resources
         resource1 = G(Resource, gateway=fake_gateway, name="resource1")
         resource2 = G(Resource, gateway=fake_gateway, name="resource2")
+        self._release_resources(fake_gateway, fake_stage, [resource1, resource2])
 
         # Create MCP server with resource names
         mcp_server = G(MCPServer, gateway=fake_gateway, stage=fake_stage)
@@ -203,6 +218,7 @@ class TestMCPServerHandler:
         # Create resources
         resource1 = G(Resource, gateway=fake_gateway, name="resource1")
         resource2 = G(Resource, gateway=fake_gateway, name="resource2")
+        self._release_resources(fake_gateway, fake_stage, [resource1, resource2])
 
         # Create MCP server with resource names
         mcp_server = G(MCPServer, gateway=fake_gateway, stage=fake_stage)
@@ -232,6 +248,7 @@ class TestMCPServerHandler:
 
     def test_sync_permissions_grants_and_revokes_oauth2_personal_client(self, fake_gateway, fake_stage):
         resource = G(Resource, gateway=fake_gateway, name="resource1")
+        self._release_resources(fake_gateway, fake_stage, [resource])
         mcp_server = G(
             MCPServer,
             gateway=fake_gateway,
@@ -268,6 +285,40 @@ class TestMCPServerHandler:
             resource_id=resource.id,
         ).exists()
 
+    def test_sync_permissions_uses_resource_ids_from_released_version(self, fake_gateway, fake_stage):
+        """Sync must use resource_id from the stage release snapshot, not live Resource.id."""
+        live_resource = G(
+            Resource,
+            gateway=fake_gateway,
+            name="tool_a",
+            kind=ResourceKindEnum.STANDARD.value,
+        )
+        released_resource_id = live_resource.id + 10000
+        resource_version = G(ResourceVersion, gateway=fake_gateway)
+        resource_version.data = [
+            {
+                "id": released_resource_id,
+                "name": live_resource.name,
+                "kind": ResourceKindEnum.STANDARD.value,
+            },
+        ]
+        resource_version.save()
+        G(Release, gateway=fake_gateway, stage=fake_stage, resource_version=resource_version)
+
+        mcp_server = G(
+            MCPServer,
+            gateway=fake_gateway,
+            stage=fake_stage,
+            _resource_names=live_resource.name,
+        )
+        G(MCPServerAppPermission, mcp_server=mcp_server, bk_app_code="app1")
+
+        MCPServerHandler.sync_permissions(mcp_server.id)
+
+        permissions = AppResourcePermission.objects.filter(bk_app_code__startswith=f"v_mcp_{mcp_server.id}_")
+        assert set(permissions.values_list("resource_id", flat=True)) == {released_resource_id}
+        assert live_resource.id not in permissions.values_list("resource_id", flat=True)
+
     def test_sync_permissions_excludes_ai_resources_from_release_snapshot(self, fake_gateway, fake_stage):
         standard_resource = G(
             Resource,
@@ -301,18 +352,18 @@ class TestMCPServerHandler:
         permissions = AppResourcePermission.objects.filter(bk_app_code__startswith=f"v_mcp_{mcp_server.id}_")
         assert set(permissions.values_list("resource_id", flat=True)) == {standard_resource.id}
 
-    def test_sync_permissions_excludes_ai_resource_without_release(self, fake_gateway, fake_stage):
-        ai_resource = G(
+    def test_sync_permissions_skips_without_release(self, fake_gateway, fake_stage):
+        resource = G(
             Resource,
             gateway=fake_gateway,
-            name="ai-resource",
-            kind=ResourceKindEnum.AI.value,
+            name="resource1",
+            kind=ResourceKindEnum.STANDARD.value,
         )
         mcp_server = G(
             MCPServer,
             gateway=fake_gateway,
             stage=fake_stage,
-            _resource_names=ai_resource.name,
+            _resource_names=resource.name,
         )
         G(MCPServerAppPermission, mcp_server=mcp_server, bk_app_code="app1")
 
@@ -320,7 +371,9 @@ class TestMCPServerHandler:
 
         assert not AppResourcePermission.objects.filter(bk_app_code__startswith=f"v_mcp_{mcp_server.id}_").exists()
 
-    def test_sync_permissions_excludes_live_ai_resource_with_standard_snapshot(self, fake_gateway, fake_stage):
+    def test_sync_permissions_uses_standard_snapshot_even_if_live_resource_kind_changed(
+        self, fake_gateway, fake_stage
+    ):
         resource = G(
             Resource,
             gateway=fake_gateway,
@@ -346,13 +399,15 @@ class TestMCPServerHandler:
 
         MCPServerHandler.sync_permissions(mcp_server.id)
 
-        assert not AppResourcePermission.objects.filter(bk_app_code__startswith=f"v_mcp_{mcp_server.id}_").exists()
+        permissions = AppResourcePermission.objects.filter(bk_app_code__startswith=f"v_mcp_{mcp_server.id}_")
+        assert set(permissions.values_list("resource_id", flat=True)) == {resource.id}
 
     def test_sync_permissions_delete_permissions(self, fake_gateway, fake_stage):
         """Test sync_permissions when existing permissions need to be deleted"""
         # Create resources
         resource1 = G(Resource, gateway=fake_gateway, name="resource1")
         resource2 = G(Resource, gateway=fake_gateway, name="resource2")
+        self._release_resources(fake_gateway, fake_stage, [resource1, resource2])
 
         # Create MCP server with only one resource name
         mcp_server = G(MCPServer, gateway=fake_gateway, stage=fake_stage)
@@ -400,6 +455,7 @@ class TestMCPServerHandler:
         resource1 = G(Resource, gateway=fake_gateway, name="resource1")
         resource2 = G(Resource, gateway=fake_gateway, name="resource2")
         resource3 = G(Resource, gateway=fake_gateway, name="resource3")
+        self._release_resources(fake_gateway, fake_stage, [resource1, resource2, resource3])
 
         # Create MCP server with resource names
         mcp_server = G(MCPServer, gateway=fake_gateway, stage=fake_stage)

--- a/src/dashboard/apigateway/apigateway/tests/biz/mcp_server/test_permission.py
+++ b/src/dashboard/apigateway/apigateway/tests/biz/mcp_server/test_permission.py
@@ -27,13 +27,28 @@ from apigateway.apps.permission.constants import GrantTypeEnum
 from apigateway.apps.permission.models import AppResourcePermission
 from apigateway.biz.mcp_server import MCPServerHandler, MCPServerPermissionHandler
 from apigateway.common.error_codes import error_codes
-from apigateway.core.models import Resource
+from apigateway.core.constants import ResourceKindEnum
+from apigateway.core.models import Release, Resource, ResourceVersion
 from apigateway.utils.time import NeverExpiresTime, now_datetime
 
 pytestmark = pytest.mark.django_db
 
 
 class TestMCPServerPermissionHandler:
+    @staticmethod
+    def _release_resources(gateway, stage, resources):
+        resource_version = G(ResourceVersion, gateway=gateway)
+        resource_version.data = [
+            {
+                "id": resource.id,
+                "name": resource.name,
+                "kind": getattr(resource, "kind", None) or ResourceKindEnum.STANDARD.value,
+            }
+            for resource in resources
+        ]
+        resource_version.save()
+        return G(Release, gateway=gateway, stage=stage, resource_version=resource_version)
+
     def test_sync_permissions_no_app_codes(self, fake_gateway, fake_stage):
         """Test sync_permissions when no app codes exist - should cleanup and return early"""
         # Create MCP server with no app permissions
@@ -70,6 +85,7 @@ class TestMCPServerPermissionHandler:
         # Create resources
         resource1 = G(Resource, gateway=fake_gateway, name="resource1")
         resource2 = G(Resource, gateway=fake_gateway, name="resource2")
+        self._release_resources(fake_gateway, fake_stage, [resource1, resource2])
 
         # Create MCP server with resource names
         mcp_server = G(MCPServer, gateway=fake_gateway, stage=fake_stage)
@@ -125,6 +141,7 @@ class TestMCPServerPermissionHandler:
         # Create resources
         resource1 = G(Resource, gateway=fake_gateway, name="resource1")
         resource2 = G(Resource, gateway=fake_gateway, name="resource2")
+        self._release_resources(fake_gateway, fake_stage, [resource1, resource2])
 
         # Create MCP server with resource names
         mcp_server = G(MCPServer, gateway=fake_gateway, stage=fake_stage)
@@ -157,6 +174,7 @@ class TestMCPServerPermissionHandler:
         # Create resources
         resource1 = G(Resource, gateway=fake_gateway, name="resource1")
         resource2 = G(Resource, gateway=fake_gateway, name="resource2")
+        self._release_resources(fake_gateway, fake_stage, [resource1, resource2])
 
         # Create MCP server with only one resource name
         mcp_server = G(MCPServer, gateway=fake_gateway, stage=fake_stage)
@@ -204,6 +222,7 @@ class TestMCPServerPermissionHandler:
         resource1 = G(Resource, gateway=fake_gateway, name="resource1")
         resource2 = G(Resource, gateway=fake_gateway, name="resource2")
         resource3 = G(Resource, gateway=fake_gateway, name="resource3")
+        self._release_resources(fake_gateway, fake_stage, [resource1, resource2, resource3])
 
         # Create MCP server with resource names
         mcp_server = G(MCPServer, gateway=fake_gateway, stage=fake_stage)


### PR DESCRIPTION
## Summary
- MCP 应用权限同步改为使用 MCP 对应环境已发布 `resource_version` 快照中的 `resource_id`
- 与 core-api 鉴权一致：按 stage Release → ResourceVersion.data 解析 id，而不再从 live `Resource` 表按 name 反查
- 无 Release 时跳过同步，避免写入与线上版本不一致的 id

## Verification
- `uv run ruff check` on changed files: passed
- `pytest ... -k sync_permissions`: 17 passed
- `pytest ... TestMCPServerHandler + TestMCPServerPermissionHandler`: 120 passed

Made with [Cursor](https://cursor.com)