### PR TITLE
fix(dashboard): convert apply-records handled_by to display names for release/1.23

### DIFF
--- a/src/dashboard/apigateway/apigateway/apis/v2/inner/serializers.py
+++ b/src/dashboard/apigateway/apigateway/apis/v2/inner/serializers.py
@@ -35,7 +35,6 @@ from apigateway.apps.mcp_server.constants import (
     MCPServerAppPermissionApplyStatusEnum,
     MCPServerProtocolTypeEnum,
 )
-from apigateway.apps.mcp_server.models import MCPServerAppPermissionApply
 from apigateway.apps.monitor.constants import AlarmStatusEnum
 from apigateway.apps.permission.constants import (
     RENEWABLE_EXPIRE_DAYS,
@@ -541,19 +540,12 @@ class MCPServerPermissionBaseSLZ(serializers.Serializer):
     def get_approval_url(self, obj) -> str:
         """获取审批 URL"""
         try:
-            if isinstance(obj, dict):
-                mcp_server_id = obj.get("mcp_server_id")
-                gateway_id = obj.get("gateway_id")
-                itsm_ticket_id = obj.get("itsm_ticket_id", "")
+            mcp_server_id = obj.get("mcp_server_id")
+            gateway_id = obj.get("gateway_id")
+            itsm_ticket_id = obj.get("itsm_ticket_id", "")
 
-                if gateway_id and mcp_server_id:
-                    return build_mcp_server_permission_approval_url(gateway_id, mcp_server_id, itsm_ticket_id)
-
-            # 如果是模型实例
-            if hasattr(obj, "mcp_server"):
-                return build_mcp_server_permission_approval_url(
-                    obj.mcp_server.gateway_id, obj.mcp_server_id, getattr(obj, "itsm_ticket_id", "")
-                )
+            if gateway_id and mcp_server_id:
+                return build_mcp_server_permission_approval_url(gateway_id, mcp_server_id, itsm_ticket_id)
         except Exception:
             # 记录错误但不中断响应
             logger.warning("Failed to build approval URL for object: %s", obj)
@@ -650,32 +642,12 @@ class MCPServerAppPermissionRecordBaseSLZ(serializers.Serializer):
     itsm_ticket_id = serializers.CharField(read_only=True, help_text="关联的 ITSM 工单 ID")
     approval_url = serializers.SerializerMethodField(help_text="权限审批 URL")
 
-    def _get_record_data(self, obj):
-        if isinstance(obj, dict):
-            return obj
-
-        if isinstance(obj, MCPServerAppPermissionApply):
-            gateway = obj.mcp_server.gateway
-            return {
-                "bk_app_code": obj.bk_app_code,
-                "applied_by": obj.applied_by,
-                "handled_by": [obj.handled_by] if obj.handled_by else gateway.maintainers,
-                "tenant_mode": gateway.tenant_mode,
-                "tenant_id": gateway.tenant_id,
-                "mcp_server_id": obj.mcp_server_id,
-                "gateway_id": obj.mcp_server.gateway_id,
-                "itsm_ticket_id": obj.itsm_ticket_id,
-            }
-
-        return {}
-
     def get_approval_url(self, obj) -> str:
         """获取审批 URL"""
-        record_data = self._get_record_data(obj)
         try:
-            mcp_server_id = record_data.get("mcp_server_id")
-            gateway_id = record_data.get("gateway_id")
-            itsm_ticket_id = record_data.get("itsm_ticket_id", "")
+            mcp_server_id = obj.get("mcp_server_id")
+            gateway_id = obj.get("gateway_id")
+            itsm_ticket_id = obj.get("itsm_ticket_id", "")
 
             if gateway_id and mcp_server_id:
                 return build_mcp_server_permission_approval_url(gateway_id, mcp_server_id, itsm_ticket_id)
@@ -687,26 +659,24 @@ class MCPServerAppPermissionRecordBaseSLZ(serializers.Serializer):
 
     def get_handled_by(self, obj):
         """获取处理人 display_name"""
-        record_data = self._get_record_data(obj)
         return ResourcePermissionHandler.convert_gateway_maintainers_to_display_names(
-            record_data.get("tenant_mode", ""),
-            record_data.get("tenant_id", ""),
-            record_data.get("handled_by") or [],
+            obj.get("tenant_mode", ""),
+            obj.get("tenant_id", ""),
+            obj.get("handled_by") or [],
         )
 
     def get_applied_by(self, obj):
         """获取申请人 display_name"""
-        record_data = self._get_record_data(obj)
         try:
             return ResourcePermissionHandler.convert_applied_by_to_display_name(
-                record_data.get("bk_app_code", ""),
-                record_data.get("applied_by", ""),
-                record_data.get("tenant_mode", ""),
-                record_data.get("tenant_id", ""),
+                obj.get("bk_app_code", ""),
+                obj.get("applied_by", ""),
+                obj.get("tenant_mode", ""),
+                obj.get("tenant_id", ""),
             )
         except Exception:
             logger.warning("Failed to convert applied_by for record object: %s", obj, exc_info=True)
-            return record_data.get("applied_by", "")
+            return obj.get("applied_by", "")
 
     class Meta:
         ref_name = "apigateway.apis.v2.inner.serializers.MCPServerAppPermissionRecordBaseSLZ"

--- a/src/dashboard/apigateway/apigateway/apis/v2/inner/serializers.py
+++ b/src/dashboard/apigateway/apigateway/apis/v2/inner/serializers.py
@@ -539,16 +539,12 @@ class MCPServerPermissionBaseSLZ(serializers.Serializer):
 
     def get_approval_url(self, obj) -> str:
         """获取审批 URL"""
-        try:
-            mcp_server_id = obj.get("mcp_server_id")
-            gateway_id = obj.get("gateway_id")
-            itsm_ticket_id = obj.get("itsm_ticket_id", "")
+        mcp_server_id = obj.get("mcp_server_id")
+        gateway_id = obj.get("gateway_id")
+        itsm_ticket_id = obj.get("itsm_ticket_id", "")
 
-            if gateway_id and mcp_server_id:
-                return build_mcp_server_permission_approval_url(gateway_id, mcp_server_id, itsm_ticket_id)
-        except Exception:
-            # 记录错误但不中断响应
-            logger.warning("Failed to build approval URL for object: %s", obj)
+        if gateway_id and mcp_server_id:
+            return build_mcp_server_permission_approval_url(gateway_id, mcp_server_id, itsm_ticket_id)
 
         return ""
 
@@ -667,16 +663,12 @@ class MCPServerAppPermissionRecordBaseSLZ(serializers.Serializer):
 
     def get_applied_by(self, obj):
         """获取申请人 display_name"""
-        try:
-            return ResourcePermissionHandler.convert_applied_by_to_display_name(
-                obj.get("bk_app_code", ""),
-                obj.get("applied_by", ""),
-                obj.get("tenant_mode", ""),
-                obj.get("tenant_id", ""),
-            )
-        except Exception:
-            logger.warning("Failed to convert applied_by for record object: %s", obj, exc_info=True)
-            return obj.get("applied_by", "")
+        return ResourcePermissionHandler.convert_applied_by_to_display_name(
+            obj.get("bk_app_code", ""),
+            obj.get("applied_by", ""),
+            obj.get("tenant_mode", ""),
+            obj.get("tenant_id", ""),
+        )
 
     class Meta:
         ref_name = "apigateway.apis.v2.inner.serializers.MCPServerAppPermissionRecordBaseSLZ"

--- a/src/dashboard/apigateway/apigateway/apis/v2/inner/serializers.py
+++ b/src/dashboard/apigateway/apigateway/apis/v2/inner/serializers.py
@@ -406,9 +406,13 @@ class AppPermissionRecordBaseSLZ(serializers.ModelSerializer):
         return ApplyStatusEnum.get_choice_label(obj.status)
 
     def get_handled_by(self, obj):
-        if obj.handled_by:
-            return [obj.handled_by]
-        return obj.gateway.maintainers
+        """按网关租户将处理人转换为 display_name"""
+        handled_by = [obj.handled_by] if obj.handled_by else obj.gateway.maintainers
+        return ResourcePermissionHandler.convert_gateway_maintainers_to_display_names(
+            obj.gateway.tenant_mode,
+            obj.gateway.tenant_id,
+            handled_by,
+        )
 
     def get_comment(self, obj):
         return obj.comment or ""

--- a/src/dashboard/apigateway/apigateway/apis/v2/inner/serializers.py
+++ b/src/dashboard/apigateway/apigateway/apis/v2/inner/serializers.py
@@ -35,6 +35,7 @@ from apigateway.apps.mcp_server.constants import (
     MCPServerAppPermissionApplyStatusEnum,
     MCPServerProtocolTypeEnum,
 )
+from apigateway.apps.mcp_server.models import MCPServerAppPermissionApply
 from apigateway.apps.monitor.constants import AlarmStatusEnum
 from apigateway.apps.permission.constants import (
     RENEWABLE_EXPIRE_DAYS,
@@ -649,22 +650,35 @@ class MCPServerAppPermissionRecordBaseSLZ(serializers.Serializer):
     itsm_ticket_id = serializers.CharField(read_only=True, help_text="关联的 ITSM 工单 ID")
     approval_url = serializers.SerializerMethodField(help_text="权限审批 URL")
 
+    def _get_record_data(self, obj):
+        if isinstance(obj, dict):
+            return obj
+
+        if isinstance(obj, MCPServerAppPermissionApply):
+            gateway = obj.mcp_server.gateway
+            return {
+                "bk_app_code": obj.bk_app_code,
+                "applied_by": obj.applied_by,
+                "handled_by": [obj.handled_by] if obj.handled_by else gateway.maintainers,
+                "tenant_mode": gateway.tenant_mode,
+                "tenant_id": gateway.tenant_id,
+                "mcp_server_id": obj.mcp_server_id,
+                "gateway_id": obj.mcp_server.gateway_id,
+                "itsm_ticket_id": obj.itsm_ticket_id,
+            }
+
+        return {}
+
     def get_approval_url(self, obj) -> str:
         """获取审批 URL"""
+        record_data = self._get_record_data(obj)
         try:
-            if isinstance(obj, dict):
-                mcp_server_id = obj.get("mcp_server_id")
-                gateway_id = obj.get("gateway_id")
-                itsm_ticket_id = obj.get("itsm_ticket_id", "")
+            mcp_server_id = record_data.get("mcp_server_id")
+            gateway_id = record_data.get("gateway_id")
+            itsm_ticket_id = record_data.get("itsm_ticket_id", "")
 
-                if gateway_id and mcp_server_id:
-                    return build_mcp_server_permission_approval_url(gateway_id, mcp_server_id, itsm_ticket_id)
-
-            # 如果是模型实例
-            if hasattr(obj, "mcp_server"):
-                return build_mcp_server_permission_approval_url(
-                    obj.mcp_server.gateway_id, obj.mcp_server_id, getattr(obj, "itsm_ticket_id", "")
-                )
+            if gateway_id and mcp_server_id:
+                return build_mcp_server_permission_approval_url(gateway_id, mcp_server_id, itsm_ticket_id)
         except Exception:
             # 记录错误但不中断响应
             logger.warning("Failed to build approval URL for object: %s", obj)
@@ -673,51 +687,26 @@ class MCPServerAppPermissionRecordBaseSLZ(serializers.Serializer):
 
     def get_handled_by(self, obj):
         """获取处理人 display_name"""
-        if isinstance(obj, dict):
-            handled_by = obj.get("handled_by") or []
-            return ResourcePermissionHandler.convert_gateway_maintainers_to_display_names(
-                obj.get("tenant_mode", ""),
-                obj.get("tenant_id", ""),
-                handled_by,
-            )
-
-        if hasattr(obj, "mcp_server"):
-            handled_by = [obj.handled_by] if obj.handled_by else obj.mcp_server.gateway.maintainers
-            return ResourcePermissionHandler.convert_gateway_maintainers_to_display_names(
-                obj.mcp_server.gateway.tenant_mode,
-                obj.mcp_server.gateway.tenant_id,
-                handled_by,
-            )
-
-        return getattr(obj, "handled_by", [])
+        record_data = self._get_record_data(obj)
+        return ResourcePermissionHandler.convert_gateway_maintainers_to_display_names(
+            record_data.get("tenant_mode", ""),
+            record_data.get("tenant_id", ""),
+            record_data.get("handled_by") or [],
+        )
 
     def get_applied_by(self, obj):
         """获取申请人 display_name"""
-        if isinstance(obj, dict):
-            try:
-                return ResourcePermissionHandler.convert_applied_by_to_display_name(
-                    obj.get("bk_app_code", ""),
-                    obj.get("applied_by", ""),
-                    obj.get("tenant_mode", ""),
-                    obj.get("tenant_id", ""),
-                )
-            except Exception:
-                logger.warning("Failed to convert applied_by for dict object: %s", obj, exc_info=True)
-                return obj.get("applied_by", "")
-
-        if hasattr(obj, "mcp_server"):
-            try:
-                return ResourcePermissionHandler.convert_applied_by_to_display_name(
-                    obj.bk_app_code,
-                    obj.applied_by,
-                    obj.mcp_server.gateway.tenant_mode,
-                    obj.mcp_server.gateway.tenant_id,
-                )
-            except Exception:
-                logger.warning("Failed to convert applied_by for model object: %s", obj, exc_info=True)
-                return getattr(obj, "applied_by", "")
-
-        return getattr(obj, "applied_by", "")
+        record_data = self._get_record_data(obj)
+        try:
+            return ResourcePermissionHandler.convert_applied_by_to_display_name(
+                record_data.get("bk_app_code", ""),
+                record_data.get("applied_by", ""),
+                record_data.get("tenant_mode", ""),
+                record_data.get("tenant_id", ""),
+            )
+        except Exception:
+            logger.warning("Failed to convert applied_by for record object: %s", obj, exc_info=True)
+            return record_data.get("applied_by", "")
 
     class Meta:
         ref_name = "apigateway.apis.v2.inner.serializers.MCPServerAppPermissionRecordBaseSLZ"

--- a/src/dashboard/apigateway/apigateway/apis/v2/inner/serializers.py
+++ b/src/dashboard/apigateway/apigateway/apis/v2/inner/serializers.py
@@ -639,7 +639,7 @@ class MCPServerAppPermissionRecordBaseSLZ(serializers.Serializer):
     id = serializers.IntegerField(read_only=True)
     applied_by = serializers.SerializerMethodField(help_text="申请人")
     applied_time = serializers.DateTimeField(read_only=True, help_text="申请时间")
-    handled_by = serializers.ListField(child=serializers.CharField(), help_text="处理人")
+    handled_by = serializers.SerializerMethodField(help_text="处理人")
     handled_time = serializers.DateTimeField(read_only=True, help_text="处理时间")
     apply_status = serializers.CharField(read_only=True, help_text="审批状态")
     apply_status_display = serializers.CharField(read_only=True)
@@ -670,6 +670,26 @@ class MCPServerAppPermissionRecordBaseSLZ(serializers.Serializer):
             logger.warning("Failed to build approval URL for object: %s", obj)
 
         return ""
+
+    def get_handled_by(self, obj):
+        """获取处理人 display_name"""
+        if isinstance(obj, dict):
+            handled_by = obj.get("handled_by") or []
+            return ResourcePermissionHandler.convert_gateway_maintainers_to_display_names(
+                obj.get("tenant_mode", ""),
+                obj.get("tenant_id", ""),
+                handled_by,
+            )
+
+        if hasattr(obj, "mcp_server"):
+            handled_by = [obj.handled_by] if obj.handled_by else obj.mcp_server.gateway.maintainers
+            return ResourcePermissionHandler.convert_gateway_maintainers_to_display_names(
+                obj.mcp_server.gateway.tenant_mode,
+                obj.mcp_server.gateway.tenant_id,
+                handled_by,
+            )
+
+        return getattr(obj, "handled_by", [])
 
     def get_applied_by(self, obj):
         """获取申请人 display_name"""

--- a/src/dashboard/apigateway/apigateway/apis/v2/inner/views.py
+++ b/src/dashboard/apigateway/apigateway/apis/v2/inner/views.py
@@ -1178,6 +1178,8 @@ class MCPServerAppPermissionRecordRetrieveApi(generics.RetrieveAPIView):
                 "itsm_ticket_id": instance.itsm_ticket_id,
                 "mcp_server_id": instance.mcp_server_id,  # 添加 mcp_server_id 用于构建审批 URL
                 "gateway_id": instance.mcp_server.gateway_id,  # 在 record 中也添加 gateway_id
+                "tenant_mode": instance.mcp_server.gateway.tenant_mode,
+                "tenant_id": instance.mcp_server.gateway.tenant_id,
             },
         }
 

--- a/src/dashboard/apigateway/apigateway/tests/apis/v2/inner/test_views.py
+++ b/src/dashboard/apigateway/apigateway/tests/apis/v2/inner/test_views.py
@@ -1524,6 +1524,83 @@ class TestAppPermissionRecordListApi:
         assert result["data"]["count"] == 0
         assert result["data"]["results"] == []
 
+    @patch("apigateway.biz.permission.permission.settings.ENABLE_MULTI_TENANT_MODE", True)
+    @patch("apigateway.biz.permission.permission.query_display_names_for_readonly")
+    def test_list_converts_pending_handled_by_maintainers_to_display_names(
+        self,
+        mock_query_display_names_for_readonly,
+        request_view,
+        fake_gateway,
+    ):
+        """pending 记录无 handled_by 时，按网关租户将 maintainers 转为 display_name"""
+        mock_query_display_names_for_readonly.return_value = ["张三", "李四"]
+        fake_gateway.tenant_mode = "single"
+        fake_gateway.tenant_id = "tenant-1"
+        fake_gateway._maintainers = "7idwx3b7nzk6xigs;bbb"
+        fake_gateway.save(update_fields=["tenant_mode", "tenant_id", "_maintainers"])
+
+        G(
+            AppPermissionRecord,
+            gateway=fake_gateway,
+            bk_app_code="test-app",
+            applied_by="test-user",
+            applied_time=timezone.now(),
+            handled_by="",
+            status="pending",
+        )
+
+        resp = request_view(
+            method="GET",
+            view_name="openapi.v2.inner.permission.apply-records",
+            data={"target_app_code": "test-app"},
+            app=mock.MagicMock(app_code="test"),
+        )
+        result = resp.json()
+
+        assert resp.status_code == 200
+        assert result["data"]["results"][0]["handled_by"] == ["张三", "李四"]
+        mock_query_display_names_for_readonly.assert_called_once_with(
+            "tenant-1",
+            ["7idwx3b7nzk6xigs", "bbb"],
+        )
+
+    @patch("apigateway.biz.permission.permission.settings.ENABLE_MULTI_TENANT_MODE", True)
+    @patch("apigateway.biz.permission.permission.query_display_names_for_readonly")
+    def test_list_converts_handled_by_to_display_names(
+        self,
+        mock_query_display_names_for_readonly,
+        request_view,
+        fake_gateway,
+    ):
+        """已处理记录按网关租户将 handled_by 转为 display_name"""
+        mock_query_display_names_for_readonly.return_value = ["管理员"]
+        fake_gateway.tenant_mode = "global"
+        fake_gateway.tenant_id = ""
+        fake_gateway.save(update_fields=["tenant_mode", "tenant_id"])
+
+        G(
+            AppPermissionRecord,
+            gateway=fake_gateway,
+            bk_app_code="test-app",
+            applied_by="test-user",
+            applied_time=timezone.now(),
+            handled_by="7idwx3b7nzk6xigs",
+            handled_time=timezone.now(),
+            status="approved",
+        )
+
+        resp = request_view(
+            method="GET",
+            view_name="openapi.v2.inner.permission.apply-records",
+            data={"target_app_code": "test-app"},
+            app=mock.MagicMock(app_code="test"),
+        )
+        result = resp.json()
+
+        assert resp.status_code == 200
+        assert result["data"]["results"][0]["handled_by"] == ["管理员"]
+        mock_query_display_names_for_readonly.assert_called_once_with("system", ["7idwx3b7nzk6xigs"])
+
 
 class TestAppAlarmRecordListApi:
     def _get_time_range_params(self):

--- a/src/dashboard/apigateway/apigateway/tests/apis/v2/inner/test_views.py
+++ b/src/dashboard/apigateway/apigateway/tests/apis/v2/inner/test_views.py
@@ -1015,6 +1015,49 @@ class TestMCPServerAppPermissionListApi:
 
 
 class TestMCPServerAppPermissionRecordListApi:
+    @patch("apigateway.biz.permission.permission.settings.ENABLE_MULTI_TENANT_MODE", True)
+    @patch("apigateway.biz.permission.permission.query_display_names_for_readonly")
+    def test_list_converts_handled_by_to_display_names(
+        self,
+        mock_query_display_names_for_readonly,
+        request_view,
+        fake_gateway,
+        fake_stage,
+    ):
+        mock_query_display_names_for_readonly.return_value = ["张三", "李四"]
+        fake_gateway.tenant_mode = "global"
+        fake_gateway.tenant_id = ""
+        fake_gateway._maintainers = "7idwx3b7nzk6xigs;bbb"
+        fake_gateway.save(update_fields=["tenant_mode", "tenant_id", "_maintainers"])
+
+        mcp_server = G(
+            MCPServer,
+            gateway=fake_gateway,
+            stage=fake_stage,
+            name="test-mcp-server",
+            is_public=True,
+            status=MCPServerStatusEnum.ACTIVE.value,
+        )
+        G(
+            MCPServerAppPermissionApply,
+            bk_app_code="test-app",
+            mcp_server=mcp_server,
+            status=MCPServerAppPermissionApplyStatusEnum.PENDING.value,
+            applied_by="test-user",
+        )
+
+        resp = request_view(
+            method="GET",
+            view_name="openapi.v2.inner.mcp_server.permission.apply-records",
+            data={"target_app_code": "test-app"},
+            app=mock.MagicMock(app_code="test"),
+        )
+        result = resp.json()
+
+        assert resp.status_code == 200
+        assert result["data"][0]["record"]["handled_by"] == ["张三", "李四"]
+        mock_query_display_names_for_readonly.assert_called_once_with("system", ["7idwx3b7nzk6xigs", "bbb"])
+
     def test_list_with_approval_url(self, request_view, fake_gateway, fake_stage, settings):
         """测试申请记录列表包含审批 URL"""
         # 设置审批 URL 模板
@@ -1141,6 +1184,50 @@ class TestMCPServerAppPermissionRecordListApi:
 
 
 class TestMCPServerAppPermissionRecordRetrieveApi:
+    @patch("apigateway.biz.permission.permission.settings.ENABLE_MULTI_TENANT_MODE", True)
+    @patch("apigateway.biz.permission.permission.query_display_names_for_readonly")
+    def test_retrieve_converts_handled_by_to_display_name(
+        self,
+        mock_query_display_names_for_readonly,
+        request_view,
+        fake_gateway,
+        fake_stage,
+    ):
+        mock_query_display_names_for_readonly.return_value = ["张三"]
+        fake_gateway.tenant_mode = "single"
+        fake_gateway.tenant_id = "tenant-1"
+        fake_gateway.save(update_fields=["tenant_mode", "tenant_id"])
+
+        mcp_server = G(
+            MCPServer,
+            gateway=fake_gateway,
+            stage=fake_stage,
+            name="test-mcp-server",
+            is_public=True,
+            status=MCPServerStatusEnum.ACTIVE.value,
+        )
+        apply_record = G(
+            MCPServerAppPermissionApply,
+            bk_app_code="test-app",
+            mcp_server=mcp_server,
+            status=MCPServerAppPermissionApplyStatusEnum.APPROVED.value,
+            applied_by="test-user",
+            handled_by="7idwx3b7nzk6xigs",
+        )
+
+        resp = request_view(
+            method="GET",
+            view_name="openapi.v2.inner.mcp_server.permission.apply-record-detail",
+            path_params={"record_id": apply_record.id},
+            data={"target_app_code": "test-app"},
+            app=mock.MagicMock(app_code="test"),
+        )
+        result = resp.json()
+
+        assert resp.status_code == 200
+        assert result["data"]["record"]["handled_by"] == ["张三"]
+        mock_query_display_names_for_readonly.assert_called_once_with("tenant-1", ["7idwx3b7nzk6xigs"])
+
     def test_retrieve_with_approval_url(self, request_view, fake_gateway, fake_stage, settings):
         """测试申请记录详情包含审批 URL"""
         # 设置审批 URL 模板


### PR DESCRIPTION
## Summary
- cherry-pick #3058 and #3132 to `release/1.23`
- source PRs:
  - https://github.com/TencentBlueKing/blueking-apigateway/pull/3058 (MCP apply-records `handled_by` display names)
  - https://github.com/TencentBlueKing/blueking-apigateway/pull/3132 (gateway apply-records `handled_by` display names)
- keep release/1.23 aligned with master for both gateway and MCP inner apply-records `handled_by` conversion via gateway tenant

## Cherry-picked commits
- `82c96d77f` fix: convert handled_by to display names in apply records (#3058)
- `1b097bd1c` refactor: normalize apply record serializer input (#3058)
- `30d7ed356` refactor: remove unused model compatibility in serializers (#3058)
- `bf3173c19` refactor: remove try-catch (#3058)
- `05cb1a9e8` fix(dashboard): convert gateway apply-records handled_by to display names (#3132)

## Verification
- `uv run make lint-check` (passed)
- focused pytest for gateway/MCP handled_by conversion (6 passed)


Made with [Cursor](https://cursor.com)