### PR TITLE
feat(dashboard): support resource keyword filter by description

### DIFF
--- a/src/dashboard/apigateway/apigateway/apis/web/resource/serializers.py
+++ b/src/dashboard/apigateway/apigateway/apis/web/resource/serializers.py
@@ -62,7 +62,7 @@ class ResourceQueryInputSLZ(serializers.Serializer):
     backend_name = serializers.CharField(allow_blank=True, required=False, help_text="后端服务名称，完整匹配")
     kind = serializers.ChoiceField(choices=ResourceKindEnum.get_choices(), required=False, help_text="资源类型")
     keyword = serializers.CharField(
-        allow_blank=True, required=False, help_text="资源筛选条件，支持模糊匹配资源名称，前端请求路径"
+        allow_blank=True, required=False, help_text="资源筛选条件，支持模糊匹配资源名称、前端请求路径、资源描述"
     )
     order_by = serializers.ChoiceField(
         choices=["-id", "name", "-name", "path", "-path", "updated_time", "-updated_time"],

--- a/src/dashboard/apigateway/apigateway/biz/resource/resource.py
+++ b/src/dashboard/apigateway/apigateway/biz/resource/resource.py
@@ -97,7 +97,9 @@ class ResourceHandler:
 
         if condition.get("keyword"):
             keyword = condition.get("keyword")
-            queryset = queryset.filter(Q(path__icontains=keyword) | Q(name__icontains=keyword))
+            queryset = queryset.filter(
+                Q(path__icontains=keyword) | Q(name__icontains=keyword) | Q(description__icontains=keyword)
+            )
 
         if condition.get("order_by"):
             queryset = queryset.order_by(condition["order_by"])

--- a/src/dashboard/apigateway/apigateway/tests/biz/resource/test_resource.py
+++ b/src/dashboard/apigateway/apigateway/tests/biz/resource/test_resource.py
@@ -152,6 +152,14 @@ class TestResourceHandler:
         resource_1 = G(Resource, gateway=fake_gateway, name="test1", method="GET", path="/test")
         resource_2 = G(Resource, gateway=fake_gateway, name="test2", method="POST", path="/test")
         resource_3 = G(Resource, gateway=fake_gateway, name="color", method="PUT", path="/green")
+        resource_4 = G(
+            Resource,
+            gateway=fake_gateway,
+            name="other",
+            method="GET",
+            path="/other",
+            description="unique desc keyword",
+        )
         label = G(APILabel, gateway=fake_gateway)
         G(ResourceLabel, api_label=label, resource=resource_1)
 
@@ -170,8 +178,11 @@ class TestResourceHandler:
         result = ResourceHandler.filter_by_resource_filter_condition(fake_gateway.id, {"keyword": "Test"})
         assert result.count() == 2
 
+        result = ResourceHandler.filter_by_resource_filter_condition(fake_gateway.id, {"keyword": "unique desc"})
+        assert list(result) == [resource_4]
+
         result = ResourceHandler.filter_by_resource_filter_condition(fake_gateway.id, {})
-        assert result.count() == 3
+        assert result.count() == 4
 
     def test_group_by_gateway_id(self):
         gateway_1 = G(Gateway)


### PR DESCRIPTION
## Summary
- Extend resource list `keyword` filtering to match `description` in addition to `name` and `path`
- Update serializer help text and unit coverage for description-based keyword matches

## Test plan
- [x] `uv run bash -lc 'cd apigateway && set -a && . apigateway/conf/unittest_env && set +a && python -m pytest --nomigrations --ds apigateway.settings -q --tb=short apigateway/tests/biz/resource/test_resource.py::TestResourceHandler::test_filter_by_resource_filter_condition'`
- [ ] Verify resource list keyword search returns resources whose description contains the keyword


Made with [Cursor](https://cursor.com)