### PR TITLE
fix(mcp-proxy): correct tool request audit logging

### DIFF
--- a/src/mcp-proxy/pkg/infra/proxy/proxy.go
+++ b/src/mcp-proxy/pkg/infra/proxy/proxy.go
@@ -968,6 +968,7 @@ func genToolHandler(toolApiConfig *ToolConfig, serverName string, rawResponseEna
 		}
 		logTruncate := config.G.McpServer.LogTruncate
 		requestBody := util.TruncateJSON(req.Params.Arguments, logTruncate.GetAuditLogMaxBodySize())
+		requestBodySize := int64(len(requestBody))
 
 		// 用于在 defer 中记录完整的调用信息（包含 response, latency 等）
 		var (
@@ -991,10 +992,9 @@ func genToolHandler(toolApiConfig *ToolConfig, serverName string, rawResponseEna
 			// 记录完整的调用信息（合并了之前的 "call tool" 和 "call tool request params" 日志）
 			auditLog.Info(
 				"call tool complete",
-				zap.String("request", requestBody),
 				zap.String("params", requestBody),
 				zap.String("response", auditResponse),
-				zap.Int64("request_body_size", int64(len(requestBody))),
+				zap.Int64("request_body_size", requestBodySize),
 				zap.Int64("response_body_size", auditResponseSize),
 				zap.String("latency", auditLatency.String()),
 				zap.String("status", auditStatus),
@@ -1022,6 +1022,7 @@ func genToolHandler(toolApiConfig *ToolConfig, serverName string, rawResponseEna
 			markAuditCallFailed(start, err, &auditStatus, &auditLatency, &auditResponse)
 			return nil, trace.WrapErrorWithTraceID(ctx, err)
 		}
+		requestBodySize = int64(len(argsBytes))
 		decoder := json.NewDecoder(bytes.NewReader(argsBytes))
 		decoder.UseNumber()
 		err = decoder.Decode(&handlerRequest)

--- a/src/mcp-proxy/pkg/infra/proxy/proxy_suite_test.go
+++ b/src/mcp-proxy/pkg/infra/proxy/proxy_suite_test.go
@@ -19,6 +19,7 @@
 package proxy
 
 import (
+	"path/filepath"
 	"testing"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -28,9 +29,25 @@ import (
 	"mcp_proxy/pkg/infra/logging"
 )
 
+var auditLogPath string
+
 var _ = BeforeSuite(func() {
+	auditLogDir := GinkgoT().TempDir()
+	auditLogPath = filepath.Join(auditLogDir, "audit.log")
+
 	// Initialize config.G to avoid nil pointer dereference when genToolHandler accesses config fields.
-	config.G = &config.Config{}
+	config.G = &config.Config{
+		Logger: config.Logger{
+			Audit: config.LogConfig{
+				Level:  "info",
+				Writer: "file",
+				Settings: map[string]string{
+					"name": "audit.log",
+					"path": auditLogDir,
+				},
+			},
+		},
+	}
 	// Initialize logger for tests
 	logging.InitLogger(config.G)
 })

--- a/src/mcp-proxy/pkg/infra/proxy/proxy_test.go
+++ b/src/mcp-proxy/pkg/infra/proxy/proxy_test.go
@@ -27,9 +27,11 @@ import (
 	"encoding/json"
 	"encoding/pem"
 	"errors"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"os"
 	"strings"
 	"sync"
 	"time"
@@ -451,6 +453,43 @@ var _ = Describe("MCPProxy", func() {
 	})
 
 	Describe("genToolHandler response payload behavior", func() {
+		It("logs tool arguments only in params with the full request size", func() {
+			var startOffset int64
+			if logInfo, err := os.Stat(auditLogPath); err == nil {
+				startOffset = logInfo.Size()
+			} else {
+				Expect(os.IsNotExist(err)).To(BeTrue())
+			}
+
+			upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				_, _ = w.Write([]byte(`{"ok":true}`))
+			}))
+			defer upstream.Close()
+
+			arguments := json.RawMessage(
+				fmt.Sprintf(`{"body_param":{"value":"%s"}}`, strings.Repeat("x", 5000)),
+			)
+			callTestToolHandler(upstream.URL, false, arguments)
+
+			logBytes, err := os.ReadFile(auditLogPath)
+			Expect(err).NotTo(HaveOccurred())
+			logBytes = logBytes[startOffset:]
+
+			var completeLog map[string]any
+			for _, line := range bytes.Split(logBytes, []byte("\n")) {
+				var entry map[string]any
+				if json.Unmarshal(line, &entry) == nil && entry["msg"] == "call tool complete" {
+					completeLog = entry
+				}
+			}
+
+			Expect(completeLog).NotTo(BeNil())
+			Expect(completeLog["params"]).To(HaveSuffix("...(truncated)"))
+			Expect(completeLog).To(HaveKeyWithValue("request_body_size", float64(len(arguments))))
+			Expect(completeLog).NotTo(HaveKey("request"))
+		})
+
 		It("returns envelope response with upstream JSON body", func() {
 			upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 				w.Header().Set("Content-Type", "application/json")
@@ -1533,7 +1572,11 @@ var _ = Describe("MCPProxy", func() {
 	})
 })
 
-func callTestToolHandler(upstream string, rawResponseEnabled bool) *mcp.CallToolResult {
+func callTestToolHandler(
+	upstream string,
+	rawResponseEnabled bool,
+	arguments ...json.RawMessage,
+) *mcp.CallToolResult {
 	upstreamURL, err := url.Parse(upstream)
 	Expect(err).NotTo(HaveOccurred())
 
@@ -1555,10 +1598,14 @@ func callTestToolHandler(upstream string, rawResponseEnabled bool) *mcp.CallTool
 	handler := genToolHandler(toolConfig, "test-server", func() bool {
 		return rawResponseEnabled
 	})
+	toolArguments := json.RawMessage(`{}`)
+	if len(arguments) > 0 {
+		toolArguments = arguments[0]
+	}
 	result, err := handler(testToolCallContext(), &mcp.CallToolRequest{
 		Params: &mcp.CallToolParamsRaw{
 			Name:      "list_items",
-			Arguments: json.RawMessage(`{}`),
+			Arguments: toolArguments,
 		},
 	})
 	Expect(err).NotTo(HaveOccurred())


### PR DESCRIPTION
## Summary

- remove the duplicate `request` field from `call tool complete` audit logs and keep `params` as the canonical MCP tool arguments field
- calculate `request_body_size` from the complete serialized arguments instead of the truncated log preview
- add regression coverage against the emitted audit log JSON

The existing structured `query`, `path`, and `body` fields are unchanged. Dashboard compatibility fallback for historical logs is also unchanged.

## Verification

- `make lint`
- `make test` (14 suites passed; integration specs in this command were environment-skipped as designed)
- `make integration` (81 passed, 0 failed, 0 skipped)