### PR TITLE
test(mcp-proxy): benchmark proxy allocation hotspots

### DIFF
--- a/src/mcp-proxy/pkg/infra/proxy/proxy_benchmark_test.go
+++ b/src/mcp-proxy/pkg/infra/proxy/proxy_benchmark_test.go
@@ -26,6 +26,7 @@ import (
 	"crypto/x509"
 	"encoding/json"
 	"encoding/pem"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -34,15 +35,25 @@ import (
 	"testing"
 	"time"
 
+	"github.com/modelcontextprotocol/go-sdk/jsonrpc"
 	"github.com/modelcontextprotocol/go-sdk/mcp"
+	segmentjson "github.com/segmentio/encoding/json"
 
 	"mcp_proxy/pkg/config"
 	"mcp_proxy/pkg/constant"
 	"mcp_proxy/pkg/infra/logging"
+	"mcp_proxy/pkg/metric"
 	"mcp_proxy/pkg/util"
 )
 
-var benchmarkToolResult *mcp.CallToolResult
+var (
+	benchmarkToolResult      *mcp.CallToolResult
+	benchmarkWireMessage     jsonrpc.Message
+	benchmarkCallToolParams  mcp.CallToolParamsRaw
+	benchmarkWireBytes       []byte
+	benchmarkResponseBody    []byte
+	benchmarkMetricsInitOnce sync.Once
+)
 
 func BenchmarkGenToolHandlerLargeJSONResponse(b *testing.B) {
 	initBenchmarkRuntime(b)
@@ -129,6 +140,189 @@ func BenchmarkGenToolHandlerLargeJSONResponse(b *testing.B) {
 	}
 }
 
+// BenchmarkGenToolHandlerLargeJSONRequest measures the production tools/call handler after
+// the MCP SDK has decoded the wire request. The arguments contain a large POST body so the
+// benchmark includes audit/API-log observation, HandlerRequest decoding, metrics, and the
+// go-openapi request-body producer.
+func BenchmarkGenToolHandlerLargeJSONRequest(b *testing.B) {
+	initBenchmarkRuntime(b)
+
+	for _, size := range []int{64 << 10, 1 << 20} {
+		size := size
+		b.Run(strconv.Itoa(size)+"B", func(b *testing.B) {
+			arguments := buildBenchmarkRequestArguments(size)
+			upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				_, _ = io.Copy(io.Discard, r.Body)
+				w.Header().Set("Content-Type", "application/json")
+				_, _ = w.Write([]byte(`{"ok":true}`))
+			}))
+			defer upstream.Close()
+
+			upstreamURL, err := url.Parse(upstream.URL)
+			if err != nil {
+				b.Fatalf("parse upstream URL: %v", err)
+			}
+
+			toolConfig := &ToolConfig{
+				Name:   "large_json_request",
+				Method: http.MethodPost,
+				Host:   upstreamURL.Host,
+				Schema: upstreamURL.Scheme,
+				Url:    "/",
+			}
+			handler := genToolHandler(toolConfig, "bench-server", func() bool {
+				return false
+			})
+			req := benchmarkCallToolRequest(toolConfig.Name, arguments)
+			ctx := benchmarkToolCallContext(b)
+
+			b.ReportAllocs()
+			b.SetBytes(int64(len(arguments)))
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				result, err := handler(ctx, req)
+				if err != nil {
+					b.Fatalf("tool handler returned error: %v", err)
+				}
+				if result == nil || len(result.Content) == 0 {
+					b.Fatal("tool handler returned empty result")
+				}
+				benchmarkToolResult = result
+			}
+		})
+	}
+}
+
+// BenchmarkMCPToolCallWireDecode isolates the official SDK's inbound copies before
+// genToolHandler starts: JSON-RPC decoding retains raw params, then MCP decoding retains
+// raw arguments. HTTP request-body io.ReadAll is intentionally outside this benchmark.
+func BenchmarkMCPToolCallWireDecode(b *testing.B) {
+	for _, size := range []int{64 << 10, 1 << 20} {
+		size := size
+		b.Run(strconv.Itoa(size)+"B", func(b *testing.B) {
+			wireBody := buildBenchmarkToolCallWireBody(size)
+
+			b.ReportAllocs()
+			b.SetBytes(int64(len(wireBody)))
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				message, err := jsonrpc.DecodeMessage(wireBody)
+				if err != nil {
+					b.Fatalf("decode JSON-RPC message: %v", err)
+				}
+				request, ok := message.(*jsonrpc.Request)
+				if !ok {
+					b.Fatalf("decoded message has type %T", message)
+				}
+				var params mcp.CallToolParamsRaw
+				decoder := segmentjson.NewDecoder(bytes.NewReader(request.Params))
+				decoder.DontMatchCaseInsensitiveStructFields()
+				if err := decoder.Decode(&params); err != nil {
+					b.Fatalf("decode tools/call params: %v", err)
+				}
+				benchmarkWireMessage = message
+				benchmarkCallToolParams = params
+			}
+		})
+	}
+}
+
+// BenchmarkMCPToolResultWireEncode isolates the official SDK's outbound copies after
+// genToolHandler returns: CallToolResult is first marshaled into Response.Result, then
+// the complete JSON-RPC response is encoded for the transport.
+func BenchmarkMCPToolResultWireEncode(b *testing.B) {
+	for _, size := range []int{64 << 10, 1 << 20} {
+		size := size
+		b.Run(strconv.Itoa(size)+"B", func(b *testing.B) {
+			body := buildBenchmarkJSONBody(size)
+			payload := newToolResponsePayload(200, "bench-upstream", "application/json", body)
+			id, err := jsonrpc.MakeID(float64(1))
+			if err != nil {
+				b.Fatalf("make JSON-RPC id: %v", err)
+			}
+
+			for _, rawResponseEnabled := range []bool{false, true} {
+				rawResponseEnabled := rawResponseEnabled
+				mode := "envelope"
+				if rawResponseEnabled {
+					mode = "raw-response"
+				}
+
+				b.Run(mode, func(b *testing.B) {
+					var resultBytes []byte
+					if rawResponseEnabled {
+						resultBytes, err = payload.marshalRawResponse()
+					} else {
+						resultBytes, err = payload.marshalEnvelope(
+							"bench-trace",
+							"bench-x-request",
+						)
+					}
+					if err != nil {
+						b.Fatalf("build tool result: %v", err)
+					}
+					result := buildToolResultFromJSONBytes(resultBytes)
+
+					b.ReportAllocs()
+					b.SetBytes(int64(len(body)))
+					b.ResetTimer()
+					for i := 0; i < b.N; i++ {
+						encodedResult, err := json.Marshal(result)
+						if err != nil {
+							b.Fatalf("marshal CallToolResult: %v", err)
+						}
+						wire, err := jsonrpc.EncodeMessage(&jsonrpc.Response{
+							ID:     id,
+							Result: encodedResult,
+						})
+						if err != nil {
+							b.Fatalf("encode JSON-RPC response: %v", err)
+						}
+						benchmarkWireBytes = wire
+					}
+				})
+			}
+		})
+	}
+}
+
+// BenchmarkReadLargeResponseBody compares the current unhinted io.ReadAll path with
+// the allocation headroom available when an upstream Content-Length can be trusted.
+func BenchmarkReadLargeResponseBody(b *testing.B) {
+	for _, size := range []int{64 << 10, 1 << 20} {
+		size := size
+		b.Run(strconv.Itoa(size)+"B", func(b *testing.B) {
+			body := buildBenchmarkJSONBody(size)
+
+			b.Run("current-io-read-all", func(b *testing.B) {
+				b.ReportAllocs()
+				b.SetBytes(int64(len(body)))
+				for i := 0; i < b.N; i++ {
+					reader := benchmarkChunkReader{body: body}
+					readBody, err := io.ReadAll(&reader)
+					if err != nil {
+						b.Fatalf("read response body: %v", err)
+					}
+					benchmarkResponseBody = readBody
+				}
+			})
+
+			b.Run("content-length-preallocated", func(b *testing.B) {
+				b.ReportAllocs()
+				b.SetBytes(int64(len(body)))
+				for i := 0; i < b.N; i++ {
+					reader := benchmarkChunkReader{body: body}
+					buffer := bytes.NewBuffer(make([]byte, 0, len(body)+bytes.MinRead))
+					if _, err := buffer.ReadFrom(&reader); err != nil {
+						b.Fatalf("read preallocated response body: %v", err)
+					}
+					benchmarkResponseBody = buffer.Bytes()
+				}
+			})
+		})
+	}
+}
+
 // BenchmarkEnvelopePreview measures the cost of rendering the envelope preview used by
 // audit/API logs. It exercises three regimes: a small JSON body that fits the limit (raw
 // embed), a large JSON body that requires truncation (string-encoded), and a non-JSON HTML
@@ -182,6 +376,8 @@ var benchmarkEnvelopePreviewSink string
 
 func initBenchmarkRuntime(b *testing.B) {
 	b.Helper()
+	b.Setenv("DEBUG", "")
+	b.Setenv("SWAGGER_DEBUG", "")
 
 	disabledLog := config.LogConfig{
 		Level:    "fatal",
@@ -200,6 +396,9 @@ func initBenchmarkRuntime(b *testing.B) {
 		},
 	}
 	logging.InitLogger(config.G)
+	benchmarkMetricsInitOnce.Do(func() {
+		metric.InitMetrics("benchmark_")
+	})
 	sharedTransportOnce = sync.Once{}
 	sharedTransport = nil
 	InitSharedTransport(config.Transport{
@@ -207,6 +406,36 @@ func initBenchmarkRuntime(b *testing.B) {
 		MaxIdleConnsPerHost:   100,
 		IdleConnTimeoutSecond: 90,
 	})
+}
+
+func benchmarkCallToolRequest(name string, arguments json.RawMessage) *mcp.CallToolRequest {
+	return &mcp.CallToolRequest{
+		Params: &mcp.CallToolParamsRaw{
+			Name:      name,
+			Arguments: arguments,
+		},
+		Extra: &mcp.RequestExtra{
+			Header: http.Header{
+				constant.RequestIDHeaderKey: []string{
+					"bench-x-request-id",
+				},
+				constant.BkGatewayRequestIDKey: []string{
+					"bench-request-id",
+				},
+				constant.BkGatewayJWTHeaderKey: []string{
+					"bench-jwt",
+				},
+				constant.BkApiMCPServerIDKey: []string{"100"},
+				constant.BkApiMCPServerNameKey: []string{
+					"bench-server",
+				},
+				constant.BkApiAllowedHeadersKey: []string{""},
+				constant.BkApiAuthorizationHeaderKey: []string{
+					"bench-authorization",
+				},
+			},
+		},
+	}
 }
 
 func benchmarkToolCallContext(b *testing.B) context.Context {
@@ -258,4 +487,41 @@ func buildBenchmarkJSONBody(targetSize int) []byte {
 	}
 	buf.WriteString(`]}`)
 	return buf.Bytes()
+}
+
+func buildBenchmarkRequestArguments(targetSize int) json.RawMessage {
+	body := buildBenchmarkJSONBody(targetSize)
+	arguments := make([]byte, 0, len(body)+len(`{"body_param":}`))
+	arguments = append(arguments, `{"body_param":`...)
+	arguments = append(arguments, body...)
+	arguments = append(arguments, '}')
+	return json.RawMessage(arguments)
+}
+
+func buildBenchmarkToolCallWireBody(targetSize int) []byte {
+	arguments := buildBenchmarkRequestArguments(targetSize)
+	wireBody := make([]byte, 0, len(arguments)+96)
+	wireBody = append(
+		wireBody,
+		`{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"large_json","arguments":`...)
+	wireBody = append(wireBody, arguments...)
+	wireBody = append(wireBody, `}}`...)
+	return wireBody
+}
+
+type benchmarkChunkReader struct {
+	body   []byte
+	offset int
+}
+
+func (r *benchmarkChunkReader) Read(p []byte) (int, error) {
+	if r.offset >= len(r.body) {
+		return 0, io.EOF
+	}
+	if len(p) > 32<<10 {
+		p = p[:32<<10]
+	}
+	n := copy(p, r.body[r.offset:])
+	r.offset += n
+	return n, nil
 }


### PR DESCRIPTION
## Summary
- add 64 KiB and 1 MiB benchmarks for the production tools/call request handler
- isolate MCP SDK inbound JSON-RPC decoding and outbound result encoding allocations
- compare the current unhinted body read with a content-length-sized buffer
- keep production behavior unchanged; this PR only adds benchmark coverage

## Why
The response marshal/unmarshal optimization is already deployed on release/1.23, but production still shows short memory spikes up to about 3.2 GiB. These benchmarks establish reproducible allocation baselines for the remaining request, response-read, and MCP SDK wire paths before implementing further optimizations.

## Verification
- benchmark smoke for all new 1 MiB cases: passed
- make build: passed
- make lint: passed with 0 issues
- proxy focused tests: 193/193 passed
- make test: 14 suites passed, composite coverage 70.1%; 81 integration-environment specs skipped by the default test configuration
