### PR TITLE
fix(dashboard): sync MCP permissions from released resource ids for release/1.23

### DIFF
--- a/src/dashboard/apigateway/apigateway/biz/mcp_server/mcp_server.py
+++ b/src/dashboard/apigateway/apigateway/biz/mcp_server/mcp_server.py
@@ -63,7 +63,7 @@ from apigateway.common.django.translation import get_current_language_code
 from apigateway.common.error_codes import error_codes
 from apigateway.components import bkaidev
 from apigateway.core.constants import GatewayStatusEnum, StageStatusEnum
-from apigateway.core.models import Gateway, Release, Resource, Stage
+from apigateway.core.models import Gateway, Release, Stage
 from apigateway.service.mcp import build_mcp_server_application_url, build_mcp_server_url, validate_mcp_prompts_payload
 from apigateway.service.resource import get_resource_id_to_labels_by_label_ids
 from apigateway.service.resource_version import (
@@ -376,14 +376,25 @@ class MCPServerHandler:
             )
             return
 
-        # 2. check the resource names, and get the resource_ids
+        # 2. resolve resource_ids from the stage's published resource_version snapshot
+        # core-api permission checks also use resource_id from the released version, not live Resource
         resource_names = mcp_server.resource_names
         if not resource_names:
             logger.debug("no resource_names, skip sync the permissions of the mcp_server %d", mcp_server_id)
             return
-        resource_ids = Resource.objects.filter(gateway_id=mcp_server.gateway_id, name__in=resource_names).values_list(
-            "id", flat=True
+        release = (
+            Release.objects.filter(gateway_id=mcp_server.gateway_id, stage_id=mcp_server.stage_id)
+            .select_related("resource_version")
+            .first()
         )
+        if not release:
+            logger.debug("no release, skip sync the permissions of the mcp_server %d", mcp_server_id)
+            return
+
+        resource_name_set = set(resource_names)
+        resource_ids = [
+            resource["id"] for resource in release.resource_version.data if resource["name"] in resource_name_set
+        ]
 
         # 3. sync the permission
         newest_virtual_app_code_resource_id_set = {

--- a/src/dashboard/apigateway/apigateway/tests/biz/mcp_server/test_mcp_server.py
+++ b/src/dashboard/apigateway/apigateway/tests/biz/mcp_server/test_mcp_server.py
@@ -52,6 +52,13 @@ class TestMCPServerHandler:
     def setup_fixtures(self):
         self.gateway = create_gateway()
 
+    @staticmethod
+    def _release_resources(gateway, stage, resources):
+        resource_version = G(ResourceVersion, gateway=gateway)
+        resource_version.data = [{"id": resource.id, "name": resource.name} for resource in resources]
+        resource_version.save()
+        return G(Release, gateway=gateway, stage=stage, resource_version=resource_version)
+
     def test_virtual_app_code_prefix(self):
         assert MCPServerHandler._virtual_app_code_prefix(1) == "v_mcp_1_"
 
@@ -143,6 +150,7 @@ class TestMCPServerHandler:
         # Create resources
         resource1 = G(Resource, gateway=fake_gateway, name="resource1")
         resource2 = G(Resource, gateway=fake_gateway, name="resource2")
+        self._release_resources(fake_gateway, fake_stage, [resource1, resource2])
 
         # Create MCP server with resource names
         mcp_server = G(MCPServer, gateway=fake_gateway, stage=fake_stage)
@@ -198,6 +206,7 @@ class TestMCPServerHandler:
         # Create resources
         resource1 = G(Resource, gateway=fake_gateway, name="resource1")
         resource2 = G(Resource, gateway=fake_gateway, name="resource2")
+        self._release_resources(fake_gateway, fake_stage, [resource1, resource2])
 
         # Create MCP server with resource names
         mcp_server = G(MCPServer, gateway=fake_gateway, stage=fake_stage)
@@ -227,6 +236,7 @@ class TestMCPServerHandler:
 
     def test_sync_permissions_grants_and_revokes_oauth2_personal_client(self, fake_gateway, fake_stage):
         resource = G(Resource, gateway=fake_gateway, name="resource1")
+        self._release_resources(fake_gateway, fake_stage, [resource])
         mcp_server = G(
             MCPServer,
             gateway=fake_gateway,
@@ -263,11 +273,49 @@ class TestMCPServerHandler:
             resource_id=resource.id,
         ).exists()
 
+    def test_sync_permissions_uses_resource_ids_from_released_version(self, fake_gateway, fake_stage):
+        """Sync must use resource_id from the stage release snapshot, not live Resource.id."""
+        live_resource = G(Resource, gateway=fake_gateway, name="tool_a")
+        released_resource_id = live_resource.id + 10000
+        resource_version = G(ResourceVersion, gateway=fake_gateway)
+        resource_version.data = [{"id": released_resource_id, "name": live_resource.name}]
+        resource_version.save()
+        G(Release, gateway=fake_gateway, stage=fake_stage, resource_version=resource_version)
+
+        mcp_server = G(
+            MCPServer,
+            gateway=fake_gateway,
+            stage=fake_stage,
+            _resource_names=live_resource.name,
+        )
+        G(MCPServerAppPermission, mcp_server=mcp_server, bk_app_code="app1")
+
+        MCPServerHandler.sync_permissions(mcp_server.id)
+
+        permissions = AppResourcePermission.objects.filter(bk_app_code__startswith=f"v_mcp_{mcp_server.id}_")
+        assert set(permissions.values_list("resource_id", flat=True)) == {released_resource_id}
+        assert live_resource.id not in permissions.values_list("resource_id", flat=True)
+
+    def test_sync_permissions_skips_without_release(self, fake_gateway, fake_stage):
+        resource = G(Resource, gateway=fake_gateway, name="resource1")
+        mcp_server = G(
+            MCPServer,
+            gateway=fake_gateway,
+            stage=fake_stage,
+            _resource_names=resource.name,
+        )
+        G(MCPServerAppPermission, mcp_server=mcp_server, bk_app_code="app1")
+
+        MCPServerHandler.sync_permissions(mcp_server.id)
+
+        assert not AppResourcePermission.objects.filter(bk_app_code__startswith=f"v_mcp_{mcp_server.id}_").exists()
+
     def test_sync_permissions_delete_permissions(self, fake_gateway, fake_stage):
         """Test sync_permissions when existing permissions need to be deleted"""
         # Create resources
         resource1 = G(Resource, gateway=fake_gateway, name="resource1")
         resource2 = G(Resource, gateway=fake_gateway, name="resource2")
+        self._release_resources(fake_gateway, fake_stage, [resource1, resource2])
 
         # Create MCP server with only one resource name
         mcp_server = G(MCPServer, gateway=fake_gateway, stage=fake_stage)
@@ -315,6 +363,7 @@ class TestMCPServerHandler:
         resource1 = G(Resource, gateway=fake_gateway, name="resource1")
         resource2 = G(Resource, gateway=fake_gateway, name="resource2")
         resource3 = G(Resource, gateway=fake_gateway, name="resource3")
+        self._release_resources(fake_gateway, fake_stage, [resource1, resource2, resource3])
 
         # Create MCP server with resource names
         mcp_server = G(MCPServer, gateway=fake_gateway, stage=fake_stage)

--- a/src/dashboard/apigateway/apigateway/tests/biz/mcp_server/test_permission.py
+++ b/src/dashboard/apigateway/apigateway/tests/biz/mcp_server/test_permission.py
@@ -27,13 +27,20 @@ from apigateway.apps.permission.constants import GrantTypeEnum
 from apigateway.apps.permission.models import AppResourcePermission
 from apigateway.biz.mcp_server import MCPServerHandler, MCPServerPermissionHandler
 from apigateway.common.error_codes import error_codes
-from apigateway.core.models import Resource
+from apigateway.core.models import Release, Resource, ResourceVersion
 from apigateway.utils.time import NeverExpiresTime, now_datetime
 
 pytestmark = pytest.mark.django_db
 
 
 class TestMCPServerPermissionHandler:
+    @staticmethod
+    def _release_resources(gateway, stage, resources):
+        resource_version = G(ResourceVersion, gateway=gateway)
+        resource_version.data = [{"id": resource.id, "name": resource.name} for resource in resources]
+        resource_version.save()
+        return G(Release, gateway=gateway, stage=stage, resource_version=resource_version)
+
     def test_sync_permissions_no_app_codes(self, fake_gateway, fake_stage):
         """Test sync_permissions when no app codes exist - should cleanup and return early"""
         # Create MCP server with no app permissions
@@ -70,6 +77,7 @@ class TestMCPServerPermissionHandler:
         # Create resources
         resource1 = G(Resource, gateway=fake_gateway, name="resource1")
         resource2 = G(Resource, gateway=fake_gateway, name="resource2")
+        self._release_resources(fake_gateway, fake_stage, [resource1, resource2])
 
         # Create MCP server with resource names
         mcp_server = G(MCPServer, gateway=fake_gateway, stage=fake_stage)
@@ -125,6 +133,7 @@ class TestMCPServerPermissionHandler:
         # Create resources
         resource1 = G(Resource, gateway=fake_gateway, name="resource1")
         resource2 = G(Resource, gateway=fake_gateway, name="resource2")
+        self._release_resources(fake_gateway, fake_stage, [resource1, resource2])
 
         # Create MCP server with resource names
         mcp_server = G(MCPServer, gateway=fake_gateway, stage=fake_stage)
@@ -157,6 +166,7 @@ class TestMCPServerPermissionHandler:
         # Create resources
         resource1 = G(Resource, gateway=fake_gateway, name="resource1")
         resource2 = G(Resource, gateway=fake_gateway, name="resource2")
+        self._release_resources(fake_gateway, fake_stage, [resource1, resource2])
 
         # Create MCP server with only one resource name
         mcp_server = G(MCPServer, gateway=fake_gateway, stage=fake_stage)
@@ -204,6 +214,7 @@ class TestMCPServerPermissionHandler:
         resource1 = G(Resource, gateway=fake_gateway, name="resource1")
         resource2 = G(Resource, gateway=fake_gateway, name="resource2")
         resource3 = G(Resource, gateway=fake_gateway, name="resource3")
+        self._release_resources(fake_gateway, fake_stage, [resource1, resource2, resource3])
 
         # Create MCP server with resource names
         mcp_server = G(MCPServer, gateway=fake_gateway, stage=fake_stage)


### PR DESCRIPTION
## Summary
- cherry-pick #3124 to `release/1.23`
- source PR: https://github.com/TencentBlueKing/blueking-apigateway/pull/3124
- adapted for release/1.23: no `ResourceKindEnum` / AI-resource filtering on this branch; sync still uses stage release `resource_version.data` ids by name

## Cherry-picked commits
- `b76f1c66e` fix(dashboard): sync MCP permissions from released resource ids

## Verification
- `pytest ... -k sync_permissions`: 15 passed
- `ruff check` on changed files: passed

Made with [Cursor](https://cursor.com)