### PR TITLE
perf(mcp-proxy): reduce response body allocations

### DIFF
--- a/src/mcp-proxy/pkg/infra/proxy/proxy.go
+++ b/src/mcp-proxy/pkg/infra/proxy/proxy.go
@@ -20,6 +20,7 @@
 package proxy
 
 import (
+	"bytes"
 	"context"
 	"crypto/tls"
 	"encoding/json"
@@ -55,6 +56,9 @@ import (
 	"mcp_proxy/pkg/metric"
 	"mcp_proxy/pkg/util"
 )
+
+// maxResponseBodyPreallocateSize limits only the initial allocation; response bodies are always read to EOF.
+const maxResponseBodyPreallocateSize = 1 << 20
 
 // sharedTransport 是所有 tool call 共用的 HTTP Transport，避免每次调用创建新连接池。
 // 通过 InitSharedTransport 从配置初始化，参数可在 config.yaml 的 mcpServer.transport 段调整。
@@ -1123,7 +1127,10 @@ func genToolHandler(toolApiConfig *ToolConfig, serverName string, rawResponseEna
 					var bodyBytes []byte
 					if response.Body() != nil {
 						var e error
-						bodyBytes, e = io.ReadAll(response.Body())
+						bodyBytes, e = readResponseBody(
+							response.Body(),
+							response.GetHeader("Content-Length"),
+						)
 						if e != nil {
 							return nil, e
 						}
@@ -1325,6 +1332,17 @@ func recordToolCallMetrics(
 		metric.MCPResponseBodySize.WithLabelValues(gatewayName, serverName, "tools/call").
 			Observe(float64(responseBodySize))
 	}
+}
+
+func readResponseBody(body io.Reader, contentLength string) ([]byte, error) {
+	size, err := strconv.ParseInt(contentLength, 10, 64)
+	if err != nil || size <= 0 || size > maxResponseBodyPreallocateSize {
+		return io.ReadAll(body)
+	}
+
+	buffer := bytes.NewBuffer(make([]byte, 0, int(size)+bytes.MinRead))
+	_, err = buffer.ReadFrom(body)
+	return buffer.Bytes(), err
 }
 
 // logToolCall logs MCP protocol-level request/response for tools/call.

--- a/src/mcp-proxy/pkg/infra/proxy/proxy.go
+++ b/src/mcp-proxy/pkg/infra/proxy/proxy.go
@@ -58,7 +58,7 @@ import (
 )
 
 // maxResponseBodyPreallocateSize limits only the initial allocation; response bodies are always read to EOF.
-const maxResponseBodyPreallocateSize = 1 << 20
+const maxResponseBodyPreallocateSize = 10 << 20
 
 // sharedTransport 是所有 tool call 共用的 HTTP Transport，避免每次调用创建新连接池。
 // 通过 InitSharedTransport 从配置初始化，参数可在 config.yaml 的 mcpServer.transport 段调整。

--- a/src/mcp-proxy/pkg/infra/proxy/proxy_benchmark_test.go
+++ b/src/mcp-proxy/pkg/infra/proxy/proxy_benchmark_test.go
@@ -286,8 +286,8 @@ func BenchmarkMCPToolResultWireEncode(b *testing.B) {
 	}
 }
 
-// BenchmarkReadLargeResponseBody compares the current unhinted io.ReadAll path with
-// the allocation headroom available when an upstream Content-Length can be trusted.
+// BenchmarkReadLargeResponseBody compares the previous unhinted io.ReadAll path with
+// the production response reader when an upstream Content-Length is available.
 func BenchmarkReadLargeResponseBody(b *testing.B) {
 	for _, size := range []int{64 << 10, 1 << 20} {
 		size := size
@@ -307,16 +307,16 @@ func BenchmarkReadLargeResponseBody(b *testing.B) {
 				}
 			})
 
-			b.Run("content-length-preallocated", func(b *testing.B) {
+			b.Run("production-content-length", func(b *testing.B) {
 				b.ReportAllocs()
 				b.SetBytes(int64(len(body)))
 				for i := 0; i < b.N; i++ {
 					reader := benchmarkChunkReader{body: body}
-					buffer := bytes.NewBuffer(make([]byte, 0, len(body)+bytes.MinRead))
-					if _, err := buffer.ReadFrom(&reader); err != nil {
-						b.Fatalf("read preallocated response body: %v", err)
+					readBody, err := readResponseBody(&reader, strconv.Itoa(len(body)))
+					if err != nil {
+						b.Fatalf("read response body: %v", err)
 					}
-					benchmarkResponseBody = buffer.Bytes()
+					benchmarkResponseBody = readBody
 				}
 			})
 		})

--- a/src/mcp-proxy/pkg/infra/proxy/proxy_benchmark_test.go
+++ b/src/mcp-proxy/pkg/infra/proxy/proxy_benchmark_test.go
@@ -58,7 +58,7 @@ var (
 func BenchmarkGenToolHandlerLargeJSONResponse(b *testing.B) {
 	initBenchmarkRuntime(b)
 
-	for _, size := range []int{64 << 10, 1 << 20} {
+	for _, size := range []int{64 << 10, 1 << 20, 10 << 20} {
 		size := size
 		b.Run(strconv.Itoa(size)+"B", func(b *testing.B) {
 			responseBody := buildBenchmarkJSONBody(size)
@@ -289,7 +289,7 @@ func BenchmarkMCPToolResultWireEncode(b *testing.B) {
 // BenchmarkReadLargeResponseBody compares the previous unhinted io.ReadAll path with
 // the production response reader when an upstream Content-Length is available.
 func BenchmarkReadLargeResponseBody(b *testing.B) {
-	for _, size := range []int{64 << 10, 1 << 20} {
+	for _, size := range []int{64 << 10, 1 << 20, 10 << 20} {
 		size := size
 		b.Run(strconv.Itoa(size)+"B", func(b *testing.B) {
 			body := buildBenchmarkJSONBody(size)

--- a/src/mcp-proxy/pkg/infra/proxy/response_body_test.go
+++ b/src/mcp-proxy/pkg/infra/proxy/response_body_test.go
@@ -1,0 +1,82 @@
+/*
+ * TencentBlueKing is pleased to support the open source community by making
+ * 蓝鲸智云 - API 网关(BlueKing - APIGateway) available.
+ * Copyright (C) Tencent. All rights reserved.
+ * Licensed under the MIT License (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ *     http://opensource.org/licenses/MIT
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * We undertake not to change the open source license (MIT license) applicable
+ * to the current version of the project delivered to anyone in the future.
+ */
+
+package proxy
+
+import (
+	"errors"
+	"io"
+	"strconv"
+	"strings"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("readResponseBody", func() {
+	DescribeTable("reads the complete response body regardless of the Content-Length hint",
+		func(contentLength, body string) {
+			result, err := readResponseBody(strings.NewReader(body), contentLength)
+
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result).To(Equal([]byte(body)))
+		},
+		Entry("with an exact length", "13", "complete-body"),
+		Entry("without a length", "", "complete-body"),
+		Entry("with an invalid length", "not-a-number", "complete-body"),
+		Entry("with a zero length", "0", "complete-body"),
+		Entry("with a negative length", "-1", "complete-body"),
+		Entry("with a length above the preallocation limit",
+			strconv.Itoa(maxResponseBodyPreallocateSize+1), "complete-body"),
+		Entry("with an underestimated length", "3", "complete-body"),
+		Entry("with an overestimated length", "1024", "complete-body"),
+	)
+
+	It("returns bytes read before a reader error and preserves the error", func() {
+		readErr := errors.New("response read failed")
+		reader := &errorResponseReader{
+			body: []byte("partial-body"),
+			err:  readErr,
+		}
+
+		result, err := readResponseBody(reader, strconv.Itoa(len(reader.body)))
+
+		Expect(result).To(Equal([]byte("partial-body")))
+		Expect(err).To(MatchError(readErr))
+	})
+})
+
+type errorResponseReader struct {
+	body []byte
+	err  error
+}
+
+func (r *errorResponseReader) Read(p []byte) (int, error) {
+	if len(r.body) == 0 {
+		return 0, r.err
+	}
+
+	n := copy(p, r.body)
+	r.body = r.body[n:]
+	if len(r.body) == 0 {
+		return n, r.err
+	}
+	return n, nil
+}
+
+var _ io.Reader = (*errorResponseReader)(nil)


### PR DESCRIPTION
## Summary
- use a validated upstream `Content-Length` as a bounded capacity hint when reading tool-call responses
- preallocate responses up to 10 MiB; keep the existing `io.ReadAll` fallback for missing, invalid, non-positive, or larger hints
- always read to EOF and preserve partial bytes/read errors, so the response contract is unchanged
- add behavior-locking unit tests and benchmark 64 KiB, 1 MiB, and 10 MiB responses through the production reader

## Benchmark

`go test -mod=mod ./pkg/infra/proxy -run '^$' -bench '^(BenchmarkReadLargeResponseBody|BenchmarkGenToolHandlerLargeJSONResponse)/10485760B' -benchmem -count=3`

| Body size | Reader | ns/op (median) | B/op (median) | allocs/op |
| --- | --- | ---: | ---: | ---: |
| 10 MiB | previous `io.ReadAll` | 9,910,456 | 52,263,207 | 38 |
| 10 MiB | production with Content-Length | 1,850,759 | 10,493,995 | 3 |

For the 10 MiB case, allocated bytes drop by about 79.9%, allocations drop from 38 to 3, and median elapsed time drops by about 81.3%.

The full handler benchmark at 10 MiB still exposes downstream JSON/MCP result costs: the envelope path uses about 82.6-83.9 MB/op and the raw-response path uses about 62.9 MB/op.

## Verification
- `go test -mod=mod ./pkg/infra/proxy`
- 10 MiB benchmark command above (`count=3`)
- `make lint` (0 issues)
- `make test` (14 suites passed; 81 Docker-backed integration specs were skipped by their suite guard)
- `git diff --check upstream/master...HEAD`
