### PR TITLE
fix(dashboard): isolate MCP APIs by gateway tenant

### DIFF
--- a/src/dashboard/apigateway/apigateway/apis/v2/inner/views.py
+++ b/src/dashboard/apigateway/apigateway/apis/v2/inner/views.py
@@ -64,6 +64,7 @@ from apigateway.common.tenant.constants import TenantModeEnum
 from apigateway.common.tenant.query import (
     gateway_filter_by_app_tenant_id,
     gateway_mcp_server_filter_by_user_tenant_id,
+    mcp_server_related_filter_by_user_tenant_id,
 )
 from apigateway.components.bkauth import get_app_tenant_info
 from apigateway.controller.publisher.publish import trigger_gateway_publish
@@ -928,6 +929,9 @@ class MCPServerPermissionListApi(generics.ListAPIView):
         queryset = MCPServer.objects.filter(is_public=True, status=MCPServerStatusEnum.ACTIVE.value).select_related(
             "gateway", "stage"
         )
+        tenant_id = get_request_tenant_id(request)
+        if tenant_id:
+            queryset = gateway_mcp_server_filter_by_user_tenant_id(queryset, tenant_id)
 
         keyword = data.get("keyword")
         if keyword:
@@ -1040,6 +1044,7 @@ class MCPServerAppPermissionApplyCreateApi(generics.CreateAPIView):
             data["mcp_server_ids"],
             data["reason"],
             data["applied_by"],
+            tenant_id=get_request_tenant_id(request),
         )
 
         if queryset.count() == 0:
@@ -1076,12 +1081,17 @@ class MCPServerAppPermissionListApi(generics.ListAPIView):
         granted_permissions = MCPServerAppPermission.objects.filter(
             bk_app_code=target_app_code,
         ).select_related("mcp_server", "mcp_server__gateway", "mcp_server__stage")
+        tenant_id = get_request_tenant_id(request)
+        if tenant_id:
+            granted_permissions = mcp_server_related_filter_by_user_tenant_id(granted_permissions, tenant_id)
 
         # 2. 查询申请通过的记录，用于获取 handled_by 信息
         approved_applies = MCPServerAppPermissionApply.objects.filter(
             bk_app_code=target_app_code,
             status__in=[MCPServerAppPermissionApplyStatusEnum.APPROVED.value],
         ).order_by("-applied_time")
+        if tenant_id:
+            approved_applies = mcp_server_related_filter_by_user_tenant_id(approved_applies, tenant_id)
         handled_by_map = {obj.mcp_server_id: obj.handled_by for obj in approved_applies}
 
         mcp_servers = [perm.mcp_server for perm in granted_permissions]
@@ -1145,6 +1155,9 @@ class MCPServerAppPermissionRecordListApi(generics.ListAPIView):
             data.get("applied_time_start"),
             data.get("applied_time_end"),
         ).select_related("mcp_server", "mcp_server__gateway", "mcp_server__stage")
+        tenant_id = get_request_tenant_id(request)
+        if tenant_id:
+            queryset = mcp_server_related_filter_by_user_tenant_id(queryset, tenant_id)
 
         mcp_server_permission_records = [
             {
@@ -1213,9 +1226,13 @@ class MCPServerAppPermissionRecordRetrieveApi(generics.RetrieveAPIView):
         data = slz.validated_data
 
         try:
-            return MCPServerAppPermissionApply.objects.select_related(
+            queryset = MCPServerAppPermissionApply.objects.select_related(
                 "mcp_server", "mcp_server__gateway", "mcp_server__stage"
-            ).get(bk_app_code=data["target_app_code"], id=record_id)
+            ).filter(bk_app_code=data["target_app_code"], id=record_id)
+            tenant_id = get_request_tenant_id(self.request)
+            if tenant_id:
+                queryset = mcp_server_related_filter_by_user_tenant_id(queryset, tenant_id)
+            return queryset.get()
         except MCPServerAppPermissionApply.DoesNotExist:
             raise error_codes.NOT_FOUND
 

--- a/src/dashboard/apigateway/apigateway/apis/v2/open/views.py
+++ b/src/dashboard/apigateway/apigateway/apis/v2/open/views.py
@@ -53,7 +53,11 @@ from apigateway.biz.resource_version import ResourceVersionHandler
 from apigateway.common.django.translation import get_current_language_code
 from apigateway.common.error_codes import error_codes
 from apigateway.common.tenant.constants import TenantModeEnum
-from apigateway.common.tenant.query import gateway_filter_by_app_tenant_id
+from apigateway.common.tenant.query import (
+    gateway_filter_by_app_tenant_id,
+    gateway_mcp_server_filter_by_user_tenant_id,
+    mcp_server_related_filter_by_user_tenant_id,
+)
 from apigateway.components.bkauth import get_app_tenant_info
 from apigateway.core.constants import (
     GatewayKindNameEnum,
@@ -306,6 +310,9 @@ class MCPServerListApi(generics.ListAPIView):
             is_public=True,
             order_by="-updated_time",
         )
+        tenant_id = get_request_tenant_id(request)
+        if tenant_id:
+            queryset = gateway_mcp_server_filter_by_user_tenant_id(queryset, tenant_id)
 
         page = self.paginate_queryset(queryset)
         context = MCPServerHandler.build_list_context(page)
@@ -354,6 +361,9 @@ class MCPServerAppPermissionListApi(generics.ListAPIView):
         slz.is_valid(raise_exception=True)
 
         queryset = MCPServerAppPermission.objects.filter(bk_app_code=slz.validated_data["bk_app_code"])
+        tenant_id = get_request_tenant_id(request)
+        if tenant_id:
+            queryset = mcp_server_related_filter_by_user_tenant_id(queryset, tenant_id)
         page = self.paginate_queryset(queryset)
 
         # Build categories map
@@ -374,8 +384,14 @@ class MCPServerAppPermissionListApi(generics.ListAPIView):
 )
 class MCPServerPermissionListApi(generics.ListAPIView):
     permission_classes = [OpenAPIV2Permission]
-    queryset = MCPServer.objects.all()
     lookup_url_kwarg = "mcp_server_id"
+
+    def get_queryset(self):
+        queryset = MCPServer.objects.all()
+        tenant_id = get_request_tenant_id(self.request)
+        if tenant_id:
+            queryset = gateway_mcp_server_filter_by_user_tenant_id(queryset, tenant_id)
+        return queryset
 
     def list(self, request, *args, **kwargs):
         instance = self.get_object()
@@ -415,6 +431,7 @@ class MCPServerAppPermissionApplyCreateApi(generics.CreateAPIView):
             data["mcp_server_ids"],
             data["reason"],
             data["applied_by"],
+            tenant_id=get_request_tenant_id(request),
         )
 
         if queryset.count() == 0:
@@ -448,6 +465,9 @@ class MCPServerAppPermissionRecordListApi(generics.ListAPIView):
         queryset = MCPServerAppPermissionApply.objects.filter(
             bk_app_code=data["bk_app_code"],
         )
+        tenant_id = get_request_tenant_id(request)
+        if tenant_id:
+            queryset = mcp_server_related_filter_by_user_tenant_id(queryset, tenant_id)
 
         if data.get("mcp_server_id"):
             queryset = queryset.filter(mcp_server_id=data["mcp_server_id"])
@@ -491,6 +511,9 @@ class MCPServerAppPermissionRecordLookupApi(generics.ListAPIView):
             bk_app_code=data["bk_app_code"],
             id__in=data["ids"],
         ).order_by("id")
+        tenant_id = get_request_tenant_id(request)
+        if tenant_id:
+            queryset = mcp_server_related_filter_by_user_tenant_id(queryset, tenant_id)
         categories_map = MCPServerHandler.build_categories_map(list(queryset.values_list("mcp_server_id", flat=True)))
         output_slz = MCPServerAppPermissionApplyRecordListOutputSLZ(
             queryset,
@@ -521,6 +544,9 @@ class UserMCPServerListApi(generics.ListAPIView):
             gateway__status=GatewayStatusEnum.ACTIVE.value,
             stage__status=StageStatusEnum.ACTIVE.value,
         )
+        tenant_id = get_request_tenant_id(request)
+        if tenant_id:
+            queryset = gateway_mcp_server_filter_by_user_tenant_id(queryset, tenant_id)
 
         is_public = slz.validated_data.get("is_public", None)
         if is_public is None:
@@ -859,9 +885,15 @@ class MCPServerRetrieveApi(generics.RetrieveAPIView):
     """
 
     permission_classes = [OpenAPIV2Permission]
-    queryset = MCPServer.objects.all()
     serializer_class = MCPServerRetrieveOutputSLZ
     lookup_url_kwarg = "mcp_server_id"
+
+    def get_queryset(self):
+        queryset = MCPServer.objects.all()
+        tenant_id = get_request_tenant_id(self.request)
+        if tenant_id:
+            queryset = gateway_mcp_server_filter_by_user_tenant_id(queryset, tenant_id)
+        return queryset
 
     def retrieve(self, request, *args, **kwargs):
         instance = self.get_object()

--- a/src/dashboard/apigateway/apigateway/biz/mcp_server/permission.py
+++ b/src/dashboard/apigateway/apigateway/biz/mcp_server/permission.py
@@ -29,7 +29,10 @@ from apigateway.apps.mcp_server.constants import (
 from apigateway.apps.mcp_server.models import MCPServer, MCPServerAppPermissionApply
 from apigateway.apps.permission.constants import FormattedGrantDimensionEnum
 from apigateway.common.error_codes import error_codes
-from apigateway.common.tenant.query import gateway_filter_by_maintainer_tenant_id
+from apigateway.common.tenant.query import (
+    gateway_filter_by_maintainer_tenant_id,
+    gateway_mcp_server_filter_by_user_tenant_id,
+)
 from apigateway.core.constants import GatewayStatusEnum, StageStatusEnum
 from apigateway.core.models import Gateway
 from apigateway.service.bk_itsm import ItsmPermissionApplyHelper
@@ -57,13 +60,21 @@ class MCPServerPermissionHandler:
         )
 
     @staticmethod
-    def create_apply(bk_app_code: str, mcp_server_ids: List[int], reason: str, applied_by: str):
+    def create_apply(
+        bk_app_code: str,
+        mcp_server_ids: List[int],
+        reason: str,
+        applied_by: str,
+        tenant_id: Optional[str] = None,
+    ):
         queryset = MCPServer.objects.filter(
             id__in=mcp_server_ids,
             status=MCPServerStatusEnum.ACTIVE.value,
             gateway__status=GatewayStatusEnum.ACTIVE.value,
             stage__status=StageStatusEnum.ACTIVE.value,
         )
+        if tenant_id:
+            queryset = gateway_mcp_server_filter_by_user_tenant_id(queryset, tenant_id)
 
         selected_mcp_server_ids = list(queryset.values_list("id", flat=True))
         if set(selected_mcp_server_ids) != set(mcp_server_ids):

--- a/src/dashboard/apigateway/apigateway/tests/apis/v2/inner/test_views.py
+++ b/src/dashboard/apigateway/apigateway/tests/apis/v2/inner/test_views.py
@@ -1092,6 +1092,7 @@ class TestMCPServerAppPermissionRecordListApi:
             view_name="openapi.v2.inner.mcp_server.permission.apply-records",
             data={"target_app_code": "test-app"},
             app=mock.MagicMock(app_code="test"),
+            HTTP_X_BK_TENANT_ID="tenant-1",
         )
         result = resp.json()
 
@@ -1262,6 +1263,7 @@ class TestMCPServerAppPermissionRecordRetrieveApi:
             path_params={"record_id": apply_record.id},
             data={"target_app_code": "test-app"},
             app=mock.MagicMock(app_code="test"),
+            HTTP_X_BK_TENANT_ID="tenant-1",
         )
         result = resp.json()
 

--- a/src/dashboard/apigateway/apigateway/tests/apis/v2/test_mcp_tenant_isolation.py
+++ b/src/dashboard/apigateway/apigateway/tests/apis/v2/test_mcp_tenant_isolation.py
@@ -1,0 +1,306 @@
+# -*- coding: utf-8 -*-
+#
+# TencentBlueKing is pleased to support the open source community by making
+# 蓝鲸智云 - API 网关(BlueKing - APIGateway) available.
+# Copyright (C) Tencent. All rights reserved.
+# Licensed under the MIT License (the "License"); you may not use this file except
+# in compliance with the License. You may obtain a copy of the License at
+#
+#     http://opensource.org/licenses/MIT
+#
+from unittest import mock
+
+import pytest
+from django_dynamic_fixture import G
+
+from apigateway.apps.mcp_server.constants import (
+    MCPServerAppPermissionApplyStatusEnum,
+    MCPServerAppPermissionGrantTypeEnum,
+    MCPServerStatusEnum,
+)
+from apigateway.apps.mcp_server.models import MCPServer, MCPServerAppPermission, MCPServerAppPermissionApply
+from apigateway.biz.mcp_server import MCPServerHandler, MCPServerPermissionHandler
+from apigateway.common.tenant.constants import TenantModeEnum
+from apigateway.core.constants import GatewayStatusEnum, StageStatusEnum
+from apigateway.core.models import Gateway, Stage
+
+TENANT_HEADER = {"HTTP_X_BK_TENANT_ID": "tenant-a"}
+TARGET_APP_CODE = "tenant-isolation-app"
+
+
+@pytest.fixture
+def tenant_mcp_servers(settings):
+    settings.ENABLE_MULTI_TENANT_MODE = True
+
+    result = {}
+    for key, tenant_mode, tenant_id in [
+        ("global", TenantModeEnum.GLOBAL.value, ""),
+        ("same", TenantModeEnum.SINGLE.value, "tenant-a"),
+        ("other", TenantModeEnum.SINGLE.value, "tenant-b"),
+    ]:
+        gateway = G(
+            Gateway,
+            name=f"tenant-isolation-{key}-gateway",
+            status=GatewayStatusEnum.ACTIVE.value,
+            is_public=True,
+            tenant_mode=tenant_mode,
+            tenant_id=tenant_id,
+        )
+        stage = G(Stage, gateway=gateway, name="prod", status=StageStatusEnum.ACTIVE.value)
+        result[key] = G(
+            MCPServer,
+            gateway=gateway,
+            stage=stage,
+            name=f"tenant-isolation-{key}-mcp",
+            status=MCPServerStatusEnum.ACTIVE.value,
+            is_public=True,
+        )
+
+    return result
+
+
+def _create_permissions(tenant_mcp_servers):
+    return {
+        key: G(
+            MCPServerAppPermission,
+            bk_app_code=TARGET_APP_CODE,
+            mcp_server=mcp_server,
+            grant_type=MCPServerAppPermissionGrantTypeEnum.APPLY.value,
+        )
+        for key, mcp_server in tenant_mcp_servers.items()
+    }
+
+
+def _create_apply_records(tenant_mcp_servers):
+    return {
+        key: G(
+            MCPServerAppPermissionApply,
+            bk_app_code=TARGET_APP_CODE,
+            mcp_server=mcp_server,
+            applied_by="test-user",
+            status=MCPServerAppPermissionApplyStatusEnum.PENDING.value,
+        )
+        for key, mcp_server in tenant_mcp_servers.items()
+    }
+
+
+class TestOpenMCPServerTenantIsolation:
+    def test_list_filters_by_gateway_tenant(self, request_view, tenant_mcp_servers):
+        response = request_view(
+            method="GET",
+            view_name="openapi.v2.open.mcp_server.list",
+            app=mock.MagicMock(app_code="test"),
+            **TENANT_HEADER,
+        )
+
+        assert response.status_code == 200
+        assert {item["name"] for item in response.json()["data"]["results"]} == {
+            tenant_mcp_servers["global"].name,
+            tenant_mcp_servers["same"].name,
+        }
+
+    def test_retrieve_hides_cross_tenant_mcp_server(self, request_view, tenant_mcp_servers, mocker):
+        build_context = mocker.patch.object(
+            MCPServerHandler,
+            "build_retrieve_context",
+            side_effect=AssertionError("cross-tenant MCP Server reached serialization"),
+        )
+
+        response = request_view(
+            method="GET",
+            view_name="openapi.v2.open.mcp_server.retrieve",
+            path_params={"mcp_server_id": tenant_mcp_servers["other"].id},
+            user=mock.MagicMock(username="test-user"),
+            app=mock.MagicMock(app_code="test"),
+            **TENANT_HEADER,
+        )
+
+        assert response.status_code == 404
+        build_context.assert_not_called()
+
+    def test_permission_list_hides_cross_tenant_mcp_server(self, request_view, tenant_mcp_servers):
+        _create_permissions(tenant_mcp_servers)
+
+        response = request_view(
+            method="GET",
+            view_name="openapi.v2.open.mcp_server.permissions.list",
+            path_params={"mcp_server_id": tenant_mcp_servers["other"].id},
+            app=mock.MagicMock(app_code="test"),
+            **TENANT_HEADER,
+        )
+
+        assert response.status_code == 404
+
+    def test_app_permission_list_filters_by_gateway_tenant(self, request_view, tenant_mcp_servers):
+        _create_permissions(tenant_mcp_servers)
+
+        response = request_view(
+            method="GET",
+            view_name="openapi.v2.open.mcp_server.app.permissions.list",
+            data={"bk_app_code": TARGET_APP_CODE},
+            app=mock.MagicMock(app_code="test"),
+            **TENANT_HEADER,
+        )
+
+        assert response.status_code == 200
+        assert {item["mcp_server"]["name"] for item in response.json()["data"]["results"]} == {
+            tenant_mcp_servers["global"].name,
+            tenant_mcp_servers["same"].name,
+        }
+
+    def test_apply_record_list_filters_by_gateway_tenant(self, request_view, tenant_mcp_servers):
+        _create_apply_records(tenant_mcp_servers)
+
+        response = request_view(
+            method="GET",
+            view_name="openapi.v2.open.mcp_server.app.permissions.apply-records.list",
+            data={"bk_app_code": TARGET_APP_CODE},
+            app=mock.MagicMock(app_code="test"),
+            **TENANT_HEADER,
+        )
+
+        assert response.status_code == 200
+        assert {item["mcp_server"]["name"] for item in response.json()["data"]["results"]} == {
+            tenant_mcp_servers["global"].name,
+            tenant_mcp_servers["same"].name,
+        }
+
+    def test_apply_record_lookup_filters_by_gateway_tenant(self, request_view, tenant_mcp_servers):
+        records = _create_apply_records(tenant_mcp_servers)
+
+        response = request_view(
+            method="GET",
+            view_name="openapi.v2.open.mcp_server.app.permissions.apply-records.lookup",
+            data={
+                "bk_app_code": TARGET_APP_CODE,
+                "ids": ",".join(str(record.id) for record in records.values()),
+            },
+            app=mock.MagicMock(app_code="test"),
+            **TENANT_HEADER,
+        )
+
+        assert response.status_code == 200
+        assert {item["id"] for item in response.json()["data"]} == {
+            records["global"].id,
+            records["same"].id,
+        }
+
+    def test_user_list_filters_by_gateway_tenant(self, request_view, tenant_mcp_servers):
+        response = request_view(
+            method="GET",
+            view_name="openapi.v2.open.user.mcp_server.list",
+            user=mock.MagicMock(username="test-user"),
+            app=mock.MagicMock(app_code="test"),
+            **TENANT_HEADER,
+        )
+
+        assert response.status_code == 200
+        assert {item["name"] for item in response.json()["data"]["results"]} == {
+            tenant_mcp_servers["global"].name,
+            tenant_mcp_servers["same"].name,
+        }
+
+    def test_apply_rejects_cross_tenant_mcp_server(self, request_view, tenant_mcp_servers, mocker):
+        create_tickets = mocker.patch.object(MCPServerPermissionHandler, "_create_itsm_tickets_for_applies")
+
+        response = request_view(
+            method="POST",
+            view_name="openapi.v2.open.mcp_server.app.permissions.apply",
+            data={
+                "bk_app_code": TARGET_APP_CODE,
+                "mcp_server_ids": [tenant_mcp_servers["other"].id],
+                "applied_by": "test-user",
+                "reason": "tenant isolation",
+            },
+            app=mock.MagicMock(app_code="test"),
+            **TENANT_HEADER,
+        )
+
+        assert response.status_code == 404
+        assert not MCPServerAppPermissionApply.objects.filter(bk_app_code=TARGET_APP_CODE).exists()
+        create_tickets.assert_not_called()
+
+
+class TestInnerMCPServerTenantIsolation:
+    def test_permission_list_filters_by_gateway_tenant(self, request_view, tenant_mcp_servers):
+        response = request_view(
+            method="GET",
+            view_name="openapi.v2.inner.mcp_server.permission.list",
+            data={"target_app_code": TARGET_APP_CODE},
+            app=mock.MagicMock(app_code="test"),
+            **TENANT_HEADER,
+        )
+
+        assert response.status_code == 200
+        assert {item["mcp_server"]["name"] for item in response.json()["data"]} == {
+            tenant_mcp_servers["global"].name,
+            tenant_mcp_servers["same"].name,
+        }
+
+    def test_app_permission_list_filters_by_gateway_tenant(self, request_view, tenant_mcp_servers):
+        _create_permissions(tenant_mcp_servers)
+
+        response = request_view(
+            method="GET",
+            view_name="openapi.v2.inner.mcp_server.permission.app-permissions",
+            data={"target_app_code": TARGET_APP_CODE},
+            app=mock.MagicMock(app_code="test"),
+            **TENANT_HEADER,
+        )
+
+        assert response.status_code == 200
+        assert {item["mcp_server"]["name"] for item in response.json()["data"]} == {
+            tenant_mcp_servers["global"].name,
+            tenant_mcp_servers["same"].name,
+        }
+
+    def test_apply_record_list_filters_by_gateway_tenant(self, request_view, tenant_mcp_servers):
+        _create_apply_records(tenant_mcp_servers)
+
+        response = request_view(
+            method="GET",
+            view_name="openapi.v2.inner.mcp_server.permission.apply-records",
+            data={"target_app_code": TARGET_APP_CODE},
+            app=mock.MagicMock(app_code="test"),
+            **TENANT_HEADER,
+        )
+
+        assert response.status_code == 200
+        assert {item["mcp_server"]["name"] for item in response.json()["data"]} == {
+            tenant_mcp_servers["global"].name,
+            tenant_mcp_servers["same"].name,
+        }
+
+    def test_apply_record_detail_hides_cross_tenant_record(self, request_view, tenant_mcp_servers):
+        records = _create_apply_records(tenant_mcp_servers)
+
+        response = request_view(
+            method="GET",
+            view_name="openapi.v2.inner.mcp_server.permission.apply-record-detail",
+            path_params={"record_id": records["other"].id},
+            data={"target_app_code": TARGET_APP_CODE},
+            app=mock.MagicMock(app_code="test"),
+            **TENANT_HEADER,
+        )
+
+        assert response.status_code == 404
+
+    def test_apply_rejects_cross_tenant_mcp_server(self, request_view, tenant_mcp_servers, mocker):
+        create_tickets = mocker.patch.object(MCPServerPermissionHandler, "_create_itsm_tickets_for_applies")
+
+        response = request_view(
+            method="POST",
+            view_name="openapi.v2.inner.mcp_server.permission.apply",
+            data={
+                "target_app_code": TARGET_APP_CODE,
+                "mcp_server_ids": [tenant_mcp_servers["other"].id],
+                "applied_by": "test-user",
+                "reason": "tenant isolation",
+            },
+            app=mock.MagicMock(app_code="test"),
+            **TENANT_HEADER,
+        )
+
+        assert response.status_code == 404
+        assert not MCPServerAppPermissionApply.objects.filter(bk_app_code=TARGET_APP_CODE).exists()
+        create_tickets.assert_not_called()


### PR DESCRIPTION
## Summary

- filter 11 MCP query endpoints to global gateways and the request tenant gateways
- reject cross-tenant MCP permission applications before records or ITSM tickets are created
- keep /api/v2/open/mcp-servers/batch-query/ behavior unchanged

## Testing

- 13 tenant-isolation regression tests
- 181 focused and compatibility tests
- 3886 dashboard tests
- make lint-check