### PR TITLE
fix: handle expected 400 when ITSM system is not registered

### DIFF
--- a/src/dashboard/apigateway/apigateway/components/bkitsm.py
+++ b/src/dashboard/apigateway/apigateway/components/bkitsm.py
@@ -31,6 +31,10 @@ from .utils import do_blueking_http_request, gen_gateway_headers
 logger = logging.getLogger(__name__)
 
 
+class ItsmSystemNotFoundError(Exception):
+    """ITSM system has not been registered yet."""
+
+
 class ItsmWorkflow(BaseModel):
     form_schema: Dict[str, Any]
 
@@ -146,6 +150,25 @@ def system_migrate(workflow_template: Dict[str, Any]) -> Dict[str, Any]:
     )
 
 
+def _system_workflow_list_http_get(system_id: str):
+    def request(*args, **kwargs):
+        ok, resp_data = http_get(*args, **kwargs)
+        if not ok:
+            response_data = resp_data.get("response_data") or {}
+            try:
+                code = int(response_data.get("code"))
+            except TypeError, ValueError:
+                code = None
+
+            if resp_data.get("status_code") == 400 and code == 40000:
+                raise ItsmSystemNotFoundError(f"ITSM system does not exist, system_id={system_id}")
+
+        return ok, resp_data
+
+    request.__name__ = http_get.__name__
+    return request
+
+
 def system_workflow_list(
     system_id: str,
     system_token: str = "",
@@ -157,6 +180,8 @@ def system_workflow_list(
 
     调用接口: system_workflow_list (GET)
     路径: /api/v1/system_workflow/list/
+
+    系统尚未注册时 ITSM 会返回 HTTP 400 且 code=40000，按未注册（空列表）处理。
     """
     data = {
         "system_id": system_id,
@@ -170,13 +195,18 @@ def system_workflow_list(
     elif settings.BK_ITSM4_SYSTEM_TOKEN:
         more_headers["SYSTEM-TOKEN"] = settings.BK_ITSM4_SYSTEM_TOKEN
 
-    resp = _call_bkitsm_api(
-        http_get,
-        "/api/v1/system_workflow/list/",
-        data,
-        more_headers=more_headers,
-        timeout=settings.BK_ITSM4_API_TIMEOUT,
-    )
+    try:
+        resp = _call_bkitsm_api(
+            _system_workflow_list_http_get(system_id),
+            "/api/v1/system_workflow/list/",
+            data,
+            more_headers=more_headers,
+            timeout=settings.BK_ITSM4_API_TIMEOUT,
+        )
+    except ItsmSystemNotFoundError:
+        logger.info("ITSM system not found, treat as not registered, system_id=%s", system_id)
+        return ItsmWorkflowList.empty()
+
     return ItsmWorkflowList.from_response(resp)
 
 

--- a/src/dashboard/apigateway/apigateway/tests/components/test_bkitsm.py
+++ b/src/dashboard/apigateway/apigateway/tests/components/test_bkitsm.py
@@ -20,6 +20,7 @@
 import pytest
 from pydantic import ValidationError
 
+from apigateway.common.error_codes import error_codes
 from apigateway.components.bkitsm import (
     ItsmFormModelUpdateResult,
     ItsmTicketItem,
@@ -28,6 +29,7 @@ from apigateway.components.bkitsm import (
     _call_bkitsm_api,
     create_ticket,
     get_ticket_by_id,
+    system_workflow_list,
     update_form_model,
 )
 
@@ -57,6 +59,66 @@ def test_itsm_workflow_list_requires_results_shape():
 
     with pytest.raises(ValidationError):
         ItsmWorkflowList.from_response({"count": 1, "results": ["invalid"]})
+
+
+def test_system_workflow_list_returns_empty_when_system_not_found(settings, mocker):
+    settings.BK_ITSM4_URL_PREFIX = "http://bk-itsm4.example.com/prod"
+    settings.BK_ITSM4_API_TIMEOUT = 30
+    settings.BK_ITSM4_SYSTEM_TOKEN = ""
+
+    mock_http_get = mocker.patch(
+        "apigateway.components.bkitsm.http_get",
+        return_value=(
+            False,
+            {
+                "error": "status_code is 400, not 2xx!",
+                "status_code": 400,
+                "response_data": {
+                    "result": False,
+                    "code": "40000",
+                    "message": "message text should not be parsed",
+                    "data": {"detail": "message text should not be parsed"},
+                },
+            },
+        ),
+    )
+    mock_http_get.__name__ = "http_get"
+
+    result = system_workflow_list(system_id="bk-apigateway")
+
+    assert result.is_registered is False
+    assert result.count == 0
+    assert result.workflows == []
+    assert "ignored_error_status_codes" not in mock_http_get.call_args.kwargs
+
+
+@pytest.mark.parametrize(
+    "status_code, code",
+    [
+        (400, "40001"),
+        (500, "40000"),
+    ],
+)
+def test_system_workflow_list_keeps_unexpected_remote_error(settings, mocker, status_code, code):
+    settings.BK_ITSM4_URL_PREFIX = "http://bk-itsm4.example.com/prod"
+    settings.BK_ITSM4_API_TIMEOUT = 30
+    settings.BK_ITSM4_SYSTEM_TOKEN = ""
+
+    mock_http_get = mocker.patch(
+        "apigateway.components.bkitsm.http_get",
+        return_value=(
+            False,
+            {
+                "error": f"status_code is {status_code}, not 2xx!",
+                "status_code": status_code,
+                "response_data": {"result": False, "code": code, "message": "remote error"},
+            },
+        ),
+    )
+    mock_http_get.__name__ = "http_get"
+
+    with pytest.raises(error_codes.REMOTE_REQUEST_ERROR.__class__):
+        system_workflow_list(system_id="bk-apigateway")
 
 
 def test_itsm_form_model_update_result_extract_updated_fields():

--- a/src/dashboard/apigateway/apigateway/tests/service/test_bk_itsm.py
+++ b/src/dashboard/apigateway/apigateway/tests/service/test_bk_itsm.py
@@ -303,6 +303,35 @@ class TestItsmPermissionApplyHelper:
 
         mock_system_migrate.assert_not_called()
 
+    def test_register_to_itsm_migrates_when_system_not_registered(self, mocker):
+        parser = argparse.ArgumentParser()
+        RegisterToItsmCommand().add_arguments(parser)
+        options = parser.parse_args([])
+
+        command = RegisterToItsmCommand()
+        mocker.patch.object(command, "_get_system_workflow_list", return_value=ItsmWorkflowList.empty())
+        mock_system_migrate = mocker.patch(
+            "apigateway.apps.bk_itsm.management.commands.register_to_itsm.system_migrate"
+        )
+        mock_ensure_config = mocker.patch.object(command, "_ensure_config_from_template")
+
+        command.handle(**vars(options))
+
+        mock_system_migrate.assert_called_once()
+        mock_ensure_config.assert_called_once()
+
+    def test_get_system_workflow_list_does_not_warn_when_system_not_found(self, mocker):
+        mocker.patch(
+            "apigateway.apps.bk_itsm.management.commands.register_to_itsm.system_workflow_list",
+            return_value=ItsmWorkflowList.empty(),
+        )
+        mock_logger = mocker.patch("apigateway.apps.bk_itsm.management.commands.register_to_itsm.logger")
+
+        result = RegisterToItsmCommand._get_system_workflow_list("bk-apigateway")
+
+        assert result.is_registered is False
+        mock_logger.warning.assert_not_called()
+
     def test_register_to_itsm_build_form_model_update_payload(self):
         parser = argparse.ArgumentParser()
         RegisterToItsmCommand().add_arguments(parser)


### PR DESCRIPTION
- 首次注册 ITSM 时，将查询未注册系统返回的预期 400 按未注册处理，避免误报失败日志。