### PR TITLE
feat(inner): add MCP server lookup API

### DIFF
--- a/src/dashboard/apigateway/apigateway/apis/v2/inner/serializers.py
+++ b/src/dashboard/apigateway/apigateway/apis/v2/inner/serializers.py
@@ -725,12 +725,6 @@ class MCPServerListInputSLZ(serializers.Serializer):
         default="-updated_time",
         help_text="排序字段，支持 id, name, updated_time, created_time，前缀 - 表示降序，默认 -updated_time",
     )
-    mcp_server_ids = serializers.CharField(
-        allow_blank=True, required=False, help_text="MCPServer ID 列表，多个以逗号 , 分割"
-    )
-    mcp_server_names = serializers.CharField(
-        allow_blank=True, required=False, help_text="MCPServer 名称列表，多个以逗号 , 分割"
-    )
     fields = serializers.CharField(
         allow_blank=True,
         required=False,
@@ -740,14 +734,30 @@ class MCPServerListInputSLZ(serializers.Serializer):
     class Meta:
         ref_name = "apigateway.apis.v2.inner.serializers.MCPServerListInputSLZ"
 
-    def validate_mcp_server_ids(self, value):
+    def validate_fields(self, value) -> set[str] | None:
+        return validate_output_fields(value, MCP_SERVER_LIST_FIELDS)
+
+
+class MCPServerLookupInputSLZ(serializers.Serializer):
+    ids = serializers.CharField(allow_blank=True, required=False, help_text="MCPServer ID 列表，多个以逗号 , 分割")
+    names = serializers.CharField(allow_blank=True, required=False, help_text="MCPServer 名称列表，多个以逗号 , 分割")
+    fields = serializers.CharField(
+        allow_blank=True,
+        required=False,
+        help_text="指定返回的字段列表，多个以逗号分割；不传时返回全部字段",
+    )
+
+    class Meta:
+        ref_name = "apigateway.apis.v2.inner.serializers.MCPServerLookupInputSLZ"
+
+    def validate_ids(self, value):
         return validate_comma_separated_ints(
             value,
             invalid_error=_("MCPServer ID 必须为整数，多个以逗号分割"),
             max_count_error=_("MCPServer ID 列表最多支持 {max_count} 个"),
         )
 
-    def validate_mcp_server_names(self, value):
+    def validate_names(self, value):
         return validate_comma_separated_names(
             value,
             max_count_error=_("MCPServer 名称列表最多支持 {max_count} 个"),
@@ -755,6 +765,11 @@ class MCPServerListInputSLZ(serializers.Serializer):
 
     def validate_fields(self, value) -> set[str] | None:
         return validate_output_fields(value, MCP_SERVER_LIST_FIELDS)
+
+    def validate(self, attrs):
+        if not attrs.get("ids") and not attrs.get("names"):
+            raise serializers.ValidationError(_("ids 和 names 不能同时为空"))
+        return attrs
 
 
 class MCPServerListOutputSLZ(_SelectableFieldsOutputSLZMixin, serializers.Serializer):

--- a/src/dashboard/apigateway/apigateway/apis/v2/inner/urls.py
+++ b/src/dashboard/apigateway/apigateway/apis/v2/inner/urls.py
@@ -213,6 +213,12 @@ urlpatterns = [
                     views.MCPServerListApi.as_view(),
                     name="openapi.v2.inner.mcp_server.list",
                 ),
+                # GET /api/v2/inner/mcp-servers/-/lookup/
+                path(
+                    "-/lookup/",
+                    views.MCPServerLookupApi.as_view(),
+                    name="openapi.v2.inner.mcp_server.lookup",
+                ),
             ]
         ),
     ),

--- a/src/dashboard/apigateway/apigateway/apis/v2/inner/views.py
+++ b/src/dashboard/apigateway/apigateway/apis/v2/inner/views.py
@@ -106,6 +106,30 @@ class MCPServerListPagination(BoundedLimitOffsetPagination):
     max_limit = INNER_BOUNDED_LIST_MAX_LIMIT
 
 
+def _serialize_mcp_servers(mcp_servers, fields):
+    include_all_fields = fields is None
+
+    context = {}
+    if include_all_fields or fields & {"stage", "gateway"}:
+        context.update(MCPServerHandler.build_list_context(mcp_servers))
+
+    mcp_server_ids = (
+        [mcp_server.id for mcp_server in mcp_servers]
+        if include_all_fields or fields & {"prompts_count", "categories"}
+        else []
+    )
+    if include_all_fields or "prompts_count" in fields:
+        context["prompts_count_map"] = MCPServerHandler.get_prompts_count_map(mcp_server_ids)
+
+    if include_all_fields or "categories" in fields:
+        context["categories"] = MCPServerHandler.build_categories_map(mcp_server_ids)
+
+    if include_all_fields or "url" in fields:
+        context["least_privileges_by_server"] = MCPServerHandler.get_least_privileges_by_server(mcp_servers)
+
+    return serializers.MCPServerListOutputSLZ(mcp_servers, many=True, context=context, fields=fields).data
+
+
 @method_decorator(
     name="get",
     decorator=swagger_auto_schema(
@@ -1240,34 +1264,37 @@ class MCPServerListApi(generics.ListAPIView):
         queryset = MCPServerHandler.build_list_queryset(
             keyword=slz.validated_data.get("keyword"),
             order_by=slz.validated_data.get("order_by", "-updated_time"),
-            ids=slz.validated_data.get("mcp_server_ids") or None,
-            names=slz.validated_data.get("mcp_server_names") or None,
         )
 
         page = self.paginate_queryset(queryset)
         fields = slz.validated_data.get("fields")
-        include_all_fields = fields is None
+        return self.get_paginated_response(_serialize_mcp_servers(page, fields))
 
-        context = {}
-        if include_all_fields or fields & {"stage", "gateway"}:
-            context.update(MCPServerHandler.build_list_context(page))
 
-        mcp_server_ids = (
-            [mcp_server.id for mcp_server in page]
-            if include_all_fields or fields & {"prompts_count", "categories"}
-            else []
+@method_decorator(
+    name="get",
+    decorator=swagger_auto_schema(
+        operation_description="按 ID 或名称查询 MCPServer",
+        query_serializer=serializers.MCPServerLookupInputSLZ,
+        responses={status.HTTP_200_OK: serializers.MCPServerListOutputSLZ(many=True)},
+        tags=["OpenAPI.V2.Inner"],
+    ),
+)
+class MCPServerLookupApi(generics.ListAPIView):
+    permission_classes = [OpenAPIV2Permission]
+
+    def list(self, request, *args, **kwargs):
+        slz = serializers.MCPServerLookupInputSLZ(data=request.query_params)
+        slz.is_valid(raise_exception=True)
+
+        mcp_servers = list(
+            MCPServerHandler.build_list_queryset(
+                ids=slz.validated_data.get("ids") or None,
+                names=slz.validated_data.get("names") or None,
+            )
         )
-        if include_all_fields or "prompts_count" in fields:
-            context["prompts_count_map"] = MCPServerHandler.get_prompts_count_map(mcp_server_ids)
-
-        if include_all_fields or "categories" in fields:
-            context["categories"] = MCPServerHandler.build_categories_map(mcp_server_ids)
-
-        if include_all_fields or "url" in fields:
-            context["least_privileges_by_server"] = MCPServerHandler.get_least_privileges_by_server(page)
-
-        output_slz = serializers.MCPServerListOutputSLZ(page, many=True, context=context, fields=fields)
-        return self.get_paginated_response(output_slz.data)
+        fields = slz.validated_data.get("fields")
+        return OKJsonResponse(data=_serialize_mcp_servers(mcp_servers, fields))
 
 
 # ===================== 网关状态变更/删除 API =====================

--- a/src/dashboard/apigateway/apigateway/data/apidocs/zh/v2_inner_list_mcp_server.md
+++ b/src/dashboard/apigateway/apigateway/data/apidocs/zh/v2_inner_list_mcp_server.md
@@ -2,6 +2,8 @@
 
 获取全量的 MCPServer 列表（应用态接口）
 
+按 MCPServer ID 或名称精确查询时，请使用 MCPServer lookup 接口。
+
 
 ### 输入参数
 
@@ -11,8 +13,6 @@
 |---------|--------|----|-----------------------------------------|
 | keyword | string | 否  | MCPServer 筛选条件，支持模糊匹配 MCPServer 名称或描述 |
 | order_by | string | 否  | 排序字段，支持 id, name, updated_time, created_time，前缀 - 表示降序，默认 -updated_time |
-| mcp_server_ids | string | 否  | MCPServer ID 列表，多个以逗号分割，最多 50 个。例如：1,2,3 |
-| mcp_server_names | string | 否  | MCPServer 名称列表，精确匹配，多个以逗号分割，最多 50 个。例如：server-1,server-2 |
 | fields | string | 否  | 指定返回的字段列表，多个以逗号分割，例如 `fields=name,title`；支持的字段见 `data.results`；不传时返回全部字段，包含不支持的字段时返回参数校验错误 |
 | limit | int | 否 | 每页数量，取值范围 1～20，默认 10 |
 | offset | int | 否 | 分页偏移量，必须大于或等于 0，默认 0 |

--- a/src/dashboard/apigateway/apigateway/data/apidocs/zh/v2_inner_lookup_mcp_servers.md
+++ b/src/dashboard/apigateway/apigateway/data/apidocs/zh/v2_inner_lookup_mcp_servers.md
@@ -1,0 +1,60 @@
+### 描述
+
+按 ID 或名称批量查询活跃的 MCPServer（应用态接口）。接口不分页，只返回 MCPServer、所属网关和环境均为启用状态的记录；未匹配的 ID 或名称不会出现在结果中。同时传入 ID 和名称时，返回两组条件的交集。
+
+
+### 输入参数
+
+#### 请求参数
+
+| 参数名称 | 参数类型 | 必选 | 描述 |
+|---|---|---|---|
+| ids | string | 否 | MCPServer ID 列表，多个以逗号分割，最多 50 个；与 `names` 不能同时为空 |
+| names | string | 否 | MCPServer 名称列表，精确匹配，多个以逗号分割，最多 50 个；与 `ids` 不能同时为空 |
+| fields | string | 否 | 指定返回的字段列表，多个以逗号分割，例如 `fields=id,name`；支持的字段见 `data`；不传时返回全部字段，包含不支持的字段时返回参数校验错误 |
+
+
+### 响应示例
+
+以下示例对应 `fields=id,name,title`。
+
+```json
+{
+  "data": [
+    {
+      "id": 1,
+      "name": "test-mcp-server",
+      "title": "测试 MCP Server"
+    }
+  ]
+}
+```
+
+### 响应参数说明
+
+| 字段 | 类型 | 描述 |
+|---|---|---|
+| data | array | 匹配的 MCPServer 列表，无分页包装 |
+| data[].id | int | MCPServer ID |
+| data[].name | string | MCPServer 名称 |
+| data[].title | string | MCPServer 中文名/显示名称 |
+| data[].description | string | MCPServer 描述 |
+| data[].is_public | bool | MCPServer 是否公开 |
+| data[].labels | array | MCPServer 标签列表 |
+| data[].resource_names | array | MCPServer 资源名称列表 |
+| data[].tool_names | array | MCPServer 工具名称列表 |
+| data[].status | string | MCPServer 状态 |
+| data[].protocol_type | string | MCPServer 协议类型 |
+| data[].oauth2_public_client_enabled | bool | 是否开启 OAuth2 公开客户端模式 |
+| data[].oauth2_personal_client_enabled | bool | 是否开启 OAuth2 个人客户端模式 |
+| data[].categories | array | MCPServer 分类列表 |
+| data[].stage | object | MCPServer 环境信息 |
+| data[].gateway | object | MCPServer 网关信息 |
+| data[].tools_count | int | MCPServer 工具数量 |
+| data[].prompts_count | int | MCPServer Prompts 数量 |
+| data[].url | string | MCPServer 访问 URL |
+| data[].detail_url | string | MCPServer 网关站点详情 URL |
+| data[].updated_by | string | 更新人 |
+| data[].created_by | string | 创建人 |
+| data[].updated_time | string | 更新时间 |
+| data[].created_time | string | 创建时间 |

--- a/src/dashboard/apigateway/apigateway/data/apigw-definitions/bk-apigateway-definition.yaml
+++ b/src/dashboard/apigateway/apigateway/data/apigw-definitions/bk-apigateway-definition.yaml
@@ -109,6 +109,7 @@ grant_permissions:
       - v2_inner_get_app_esb_component_permission_apply_record
       # mcp server related
       - v2_inner_list_mcp_server
+      - v2_inner_lookup_mcp_servers
       - v2_inner_list_mcp_server_permissions
       - v2_inner_apply_mcp_server_permission
       - v2_inner_list_mcp_server_app_permissions
@@ -131,6 +132,7 @@ grant_permissions:
     grant_dimension: "resource"
     resource_names:
       - v2_inner_list_mcp_server
+      - v2_inner_lookup_mcp_servers
       - v2_inner_lookup_gateways
       - v2_inner_list_gateway_released_resources
       - v2_inner_list_oauth2_resource_scopes

--- a/src/dashboard/apigateway/apigateway/data/apigw-definitions/bk-apigateway-resources.yaml
+++ b/src/dashboard/apigateway/apigateway/data/apigw-definitions/bk-apigateway-resources.yaml
@@ -7477,18 +7477,6 @@ paths:
             default: -updated_time
           description: 排序字段，支持 id, name, updated_time, created_time，前缀 - 表示降序，默认 -updated_time
           example: -updated_time
-        - name: mcp_server_ids
-          in: query
-          schema:
-            type: string
-          description: MCPServer ID 列表，多个以逗号分割，最多 50 个
-          example: "1,2,3"
-        - name: mcp_server_names
-          in: query
-          schema:
-            type: string
-          description: MCPServer 名称列表，精确匹配，多个以逗号分割，最多 50 个
-          example: "server-1,server-2"
         - name: fields
           in: query
           schema:
@@ -7527,6 +7515,64 @@ paths:
           name: default
           method: get
           path: /backend/api/v2/inner/mcp-servers/
+          matchSubpath: false
+          timeout: 0
+        pluginConfigs: []
+        authConfig:
+          userVerifiedRequired: false
+          appVerifiedRequired: true
+          resourcePermissionRequired: true
+        descriptionEn: None
+  /api/v2/inner/mcp-servers/-/lookup/:
+    get:
+      operationId: v2_inner_lookup_mcp_servers
+      description: 按 ID 或名称批量查询 MCPServer
+      tags:
+      - v2_inner
+      parameters:
+        - name: ids
+          in: query
+          required: false
+          schema:
+            type: string
+          description: MCPServer ID 列表，多个以逗号分割，最多 50 个；与 names 不能同时为空，同时传入时取交集
+          example: "1,2,3"
+        - name: names
+          in: query
+          required: false
+          schema:
+            type: string
+          description: MCPServer 名称列表，精确匹配，多个以逗号分割，最多 50 个；与 ids 不能同时为空，同时传入时取交集
+          example: "server-1,server-2"
+        - name: fields
+          in: query
+          required: false
+          schema:
+            type: string
+          description: 指定返回的字段列表，多个以逗号分割；不传时返回全部字段
+          example: id,name
+      responses:
+        '200':
+          description: 成功返回匹配的 MCPServer 列表，无分页包装
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  data:
+                    type: array
+                    items:
+                      type: object
+                      additionalProperties: true
+      x-bk-apigateway-resource:
+        isPublic: false
+        allowApplyPermission: false
+        matchSubpath: false
+        enableWebsocket: false
+        backend:
+          name: default
+          method: get
+          path: /backend/api/v2/inner/mcp-servers/-/lookup/
           matchSubpath: false
           timeout: 0
         pluginConfigs: []

--- a/src/dashboard/apigateway/apigateway/tests/apis/v2/inner/test_views.py
+++ b/src/dashboard/apigateway/apigateway/tests/apis/v2/inner/test_views.py
@@ -2420,8 +2420,9 @@ class TestMCPServerListApi:
         assert len(result["data"]["results"]) == 1
         assert result["data"]["results"][0]["id"] == mcp_server1.id
 
-    def test_list_with_mcp_server_ids_filter(self, request_view, fake_gateway):
-        """测试使用 mcp_server_ids 筛选 MCPServer"""
+
+class TestMCPServerLookupApi:
+    def test_lookup_with_ids_returns_unpaginated_results(self, request_view, fake_gateway):
         fake_gateway.status = GatewayStatusEnum.ACTIVE.value
         fake_gateway.maintainers = ["admin"]
         fake_gateway.is_official = True
@@ -2457,23 +2458,35 @@ class TestMCPServerListApi:
             protocol_type=MCPServerProtocolTypeEnum.SSE.value,
         )
 
-        # 只筛选 server1 和 server3
         resp = request_view(
             method="GET",
-            view_name="openapi.v2.inner.mcp_server.list",
-            data={"mcp_server_ids": f"{mcp_server1.id},{mcp_server3.id}"},
+            view_name="openapi.v2.inner.mcp_server.lookup",
+            data={"ids": f"{mcp_server1.id},{mcp_server3.id}", "fields": "id,name"},
             app=mock.MagicMock(app_code="test"),
         )
         result = resp.json()
 
         assert resp.status_code == 200
-        result_ids = [item["id"] for item in result["data"]["results"]]
-        assert mcp_server1.id in result_ids
-        assert mcp_server3.id in result_ids
-        assert mcp_server2.id not in result_ids
+        assert isinstance(result["data"], list)
+        assert {item["id"] for item in result["data"]} == {mcp_server1.id, mcp_server3.id}
+        assert mcp_server2.id not in {item["id"] for item in result["data"]}
+        assert all(set(item) == {"id", "name"} for item in result["data"])
 
-    def test_list_with_mcp_server_names_filter(self, request_view, fake_gateway):
-        """测试使用 mcp_server_names 精确筛选 MCPServer，未命中的名称被忽略"""
+        resp = request_view(
+            method="GET",
+            view_name="openapi.v2.inner.mcp_server.lookup",
+            data={
+                "ids": f"{mcp_server1.id},{mcp_server2.id}",
+                "names": f"{mcp_server2.name},{mcp_server3.name}",
+                "fields": "id",
+            },
+            app=mock.MagicMock(app_code="test"),
+        )
+
+        assert resp.status_code == 200
+        assert resp.json()["data"] == [{"id": mcp_server2.id}]
+
+    def test_lookup_with_names_uses_exact_match_and_ignores_missing_names(self, request_view, fake_gateway):
         fake_gateway.status = GatewayStatusEnum.ACTIVE.value
         fake_gateway.save()
 
@@ -2498,61 +2511,39 @@ class TestMCPServerListApi:
 
         resp = request_view(
             method="GET",
-            view_name="openapi.v2.inner.mcp_server.list",
-            data={"mcp_server_names": "private-server,missing-server"},
+            view_name="openapi.v2.inner.mcp_server.lookup",
+            data={"names": "private-server,missing-server", "fields": "id,title"},
             app=mock.MagicMock(app_code="test"),
         )
 
         assert resp.status_code == 200
-        results = resp.json()["data"]["results"]
+        results = resp.json()["data"]
         assert [item["id"] for item in results] == [private_mcp_server.id]
         assert results[0]["title"] == "Private Server"
 
-    def test_list_with_mcp_server_ids_empty(self, request_view, fake_gateway):
-        """测试 mcp_server_ids 为空时返回所有"""
-        fake_gateway.status = GatewayStatusEnum.ACTIVE.value
-        fake_gateway.maintainers = ["admin"]
-        fake_gateway.save()
-
-        stage = G(Stage, gateway=fake_gateway, status=StageStatusEnum.ACTIVE.value)
-
-        mcp_server = G(
-            MCPServer,
-            gateway=fake_gateway,
-            stage=stage,
-            name="server-empty-ids-test",
-            is_public=True,
-            status=MCPServerStatusEnum.ACTIVE.value,
-            protocol_type=MCPServerProtocolTypeEnum.SSE.value,
-        )
-
-        # mcp_server_ids 为空字符串，应返回所有
+    @pytest.mark.parametrize("data", [{}, {"ids": ""}, {"names": ", ,"}])
+    def test_lookup_rejects_missing_or_empty_lookup_keys(self, request_view, data):
         resp = request_view(
             method="GET",
-            view_name="openapi.v2.inner.mcp_server.list",
-            data={"mcp_server_ids": ""},
-            app=mock.MagicMock(app_code="test"),
-        )
-        result = resp.json()
-
-        assert resp.status_code == 200
-        result_ids = [item["id"] for item in result["data"]["results"]]
-        assert mcp_server.id in result_ids
-
-    def test_list_with_mcp_server_ids_invalid(self, request_view, fake_gateway, mocker):
-        """测试 mcp_server_ids 包含非法值时返回 400"""
-        fake_gateway.status = GatewayStatusEnum.ACTIVE.value
-        fake_gateway.save()
-
-        resp = request_view(
-            method="GET",
-            view_name="openapi.v2.inner.mcp_server.list",
-            data={"mcp_server_ids": "abc,def"},
+            view_name="openapi.v2.inner.mcp_server.lookup",
+            data=data,
             app=mock.MagicMock(app_code="test"),
         )
 
         assert resp.status_code == 400
 
+    def test_lookup_rejects_invalid_ids(self, request_view):
+        resp = request_view(
+            method="GET",
+            view_name="openapi.v2.inner.mcp_server.lookup",
+            data={"ids": "abc,def"},
+            app=mock.MagicMock(app_code="test"),
+        )
+
+        assert resp.status_code == 400
+
+
+class TestMCPServerListOutputApi:
     def test_list_returns_oauth2_public_client_enabled_true(self, request_view, fake_gateway):
         """测试 MCPServer 列表接口返回 oauth2_public_client_enabled=True"""
         fake_gateway.status = GatewayStatusEnum.ACTIVE.value

--- a/src/dashboard/apigateway/apigateway/tests/lint/test_bk_auth_resource_grants.py
+++ b/src/dashboard/apigateway/apigateway/tests/lint/test_bk_auth_resource_grants.py
@@ -8,6 +8,7 @@ GATEWAY_DEFINITION = Path(settings.BASE_DIR) / "data/apigw-definitions/bk-apigat
 
 EXPECTED_BK_AUTH_INNER_RESOURCES = {
     "v2_inner_list_mcp_server",
+    "v2_inner_lookup_mcp_servers",
     "v2_inner_lookup_gateways",
     "v2_inner_list_gateway_released_resources",
     "v2_inner_list_oauth2_resource_scopes",


### PR DESCRIPTION
### Description

Separate exact MCP server lookup from the paginated list endpoint.

- keep `/api/v2/inner/mcp-servers/` as the paginated list API
- add `/api/v2/inner/mcp-servers/-/lookup/` as an unpaginated lookup API
- accept `ids` and `names` without the `mcp_server_` prefix
- synchronize gateway resources, grants, API documentation, and regression tests

### Verification

- focused MCP inner API tests: 29 passed
- `uv run make edition-ee && uv run make lint-check`: passed
- OpenAPI consistency: 0 errors, 41 baseline warnings
- `uv run make edition-ee && uv run make test`: 3821 passed

### Checklist

- [x] 填写 PR 描述及相关 issue (write PR description and related issue)
- [x] 代码风格检查通过 (code style check passed)
- [x] PR 中包含单元测试 (include unit test)
- [x] 单元测试通过 (unit test passed)
- [ ] 本地开发联调环境验证通过 (local development environment verification passed)
