### PR TITLE
fix(mcp): 发布切换期间保留新旧资源 ID 权限

### DIFF
--- a/src/dashboard/apigateway/apigateway/apps/mcp_server/constants.py
+++ b/src/dashboard/apigateway/apigateway/apps/mcp_server/constants.py
@@ -22,7 +22,12 @@ from blue_krill.data_types.enum import EnumField, StructuredEnum
 from django.conf import settings
 from django.utils.translation import gettext_lazy as _
 
-SYNC_STAGE_MCP_SERVER_PERMISSIONS_TASK_NAME = "apigateway.apps.mcp_server.tasks.sync_stage_mcp_server_permissions"
+ADD_STAGE_MCP_SERVER_PERMISSIONS_BEFORE_RELEASE_UPDATE_TASK_NAME = (
+    "apigateway.apps.mcp_server.tasks.add_stage_mcp_server_permissions_before_release_update"
+)
+RECONCILE_STAGE_MCP_SERVER_PERMISSIONS_AFTER_RELEASE_TASK_NAME = (
+    "apigateway.apps.mcp_server.tasks.reconcile_stage_mcp_server_permissions_after_release"
+)
 
 
 class MCPServerStatusEnum(StructuredEnum):

--- a/src/dashboard/apigateway/apigateway/apps/mcp_server/constants.py
+++ b/src/dashboard/apigateway/apigateway/apps/mcp_server/constants.py
@@ -22,6 +22,8 @@ from blue_krill.data_types.enum import EnumField, StructuredEnum
 from django.conf import settings
 from django.utils.translation import gettext_lazy as _
 
+SYNC_STAGE_MCP_SERVER_PERMISSIONS_TASK_NAME = "apigateway.apps.mcp_server.tasks.sync_stage_mcp_server_permissions"
+
 
 class MCPServerStatusEnum(StructuredEnum):
     INACTIVE = EnumField(0, "已停用")

--- a/src/dashboard/apigateway/apigateway/apps/mcp_server/tasks.py
+++ b/src/dashboard/apigateway/apigateway/apps/mcp_server/tasks.py
@@ -23,14 +23,56 @@ from typing import Any, Dict, List, Optional, Set, Tuple
 from celery import shared_task
 from django.conf import settings
 
+from apigateway.apps.mcp_server.constants import SYNC_STAGE_MCP_SERVER_PERMISSIONS_TASK_NAME
+from apigateway.apps.mcp_server.models import MCPServer
 from apigateway.biz.mcp_server import (
     MCPServerHandler,
     MCPServerPromptHandler,
 )
 from apigateway.core.constants import ReleaseHistoryStatusEnum
+from apigateway.core.models import Release, ResourceVersion
 from apigateway.service.release import wait_release_done
 
 logger = logging.getLogger(__name__)
+
+
+@shared_task(name=SYNC_STAGE_MCP_SERVER_PERMISSIONS_TASK_NAME, ignore_result=True)
+def sync_stage_mcp_server_permissions(
+    stage_id: int,
+    resource_version_id: Optional[int] = None,
+    delete_stale: bool = True,
+    expected_resource_version_id: Optional[int] = None,
+) -> None:
+    """同步环境下所有 MCP Server 的资源权限。"""
+    if expected_resource_version_id is not None:
+        current_resource_version_id = (
+            Release.objects.filter(stage_id=stage_id).values_list("resource_version_id", flat=True).first()
+        )
+        if current_resource_version_id != expected_resource_version_id:
+            logger.info(
+                "skip stale mcp server permission sync, stage_id=%d, expected_resource_version_id=%d, "
+                "current_resource_version_id=%s",
+                stage_id,
+                expected_resource_version_id,
+                current_resource_version_id,
+            )
+            return
+
+    resource_version = None
+    if resource_version_id is not None:
+        resource_version = ResourceVersion.objects.get(id=resource_version_id)
+
+    mcp_server_ids = MCPServer.objects.filter(stage_id=stage_id).values_list("id", flat=True)
+    for mcp_server_id in mcp_server_ids:
+        if resource_version is not None:
+            MCPServerHandler.sync_permissions(
+                mcp_server_id,
+                resource_version=resource_version,
+                delete_stale=delete_stale,
+            )
+            continue
+
+        MCPServerHandler.sync_permissions(mcp_server_id)
 
 
 def _collect_prompt_ids(

--- a/src/dashboard/apigateway/apigateway/apps/mcp_server/tasks.py
+++ b/src/dashboard/apigateway/apigateway/apps/mcp_server/tasks.py
@@ -18,61 +18,143 @@
 #
 import logging
 from collections import defaultdict
-from typing import Any, Dict, List, Optional, Set, Tuple
+from contextlib import contextmanager
+from typing import Any, Dict, Iterator, List, Optional, Set, Tuple
 
+import redis_lock
 from celery import shared_task
 from django.conf import settings
 
-from apigateway.apps.mcp_server.constants import SYNC_STAGE_MCP_SERVER_PERMISSIONS_TASK_NAME
+from apigateway.apps.mcp_server.constants import (
+    ADD_STAGE_MCP_SERVER_PERMISSIONS_BEFORE_RELEASE_UPDATE_TASK_NAME,
+    RECONCILE_STAGE_MCP_SERVER_PERMISSIONS_AFTER_RELEASE_TASK_NAME,
+)
 from apigateway.apps.mcp_server.models import MCPServer
 from apigateway.biz.mcp_server import (
     MCPServerHandler,
     MCPServerPromptHandler,
 )
 from apigateway.core.constants import ReleaseHistoryStatusEnum
-from apigateway.core.models import Release, ResourceVersion
+from apigateway.core.models import Release, ReleaseHistory, ResourceVersion
 from apigateway.service.release import wait_release_done
+from apigateway.utils.exception import LockTimeout
+from apigateway.utils.redis_utils import get_default_redis_client
 
 logger = logging.getLogger(__name__)
 
 
-@shared_task(name=SYNC_STAGE_MCP_SERVER_PERMISSIONS_TASK_NAME, ignore_result=True)
-def sync_stage_mcp_server_permissions(
+def _get_mcp_server_permission_sync_lock(stage_id: int):
+    return redis_lock.Lock(
+        get_default_redis_client(),
+        f"mcp_server_permission_sync:{stage_id}",
+        expire=settings.REDIS_PUBLISH_LOCK_TIMEOUT,
+        auto_renewal=True,
+        strict=False,
+    )
+
+
+@contextmanager
+def _stage_mcp_server_permission_sync_lock(stage_id: int) -> Iterator[None]:
+    lock = _get_mcp_server_permission_sync_lock(stage_id)
+    lock_acquired = lock.acquire(
+        blocking=True,
+        timeout=settings.REDIS_PUBLISH_LOCK_TIMEOUT,
+    )
+    if not lock_acquired:
+        raise LockTimeout("Timeout while waiting for MCP Server permission sync lock")
+
+    try:
+        yield
+    finally:
+        try:
+            lock.release()
+        except Exception:
+            logger.exception("release mcp server permission sync lock failed, stage_id=%d", stage_id)
+
+
+def _sync_stage_mcp_server_permissions(
     stage_id: int,
-    resource_version_id: Optional[int] = None,
-    delete_stale: bool = True,
-    expected_resource_version_id: Optional[int] = None,
+    resource_version: ResourceVersion,
+    *,
+    delete_stale: bool,
 ) -> None:
-    """同步环境下所有 MCP Server 的资源权限。"""
-    if expected_resource_version_id is not None:
-        current_resource_version_id = (
-            Release.objects.filter(stage_id=stage_id).values_list("resource_version_id", flat=True).first()
-        )
-        if current_resource_version_id != expected_resource_version_id:
-            logger.info(
-                "skip stale mcp server permission sync, stage_id=%d, expected_resource_version_id=%d, "
-                "current_resource_version_id=%s",
-                stage_id,
-                expected_resource_version_id,
-                current_resource_version_id,
-            )
-            return
-
-    resource_version = None
-    if resource_version_id is not None:
-        resource_version = ResourceVersion.objects.get(id=resource_version_id)
-
     mcp_server_ids = MCPServer.objects.filter(stage_id=stage_id).values_list("id", flat=True)
     for mcp_server_id in mcp_server_ids:
-        if resource_version is not None:
+        try:
             MCPServerHandler.sync_permissions(
                 mcp_server_id,
                 resource_version=resource_version,
                 delete_stale=delete_stale,
             )
-            continue
+        except Exception:
+            logger.exception(
+                "sync mcp server permissions failed, stage_id=%d, mcp_server_id=%d",
+                stage_id,
+                mcp_server_id,
+            )
 
-        MCPServerHandler.sync_permissions(mcp_server_id)
+
+@shared_task(name=ADD_STAGE_MCP_SERVER_PERMISSIONS_BEFORE_RELEASE_UPDATE_TASK_NAME, ignore_result=True)
+def add_stage_mcp_server_permissions_before_release_update(
+    stage_id: int,
+    resource_version_id: int,
+) -> None:
+    """发布数据面成功后、更新 Release 前，补充候选资源版本对应的权限。"""
+    try:
+        with _stage_mcp_server_permission_sync_lock(stage_id):
+            resource_version = ResourceVersion.objects.filter(id=resource_version_id).first()
+            if resource_version is None:
+                logger.warning(
+                    "skip adding mcp server permissions because resource version does not exist, "
+                    "stage_id=%d, resource_version_id=%d",
+                    stage_id,
+                    resource_version_id,
+                )
+                return
+
+            _sync_stage_mcp_server_permissions(stage_id, resource_version, delete_stale=False)
+    except Exception:
+        logger.exception("add stage mcp server permissions failed, stage_id=%d", stage_id)
+
+
+@shared_task(name=RECONCILE_STAGE_MCP_SERVER_PERMISSIONS_AFTER_RELEASE_TASK_NAME, ignore_result=True)
+def reconcile_stage_mcp_server_permissions_after_release(
+    stage_id: int,
+    expected_resource_version_id: int,
+    expected_publish_id: int,
+) -> None:
+    """发布成功后，将环境下所有 MCP Server 权限收敛到当前发布版本。"""
+    try:
+        with _stage_mcp_server_permission_sync_lock(stage_id):
+            release = Release.objects.filter(stage_id=stage_id).select_related("resource_version").first()
+            current_resource_version_id = release.resource_version_id if release else None
+            if current_resource_version_id != expected_resource_version_id:
+                logger.info(
+                    "skip stale mcp server permission reconciliation, stage_id=%d, "
+                    "expected_resource_version_id=%d, current_resource_version_id=%s",
+                    stage_id,
+                    expected_resource_version_id,
+                    current_resource_version_id,
+                )
+                return
+
+            newer_release_exists = (
+                ReleaseHistory.objects.filter(stage_id=stage_id, id__gt=expected_publish_id)
+                .exclude(resource_version_id=expected_resource_version_id)
+                .exists()
+            )
+            if newer_release_exists:
+                logger.info(
+                    "skip stale mcp server permission reconciliation because a newer publish has started, "
+                    "stage_id=%d, expected_publish_id=%d",
+                    stage_id,
+                    expected_publish_id,
+                )
+                return
+
+            _sync_stage_mcp_server_permissions(stage_id, release.resource_version, delete_stale=True)
+    except Exception:
+        logger.exception("reconcile stage mcp server permissions failed, stage_id=%d", stage_id)
 
 
 def _collect_prompt_ids(

--- a/src/dashboard/apigateway/apigateway/apps/mcp_server/tasks.py
+++ b/src/dashboard/apigateway/apigateway/apps/mcp_server/tasks.py
@@ -35,7 +35,7 @@ from apigateway.biz.mcp_server import (
     MCPServerPromptHandler,
 )
 from apigateway.core.constants import ReleaseHistoryStatusEnum
-from apigateway.core.models import Release, ReleaseHistory, ResourceVersion
+from apigateway.core.models import PublishEvent, Release, ReleaseHistory, ResourceVersion
 from apigateway.service.release import wait_release_done
 from apigateway.utils.exception import LockTimeout
 from apigateway.utils.redis_utils import get_default_redis_client
@@ -140,12 +140,23 @@ def reconcile_stage_mcp_server_permissions_after_release(
                 )
                 return
 
-            newer_release_exists = (
+            newer_release_history_ids = list(
                 ReleaseHistory.objects.filter(stage_id=stage_id, id__gt=expected_release_history_id)
                 .exclude(resource_version_id=expected_resource_version_id)
-                .exists()
+                .values_list("id", flat=True)
             )
-            if newer_release_exists:
+            latest_publish_event_map = PublishEvent.objects.get_release_history_id_to_latest_publish_event_map(
+                newer_release_history_ids
+            )
+            newer_non_failed_release_exists = any(
+                publish_event is None
+                or publish_event.get_release_history_status() != ReleaseHistoryStatusEnum.FAILURE.value
+                for publish_event in (
+                    latest_publish_event_map.get(release_history_id)
+                    for release_history_id in newer_release_history_ids
+                )
+            )
+            if newer_non_failed_release_exists:
                 logger.info(
                     "skip stale mcp server permission reconciliation because a newer publish has started, "
                     "stage_id=%d, expected_release_history_id=%d",

--- a/src/dashboard/apigateway/apigateway/apps/mcp_server/tasks.py
+++ b/src/dashboard/apigateway/apigateway/apps/mcp_server/tasks.py
@@ -43,19 +43,15 @@ from apigateway.utils.redis_utils import get_default_redis_client
 logger = logging.getLogger(__name__)
 
 
-def _get_mcp_server_permission_sync_lock(stage_id: int):
-    return redis_lock.Lock(
+@contextmanager
+def _stage_mcp_server_permission_sync_lock(stage_id: int) -> Iterator[None]:
+    lock = redis_lock.Lock(
         get_default_redis_client(),
         f"mcp_server_permission_sync:{stage_id}",
         expire=settings.REDIS_PUBLISH_LOCK_TIMEOUT,
         auto_renewal=True,
         strict=False,
     )
-
-
-@contextmanager
-def _stage_mcp_server_permission_sync_lock(stage_id: int) -> Iterator[None]:
-    lock = _get_mcp_server_permission_sync_lock(stage_id)
     lock_acquired = lock.acquire(
         blocking=True,
         timeout=settings.REDIS_PUBLISH_LOCK_TIMEOUT,
@@ -101,6 +97,9 @@ def add_stage_mcp_server_permissions_before_release_update(
 ) -> None:
     """发布数据面成功后、更新 Release 前，补充候选资源版本对应的权限。"""
     try:
+        if not MCPServer.objects.filter(stage_id=stage_id).exists():
+            return
+
         with _stage_mcp_server_permission_sync_lock(stage_id):
             resource_version = ResourceVersion.objects.filter(id=resource_version_id).first()
             if resource_version is None:
@@ -121,10 +120,13 @@ def add_stage_mcp_server_permissions_before_release_update(
 def reconcile_stage_mcp_server_permissions_after_release(
     stage_id: int,
     expected_resource_version_id: int,
-    expected_publish_id: int,
+    expected_release_history_id: int,
 ) -> None:
     """发布成功后，将环境下所有 MCP Server 权限收敛到当前发布版本。"""
     try:
+        if not MCPServer.objects.filter(stage_id=stage_id).exists():
+            return
+
         with _stage_mcp_server_permission_sync_lock(stage_id):
             release = Release.objects.filter(stage_id=stage_id).select_related("resource_version").first()
             current_resource_version_id = release.resource_version_id if release else None
@@ -139,16 +141,16 @@ def reconcile_stage_mcp_server_permissions_after_release(
                 return
 
             newer_release_exists = (
-                ReleaseHistory.objects.filter(stage_id=stage_id, id__gt=expected_publish_id)
+                ReleaseHistory.objects.filter(stage_id=stage_id, id__gt=expected_release_history_id)
                 .exclude(resource_version_id=expected_resource_version_id)
                 .exists()
             )
             if newer_release_exists:
                 logger.info(
                     "skip stale mcp server permission reconciliation because a newer publish has started, "
-                    "stage_id=%d, expected_publish_id=%d",
+                    "stage_id=%d, expected_release_history_id=%d",
                     stage_id,
-                    expected_publish_id,
+                    expected_release_history_id,
                 )
                 return
 

--- a/src/dashboard/apigateway/apigateway/biz/mcp_server/mcp_server.py
+++ b/src/dashboard/apigateway/apigateway/biz/mcp_server/mcp_server.py
@@ -486,7 +486,7 @@ class MCPServerHandler:
         # 3.4 add and delete
         logger.debug("add %d permissions, delete %d permissions", len(to_add), len(to_delete))
         if to_add:
-            AppResourcePermission.objects.bulk_create(to_add)
+            AppResourcePermission.objects.bulk_create(to_add, ignore_conflicts=True)
         if to_delete:
             AppResourcePermission.objects.filter(id__in=to_delete).delete()
 

--- a/src/dashboard/apigateway/apigateway/biz/mcp_server/mcp_server.py
+++ b/src/dashboard/apigateway/apigateway/biz/mcp_server/mcp_server.py
@@ -64,7 +64,7 @@ from apigateway.common.django.translation import get_current_language_code
 from apigateway.common.error_codes import error_codes
 from apigateway.components import bkaidev
 from apigateway.core.constants import GatewayStatusEnum, ResourceKindEnum, StageStatusEnum
-from apigateway.core.models import Gateway, Release, Stage
+from apigateway.core.models import Gateway, Release, ResourceVersion, Stage
 from apigateway.service.mcp import build_mcp_server_application_url, build_mcp_server_url
 from apigateway.service.resource import get_resource_id_to_labels_by_label_ids
 from apigateway.service.resource_version import (
@@ -358,11 +358,35 @@ class MCPServerHandler:
             )
 
     @staticmethod
+    def _get_permission_resource_version(
+        mcp_server: MCPServer,
+        resource_version: Optional[ResourceVersion],
+    ) -> Optional[ResourceVersion]:
+        if resource_version is not None:
+            return resource_version
+
+        release = (
+            Release.objects.filter(gateway_id=mcp_server.gateway_id, stage_id=mcp_server.stage_id)
+            .select_related("resource_version")
+            .first()
+        )
+        if not release:
+            return None
+
+        return release.resource_version
+
+    @staticmethod
     @transaction.atomic
-    def sync_permissions(mcp_server_id: int) -> None:
+    def sync_permissions(
+        mcp_server_id: int,
+        resource_version: Optional[ResourceVersion] = None,
+        delete_stale: bool = True,
+    ) -> None:
         """同步 MCPServer 的权限，包括 OAuth2 内置客户端权限
         Args:
             mcp_server_id (int): mcp_server 的 id
+            resource_version (Optional[ResourceVersion]): 用于解析资源 ID 的资源版本，默认使用当前发布版本
+            delete_stale (bool): 是否删除不在目标资源版本中的旧权限
         """
         mcp_server = MCPServer.objects.get(id=mcp_server_id)
 
@@ -380,12 +404,13 @@ class MCPServerHandler:
         # 1. fetch the app codes in mcp_server_app_permission
         app_codes = MCPServerAppPermission.objects.filter(mcp_server=mcp_server).values_list("bk_app_code", flat=True)
         if not app_codes:
-            logger.debug("no app_codes, cleanup the permissions of the mcp_server %d", mcp_server_id)
+            logger.debug("no app_codes, sync the permissions of the mcp_server %d", mcp_server_id)
             # if no app_codes, cleanup the permissions of the mcp_server
-            MCPServerHandler.cleanup_all_resource_permissions(
-                gateway_id=mcp_server.gateway_id,
-                mcp_server_id=mcp_server_id,
-            )
+            if delete_stale:
+                MCPServerHandler.cleanup_all_resource_permissions(
+                    gateway_id=mcp_server.gateway_id,
+                    mcp_server_id=mcp_server_id,
+                )
             return
 
         # 2. resolve resource_ids from the stage's published resource_version snapshot
@@ -394,19 +419,15 @@ class MCPServerHandler:
         if not resource_names:
             logger.debug("no resource_names, skip sync the permissions of the mcp_server %d", mcp_server_id)
             return
-        release = (
-            Release.objects.filter(gateway_id=mcp_server.gateway_id, stage_id=mcp_server.stage_id)
-            .select_related("resource_version")
-            .first()
-        )
-        if not release:
+        resource_version = MCPServerHandler._get_permission_resource_version(mcp_server, resource_version)
+        if resource_version is None:
             logger.debug("no release, skip sync the permissions of the mcp_server %d", mcp_server_id)
             return
 
         resource_name_set = set(resource_names)
         resource_ids = [
             resource["id"]
-            for resource in release.resource_version.data
+            for resource in resource_version.data
             if resource["name"] in resource_name_set
             and (resource.get("kind") or ResourceKindEnum.STANDARD.value) == ResourceKindEnum.STANDARD.value
         ]
@@ -451,9 +472,11 @@ class MCPServerHandler:
             )
 
         # 3.3 check to delete
-        to_delete_virtual_app_code_resource_id_set = (
-            current_virtual_app_code_resource_id_set - newest_virtual_app_code_resource_id_set
-        )
+        to_delete_virtual_app_code_resource_id_set = set()
+        if delete_stale:
+            to_delete_virtual_app_code_resource_id_set = (
+                current_virtual_app_code_resource_id_set - newest_virtual_app_code_resource_id_set
+            )
         to_delete: List[int] = []
         for permission in current_permissions:
             if (permission.bk_app_code, permission.resource_id) in to_delete_virtual_app_code_resource_id_set:

--- a/src/dashboard/apigateway/apigateway/biz/release/gateway_releaser.py
+++ b/src/dashboard/apigateway/apigateway/biz/release/gateway_releaser.py
@@ -31,7 +31,7 @@ from apigateway.apps.data_plane.constants import (
     resource_version_uses_oauth2,
 )
 from apigateway.apps.data_plane.models import DataPlane, GatewayDataPlaneBinding
-from apigateway.apps.mcp_server.constants import SYNC_STAGE_MCP_SERVER_PERMISSIONS_TASK_NAME
+from apigateway.apps.mcp_server.constants import ADD_STAGE_MCP_SERVER_PERMISSIONS_BEFORE_RELEASE_UPDATE_TASK_NAME
 from apigateway.apps.programmable_gateway.models import ProgrammableGatewayDeployHistory
 from apigateway.biz.audit import Auditor
 from apigateway.controller.distributor.connection import (
@@ -261,11 +261,10 @@ class GatewayReleaser:
             data_plane_id=data_plane.id,
         )
         add_mcp_server_permissions = signature(
-            SYNC_STAGE_MCP_SERVER_PERMISSIONS_TASK_NAME,
+            ADD_STAGE_MCP_SERVER_PERMISSIONS_BEFORE_RELEASE_UPDATE_TASK_NAME,
             kwargs={
                 "stage_id": release.stage.id,
                 "resource_version_id": release_history.resource_version.id,
-                "delete_stale": False,
             },
             immutable=True,
         )

--- a/src/dashboard/apigateway/apigateway/biz/release/gateway_releaser.py
+++ b/src/dashboard/apigateway/apigateway/biz/release/gateway_releaser.py
@@ -21,6 +21,7 @@ from dataclasses import dataclass
 from typing import List
 
 from blue_krill.async_utils.django_utils import delay_on_commit
+from celery import signature
 from django.conf import settings
 from rest_framework.exceptions import ValidationError
 
@@ -30,6 +31,7 @@ from apigateway.apps.data_plane.constants import (
     resource_version_uses_oauth2,
 )
 from apigateway.apps.data_plane.models import DataPlane, GatewayDataPlaneBinding
+from apigateway.apps.mcp_server.constants import SYNC_STAGE_MCP_SERVER_PERMISSIONS_TASK_NAME
 from apigateway.apps.programmable_gateway.models import ProgrammableGatewayDeployHistory
 from apigateway.biz.audit import Auditor
 from apigateway.controller.distributor.connection import (
@@ -258,9 +260,18 @@ class GatewayReleaser:
             publish_id=release_history.pk,
             data_plane_id=data_plane.id,
         )
+        add_mcp_server_permissions = signature(
+            SYNC_STAGE_MCP_SERVER_PERMISSIONS_TASK_NAME,
+            kwargs={
+                "stage_id": release.stage.id,
+                "resource_version_id": release_history.resource_version.id,
+                "delete_stale": False,
+            },
+            immutable=True,
+        )
 
         # 使用 celery 的编排能力，task 执行成功才会执行 release_success_callback
-        delay_on_commit(task | release_success_callback)
+        delay_on_commit(task | add_mcp_server_permissions | release_success_callback)
 
 
 def release_gateway(

--- a/src/dashboard/apigateway/apigateway/controller/tasks/release.py
+++ b/src/dashboard/apigateway/apigateway/controller/tasks/release.py
@@ -23,7 +23,7 @@ from typing import TYPE_CHECKING
 from celery import current_app, shared_task
 
 from apigateway.apps.data_plane.models import DataPlane
-from apigateway.apps.mcp_server.constants import SYNC_STAGE_MCP_SERVER_PERMISSIONS_TASK_NAME
+from apigateway.apps.mcp_server.constants import RECONCILE_STAGE_MCP_SERVER_PERMISSIONS_AFTER_RELEASE_TASK_NAME
 from apigateway.apps.support.models import ReleasedResourceDoc, ResourceDocVersion
 from apigateway.common.constants import RELEASE_GATEWAY_INTERVAL_SECOND
 from apigateway.controller.distributor.etcd import GatewayResourceDistributor
@@ -68,14 +68,6 @@ def _release_gateway(
             release_task_id=procedure_logger.release_task_id,
             publish_id=release_history.id,
         )
-        if is_success:
-            PublishEventReporter.report_distribute_config_success(
-                release_history,
-            )
-
-        else:
-            PublishEventReporter.report_distribute_config_failure(release_history, fail_msg)
-            return False
     except Exception as err:  # pylint: disable=broad-except
         # 记录失败原因
         procedure_logger.exception("release failed")
@@ -84,6 +76,13 @@ def _release_gateway(
         # 异常抛出，让 celery 停止编排
         raise
 
+    if not is_success:
+        PublishEventReporter.report_distribute_config_failure(release_history, fail_msg)
+        raise RuntimeError(fail_msg)
+
+    PublishEventReporter.report_distribute_config_success(
+        release_history,
+    )
     return True
 
 
@@ -232,10 +231,11 @@ def update_release_data_after_success(
         resource_version.id,
     )
     current_app.send_task(
-        SYNC_STAGE_MCP_SERVER_PERMISSIONS_TASK_NAME,
+        RECONCILE_STAGE_MCP_SERVER_PERMISSIONS_AFTER_RELEASE_TASK_NAME,
         kwargs={
             "stage_id": release.stage.id,
             "expected_resource_version_id": resource_version.id,
+            "expected_publish_id": publish_id,
         },
         countdown=MCP_SERVER_PERMISSION_CLEANUP_DELAY_SECONDS,
     )

--- a/src/dashboard/apigateway/apigateway/controller/tasks/release.py
+++ b/src/dashboard/apigateway/apigateway/controller/tasks/release.py
@@ -235,7 +235,7 @@ def update_release_data_after_success(
         kwargs={
             "stage_id": release.stage.id,
             "expected_resource_version_id": resource_version.id,
-            "expected_publish_id": publish_id,
+            "expected_release_history_id": publish_id,
         },
         countdown=MCP_SERVER_PERMISSION_CLEANUP_DELAY_SECONDS,
     )

--- a/src/dashboard/apigateway/apigateway/controller/tasks/release.py
+++ b/src/dashboard/apigateway/apigateway/controller/tasks/release.py
@@ -20,9 +20,10 @@ import time
 from datetime import datetime
 from typing import TYPE_CHECKING
 
-from celery import shared_task
+from celery import current_app, shared_task
 
 from apigateway.apps.data_plane.models import DataPlane
+from apigateway.apps.mcp_server.constants import SYNC_STAGE_MCP_SERVER_PERMISSIONS_TASK_NAME
 from apigateway.apps.support.models import ReleasedResourceDoc, ResourceDocVersion
 from apigateway.common.constants import RELEASE_GATEWAY_INTERVAL_SECOND
 from apigateway.controller.distributor.etcd import GatewayResourceDistributor
@@ -46,6 +47,8 @@ if TYPE_CHECKING:
     from apigateway.controller.distributor.base import BaseDistributor
 
 logger = logging.getLogger(__name__)
+
+MCP_SERVER_PERMISSION_CLEANUP_DELAY_SECONDS = 120
 
 
 def _release_gateway(
@@ -227,6 +230,14 @@ def update_release_data_after_success(
     update_stage_mcp_server_related_resource_names(
         release.stage.id,
         resource_version.id,
+    )
+    current_app.send_task(
+        SYNC_STAGE_MCP_SERVER_PERMISSIONS_TASK_NAME,
+        kwargs={
+            "stage_id": release.stage.id,
+            "expected_resource_version_id": resource_version.id,
+        },
+        countdown=MCP_SERVER_PERMISSION_CLEANUP_DELAY_SECONDS,
     )
 
     try:

--- a/src/dashboard/apigateway/apigateway/tests/apps/mcp_server/test_tasks.py
+++ b/src/dashboard/apigateway/apigateway/tests/apps/mcp_server/test_tasks.py
@@ -15,7 +15,7 @@
 # We undertake not to change the open source license (MIT license) applicable
 # to the current version of the project delivered to anyone in the future.
 #
-from unittest.mock import call, patch
+from unittest.mock import Mock, call, patch
 
 import pytest
 from ddf import G
@@ -23,8 +23,9 @@ from ddf import G
 from apigateway.apps.mcp_server.models import MCPServer
 from apigateway.apps.mcp_server.tasks import (
     _fetch_updated_prompts,
+    add_stage_mcp_server_permissions_before_release_update,
+    reconcile_stage_mcp_server_permissions_after_release,
     sync_mcp_server_after_release,
-    sync_stage_mcp_server_permissions,
 )
 from apigateway.core.constants import ReleaseHistoryStatusEnum
 from apigateway.core.models import Release, ReleaseHistory, ResourceVersion
@@ -46,7 +47,18 @@ class TestFetchUpdatedPrompts:
         assert "expected dict" in caplog.text
 
 
-class TestSyncStageMcpServerPermissions:
+class TestStageMcpServerPermissionSync:
+    @pytest.fixture(autouse=True)
+    def mock_permission_sync_lock(self):
+        lock = Mock()
+        lock.acquire.return_value = True
+        with patch(
+            "apigateway.apps.mcp_server.tasks._get_mcp_server_permission_sync_lock",
+            return_value=lock,
+            create=True,
+        ):
+            yield
+
     def test_adds_permissions_from_explicit_resource_version(self, fake_gateway, fake_stage):
         resource_version = G(ResourceVersion, gateway=fake_gateway)
         mcp_servers = [
@@ -55,10 +67,9 @@ class TestSyncStageMcpServerPermissions:
         ]
 
         with patch("apigateway.apps.mcp_server.tasks.MCPServerHandler.sync_permissions") as mock_sync:
-            sync_stage_mcp_server_permissions(
+            add_stage_mcp_server_permissions_before_release_update(
                 stage_id=fake_stage.id,
                 resource_version_id=resource_version.id,
-                delete_stale=False,
             )
 
         mock_sync.assert_has_calls(
@@ -69,28 +80,98 @@ class TestSyncStageMcpServerPermissions:
             any_order=True,
         )
 
-    def test_strong_sync_uses_current_release_without_handler_arguments(
-        self, fake_gateway, fake_stage, fake_resource_version
-    ):
+    def test_strong_sync_uses_current_release(self, fake_gateway, fake_stage, fake_resource_version):
         G(Release, gateway=fake_gateway, stage=fake_stage, resource_version=fake_resource_version)
         mcp_server = G(MCPServer, gateway=fake_gateway, stage=fake_stage)
 
         with patch("apigateway.apps.mcp_server.tasks.MCPServerHandler.sync_permissions") as mock_sync:
-            sync_stage_mcp_server_permissions(
+            reconcile_stage_mcp_server_permissions_after_release(
                 stage_id=fake_stage.id,
                 expected_resource_version_id=fake_resource_version.id,
+                expected_publish_id=1,
             )
 
-        mock_sync.assert_called_once_with(mcp_server.id)
+        mock_sync.assert_called_once_with(
+            mcp_server.id,
+            resource_version=fake_resource_version,
+            delete_stale=True,
+        )
+
+    def test_missing_explicit_resource_version_is_logged_and_skipped(self, fake_stage, caplog):
+        missing_resource_version_id = 999999
+
+        with (
+            patch("apigateway.apps.mcp_server.tasks.MCPServerHandler.sync_permissions") as mock_sync,
+            caplog.at_level("WARNING"),
+        ):
+            add_stage_mcp_server_permissions_before_release_update(
+                stage_id=fake_stage.id,
+                resource_version_id=missing_resource_version_id,
+            )
+
+        mock_sync.assert_not_called()
+        assert f"resource_version_id={missing_resource_version_id}" in caplog.text
+
+    def test_handler_failure_is_logged_without_stopping_other_servers(
+        self, fake_gateway, fake_stage, fake_resource_version, caplog
+    ):
+        mcp_servers = [
+            G(MCPServer, gateway=fake_gateway, stage=fake_stage),
+            G(MCPServer, gateway=fake_gateway, stage=fake_stage),
+        ]
+
+        with (
+            patch(
+                "apigateway.apps.mcp_server.tasks.MCPServerHandler.sync_permissions",
+                side_effect=[RuntimeError("database unavailable"), None],
+            ) as mock_sync,
+            caplog.at_level("ERROR"),
+        ):
+            add_stage_mcp_server_permissions_before_release_update(
+                stage_id=fake_stage.id,
+                resource_version_id=fake_resource_version.id,
+            )
+
+        assert mock_sync.call_count == 2
+        assert f"mcp_server_id={mcp_servers[0].id}" in caplog.text
+
+    def test_cleanup_skips_when_a_newer_resource_version_publish_has_started(
+        self, fake_gateway, fake_stage, fake_resource_version
+    ):
+        G(Release, gateway=fake_gateway, stage=fake_stage, resource_version=fake_resource_version)
+        current_history = G(
+            ReleaseHistory,
+            gateway=fake_gateway,
+            stage=fake_stage,
+            resource_version=fake_resource_version,
+        )
+        newer_resource_version = G(ResourceVersion, gateway=fake_gateway)
+        G(
+            ReleaseHistory,
+            gateway=fake_gateway,
+            stage=fake_stage,
+            resource_version=newer_resource_version,
+        )
+        G(MCPServer, gateway=fake_gateway, stage=fake_stage)
+
+        with patch("apigateway.apps.mcp_server.tasks.MCPServerHandler.sync_permissions") as mock_sync:
+            reconcile_stage_mcp_server_permissions_after_release(
+                stage_id=fake_stage.id,
+                expected_resource_version_id=fake_resource_version.id,
+                expected_publish_id=current_history.id,
+            )
+
+        mock_sync.assert_not_called()
 
     def test_strong_sync_skips_when_release_has_changed(self, fake_gateway, fake_stage, fake_resource_version):
         G(Release, gateway=fake_gateway, stage=fake_stage, resource_version=fake_resource_version)
         G(MCPServer, gateway=fake_gateway, stage=fake_stage)
 
         with patch("apigateway.apps.mcp_server.tasks.MCPServerHandler.sync_permissions") as mock_sync:
-            sync_stage_mcp_server_permissions(
+            reconcile_stage_mcp_server_permissions_after_release(
                 stage_id=fake_stage.id,
                 expected_resource_version_id=fake_resource_version.id + 1,
+                expected_publish_id=1,
             )
 
         mock_sync.assert_not_called()

--- a/src/dashboard/apigateway/apigateway/tests/apps/mcp_server/test_tasks.py
+++ b/src/dashboard/apigateway/apigateway/tests/apps/mcp_server/test_tasks.py
@@ -15,15 +15,19 @@
 # We undertake not to change the open source license (MIT license) applicable
 # to the current version of the project delivered to anyone in the future.
 #
-from unittest.mock import patch
+from unittest.mock import call, patch
 
 import pytest
 from ddf import G
 
 from apigateway.apps.mcp_server.models import MCPServer
-from apigateway.apps.mcp_server.tasks import _fetch_updated_prompts, sync_mcp_server_after_release
+from apigateway.apps.mcp_server.tasks import (
+    _fetch_updated_prompts,
+    sync_mcp_server_after_release,
+    sync_stage_mcp_server_permissions,
+)
 from apigateway.core.constants import ReleaseHistoryStatusEnum
-from apigateway.core.models import ReleaseHistory
+from apigateway.core.models import Release, ReleaseHistory, ResourceVersion
 
 
 class TestFetchUpdatedPrompts:
@@ -40,6 +44,56 @@ class TestFetchUpdatedPrompts:
         assert result == {1: {"id": 1, "name": "ok"}}
         assert "without id" in caplog.text
         assert "expected dict" in caplog.text
+
+
+class TestSyncStageMcpServerPermissions:
+    def test_adds_permissions_from_explicit_resource_version(self, fake_gateway, fake_stage):
+        resource_version = G(ResourceVersion, gateway=fake_gateway)
+        mcp_servers = [
+            G(MCPServer, gateway=fake_gateway, stage=fake_stage),
+            G(MCPServer, gateway=fake_gateway, stage=fake_stage),
+        ]
+
+        with patch("apigateway.apps.mcp_server.tasks.MCPServerHandler.sync_permissions") as mock_sync:
+            sync_stage_mcp_server_permissions(
+                stage_id=fake_stage.id,
+                resource_version_id=resource_version.id,
+                delete_stale=False,
+            )
+
+        mock_sync.assert_has_calls(
+            [
+                call(mcp_servers[0].id, resource_version=resource_version, delete_stale=False),
+                call(mcp_servers[1].id, resource_version=resource_version, delete_stale=False),
+            ],
+            any_order=True,
+        )
+
+    def test_strong_sync_uses_current_release_without_handler_arguments(
+        self, fake_gateway, fake_stage, fake_resource_version
+    ):
+        G(Release, gateway=fake_gateway, stage=fake_stage, resource_version=fake_resource_version)
+        mcp_server = G(MCPServer, gateway=fake_gateway, stage=fake_stage)
+
+        with patch("apigateway.apps.mcp_server.tasks.MCPServerHandler.sync_permissions") as mock_sync:
+            sync_stage_mcp_server_permissions(
+                stage_id=fake_stage.id,
+                expected_resource_version_id=fake_resource_version.id,
+            )
+
+        mock_sync.assert_called_once_with(mcp_server.id)
+
+    def test_strong_sync_skips_when_release_has_changed(self, fake_gateway, fake_stage, fake_resource_version):
+        G(Release, gateway=fake_gateway, stage=fake_stage, resource_version=fake_resource_version)
+        G(MCPServer, gateway=fake_gateway, stage=fake_stage)
+
+        with patch("apigateway.apps.mcp_server.tasks.MCPServerHandler.sync_permissions") as mock_sync:
+            sync_stage_mcp_server_permissions(
+                stage_id=fake_stage.id,
+                expected_resource_version_id=fake_resource_version.id + 1,
+            )
+
+        mock_sync.assert_not_called()
 
 
 class TestSyncMcpServerAfterRelease:

--- a/src/dashboard/apigateway/apigateway/tests/apps/mcp_server/test_tasks.py
+++ b/src/dashboard/apigateway/apigateway/tests/apps/mcp_server/test_tasks.py
@@ -27,8 +27,12 @@ from apigateway.apps.mcp_server.tasks import (
     reconcile_stage_mcp_server_permissions_after_release,
     sync_mcp_server_after_release,
 )
-from apigateway.core.constants import ReleaseHistoryStatusEnum
-from apigateway.core.models import Release, ReleaseHistory, ResourceVersion
+from apigateway.core.constants import (
+    PublishEventNameTypeEnum,
+    PublishEventStatusEnum,
+    ReleaseHistoryStatusEnum,
+)
+from apigateway.core.models import PublishEvent, Release, ReleaseHistory, ResourceVersion
 
 
 class TestFetchUpdatedPrompts:
@@ -52,10 +56,13 @@ class TestStageMcpServerPermissionSync:
     def mock_permission_sync_lock(self):
         lock = Mock()
         lock.acquire.return_value = True
-        with patch(
-            "apigateway.apps.mcp_server.tasks.redis_lock.Lock",
-            return_value=lock,
-        ) as lock_constructor:
+        with (
+            patch("apigateway.apps.mcp_server.tasks.get_default_redis_client"),
+            patch(
+                "apigateway.apps.mcp_server.tasks.redis_lock.Lock",
+                return_value=lock,
+            ) as lock_constructor,
+        ):
             yield lock_constructor
 
     def test_add_skips_stage_without_mcp_servers(self, fake_stage, mock_permission_sync_lock):
@@ -99,6 +106,30 @@ class TestStageMcpServerPermissionSync:
             ],
             any_order=True,
         )
+
+    def test_add_lock_timeout_is_logged_without_blocking_release(
+        self,
+        fake_gateway,
+        fake_stage,
+        fake_resource_version,
+        mock_permission_sync_lock,
+        caplog,
+    ):
+        G(MCPServer, gateway=fake_gateway, stage=fake_stage)
+        mock_permission_sync_lock.return_value.acquire.return_value = False
+
+        with (
+            patch("apigateway.apps.mcp_server.tasks.MCPServerHandler.sync_permissions") as mock_sync,
+            caplog.at_level("ERROR"),
+        ):
+            add_stage_mcp_server_permissions_before_release_update(
+                stage_id=fake_stage.id,
+                resource_version_id=fake_resource_version.id,
+            )
+
+        mock_sync.assert_not_called()
+        assert f"stage_id={fake_stage.id}" in caplog.text
+        assert "add stage mcp server permissions failed" in caplog.text
 
     def test_strong_sync_uses_current_release(self, fake_gateway, fake_stage, fake_resource_version):
         G(Release, gateway=fake_gateway, stage=fake_stage, resource_version=fake_resource_version)
@@ -183,6 +214,47 @@ class TestStageMcpServerPermissionSync:
             )
 
         mock_sync.assert_not_called()
+
+    def test_cleanup_ignores_a_failed_newer_resource_version_publish(
+        self, fake_gateway, fake_stage, fake_resource_version
+    ):
+        G(Release, gateway=fake_gateway, stage=fake_stage, resource_version=fake_resource_version)
+        current_history = G(
+            ReleaseHistory,
+            gateway=fake_gateway,
+            stage=fake_stage,
+            resource_version=fake_resource_version,
+        )
+        newer_resource_version = G(ResourceVersion, gateway=fake_gateway)
+        failed_history = G(
+            ReleaseHistory,
+            gateway=fake_gateway,
+            stage=fake_stage,
+            resource_version=newer_resource_version,
+        )
+        G(
+            PublishEvent,
+            gateway=fake_gateway,
+            stage=fake_stage,
+            publish=failed_history,
+            name=PublishEventNameTypeEnum.VALIDATE_CONFIGURATION.value,
+            step=0,
+            status=PublishEventStatusEnum.FAILURE.value,
+        )
+        mcp_server = G(MCPServer, gateway=fake_gateway, stage=fake_stage)
+
+        with patch("apigateway.apps.mcp_server.tasks.MCPServerHandler.sync_permissions") as mock_sync:
+            reconcile_stage_mcp_server_permissions_after_release(
+                stage_id=fake_stage.id,
+                expected_resource_version_id=fake_resource_version.id,
+                expected_release_history_id=current_history.id,
+            )
+
+        mock_sync.assert_called_once_with(
+            mcp_server.id,
+            resource_version=fake_resource_version,
+            delete_stale=True,
+        )
 
     def test_strong_sync_skips_when_release_has_changed(self, fake_gateway, fake_stage, fake_resource_version):
         G(Release, gateway=fake_gateway, stage=fake_stage, resource_version=fake_resource_version)

--- a/src/dashboard/apigateway/apigateway/tests/apps/mcp_server/test_tasks.py
+++ b/src/dashboard/apigateway/apigateway/tests/apps/mcp_server/test_tasks.py
@@ -53,11 +53,31 @@ class TestStageMcpServerPermissionSync:
         lock = Mock()
         lock.acquire.return_value = True
         with patch(
-            "apigateway.apps.mcp_server.tasks._get_mcp_server_permission_sync_lock",
+            "apigateway.apps.mcp_server.tasks.redis_lock.Lock",
             return_value=lock,
-            create=True,
-        ):
-            yield
+        ) as lock_constructor:
+            yield lock_constructor
+
+    def test_add_skips_stage_without_mcp_servers(self, fake_stage, mock_permission_sync_lock):
+        with patch("apigateway.apps.mcp_server.tasks.ResourceVersion.objects.filter") as mock_filter:
+            add_stage_mcp_server_permissions_before_release_update(
+                stage_id=fake_stage.id,
+                resource_version_id=1,
+            )
+
+        mock_permission_sync_lock.assert_not_called()
+        mock_filter.assert_not_called()
+
+    def test_reconcile_skips_stage_without_mcp_servers(self, fake_stage, mock_permission_sync_lock):
+        with patch("apigateway.apps.mcp_server.tasks.Release.objects.filter") as mock_filter:
+            reconcile_stage_mcp_server_permissions_after_release(
+                stage_id=fake_stage.id,
+                expected_resource_version_id=1,
+                expected_release_history_id=1,
+            )
+
+        mock_permission_sync_lock.assert_not_called()
+        mock_filter.assert_not_called()
 
     def test_adds_permissions_from_explicit_resource_version(self, fake_gateway, fake_stage):
         resource_version = G(ResourceVersion, gateway=fake_gateway)
@@ -88,7 +108,7 @@ class TestStageMcpServerPermissionSync:
             reconcile_stage_mcp_server_permissions_after_release(
                 stage_id=fake_stage.id,
                 expected_resource_version_id=fake_resource_version.id,
-                expected_publish_id=1,
+                expected_release_history_id=1,
             )
 
         mock_sync.assert_called_once_with(
@@ -97,7 +117,8 @@ class TestStageMcpServerPermissionSync:
             delete_stale=True,
         )
 
-    def test_missing_explicit_resource_version_is_logged_and_skipped(self, fake_stage, caplog):
+    def test_missing_explicit_resource_version_is_logged_and_skipped(self, fake_gateway, fake_stage, caplog):
+        G(MCPServer, gateway=fake_gateway, stage=fake_stage)
         missing_resource_version_id = 999999
 
         with (
@@ -158,7 +179,7 @@ class TestStageMcpServerPermissionSync:
             reconcile_stage_mcp_server_permissions_after_release(
                 stage_id=fake_stage.id,
                 expected_resource_version_id=fake_resource_version.id,
-                expected_publish_id=current_history.id,
+                expected_release_history_id=current_history.id,
             )
 
         mock_sync.assert_not_called()
@@ -171,7 +192,7 @@ class TestStageMcpServerPermissionSync:
             reconcile_stage_mcp_server_permissions_after_release(
                 stage_id=fake_stage.id,
                 expected_resource_version_id=fake_resource_version.id + 1,
-                expected_publish_id=1,
+                expected_release_history_id=1,
             )
 
         mock_sync.assert_not_called()

--- a/src/dashboard/apigateway/apigateway/tests/biz/mcp_server/test_mcp_server.py
+++ b/src/dashboard/apigateway/apigateway/tests/biz/mcp_server/test_mcp_server.py
@@ -360,6 +360,80 @@ class TestMCPServerHandler:
 
         assert set(permissions.values_list("resource_id", flat=True)) == {new_resource_id}
 
+    def test_sync_permissions_add_only_keeps_existing_permissions_without_app_codes(self, fake_gateway, fake_stage):
+        resource_version = G(ResourceVersion, gateway=fake_gateway)
+        resource_version.data = [{"id": 10002, "name": "tool_a"}]
+        resource_version.save()
+        mcp_server = G(
+            MCPServer,
+            gateway=fake_gateway,
+            stage=fake_stage,
+            _resource_names="tool_a",
+        )
+        existing_permission = G(
+            AppResourcePermission,
+            gateway=fake_gateway,
+            bk_app_code=f"v_mcp_{mcp_server.id}_app1",
+            resource_id=10001,
+        )
+
+        MCPServerHandler.sync_permissions(
+            mcp_server.id,
+            resource_version=resource_version,
+            delete_stale=False,
+        )
+
+        assert AppResourcePermission.objects.filter(id=existing_permission.id).exists()
+
+    def test_sync_permissions_add_only_is_idempotent_when_another_worker_inserts_first(
+        self, fake_gateway, fake_stage, mocker
+    ):
+        resource_id = 10003
+        resource_version = G(ResourceVersion, gateway=fake_gateway)
+        resource_version.data = [{"id": resource_id, "name": "tool_a"}]
+        resource_version.save()
+        mcp_server = G(
+            MCPServer,
+            gateway=fake_gateway,
+            stage=fake_stage,
+            _resource_names="tool_a",
+        )
+        G(MCPServerAppPermission, mcp_server=mcp_server, bk_app_code="app1")
+        virtual_app_code = f"v_mcp_{mcp_server.id}_app1"
+        original_bulk_create = AppResourcePermission.objects.bulk_create
+
+        def insert_competing_permission(objects, **kwargs):
+            permission = objects[0]
+            AppResourcePermission.objects.create(
+                gateway_id=permission.gateway_id,
+                bk_app_code=permission.bk_app_code,
+                resource_id=permission.resource_id,
+                expires=permission.expires,
+                grant_type=permission.grant_type,
+            )
+            return original_bulk_create(objects, **kwargs)
+
+        mocker.patch.object(
+            AppResourcePermission.objects,
+            "bulk_create",
+            side_effect=insert_competing_permission,
+        )
+
+        MCPServerHandler.sync_permissions(
+            mcp_server.id,
+            resource_version=resource_version,
+            delete_stale=False,
+        )
+
+        assert (
+            AppResourcePermission.objects.filter(
+                gateway=fake_gateway,
+                bk_app_code=virtual_app_code,
+                resource_id=resource_id,
+            ).count()
+            == 1
+        )
+
     def test_sync_permissions_excludes_ai_resources_from_release_snapshot(self, fake_gateway, fake_stage):
         standard_resource = G(
             Resource,

--- a/src/dashboard/apigateway/apigateway/tests/biz/mcp_server/test_mcp_server.py
+++ b/src/dashboard/apigateway/apigateway/tests/biz/mcp_server/test_mcp_server.py
@@ -319,6 +319,47 @@ class TestMCPServerHandler:
         assert set(permissions.values_list("resource_id", flat=True)) == {released_resource_id}
         assert live_resource.id not in permissions.values_list("resource_id", flat=True)
 
+    def test_sync_permissions_adds_candidate_version_before_strong_sync(self, fake_gateway, fake_stage):
+        old_resource_id = 10001
+        new_resource_id = 10002
+        old_resource_version = G(ResourceVersion, gateway=fake_gateway)
+        old_resource_version.data = [{"id": old_resource_id, "name": "tool_a"}]
+        old_resource_version.save()
+        release = G(Release, gateway=fake_gateway, stage=fake_stage, resource_version=old_resource_version)
+
+        new_resource_version = G(ResourceVersion, gateway=fake_gateway)
+        new_resource_version.data = [{"id": new_resource_id, "name": "tool_a"}]
+        new_resource_version.save()
+        mcp_server = G(
+            MCPServer,
+            gateway=fake_gateway,
+            stage=fake_stage,
+            _resource_names="tool_a",
+        )
+        G(MCPServerAppPermission, mcp_server=mcp_server, bk_app_code="app1")
+        virtual_app_code = f"v_mcp_{mcp_server.id}_app1"
+        G(
+            AppResourcePermission,
+            gateway=fake_gateway,
+            bk_app_code=virtual_app_code,
+            resource_id=old_resource_id,
+        )
+
+        MCPServerHandler.sync_permissions(
+            mcp_server.id,
+            resource_version=new_resource_version,
+            delete_stale=False,
+        )
+
+        permissions = AppResourcePermission.objects.filter(bk_app_code=virtual_app_code)
+        assert set(permissions.values_list("resource_id", flat=True)) == {old_resource_id, new_resource_id}
+
+        release.resource_version = new_resource_version
+        release.save(update_fields=["resource_version"])
+        MCPServerHandler.sync_permissions(mcp_server.id)
+
+        assert set(permissions.values_list("resource_id", flat=True)) == {new_resource_id}
+
     def test_sync_permissions_excludes_ai_resources_from_release_snapshot(self, fake_gateway, fake_stage):
         standard_resource = G(
             Resource,

--- a/src/dashboard/apigateway/apigateway/tests/biz/release/test_release.py
+++ b/src/dashboard/apigateway/apigateway/tests/biz/release/test_release.py
@@ -206,11 +206,13 @@ class TestGatewayReleaser:
         publish_chain = delay_on_commit.call_args.args[0]
         assert len(publish_chain.tasks) == 3
         permission_sync = publish_chain.tasks[1]
-        assert permission_sync.task == "apigateway.apps.mcp_server.tasks.sync_stage_mcp_server_permissions"
+        assert (
+            permission_sync.task
+            == "apigateway.apps.mcp_server.tasks.add_stage_mcp_server_permissions_before_release_update"
+        )
         assert permission_sync.kwargs == {
             "stage_id": fake_stage.id,
             "resource_version_id": fake_resource_version.id,
-            "delete_stale": False,
         }
         assert permission_sync.immutable is True
 

--- a/src/dashboard/apigateway/apigateway/tests/biz/release/test_release.py
+++ b/src/dashboard/apigateway/apigateway/tests/biz/release/test_release.py
@@ -186,6 +186,34 @@ class TestGatewayReleaser:
 
         assert check_connection.call_count == 2
 
+    def test_release_adds_mcp_permissions_before_updating_release(
+        self, fake_gateway, fake_stage, fake_resource_version, mocker
+    ):
+        data_plane = G(DataPlane, name="plane-1")
+        release = G(Release, gateway=fake_gateway, stage=fake_stage, resource_version=fake_resource_version)
+        release_history = G(
+            ReleaseHistory,
+            gateway=fake_gateway,
+            stage=fake_stage,
+            resource_version=fake_resource_version,
+        )
+        releaser = GatewayReleaser(fake_gateway, fake_stage, fake_resource_version)
+        mocker.patch("apigateway.biz.release.gateway_releaser.PublishEventReporter.report_create_publish_task_doing")
+        delay_on_commit = mocker.patch("apigateway.biz.release.gateway_releaser.delay_on_commit")
+
+        releaser._do_release(release, release_history, data_plane)
+
+        publish_chain = delay_on_commit.call_args.args[0]
+        assert len(publish_chain.tasks) == 3
+        permission_sync = publish_chain.tasks[1]
+        assert permission_sync.task == "apigateway.apps.mcp_server.tasks.sync_stage_mcp_server_permissions"
+        assert permission_sync.kwargs == {
+            "stage_id": fake_stage.id,
+            "resource_version_id": fake_resource_version.id,
+            "delete_stale": False,
+        }
+        assert permission_sync.immutable is True
+
 
 class TestReleaseHandler:
     def test_package_release_gateway_export_is_callable(self):

--- a/src/dashboard/apigateway/apigateway/tests/controller/tasks/test_release.py
+++ b/src/dashboard/apigateway/apigateway/tests/controller/tasks/test_release.py
@@ -47,11 +47,18 @@ def test_update_release_success_reconciles_without_reversing_publish_on_failure(
     )
     mocker.patch("apigateway.controller.tasks.release.ReleasedResourceDoc.objects")
     mocker.patch("apigateway.controller.tasks.release.clear_unreleased_resource_doc")
-    mocker.patch("apigateway.controller.tasks.release.update_stage_mcp_server_related_resource_names")
+    update_resource_names = mocker.patch(
+        "apigateway.controller.tasks.release.update_stage_mcp_server_related_resource_names"
+    )
+    send_task = mocker.patch("apigateway.controller.tasks.release.current_app.send_task")
     reconcile = mocker.patch(
         "apigateway.controller.tasks.release.OAuth2BuiltinPermissionReconciler"
     ).return_value.reconcile_gateway
     reconcile.side_effect = RuntimeError("redis unavailable")
+    events = []
+    release.save.side_effect = lambda: events.append("save_release")
+    update_resource_names.side_effect = lambda *args: events.append("update_resource_names")
+    send_task.side_effect = lambda *args, **kwargs: events.append("schedule_cleanup")
 
     update_release_data_after_success(
         publish_id=1,
@@ -62,3 +69,9 @@ def test_update_release_success_reconciles_without_reversing_publish_on_failure(
     )
 
     reconcile.assert_called_once_with(gateway)
+    assert events == ["save_release", "update_resource_names", "schedule_cleanup"]
+    send_task.assert_called_once_with(
+        "apigateway.apps.mcp_server.tasks.sync_stage_mcp_server_permissions",
+        kwargs={"stage_id": stage.id, "expected_resource_version_id": resource_version.id},
+        countdown=120,
+    )

--- a/src/dashboard/apigateway/apigateway/tests/controller/tasks/test_release.py
+++ b/src/dashboard/apigateway/apigateway/tests/controller/tasks/test_release.py
@@ -77,7 +77,7 @@ def test_update_release_success_reconciles_without_reversing_publish_on_failure(
         kwargs={
             "stage_id": stage.id,
             "expected_resource_version_id": resource_version.id,
-            "expected_publish_id": 1,
+            "expected_release_history_id": 1,
         },
         countdown=120,
     )

--- a/src/dashboard/apigateway/apigateway/tests/controller/tasks/test_release.py
+++ b/src/dashboard/apigateway/apigateway/tests/controller/tasks/test_release.py
@@ -18,7 +18,9 @@
 
 from unittest.mock import Mock
 
-from apigateway.controller.tasks.release import update_release_data_after_success
+import pytest
+
+from apigateway.controller.tasks.release import _release_gateway, update_release_data_after_success
 from apigateway.core.constants import ReleaseHistoryStatusEnum
 
 
@@ -71,7 +73,28 @@ def test_update_release_success_reconciles_without_reversing_publish_on_failure(
     reconcile.assert_called_once_with(gateway)
     assert events == ["save_release", "update_resource_names", "schedule_cleanup"]
     send_task.assert_called_once_with(
-        "apigateway.apps.mcp_server.tasks.sync_stage_mcp_server_permissions",
-        kwargs={"stage_id": stage.id, "expected_resource_version_id": resource_version.id},
+        "apigateway.apps.mcp_server.tasks.reconcile_stage_mcp_server_permissions_after_release",
+        kwargs={
+            "stage_id": stage.id,
+            "expected_resource_version_id": resource_version.id,
+            "expected_publish_id": 1,
+        },
         countdown=120,
     )
+
+
+def test_release_gateway_raises_when_distribution_returns_failure(mocker):
+    distributor = Mock()
+    distributor.distribute.return_value = False, "etcd sync failed"
+    release_history = Mock(id=1)
+    procedure_logger = Mock(release_task_id="task-1")
+    mocker.patch("apigateway.controller.tasks.release.PublishEventReporter.report_create_publish_task_success")
+    mocker.patch("apigateway.controller.tasks.release.PublishEventReporter.report_distribute_config_doing")
+    report_failure = mocker.patch(
+        "apigateway.controller.tasks.release.PublishEventReporter.report_distribute_config_failure"
+    )
+
+    with pytest.raises(RuntimeError, match="etcd sync failed"):
+        _release_gateway(distributor, release_history, procedure_logger)
+
+    report_failure.assert_called_once_with(release_history, "etcd sync failed")


### PR DESCRIPTION
## 背景

#3124 已将 MCP 权限同步的资源 ID 真相源切换为 Release 快照，但资源发布成功后仍存在生命周期缺口：删除资源并新建同名资源时，Release 会切换到新 resource_id，而 AppResourcePermission 仍可能保留旧 resource_id，导致 MCP 调用鉴权失败。

## 方案

- 扩展 MCPServerHandler.sync_permissions，支持显式 ResourceVersion 和仅新增、不删除模式。
- 在数据面发布成功后、Release 元数据更新前，按候选 ResourceVersion 增量补齐新 resource_id 权限，同时保留旧 ID。
- 数据面发布结果 `is_success=False` 时，发布任务记录失败事件并抛出异常，使 Celery 将任务标记为 FAILURE，同时停止后续权限补齐和 Release 更新回调。
- Release 和 MCP resource_names 更新后，延迟 120 秒触发默认强同步，清理旧 ID 权限。
- 延迟任务校验 Release.resource_version_id；存在较新资源版本发布时，仅在其最新 PublishEvent 未明确失败的情况下阻止当前版本清理，避免失败发布永久阻塞权限收敛。
- 使用任务名解耦发布链与 MCP biz 域，保持 import-linter 的 biz-domain-independence 约束。

## 验证

- TDD 回归：覆盖失败的较新发布不阻塞当前版本权限收敛，以及锁超时仅记录错误、不阻塞发布链的现有契约。
- MCP permission task 测试：14 passed。
- Dashboard 全量测试：3766 passed。
- `uv run make lint-check`：通过，ruff、mypy、import-linter 均为绿色；API 一致性检查 0 error，保留仓库既有 40 warnings。
- 提交钩子：ruff-formatter、ruff、mypy、import-linter、敏感信息检查全部通过。

## 范围

按当前方案不处理多数据面之间的发布协调；锁超时保持记录错误并结束当前权限同步任务，不增加重试补偿。
