### PR TITLE
test(mcp-proxy): benchmark proxy allocation hotspots

### DIFF
--- a/src/mcp-proxy/go.mod
+++ b/src/mcp-proxy/go.mod
@@ -19,6 +19,7 @@ require (
 	github.com/onsi/gomega v1.37.0
 	github.com/prometheus/client_golang v1.22.0
 	github.com/prometheus/client_model v0.6.1
+	github.com/segmentio/encoding v0.5.4
 	github.com/spf13/cast v1.10.0
 	github.com/spf13/cobra v1.9.1
 	github.com/spf13/viper v1.21.0
@@ -121,7 +122,6 @@ require (
 	github.com/sagikazarmark/locafero v0.11.0 // indirect
 	github.com/santhosh-tekuri/jsonschema/v6 v6.0.2 // indirect
 	github.com/segmentio/asm v1.2.0 // indirect
-	github.com/segmentio/encoding v0.5.4 // indirect
 	github.com/shopspring/decimal v1.4.0 // indirect
 	github.com/sourcegraph/conc v0.3.1-0.20240121214520-5f936abd7ae8 // indirect
 	github.com/spf13/afero v1.15.0 // indirect

--- a/src/mcp-proxy/pkg/infra/proxy/proxy_benchmark_test.go
+++ b/src/mcp-proxy/pkg/infra/proxy/proxy_benchmark_test.go
@@ -35,15 +35,25 @@ import (
 	"testing"
 	"time"
 
+	"github.com/modelcontextprotocol/go-sdk/jsonrpc"
 	"github.com/modelcontextprotocol/go-sdk/mcp"
+	segmentjson "github.com/segmentio/encoding/json"
 
 	"mcp_proxy/pkg/config"
 	"mcp_proxy/pkg/constant"
 	"mcp_proxy/pkg/infra/logging"
+	"mcp_proxy/pkg/metric"
 	"mcp_proxy/pkg/util"
 )
 
-var benchmarkToolResult *mcp.CallToolResult
+var (
+	benchmarkToolResult      *mcp.CallToolResult
+	benchmarkWireMessage     jsonrpc.Message
+	benchmarkCallToolParams  mcp.CallToolParamsRaw
+	benchmarkWireBytes       []byte
+	benchmarkResponseBody    []byte
+	benchmarkMetricsInitOnce sync.Once
+)
 
 func BenchmarkGenToolHandlerLargeJSONResponse(b *testing.B) {
 	initBenchmarkRuntime(b)
@@ -130,6 +140,10 @@ func BenchmarkGenToolHandlerLargeJSONResponse(b *testing.B) {
 	}
 }
 
+// BenchmarkGenToolHandlerLargeJSONRequest measures the production tools/call handler after
+// the MCP SDK has decoded the wire request. The arguments contain a large POST body so the
+// benchmark includes audit/API-log observation, HandlerRequest decoding, metrics, and the
+// go-openapi request-body producer.
 func BenchmarkGenToolHandlerLargeJSONRequest(b *testing.B) {
 	initBenchmarkRuntime(b)
 
@@ -159,33 +173,7 @@ func BenchmarkGenToolHandlerLargeJSONRequest(b *testing.B) {
 			handler := genToolHandler(toolConfig, "bench-server", func() bool {
 				return false
 			})
-			req := &mcp.CallToolRequest{
-				Params: &mcp.CallToolParamsRaw{
-					Name:      toolConfig.Name,
-					Arguments: arguments,
-				},
-				Extra: &mcp.RequestExtra{
-					Header: http.Header{
-						constant.RequestIDHeaderKey: []string{
-							"bench-x-request-id",
-						},
-						constant.BkGatewayRequestIDKey: []string{
-							"bench-request-id",
-						},
-						constant.BkGatewayJWTHeaderKey: []string{
-							"bench-jwt",
-						},
-						constant.BkApiMCPServerIDKey: []string{"100"},
-						constant.BkApiMCPServerNameKey: []string{
-							"bench-server",
-						},
-						constant.BkApiAllowedHeadersKey: []string{""},
-						constant.BkApiAuthorizationHeaderKey: []string{
-							"bench-authorization",
-						},
-					},
-				},
-			}
+			req := benchmarkCallToolRequest(toolConfig.Name, arguments)
 			ctx := benchmarkToolCallContext(b)
 
 			b.ReportAllocs()
@@ -201,6 +189,136 @@ func BenchmarkGenToolHandlerLargeJSONRequest(b *testing.B) {
 				}
 				benchmarkToolResult = result
 			}
+		})
+	}
+}
+
+// BenchmarkMCPToolCallWireDecode isolates the official SDK's inbound copies before
+// genToolHandler starts: JSON-RPC decoding retains raw params, then MCP decoding retains
+// raw arguments. HTTP request-body io.ReadAll is intentionally outside this benchmark.
+func BenchmarkMCPToolCallWireDecode(b *testing.B) {
+	for _, size := range []int{64 << 10, 1 << 20} {
+		size := size
+		b.Run(strconv.Itoa(size)+"B", func(b *testing.B) {
+			wireBody := buildBenchmarkToolCallWireBody(size)
+
+			b.ReportAllocs()
+			b.SetBytes(int64(len(wireBody)))
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				message, err := jsonrpc.DecodeMessage(wireBody)
+				if err != nil {
+					b.Fatalf("decode JSON-RPC message: %v", err)
+				}
+				request, ok := message.(*jsonrpc.Request)
+				if !ok {
+					b.Fatalf("decoded message has type %T", message)
+				}
+				var params mcp.CallToolParamsRaw
+				decoder := segmentjson.NewDecoder(bytes.NewReader(request.Params))
+				decoder.DontMatchCaseInsensitiveStructFields()
+				if err := decoder.Decode(&params); err != nil {
+					b.Fatalf("decode tools/call params: %v", err)
+				}
+				benchmarkWireMessage = message
+				benchmarkCallToolParams = params
+			}
+		})
+	}
+}
+
+// BenchmarkMCPToolResultWireEncode isolates the official SDK's outbound copies after
+// genToolHandler returns: CallToolResult is first marshaled into Response.Result, then
+// the complete JSON-RPC response is encoded for the transport.
+func BenchmarkMCPToolResultWireEncode(b *testing.B) {
+	for _, size := range []int{64 << 10, 1 << 20} {
+		size := size
+		b.Run(strconv.Itoa(size)+"B", func(b *testing.B) {
+			body := buildBenchmarkJSONBody(size)
+			payload := newToolResponsePayload(200, "bench-upstream", "application/json", body)
+			id, err := jsonrpc.MakeID(float64(1))
+			if err != nil {
+				b.Fatalf("make JSON-RPC id: %v", err)
+			}
+
+			for _, rawResponseEnabled := range []bool{false, true} {
+				rawResponseEnabled := rawResponseEnabled
+				mode := "envelope"
+				if rawResponseEnabled {
+					mode = "raw-response"
+				}
+
+				b.Run(mode, func(b *testing.B) {
+					var resultBytes []byte
+					if rawResponseEnabled {
+						resultBytes, err = payload.marshalRawResponse()
+					} else {
+						resultBytes, err = payload.marshalEnvelope(
+							"bench-trace",
+							"bench-x-request",
+						)
+					}
+					if err != nil {
+						b.Fatalf("build tool result: %v", err)
+					}
+					result := buildToolResultFromJSONBytes(resultBytes)
+
+					b.ReportAllocs()
+					b.SetBytes(int64(len(body)))
+					b.ResetTimer()
+					for i := 0; i < b.N; i++ {
+						encodedResult, err := json.Marshal(result)
+						if err != nil {
+							b.Fatalf("marshal CallToolResult: %v", err)
+						}
+						wire, err := jsonrpc.EncodeMessage(&jsonrpc.Response{
+							ID:     id,
+							Result: encodedResult,
+						})
+						if err != nil {
+							b.Fatalf("encode JSON-RPC response: %v", err)
+						}
+						benchmarkWireBytes = wire
+					}
+				})
+			}
+		})
+	}
+}
+
+// BenchmarkReadLargeResponseBody compares the current unhinted io.ReadAll path with
+// the allocation headroom available when an upstream Content-Length can be trusted.
+func BenchmarkReadLargeResponseBody(b *testing.B) {
+	for _, size := range []int{64 << 10, 1 << 20} {
+		size := size
+		b.Run(strconv.Itoa(size)+"B", func(b *testing.B) {
+			body := buildBenchmarkJSONBody(size)
+
+			b.Run("current-io-read-all", func(b *testing.B) {
+				b.ReportAllocs()
+				b.SetBytes(int64(len(body)))
+				for i := 0; i < b.N; i++ {
+					reader := benchmarkChunkReader{body: body}
+					readBody, err := io.ReadAll(&reader)
+					if err != nil {
+						b.Fatalf("read response body: %v", err)
+					}
+					benchmarkResponseBody = readBody
+				}
+			})
+
+			b.Run("content-length-preallocated", func(b *testing.B) {
+				b.ReportAllocs()
+				b.SetBytes(int64(len(body)))
+				for i := 0; i < b.N; i++ {
+					reader := benchmarkChunkReader{body: body}
+					buffer := bytes.NewBuffer(make([]byte, 0, len(body)+bytes.MinRead))
+					if _, err := buffer.ReadFrom(&reader); err != nil {
+						b.Fatalf("read preallocated response body: %v", err)
+					}
+					benchmarkResponseBody = buffer.Bytes()
+				}
+			})
 		})
 	}
 }
@@ -258,6 +376,8 @@ var benchmarkEnvelopePreviewSink string
 
 func initBenchmarkRuntime(b *testing.B) {
 	b.Helper()
+	b.Setenv("DEBUG", "")
+	b.Setenv("SWAGGER_DEBUG", "")
 
 	disabledLog := config.LogConfig{
 		Level:    "fatal",
@@ -276,6 +396,9 @@ func initBenchmarkRuntime(b *testing.B) {
 		},
 	}
 	logging.InitLogger(config.G)
+	benchmarkMetricsInitOnce.Do(func() {
+		metric.InitMetrics("benchmark_")
+	})
 	sharedTransportOnce = sync.Once{}
 	sharedTransport = nil
 	InitSharedTransport(config.Transport{
@@ -283,6 +406,36 @@ func initBenchmarkRuntime(b *testing.B) {
 		MaxIdleConnsPerHost:   100,
 		IdleConnTimeoutSecond: 90,
 	})
+}
+
+func benchmarkCallToolRequest(name string, arguments json.RawMessage) *mcp.CallToolRequest {
+	return &mcp.CallToolRequest{
+		Params: &mcp.CallToolParamsRaw{
+			Name:      name,
+			Arguments: arguments,
+		},
+		Extra: &mcp.RequestExtra{
+			Header: http.Header{
+				constant.RequestIDHeaderKey: []string{
+					"bench-x-request-id",
+				},
+				constant.BkGatewayRequestIDKey: []string{
+					"bench-request-id",
+				},
+				constant.BkGatewayJWTHeaderKey: []string{
+					"bench-jwt",
+				},
+				constant.BkApiMCPServerIDKey: []string{"100"},
+				constant.BkApiMCPServerNameKey: []string{
+					"bench-server",
+				},
+				constant.BkApiAllowedHeadersKey: []string{""},
+				constant.BkApiAuthorizationHeaderKey: []string{
+					"bench-authorization",
+				},
+			},
+		},
+	}
 }
 
 func benchmarkToolCallContext(b *testing.B) context.Context {
@@ -343,4 +496,32 @@ func buildBenchmarkRequestArguments(targetSize int) json.RawMessage {
 	arguments = append(arguments, body...)
 	arguments = append(arguments, '}')
 	return json.RawMessage(arguments)
+}
+
+func buildBenchmarkToolCallWireBody(targetSize int) []byte {
+	arguments := buildBenchmarkRequestArguments(targetSize)
+	wireBody := make([]byte, 0, len(arguments)+96)
+	wireBody = append(
+		wireBody,
+		`{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"large_json","arguments":`...)
+	wireBody = append(wireBody, arguments...)
+	wireBody = append(wireBody, `}}`...)
+	return wireBody
+}
+
+type benchmarkChunkReader struct {
+	body   []byte
+	offset int
+}
+
+func (r *benchmarkChunkReader) Read(p []byte) (int, error) {
+	if r.offset >= len(r.body) {
+		return 0, io.EOF
+	}
+	if len(p) > 32<<10 {
+		p = p[:32<<10]
+	}
+	n := copy(p, r.body[r.offset:])
+	r.offset += n
+	return n, nil
 }


### PR DESCRIPTION
## Summary
- add 64 KiB and 1 MiB benchmarks for the production tools/call request handler
- isolate MCP SDK inbound JSON-RPC decoding and outbound result encoding allocations
- compare the current unhinted body read with a content-length-sized buffer
- keep production behavior unchanged; this PR only adds benchmark coverage
- mark the already-pinned segmentio encoding module as direct because the benchmark imports it

## Why
The response marshal/unmarshal optimization is already deployed, but production still shows short memory spikes up to about 3.2 GiB. These benchmarks establish reproducible allocation baselines for the remaining request, response-read, and MCP SDK wire paths before implementing further optimizations.

## Verification
- all new 1 MiB benchmark cases executed successfully
- make build: passed
- make lint: passed with 0 issues
- proxy focused tests: 200/200 passed
- make test: 14 suites passed, composite coverage 71.5%; 81 integration-environment specs skipped by the default test configuration

## Porting note
- carried from #3171 onto the latest upstream master
- conflict resolution preserved the request benchmark already present on master and added the new SDK and body-read cases
