### PR TITLE
fix(dashboard): surface readable PaaS API failures

### DIFF
--- a/src/dashboard/apigateway/apigateway/components/bkpaas.py
+++ b/src/dashboard/apigateway/apigateway/components/bkpaas.py
@@ -19,7 +19,7 @@
 import logging
 import os
 from functools import lru_cache
-from typing import TYPE_CHECKING, Any, Dict, Iterable, List, Optional
+from typing import TYPE_CHECKING, Any, Dict, Iterable, List, NoReturn, Optional
 from urllib.parse import urlparse
 
 from cachetools import TTLCache, cached
@@ -62,6 +62,15 @@ def get_paas3_url_prefix() -> str:
     return settings.BK_API_URL_TMPL.format(api_name=gateway_name) + "/prod"
 
 
+def _raise_paas_request_error(method: str, url: str, resp_data: Dict[str, Any]) -> NoReturn:
+    response_data = resp_data.get("response_data")
+    detail = response_data.get("detail") if isinstance(response_data, dict) else None
+    error = detail or resp_data.get("error", "unknown error")
+    raise error_codes.REMOTE_REQUEST_ERROR.format(
+        f"request paasv3 fail! Request=[{method} {urlparse(url).path} request_id={local.request_id}] error={error}"
+    )
+
+
 def _call_paasv3_uni_apps_query_by_id(
     tenant_id: str,
     app_codes: List[str],
@@ -86,11 +95,7 @@ def _call_paasv3_uni_apps_query_by_id(
             local.request_id,
             resp_data["error"],
         )
-        raise error_codes.REMOTE_REQUEST_ERROR.format(
-            f"request paasv3 fail! "
-            f"Request=[http_get {urlparse(url).path} request_id={local.request_id}]"
-            f"error={resp_data['error']}"
-        )
+        _raise_paas_request_error("http_get", url, resp_data)
     # response:
     # - tenant_id is the owner(user tenant_id) of the app, global app is owned by system
     # - app_tenant_id is the tenant_id of the app, global app is empty
@@ -120,11 +125,7 @@ def get_paas_apps_by_username(username: str, tenant_id: str) -> List[Dict[str, A
             local.request_id,
             resp_data["error"],
         )
-        raise error_codes.REMOTE_REQUEST_ERROR.format(
-            f"request paasv3 fail! "
-            f"Request=[http_get {urlparse(url).path} request_id={local.request_id}]"
-            f"error={resp_data['error']}"
-        )
+        _raise_paas_request_error("http_get", url, resp_data)
 
     return resp_data
 
@@ -227,11 +228,7 @@ def get_paas_repo_authorization(
             local.request_id,
             resp_data["error"],
         )
-        raise error_codes.REMOTE_REQUEST_ERROR.format(
-            f"request paasv3 fail! "
-            f"Request=[http_get {urlparse(url).path} request_id={local.request_id}]"
-            f"error={resp_data['error']}"
-        )
+        _raise_paas_request_error("http_get", url, resp_data)
 
     return {
         "authorized": True,
@@ -289,11 +286,7 @@ def create_paas_app(
             local.request_id,
             resp_data["error"],
         )
-        raise error_codes.REMOTE_REQUEST_ERROR.format(
-            f"request paasv3 fail! "
-            f"Request=[http_get {urlparse(url).path} request_id={local.request_id}]"
-            f"error={resp_data['error']}"
-        )
+        _raise_paas_request_error("http_post", url, resp_data)
     return True
 
 
@@ -334,11 +327,7 @@ def deploy_paas_app(
             local.request_id,
             resp_data["error"],
         )
-        raise error_codes.REMOTE_REQUEST_ERROR.format(
-            f"request paasv3 fail! "
-            f"Request=[http_get {urlparse(url).path} request_id={local.request_id}]"
-            f"error={resp_data['error']}"
-        )
+        _raise_paas_request_error("http_post", url, resp_data)
     return resp_data["deployment_id"]
 
 
@@ -359,6 +348,7 @@ def paas_app_module_offline(app_code: str, module: str, env: str, user_credentia
             local.request_id,
             resp_data["error"],
         )
+        _raise_paas_request_error("http_post", url, resp_data)
     return resp_data.get("offline_operation_id", "")
 
 
@@ -387,6 +377,7 @@ def set_paas_stage_env(
                 local.request_id,
                 resp_data["error"],
             )
+            _raise_paas_request_error("http_post", url, resp_data)
 
     return True
 
@@ -412,6 +403,7 @@ def get_paas_deploy_phases_framework(
             local.request_id,
             resp_data["error"],
         )
+        _raise_paas_request_error("http_get", url, resp_data)
     return resp_data
 
 
@@ -437,6 +429,7 @@ def get_paas_deploy_phases_instance(
             local.request_id,
             resp_data["error"],
         )
+        _raise_paas_request_error("http_get", url, resp_data)
     return resp_data
 
 
@@ -457,6 +450,7 @@ def get_pass_deploy_streams_history_events(deploy_id: str, user_credentials: Opt
             local.request_id,
             resp_data["error"],
         )
+        _raise_paas_request_error("http_get", url, resp_data)
     return resp_data
 
 
@@ -481,6 +475,7 @@ def get_paas_deployment_result(
             local.request_id,
             resp_data["error"],
         )
+        _raise_paas_request_error("http_get", url, resp_data)
     return resp_data
 
 
@@ -505,6 +500,7 @@ def get_paas_offline_result(
             local.request_id,
             resp_data["error"],
         )
+        _raise_paas_request_error("http_get", url, resp_data)
     return resp_data
 
 
@@ -525,6 +521,7 @@ def get_paas_runtime_info(app_code: str, module: str, user_credentials: Optional
             local.request_id,
             resp_data["error"],
         )
+        _raise_paas_request_error("http_get", url, resp_data)
     return resp_data
 
 
@@ -545,6 +542,7 @@ def get_paas_repo_branch_info(app_code: str, module: str, user_credentials: Opti
             local.request_id,
             resp_data["error"],
         )
+        _raise_paas_request_error("http_get", url, resp_data)
     branch_list = []
     branch_commit_info = {}
     for branch in resp_data.get("results", []):
@@ -597,9 +595,5 @@ def update_app_maintainers(app_code: str, maintainers: List[str], user_credentia
             local.request_id,
             resp_data["error"],
         )
-        raise error_codes.REMOTE_REQUEST_ERROR.format(
-            f"request paasv3 fail! "
-            f"Request=[http_post {urlparse(url).path} request_id={local.request_id}]"
-            f"error={resp_data['error']}"
-        )
+        _raise_paas_request_error("http_post", url, resp_data)
     return True

--- a/src/dashboard/apigateway/apigateway/tests/components/test_bkpaas.py
+++ b/src/dashboard/apigateway/apigateway/tests/components/test_bkpaas.py
@@ -25,7 +25,16 @@ from apigateway.components.bkpaas import (
     REQ_PAAS_API_TIMEOUT,
     get_app_maintainers,
     get_paas_apps_by_username,
+    get_paas_deploy_phases_framework,
+    get_paas_deploy_phases_instance,
+    get_paas_deployment_result,
+    get_paas_offline_result,
     get_paas_repo_authorization,
+    get_paas_repo_branch_info,
+    get_paas_runtime_info,
+    get_pass_deploy_streams_history_events,
+    paas_app_module_offline,
+    set_paas_stage_env,
 )
 
 
@@ -147,3 +156,73 @@ class TestGetPaaSAppsByUsername:
             "X-Gateway": "1",
             "X-Bk-Tenant-Id": "tenant-a",
         }
+
+
+@pytest.mark.parametrize(
+    "call_paas_api",
+    [
+        pytest.param(lambda: paas_app_module_offline("demo", "default", "prod"), id="offline"),
+        pytest.param(
+            lambda: set_paas_stage_env("demo", "default", "prod", {"RELEASE_VERSION": "1.0.0"}),
+            id="set-stage-env",
+        ),
+        pytest.param(
+            lambda: get_paas_deploy_phases_framework("demo", "default", "prod"),
+            id="deploy-phases-framework",
+        ),
+        pytest.param(
+            lambda: get_paas_deploy_phases_instance("demo", "default", "prod", "deploy-id"),
+            id="deploy-phases-instance",
+        ),
+        pytest.param(
+            lambda: get_pass_deploy_streams_history_events("deploy-id"),
+            id="deploy-stream-events",
+        ),
+        pytest.param(
+            lambda: get_paas_deployment_result("demo", "default", "deploy-id"),
+            id="deployment-result",
+        ),
+        pytest.param(
+            lambda: get_paas_offline_result("demo", "default", "deploy-id"),
+            id="offline-result",
+        ),
+        pytest.param(lambda: get_paas_runtime_info("demo", "default"), id="runtime-info"),
+        pytest.param(lambda: get_paas_repo_branch_info("demo", "default"), id="repo-branch-info"),
+    ],
+)
+def test_paas_api_failure_raises_readable_remote_request_error(mocker, call_paas_api):
+    detail = "无法获取源码信息: AccessToken无权限访问该仓库"
+    failed_response = {
+        "error": r"status_code is 400, resp.body=b'{\"detail\":\"\xe6\x97\xa0\xe6\xb3\x95\"}'",
+        "status_code": 400,
+        "response_data": {
+            "code": "CANNOT_GET_REPO",
+            "detail": detail,
+        },
+    }
+    mocker.patch("apigateway.components.bkpaas.get_paas3_url_prefix", return_value="https://paas.example.com/prod")
+    mocker.patch("apigateway.components.bkpaas.gen_gateway_headers", return_value={"X-Gateway": "1"})
+    mocker.patch("apigateway.components.bkpaas.http_get", return_value=(False, failed_response))
+    mocker.patch("apigateway.components.bkpaas.http_post", return_value=(False, failed_response))
+
+    with pytest.raises(error_codes.REMOTE_REQUEST_ERROR.__class__) as exc_info:
+        call_paas_api()
+
+    message = str(exc_info.value.code.message)
+    assert detail in message
+    assert r"\xe6\x97\xa0" not in message
+
+
+def test_paas_api_failure_falls_back_to_transport_error(mocker):
+    transport_error = "request timed out"
+    mocker.patch("apigateway.components.bkpaas.get_paas3_url_prefix", return_value="https://paas.example.com/prod")
+    mocker.patch("apigateway.components.bkpaas.gen_gateway_headers", return_value={"X-Gateway": "1"})
+    mocker.patch(
+        "apigateway.components.bkpaas.http_post",
+        return_value=(False, {"error": transport_error}),
+    )
+
+    with pytest.raises(error_codes.REMOTE_REQUEST_ERROR.__class__) as exc_info:
+        paas_app_module_offline("demo", "default", "prod")
+
+    assert transport_error in str(exc_info.value.code.message)


### PR DESCRIPTION
## Summary
- raise `REMOTE_REQUEST_ERROR` consistently when PaaS operations return non-2xx responses
- prefer parsed downstream `response_data.detail` so users receive readable error messages, with transport errors as fallback
- cover the affected PaaS wrappers and fallback behavior with regression tests

## Verification
- focused PaaS component tests: 16 passed
- `uv run make edition-ee && uv run make lint-check`
- `uv run make test`: 3842 passed

Made with [Cursor](https://cursor.com)