### PR TITLE
perf(mcp-proxy): reduce tool request allocations

### DIFF
--- a/src/mcp-proxy/pkg/infra/proxy/proxy.go
+++ b/src/mcp-proxy/pkg/infra/proxy/proxy.go
@@ -20,7 +20,6 @@
 package proxy
 
 import (
-	"bytes"
 	"context"
 	"crypto/tls"
 	"encoding/json"
@@ -931,6 +930,7 @@ func genToolHandler(toolApiConfig *ToolConfig, serverName string, rawResponseEna
 		}
 
 		// MCP protocol-level logging and metrics
+		var requestPayload *toolRequestPayload
 		var responsePayload *toolResponsePayload
 		defer func() {
 			if r := recover(); r != nil {
@@ -949,12 +949,23 @@ func genToolHandler(toolApiConfig *ToolConfig, serverName string, rawResponseEna
 				serverName,
 				toolApiConfig.Name,
 				req,
+				requestPayload,
 				result,
 				responsePayload,
 				err,
 				start,
 			)
-			logToolCall(ctx, serverName, toolApiConfig.Name, req, result, responsePayload, err, start)
+			logToolCall(
+				ctx,
+				serverName,
+				toolApiConfig.Name,
+				req,
+				requestPayload,
+				result,
+				responsePayload,
+				err,
+				start,
+			)
 		}()
 
 		// Prepare audit log with request context
@@ -967,8 +978,9 @@ func genToolHandler(toolApiConfig *ToolConfig, serverName string, rawResponseEna
 			return nil, trace.WrapErrorWithTraceID(ctx, fmt.Errorf("sign inner jwt failed: %w", err))
 		}
 		logTruncate := config.G.McpServer.LogTruncate
-		requestBody := util.TruncateJSON(req.Params.Arguments, logTruncate.GetAuditLogMaxBodySize())
-		requestBodySize := int64(len(requestBody))
+		arguments := req.Params.Arguments
+		var requestBody string
+		var requestBodySize int64
 
 		// 用于在 defer 中记录完整的调用信息（包含 response, latency 等）
 		var (
@@ -980,7 +992,7 @@ func genToolHandler(toolApiConfig *ToolConfig, serverName string, rawResponseEna
 			auditHeaderInfo    map[string]string
 			auditQueryParam    QueryParam
 			auditPathParam     StringParamMap
-			auditBodyParam     json.RawMessage
+			auditBodyParam     = "null"
 		)
 
 		// 在函数返回时记录完整的 audit log，包含 response, latency 等字段
@@ -1002,18 +1014,16 @@ func genToolHandler(toolApiConfig *ToolConfig, serverName string, rawResponseEna
 				zap.Any("header", util.MaskSensitiveHeaders(auditHeaderInfo)),
 				zap.Any("query", auditQueryParam),
 				zap.Any("path", auditPathParam),
-				zap.String(
-					"body",
-					util.TruncateJSON(auditBodyParam, logTruncate.GetAuditLogMaxBodySize()),
-				),
+				zap.String("body", auditBodyParam),
 			)
 			if recoveredPanic != nil {
 				panic(recoveredPanic)
 			}
 		}()
-		var handlerRequest HandlerRequest
-		argsBytes, err := json.Marshal(req.Params.Arguments)
+		requestPayload, err = newToolRequestPayload(arguments)
 		if err != nil {
+			requestBody = util.TruncateJSON(arguments, logTruncate.GetAuditLogMaxBodySize())
+			requestBodySize = int64(len(requestBody))
 			auditLog.Error(
 				"marshal arguments err",
 				zap.Any("arguments", req.Params.Arguments),
@@ -1022,13 +1032,12 @@ func genToolHandler(toolApiConfig *ToolConfig, serverName string, rawResponseEna
 			markAuditCallFailed(start, err, &auditStatus, &auditLatency, &auditResponse)
 			return nil, trace.WrapErrorWithTraceID(ctx, err)
 		}
-		requestBodySize = int64(len(argsBytes))
-		decoder := json.NewDecoder(bytes.NewReader(argsBytes))
-		decoder.UseNumber()
-		err = decoder.Decode(&handlerRequest)
+		requestBody = requestPayload.auditPreview(logTruncate.GetAuditLogMaxBodySize())
+		requestBodySize = requestPayload.auditSize()
+		handlerRequest, err := requestPayload.decodeHandlerRequest()
 		if err != nil {
 			auditLog.Error("unmarshal handler request err", zap.String("request",
-				string(argsBytes)), zap.Error(err))
+				string(requestPayload.rawArguments)), zap.Error(err))
 			markAuditCallFailed(start, err, &auditStatus, &auditLatency, &auditResponse)
 			return nil, trace.WrapErrorWithTraceID(ctx, err)
 		}
@@ -1089,7 +1098,7 @@ func genToolHandler(toolApiConfig *ToolConfig, serverName string, rawResponseEna
 
 				if err = setHandlerRequestParams(
 					req,
-					&handlerRequest,
+					handlerRequest,
 					headerInfo,
 					auditLog,
 				); err != nil {
@@ -1158,7 +1167,10 @@ func genToolHandler(toolApiConfig *ToolConfig, serverName string, rawResponseEna
 		auditHeaderInfo = headerInfo
 		auditQueryParam = handlerRequest.QueryParam
 		auditPathParam = handlerRequest.PathParam
-		auditBodyParam = handlerRequest.BodyParam
+		auditBodyParam = requestPayload.bodyAuditPreview(
+			handlerRequest.BodyParam,
+			logTruncate.GetAuditLogMaxBodySize(),
+		)
 
 		openAPIClient := cli.New(toolApiConfig.Host, toolApiConfig.BasePath, []string{toolApiConfig.Schema})
 		submit, err := openAPIClient.Submit(operation)
@@ -1240,8 +1252,9 @@ func recordToolCallMetrics(
 	ctx context.Context,
 	serverName, toolName string,
 	req *mcp.CallToolRequest,
+	requestPayload *toolRequestPayload,
 	result *mcp.CallToolResult,
-	payload *toolResponsePayload,
+	responsePayload *toolResponsePayload,
 	err error,
 	start time.Time,
 ) {
@@ -1288,16 +1301,19 @@ func recordToolCallMetrics(
 	if metric.MCPRequestBodySize != nil && metric.MCPResponseBodySize != nil {
 		var requestBodySize, responseBodySize int64
 
-		// Calculate request body size from CallToolRequest
-		if req != nil && req.Params != nil && req.Params.Arguments != nil {
+		// Reuse canonical request bytes on the normal path. The fallback preserves
+		// request-size metrics for errors returned before the payload is built.
+		if requestPayload != nil {
+			requestBodySize = requestPayload.metricSize()
+		} else if req != nil && req.Params != nil && req.Params.Arguments != nil {
 			if paramsBytes, marshalErr := json.Marshal(req.Params.Arguments); marshalErr == nil {
 				requestBodySize = int64(len(paramsBytes))
 			}
 		}
 
 		// Calculate response body size from raw payload when available.
-		if payload != nil {
-			responseBodySize = int64(len(payload.rawBody))
+		if responsePayload != nil {
+			responseBodySize = int64(len(responsePayload.rawBody))
 		} else if result != nil {
 			if resultBytes, marshalErr := json.Marshal(result); marshalErr == nil {
 				responseBodySize = int64(len(resultBytes))
@@ -1319,8 +1335,9 @@ func logToolCall(
 	serverName string,
 	toolName string,
 	req *mcp.CallToolRequest,
+	requestPayload *toolRequestPayload,
 	result *mcp.CallToolResult,
-	payload *toolResponsePayload,
+	responsePayload *toolResponsePayload,
 	err error,
 	start time.Time,
 ) {
@@ -1343,12 +1360,12 @@ func logToolCall(
 	traceID := trace.GetTraceIDFromContext(ctx)
 
 	// Serialize request params and response
-	params, requestBodySize := serializeToolCallRequest(req, logTruncate)
+	params, requestBodySize := serializeToolCallRequest(req, requestPayload, logTruncate)
 	response, responseBodySize, upstreamRequestID := serializeToolCallResponse(
 		traceID,
 		ctxInfo.xRequestID,
 		result,
-		payload,
+		responsePayload,
 		hasError,
 		logTruncate,
 	)
@@ -1412,7 +1429,16 @@ func logToolCall(
 }
 
 // serializeToolCallRequest serializes the tool call request params.
-func serializeToolCallRequest(req *mcp.CallToolRequest, logTruncate config.LogTruncate) (string, int64) {
+func serializeToolCallRequest(
+	req *mcp.CallToolRequest,
+	payload *toolRequestPayload,
+	logTruncate config.LogTruncate,
+) (string, int64) {
+	if payload != nil {
+		return payload.apiLogPreview(logTruncate.GetAPILogRequestSize())
+	}
+	// Payload-nil fallback handles errors returned before request arguments are
+	// canonicalized, such as inner-JWT signing failures.
 	if req == nil || req.Params == nil || req.Params.Arguments == nil {
 		return "", 0
 	}

--- a/src/mcp-proxy/pkg/infra/proxy/proxy_benchmark_test.go
+++ b/src/mcp-proxy/pkg/infra/proxy/proxy_benchmark_test.go
@@ -26,6 +26,7 @@ import (
 	"crypto/x509"
 	"encoding/json"
 	"encoding/pem"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -124,6 +125,81 @@ func BenchmarkGenToolHandlerLargeJSONResponse(b *testing.B) {
 						benchmarkToolResult = result
 					}
 				})
+			}
+		})
+	}
+}
+
+func BenchmarkGenToolHandlerLargeJSONRequest(b *testing.B) {
+	initBenchmarkRuntime(b)
+
+	for _, size := range []int{64 << 10, 1 << 20} {
+		size := size
+		b.Run(strconv.Itoa(size)+"B", func(b *testing.B) {
+			arguments := buildBenchmarkRequestArguments(size)
+			upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				_, _ = io.Copy(io.Discard, r.Body)
+				w.Header().Set("Content-Type", "application/json")
+				_, _ = w.Write([]byte(`{"ok":true}`))
+			}))
+			defer upstream.Close()
+
+			upstreamURL, err := url.Parse(upstream.URL)
+			if err != nil {
+				b.Fatalf("parse upstream URL: %v", err)
+			}
+
+			toolConfig := &ToolConfig{
+				Name:   "large_json_request",
+				Method: http.MethodPost,
+				Host:   upstreamURL.Host,
+				Schema: upstreamURL.Scheme,
+				Url:    "/",
+			}
+			handler := genToolHandler(toolConfig, "bench-server", func() bool {
+				return false
+			})
+			req := &mcp.CallToolRequest{
+				Params: &mcp.CallToolParamsRaw{
+					Name:      toolConfig.Name,
+					Arguments: arguments,
+				},
+				Extra: &mcp.RequestExtra{
+					Header: http.Header{
+						constant.RequestIDHeaderKey: []string{
+							"bench-x-request-id",
+						},
+						constant.BkGatewayRequestIDKey: []string{
+							"bench-request-id",
+						},
+						constant.BkGatewayJWTHeaderKey: []string{
+							"bench-jwt",
+						},
+						constant.BkApiMCPServerIDKey: []string{"100"},
+						constant.BkApiMCPServerNameKey: []string{
+							"bench-server",
+						},
+						constant.BkApiAllowedHeadersKey: []string{""},
+						constant.BkApiAuthorizationHeaderKey: []string{
+							"bench-authorization",
+						},
+					},
+				},
+			}
+			ctx := benchmarkToolCallContext(b)
+
+			b.ReportAllocs()
+			b.SetBytes(int64(len(arguments)))
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				result, err := handler(ctx, req)
+				if err != nil {
+					b.Fatalf("tool handler returned error: %v", err)
+				}
+				if result == nil || len(result.Content) == 0 {
+					b.Fatal("tool handler returned empty result")
+				}
+				benchmarkToolResult = result
 			}
 		})
 	}
@@ -258,4 +334,13 @@ func buildBenchmarkJSONBody(targetSize int) []byte {
 	}
 	buf.WriteString(`]}`)
 	return buf.Bytes()
+}
+
+func buildBenchmarkRequestArguments(targetSize int) json.RawMessage {
+	body := buildBenchmarkJSONBody(targetSize)
+	arguments := make([]byte, 0, len(body)+len(`{"body_param":}`))
+	arguments = append(arguments, `{"body_param":`...)
+	arguments = append(arguments, body...)
+	arguments = append(arguments, '}')
+	return json.RawMessage(arguments)
 }

--- a/src/mcp-proxy/pkg/infra/proxy/proxy_suite_test.go
+++ b/src/mcp-proxy/pkg/infra/proxy/proxy_suite_test.go
@@ -27,17 +27,30 @@ import (
 
 	"mcp_proxy/pkg/config"
 	"mcp_proxy/pkg/infra/logging"
+	"mcp_proxy/pkg/metric"
 )
 
-var auditLogPath string
+var (
+	apiLogPath   string
+	auditLogPath string
+)
 
 var _ = BeforeSuite(func() {
 	auditLogDir := GinkgoT().TempDir()
+	apiLogPath = filepath.Join(auditLogDir, "api.log")
 	auditLogPath = filepath.Join(auditLogDir, "audit.log")
 
 	// Initialize config.G to avoid nil pointer dereference when genToolHandler accesses config fields.
 	config.G = &config.Config{
 		Logger: config.Logger{
+			API: config.LogConfig{
+				Level:  "info",
+				Writer: "file",
+				Settings: map[string]string{
+					"name": "api.log",
+					"path": auditLogDir,
+				},
+			},
 			Audit: config.LogConfig{
 				Level:  "info",
 				Writer: "file",
@@ -50,6 +63,7 @@ var _ = BeforeSuite(func() {
 	}
 	// Initialize logger for tests
 	logging.InitLogger(config.G)
+	metric.InitMetrics("test_")
 })
 
 func TestProxy(t *testing.T) {

--- a/src/mcp-proxy/pkg/infra/proxy/proxy_test.go
+++ b/src/mcp-proxy/pkg/infra/proxy/proxy_test.go
@@ -42,6 +42,8 @@ import (
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	"github.com/prometheus/client_golang/prometheus"
+	dto "github.com/prometheus/client_model/go"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/propagation"
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
@@ -52,7 +54,9 @@ import (
 	"mcp_proxy/pkg/config"
 	"mcp_proxy/pkg/constant"
 	"mcp_proxy/pkg/infra/bkaidevtrace"
+	"mcp_proxy/pkg/infra/logging"
 	"mcp_proxy/pkg/infra/trace"
+	"mcp_proxy/pkg/metric"
 	"mcp_proxy/pkg/util"
 )
 
@@ -454,6 +458,61 @@ var _ = Describe("MCPProxy", func() {
 	})
 
 	Describe("genToolHandler response payload behavior", func() {
+		It("preserves protocol request logs and size metrics when inner JWT signing fails", func() {
+			metric.MCPRequestBodySize.Reset()
+
+			var startOffset int64
+			if logInfo, err := os.Stat(apiLogPath); err == nil {
+				startOffset = logInfo.Size()
+			} else {
+				Expect(os.IsNotExist(err)).To(BeTrue())
+			}
+
+			arguments := json.RawMessage("{\n  \"body_param\": {\"value\": \"fallback\"}\n}")
+			expectedParams := `{"body_param":{"value":"fallback"}}`
+			handler := genToolHandler(&ToolConfig{Name: "list_items"}, "test-server", func() bool {
+				return false
+			})
+			ctx := context.WithValue(testToolCallContext(), constant.BkGatewayPrivateKey, []byte(nil))
+			result, err := handler(ctx, &mcp.CallToolRequest{
+				Params: &mcp.CallToolParamsRaw{
+					Name:      "list_items",
+					Arguments: arguments,
+				},
+			})
+
+			Expect(result).To(BeNil())
+			Expect(err).To(MatchError(ContainSubstring("private key not found in context")))
+			Expect(logging.GetAPILogger().Sync()).To(Succeed())
+
+			logBytes, err := os.ReadFile(apiLogPath)
+			Expect(err).NotTo(HaveOccurred())
+			logBytes = logBytes[startOffset:]
+			var protocolLog map[string]any
+			for _, line := range bytes.Split(logBytes, []byte("\n")) {
+				var entry map[string]any
+				if json.Unmarshal(line, &entry) == nil && entry["mcp_method"] == "tools/call" {
+					protocolLog = entry
+				}
+			}
+			Expect(protocolLog).NotTo(BeNil())
+			Expect(protocolLog).To(HaveKeyWithValue("params", expectedParams))
+			Expect(protocolLog).To(HaveKeyWithValue("request_body_size", float64(len(expectedParams))))
+
+			observer, err := metric.MCPRequestBodySize.GetMetricWithLabelValues(
+				"test-gateway",
+				"test-server",
+				"tools/call",
+			)
+			Expect(err).NotTo(HaveOccurred())
+			prometheusMetric, ok := observer.(prometheus.Metric)
+			Expect(ok).To(BeTrue())
+			metricData := &dto.Metric{}
+			Expect(prometheusMetric.Write(metricData)).To(Succeed())
+			Expect(metricData.GetHistogram().GetSampleCount()).To(Equal(uint64(1)))
+			Expect(metricData.GetHistogram().GetSampleSum()).To(Equal(float64(len(expectedParams))))
+		})
+
 		It("logs tool arguments only in params with the full request size", func() {
 			var startOffset int64
 			if logInfo, err := os.Stat(auditLogPath); err == nil {

--- a/src/mcp-proxy/pkg/infra/proxy/proxy_test.go
+++ b/src/mcp-proxy/pkg/infra/proxy/proxy_test.go
@@ -28,6 +28,7 @@ import (
 	"encoding/pem"
 	"errors"
 	"fmt"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -461,16 +462,22 @@ var _ = Describe("MCPProxy", func() {
 				Expect(os.IsNotExist(err)).To(BeTrue())
 			}
 
-			upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			var upstreamBody []byte
+			upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				var err error
+				upstreamBody, err = io.ReadAll(r.Body)
+				Expect(err).NotTo(HaveOccurred())
 				w.Header().Set("Content-Type", "application/json")
 				_, _ = w.Write([]byte(`{"ok":true}`))
 			}))
 			defer upstream.Close()
 
 			arguments := json.RawMessage(
-				fmt.Sprintf(`{"body_param":{"value":"%s"}}`, strings.Repeat("x", 5000)),
+				fmt.Sprintf("{\n  \"body_param\": {\"value\":\"%s\"}\n}", strings.Repeat("x", 5000)),
 			)
 			callTestToolHandler(upstream.URL, false, arguments)
+			canonicalArguments, err := json.Marshal(arguments)
+			Expect(err).NotTo(HaveOccurred())
 
 			logBytes, err := os.ReadFile(auditLogPath)
 			Expect(err).NotTo(HaveOccurred())
@@ -485,9 +492,13 @@ var _ = Describe("MCPProxy", func() {
 			}
 
 			Expect(completeLog).NotTo(BeNil())
-			Expect(completeLog["params"]).To(HaveSuffix("...(truncated)"))
-			Expect(completeLog).To(HaveKeyWithValue("request_body_size", float64(len(arguments))))
+			Expect(completeLog["params"]).To(Equal(util.TruncateJSON(
+				arguments,
+				config.G.McpServer.LogTruncate.GetAuditLogMaxBodySize(),
+			)))
+			Expect(completeLog).To(HaveKeyWithValue("request_body_size", float64(len(canonicalArguments))))
 			Expect(completeLog).NotTo(HaveKey("request"))
+			Expect(upstreamBody).To(MatchJSON(`{"value":"` + strings.Repeat("x", 5000) + `"}`))
 		})
 
 		It("returns envelope response with upstream JSON body", func() {

--- a/src/mcp-proxy/pkg/infra/proxy/request_payload.go
+++ b/src/mcp-proxy/pkg/infra/proxy/request_payload.go
@@ -1,0 +1,93 @@
+/*
+ * TencentBlueKing is pleased to support the open source community by making
+ * 蓝鲸智云 - API 网关(BlueKing - APIGateway) available.
+ * Copyright (C) Tencent. All rights reserved.
+ * Licensed under the MIT License (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ *     http://opensource.org/licenses/MIT
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * We undertake not to change the open source license (MIT license) applicable
+ * to the current version of the project delivered to anyone in the future.
+ */
+
+package proxy
+
+import (
+	"bytes"
+	"encoding/json"
+)
+
+// toolRequestPayload owns the canonical JSON bytes for one tools/call request.
+// The bytes are reused for request decoding, logs, and metrics instead of marshaling
+// CallToolParamsRaw.Arguments independently at each observation point.
+type toolRequestPayload struct {
+	rawArguments     []byte
+	argumentsPresent bool
+}
+
+func newToolRequestPayload(arguments json.RawMessage) (*toolRequestPayload, error) {
+	rawArguments, err := json.Marshal(arguments)
+	if err != nil {
+		return nil, err
+	}
+	return &toolRequestPayload{
+		rawArguments:     rawArguments,
+		argumentsPresent: arguments != nil,
+	}, nil
+}
+
+func (p *toolRequestPayload) decodeHandlerRequest() (*HandlerRequest, error) {
+	var handlerRequest HandlerRequest
+	decoder := json.NewDecoder(bytes.NewReader(p.rawArguments))
+	decoder.UseNumber()
+	if err := decoder.Decode(&handlerRequest); err != nil {
+		return nil, err
+	}
+	return &handlerRequest, nil
+}
+
+func (p *toolRequestPayload) auditPreview(limit int) string {
+	return truncateRequestJSON(p.rawArguments, limit)
+}
+
+func (p *toolRequestPayload) bodyAuditPreview(body json.RawMessage, limit int) string {
+	if body == nil {
+		return truncateRequestJSON([]byte("null"), limit)
+	}
+	return truncateRequestJSON(body, limit)
+}
+
+func (p *toolRequestPayload) auditSize() int64 {
+	return int64(len(p.rawArguments))
+}
+
+func (p *toolRequestPayload) metricSize() int64 {
+	if !p.argumentsPresent {
+		return 0
+	}
+	return int64(len(p.rawArguments))
+}
+
+func (p *toolRequestPayload) apiLogPreview(limit int) (string, int64) {
+	if !p.argumentsPresent {
+		return "", 0
+	}
+	preview := p.rawArguments
+	if len(preview) > limit {
+		preview = preview[:limit]
+	}
+	return string(preview), int64(len(p.rawArguments))
+}
+
+func truncateRequestJSON(content []byte, limit int) string {
+	if len(content) > limit {
+		return string(content[:limit]) + truncatedSuffix
+	}
+	return string(content)
+}

--- a/src/mcp-proxy/pkg/infra/proxy/request_payload_test.go
+++ b/src/mcp-proxy/pkg/infra/proxy/request_payload_test.go
@@ -1,0 +1,98 @@
+/*
+ * TencentBlueKing is pleased to support the open source community by making
+ * 蓝鲸智云 - API 网关(BlueKing - APIGateway) available.
+ * Copyright (C) Tencent. All rights reserved.
+ * Licensed under the MIT License (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ *     http://opensource.org/licenses/MIT
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * We undertake not to change the open source license (MIT license) applicable
+ * to the current version of the project delivered to anyone in the future.
+ */
+
+package proxy
+
+import (
+	"encoding/json"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("toolRequestPayload", func() {
+	It("canonicalizes arguments once and preserves parameter semantics", func() {
+		arguments := json.RawMessage(`{
+			"header_param": {"X-Trace-ID": 2005000002},
+			"query_param": {"ids": [2005000002, 9007199254740992]},
+			"path_param": {"id": 7643696123382648115},
+			"body_param": {"html": "<p>value</p>", "id": 7643696123382648115}
+		}`)
+		expected, err := json.Marshal(arguments)
+		Expect(err).NotTo(HaveOccurred())
+
+		payload, err := newToolRequestPayload(arguments)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(payload.rawArguments).To(Equal(expected))
+		Expect(payload.auditSize()).To(Equal(int64(len(expected))))
+		Expect(payload.metricSize()).To(Equal(int64(len(expected))))
+
+		handlerRequest, err := payload.decodeHandlerRequest()
+		Expect(err).NotTo(HaveOccurred())
+		Expect(handlerRequest.HeaderParam["X-Trace-ID"]).To(Equal("2005000002"))
+		Expect(handlerRequest.QueryParam["ids"]).To(Equal([]string{"2005000002", "9007199254740992"}))
+		Expect(handlerRequest.PathParam["id"]).To(Equal("7643696123382648115"))
+		Expect(string(handlerRequest.BodyParam)).To(Equal(
+			`{"html":"\u003cp\u003evalue\u003c/p\u003e","id":7643696123382648115}`,
+		))
+	})
+
+	It("keeps the existing audit and API log truncation formats", func() {
+		arguments := json.RawMessage(`{"body_param":{"value":"abcdefghijklmnopqrstuvwxyz"}}`)
+		payload, err := newToolRequestPayload(arguments)
+		Expect(err).NotTo(HaveOccurred())
+
+		Expect(payload.auditPreview(20)).To(Equal(
+			string(payload.rawArguments[:20]) + truncatedSuffix,
+		))
+		params, size := payload.apiLogPreview(20)
+		Expect(params).To(Equal(string(payload.rawArguments[:20])))
+		Expect(size).To(Equal(int64(len(payload.rawArguments))))
+
+		handlerRequest, err := payload.decodeHandlerRequest()
+		Expect(err).NotTo(HaveOccurred())
+		Expect(payload.bodyAuditPreview(handlerRequest.BodyParam, 20)).To(Equal(
+			string(handlerRequest.BodyParam[:20]) + truncatedSuffix,
+		))
+	})
+
+	DescribeTable("preserves null request compatibility",
+		func(arguments json.RawMessage) {
+			payload, err := newToolRequestPayload(arguments)
+			Expect(err).NotTo(HaveOccurred())
+
+			handlerRequest, err := payload.decodeHandlerRequest()
+			Expect(err).NotTo(HaveOccurred())
+			Expect(payload.bodyAuditPreview(handlerRequest.BodyParam, 100)).To(Equal("null"))
+		},
+		Entry("missing body_param", json.RawMessage(`{}`)),
+		Entry("explicit null body_param", json.RawMessage(`{"body_param":null}`)),
+	)
+
+	It("keeps nil arguments empty in API logs and metrics but null in audit logs", func() {
+		payload, err := newToolRequestPayload(nil)
+		Expect(err).NotTo(HaveOccurred())
+
+		Expect(payload.auditPreview(100)).To(Equal("null"))
+		Expect(payload.auditSize()).To(Equal(int64(4)))
+		Expect(payload.metricSize()).To(BeZero())
+		params, size := payload.apiLogPreview(100)
+		Expect(params).To(BeEmpty())
+		Expect(size).To(BeZero())
+	})
+})


### PR DESCRIPTION
## Summary

- canonicalize `tools/call` arguments once and reuse the resulting bytes for request decoding, audit logs, API logs, and metrics
- preserve the existing early-error fallbacks and request/audit ordering
- add compatibility coverage and a large-request benchmark, following the response-side optimization in #2856

## Behavior compatibility

The forwarded request, audit fields, bounded API-log preview, request size, and metrics continue to use the same canonical JSON representation. Invalid JSON and failures before payload construction retain the existing fallback behavior.

## Benchmark

Command:

```shell
DEBUG= go test -mod=vendor ./pkg/infra/proxy -run '^$' -bench BenchmarkGenToolHandlerLargeJSONRequest -benchmem -benchtime=3x -count=5
```

Median results:

| Payload | Metric | Before | After | Change |
| --- | ---: | ---: | ---: | ---: |
| 64 KiB | ns/op | 5,163,058 | 3,911,720 | -24.2% |
| 64 KiB | B/op | 1,157,552 | 705,256 | -39.1% |
| 64 KiB | allocs/op | 445 | 438 | -1.6% |
| 1 MiB | ns/op | 50,658,877 | 30,838,386 | -39.1% |
| 1 MiB | B/op | 15,590,453 | 8,932,226 | -42.7% |
| 1 MiB | allocs/op | 476 | 461 | -3.2% |

For a 1 MiB request, this removes about 6.35 MiB of transient allocations per operation.

## Verification

- `make fmt`
- `make build`
- `make lint`
- `make test` (14 suites, 70.1% composite coverage)
- `make integration` (81 passed, 0 skipped)
- `git diff --check`
