### PR TITLE
fix(dashboard): filter inner MCP servers by tenant

### DIFF
--- a/src/dashboard/apigateway/apigateway/apis/v2/inner/views.py
+++ b/src/dashboard/apigateway/apigateway/apis/v2/inner/views.py
@@ -61,7 +61,10 @@ from apigateway.biz.validators import BKAppCodeValidator
 from apigateway.common.error_codes import error_codes
 from apigateway.common.pagination import BoundedLimitOffsetPagination
 from apigateway.common.tenant.constants import TenantModeEnum
-from apigateway.common.tenant.query import gateway_filter_by_app_tenant_id
+from apigateway.common.tenant.query import (
+    gateway_filter_by_app_tenant_id,
+    gateway_mcp_server_filter_by_user_tenant_id,
+)
 from apigateway.components.bkauth import get_app_tenant_info
 from apigateway.controller.publisher.publish import trigger_gateway_publish
 from apigateway.core.constants import (
@@ -1285,6 +1288,9 @@ class MCPServerListApi(generics.ListAPIView):
             keyword=slz.validated_data.get("keyword"),
             order_by=slz.validated_data.get("order_by", "-updated_time"),
         )
+        tenant_id = get_request_tenant_id(request)
+        if tenant_id:
+            queryset = gateway_mcp_server_filter_by_user_tenant_id(queryset, tenant_id)
 
         page = self.paginate_queryset(queryset)
         fields = slz.validated_data.get("fields")
@@ -1307,12 +1313,14 @@ class MCPServerLookupApi(generics.ListAPIView):
         slz = serializers.MCPServerLookupInputSLZ(data=request.query_params)
         slz.is_valid(raise_exception=True)
 
-        mcp_servers = list(
-            MCPServerHandler.build_list_queryset(
-                ids=slz.validated_data.get("ids") or None,
-                names=slz.validated_data.get("names") or None,
-            )
+        queryset = MCPServerHandler.build_list_queryset(
+            ids=slz.validated_data.get("ids") or None,
+            names=slz.validated_data.get("names") or None,
         )
+        tenant_id = get_request_tenant_id(request)
+        if tenant_id:
+            queryset = gateway_mcp_server_filter_by_user_tenant_id(queryset, tenant_id)
+        mcp_servers = list(queryset)
         fields = slz.validated_data.get("fields")
         return OKJsonResponse(data=_serialize_mcp_servers(mcp_servers, fields))
 

--- a/src/dashboard/apigateway/apigateway/tests/apis/v2/inner/test_views.py
+++ b/src/dashboard/apigateway/apigateway/tests/apis/v2/inner/test_views.py
@@ -47,6 +47,7 @@ from apigateway.apps.mcp_server.models import (
 from apigateway.apps.monitor.constants import AlarmStatusEnum, AlarmTypeEnum
 from apigateway.apps.monitor.models import AlarmRecord
 from apigateway.apps.permission.models import AppPermissionRecord
+from apigateway.common.tenant.constants import TenantModeEnum
 from apigateway.core.constants import GatewayKindEnum, GatewayStatusEnum, StageStatusEnum
 from apigateway.core.models import Gateway, Release, Resource, Stage
 from apigateway.tests.utils.testing import get_response_json
@@ -2039,6 +2040,66 @@ class TestMCPServerListApi:
 
         assert resp.status_code == 400
 
+    def test_list_filters_by_gateway_tenant(self, request_view, settings):
+        settings.ENABLE_MULTI_TENANT_MODE = True
+        gateways = [
+            G(
+                Gateway,
+                name="global-gateway",
+                status=GatewayStatusEnum.ACTIVE.value,
+                tenant_mode=TenantModeEnum.GLOBAL.value,
+                tenant_id="",
+            ),
+            G(
+                Gateway,
+                name="tenant-a-gateway",
+                status=GatewayStatusEnum.ACTIVE.value,
+                tenant_mode=TenantModeEnum.SINGLE.value,
+                tenant_id="tenant-a",
+            ),
+            G(
+                Gateway,
+                name="tenant-b-gateway",
+                status=GatewayStatusEnum.ACTIVE.value,
+                tenant_mode=TenantModeEnum.SINGLE.value,
+                tenant_id="tenant-b",
+            ),
+        ]
+        for gateway in gateways:
+            stage = G(Stage, gateway=gateway, status=StageStatusEnum.ACTIVE.value)
+            G(
+                MCPServer,
+                gateway=gateway,
+                stage=stage,
+                name=f"{gateway.name}-mcp",
+                status=MCPServerStatusEnum.ACTIVE.value,
+            )
+
+        resp = request_view(
+            method="GET",
+            view_name="openapi.v2.inner.mcp_server.list",
+            data={"fields": "name", "order_by": "name"},
+            app=mock.MagicMock(app_code="test"),
+            HTTP_X_BK_TENANT_ID="tenant-a",
+        )
+
+        assert resp.status_code == 200
+        assert [item["name"] for item in resp.json()["data"]["results"]] == [
+            "global-gateway-mcp",
+            "tenant-a-gateway-mcp",
+        ]
+
+    def test_list_requires_tenant_header_in_multi_tenant_mode(self, request_view, settings):
+        settings.ENABLE_MULTI_TENANT_MODE = True
+
+        resp = request_view(
+            method="GET",
+            view_name="openapi.v2.inner.mcp_server.list",
+            app=mock.MagicMock(app_code="test"),
+        )
+
+        assert resp.status_code == 400
+
     def test_list_with_dynamic_fields_skips_unneeded_context_building(self, request_view, fake_gateway, mocker):
         fake_gateway.status = GatewayStatusEnum.ACTIVE.value
         fake_gateway.save(update_fields=["status"])
@@ -2423,6 +2484,69 @@ class TestMCPServerListApi:
 
 
 class TestMCPServerLookupApi:
+    def test_lookup_filters_by_gateway_tenant(self, request_view, settings):
+        settings.ENABLE_MULTI_TENANT_MODE = True
+        gateways = [
+            G(
+                Gateway,
+                name="global-lookup-gateway",
+                status=GatewayStatusEnum.ACTIVE.value,
+                tenant_mode=TenantModeEnum.GLOBAL.value,
+                tenant_id="",
+            ),
+            G(
+                Gateway,
+                name="tenant-a-lookup-gateway",
+                status=GatewayStatusEnum.ACTIVE.value,
+                tenant_mode=TenantModeEnum.SINGLE.value,
+                tenant_id="tenant-a",
+            ),
+            G(
+                Gateway,
+                name="tenant-b-lookup-gateway",
+                status=GatewayStatusEnum.ACTIVE.value,
+                tenant_mode=TenantModeEnum.SINGLE.value,
+                tenant_id="tenant-b",
+            ),
+        ]
+        mcp_server_names = []
+        for gateway in gateways:
+            stage = G(Stage, gateway=gateway, status=StageStatusEnum.ACTIVE.value)
+            mcp_server = G(
+                MCPServer,
+                gateway=gateway,
+                stage=stage,
+                name=f"{gateway.name}-mcp",
+                status=MCPServerStatusEnum.ACTIVE.value,
+            )
+            mcp_server_names.append(mcp_server.name)
+
+        resp = request_view(
+            method="GET",
+            view_name="openapi.v2.inner.mcp_server.lookup",
+            data={"names": ",".join(mcp_server_names), "fields": "name"},
+            app=mock.MagicMock(app_code="test"),
+            HTTP_X_BK_TENANT_ID="tenant-a",
+        )
+
+        assert resp.status_code == 200
+        assert {item["name"] for item in resp.json()["data"]} == {
+            "global-lookup-gateway-mcp",
+            "tenant-a-lookup-gateway-mcp",
+        }
+
+    def test_lookup_requires_tenant_header_in_multi_tenant_mode(self, request_view, settings):
+        settings.ENABLE_MULTI_TENANT_MODE = True
+
+        resp = request_view(
+            method="GET",
+            view_name="openapi.v2.inner.mcp_server.lookup",
+            data={"names": "missing"},
+            app=mock.MagicMock(app_code="test"),
+        )
+
+        assert resp.status_code == 400
+
     def test_lookup_with_ids_returns_unpaginated_results(self, request_view, fake_gateway):
         fake_gateway.status = GatewayStatusEnum.ACTIVE.value
         fake_gateway.maintainers = ["admin"]


### PR DESCRIPTION
## Summary

- read the request tenant ID in the inner MCP Server list and lookup endpoints
- restrict results to global gateways and gateways owned by the current tenant
- reject missing tenant headers in multi-tenant mode
- add regression coverage for list and lookup tenant isolation

## Verification

- focused MCP Server list and lookup tests: 29 passed
- Dashboard full test suite: 3872 passed
- Dashboard lint-check: passed, OpenAPI consistency 0 errors with 39 existing warnings
- pre-commit hooks: passed
