### PR TITLE
fix(dashboard): convert gateway apply-records handled_by to display names

### DIFF
--- a/src/dashboard/apigateway/apigateway/apis/v2/inner/serializers.py
+++ b/src/dashboard/apigateway/apigateway/apis/v2/inner/serializers.py
@@ -411,9 +411,13 @@ class AppPermissionRecordBaseSLZ(serializers.ModelSerializer):
         return ApplyStatusEnum.get_choice_label(obj.status)
 
     def get_handled_by(self, obj):
-        if obj.handled_by:
-            return [obj.handled_by]
-        return obj.gateway.maintainers
+        """按网关租户将处理人转换为 display_name"""
+        handled_by = [obj.handled_by] if obj.handled_by else obj.gateway.maintainers
+        return ResourcePermissionHandler.convert_gateway_maintainers_to_display_names(
+            obj.gateway.tenant_mode,
+            obj.gateway.tenant_id,
+            handled_by,
+        )
 
     def get_comment(self, obj):
         return obj.comment or ""

--- a/src/dashboard/apigateway/apigateway/tests/apis/v2/inner/test_views.py
+++ b/src/dashboard/apigateway/apigateway/tests/apis/v2/inner/test_views.py
@@ -1564,6 +1564,83 @@ class TestAppPermissionRecordListApi:
         assert result["data"]["count"] == 0
         assert result["data"]["results"] == []
 
+    @patch("apigateway.biz.permission.permission.settings.ENABLE_MULTI_TENANT_MODE", True)
+    @patch("apigateway.biz.permission.permission.query_display_names_for_readonly")
+    def test_list_converts_pending_handled_by_maintainers_to_display_names(
+        self,
+        mock_query_display_names_for_readonly,
+        request_view,
+        fake_gateway,
+    ):
+        """pending 记录无 handled_by 时，按网关租户将 maintainers 转为 display_name"""
+        mock_query_display_names_for_readonly.return_value = ["张三", "李四"]
+        fake_gateway.tenant_mode = "single"
+        fake_gateway.tenant_id = "tenant-1"
+        fake_gateway._maintainers = "7idwx3b7nzk6xigs;bbb"
+        fake_gateway.save(update_fields=["tenant_mode", "tenant_id", "_maintainers"])
+
+        G(
+            AppPermissionRecord,
+            gateway=fake_gateway,
+            bk_app_code="test-app",
+            applied_by="test-user",
+            applied_time=timezone.now(),
+            handled_by="",
+            status="pending",
+        )
+
+        resp = request_view(
+            method="GET",
+            view_name="openapi.v2.inner.permission.apply-records",
+            data={"target_app_code": "test-app"},
+            app=mock.MagicMock(app_code="test"),
+        )
+        result = resp.json()
+
+        assert resp.status_code == 200
+        assert result["data"]["results"][0]["handled_by"] == ["张三", "李四"]
+        mock_query_display_names_for_readonly.assert_called_once_with(
+            "tenant-1",
+            ["7idwx3b7nzk6xigs", "bbb"],
+        )
+
+    @patch("apigateway.biz.permission.permission.settings.ENABLE_MULTI_TENANT_MODE", True)
+    @patch("apigateway.biz.permission.permission.query_display_names_for_readonly")
+    def test_list_converts_handled_by_to_display_names(
+        self,
+        mock_query_display_names_for_readonly,
+        request_view,
+        fake_gateway,
+    ):
+        """已处理记录按网关租户将 handled_by 转为 display_name"""
+        mock_query_display_names_for_readonly.return_value = ["管理员"]
+        fake_gateway.tenant_mode = "global"
+        fake_gateway.tenant_id = ""
+        fake_gateway.save(update_fields=["tenant_mode", "tenant_id"])
+
+        G(
+            AppPermissionRecord,
+            gateway=fake_gateway,
+            bk_app_code="test-app",
+            applied_by="test-user",
+            applied_time=timezone.now(),
+            handled_by="7idwx3b7nzk6xigs",
+            handled_time=timezone.now(),
+            status="approved",
+        )
+
+        resp = request_view(
+            method="GET",
+            view_name="openapi.v2.inner.permission.apply-records",
+            data={"target_app_code": "test-app"},
+            app=mock.MagicMock(app_code="test"),
+        )
+        result = resp.json()
+
+        assert resp.status_code == 200
+        assert result["data"]["results"][0]["handled_by"] == ["管理员"]
+        mock_query_display_names_for_readonly.assert_called_once_with("system", ["7idwx3b7nzk6xigs"])
+
 
 class TestAppAlarmRecordListApi:
     def _get_time_range_params(self):


### PR DESCRIPTION
## Summary
- Convert gateway inner API `/gateways/permissions/apply-records/` `handled_by` to display names.
- Resolve via the gateway's own tenant + username (same helper as MCP maintainers), not the applicant app tenant.
- Pending records continue to fall back to gateway maintainers before conversion.

## Verification
- `uv run make lint-check` (passed)
- `uv run bash -lc 'cd apigateway && set -a && . apigateway/conf/unittest_env && set +a && python -m pytest --nomigrations --ds apigateway.settings -q --tb=short apigateway/tests/apis/v2/inner/test_views.py::TestAppPermissionRecordListApi apigateway/tests/apis/v2/inner/test_views.py::TestMCPServerAppPermissionRecordListApi::test_list_converts_handled_by_to_display_names'` (5 passed)


Made with [Cursor](https://cursor.com)