### PR TITLE
fix(dashboard): keep programmable stage list usable after PaaS publish for release/1.23

### DIFF
--- a/src/dashboard/apigateway/apigateway/biz/programmable/releaser.py
+++ b/src/dashboard/apigateway/apigateway/biz/programmable/releaser.py
@@ -195,6 +195,7 @@ class ProgrammableGatewayReleaser:
                     gateway=gateway, stage_id=stage_id, version=stage_release["resource_version_display"]
                 ).first()
                 or deploy_history  # 回退到最新记录
+                or last_deploy_history  # 从开发者中心发布时可能没有 deploy history
             )
             # 查询当前生效环境的 release history
             last_release_history = ReleaseHistory.objects.filter(
@@ -204,7 +205,8 @@ class ProgrammableGatewayReleaser:
                 last_publish_status = ReleaseHandler.get_release_status(last_release_history.id)
 
             # 如果 stage_release 的版本和 deploy_history 的第一个不一致，说明正在发布
-            if stage_release["resource_version_display"] != deploy_history.version:
+            # 从开发者中心直接发布时可能没有 deploy_history
+            if deploy_history and stage_release["resource_version_display"] != deploy_history.version:
                 latest_deploy_history = deploy_history
                 latest_publish_status = ReleaseHistoryStatusEnum.DOING.value
 

--- a/src/dashboard/apigateway/apigateway/tests/biz/programmable/test_releaser.py
+++ b/src/dashboard/apigateway/apigateway/tests/biz/programmable/test_releaser.py
@@ -22,7 +22,8 @@ from ddf import G
 
 from apigateway.apps.programmable_gateway.models import ProgrammableGatewayDeployHistory
 from apigateway.biz.programmable import ProgrammableGatewayReleaser
-from apigateway.core.models import Gateway, Stage
+from apigateway.common.tenant.user_credentials import UserCredentials
+from apigateway.core.models import Gateway, Release, ResourceVersion, Stage
 from apigateway.tests.utils.testing import dummy_time
 
 pytestmark = pytest.mark.django_db
@@ -118,3 +119,21 @@ class TestProgrammableGatewayReleaser:
                 gateway, fuzzy=test.get("fuzzy", True), **test["params"]
             )
             assert result.count() == test["expected"]["count"]
+
+    def test_get_stage_deploy_status_without_deploy_history_when_stage_released(self):
+        """从开发者中心发布后，网关侧可能只有 Release 而没有 DeployHistory。"""
+        gateway = G(Gateway)
+        stage = G(Stage, gateway=gateway, status=1)
+        resource_version = G(ResourceVersion, gateway=gateway, version="1.0.0")
+        G(Release, gateway=gateway, stage=stage, resource_version=resource_version)
+        user_credentials = UserCredentials(credentials="token", tenant_id="default")
+
+        result = ProgrammableGatewayReleaser.get_stage_deploy_status(gateway, stage.id, user_credentials)
+
+        assert result["latest_publish_status"] == ""
+        assert result["last_publish_status"] == ""
+        assert result["latest_history_id"] == 0
+        assert result["last_deploy_history"] is not None
+        assert result["last_deploy_history"].pk is None
+        assert result["latest_deploy_history"] is not None
+        assert result["latest_deploy_history"].pk is None


### PR DESCRIPTION
## Summary
- cherry-pick #3165 to release/1.23
- source PR: https://github.com/TencentBlueKing/blueking-apigateway/pull/3165

## Cherry-picked commits
- 7631748a23edff82626664bebe03fef13e80a57d fix(dashboard): keep programmable stage list usable after PaaS publish
