### PR TITLE
fix(dashboard): filter gateway name permission by tenant

### DIFF
--- a/src/dashboard/apigateway/apigateway/apis/v2/permissions.py
+++ b/src/dashboard/apigateway/apigateway/apis/v2/permissions.py
@@ -22,6 +22,8 @@ from django.http import Http404
 from django.utils.translation import gettext_lazy
 from rest_framework import permissions
 
+from apigateway.apis.v2.tenant import get_request_tenant_id
+from apigateway.common.tenant.query import gateway_filter_by_app_tenant_id
 from apigateway.core.models import Gateway, GatewayRelatedApp
 from apigateway.utils.django import get_object_or_None
 
@@ -63,7 +65,7 @@ class OpenAPIV2GatewayNamePermission(permissions.BasePermission):
         _set_request_tenant_id(request)
 
         # 路径参数 gateway_id 必须存在
-        gateway_obj = self.get_gateway_object(view)
+        gateway_obj = self.get_gateway_object(request, view)
 
         if not gateway_obj:
             raise Http404
@@ -71,7 +73,7 @@ class OpenAPIV2GatewayNamePermission(permissions.BasePermission):
 
         return True
 
-    def get_gateway_object(self, view):
+    def get_gateway_object(self, request, view):
         """
         根据路径参数 gateway_name 获取网关对象
         若 gateway_name 不在路径参数中，或网关不存在，返回 None
@@ -81,8 +83,13 @@ class OpenAPIV2GatewayNamePermission(permissions.BasePermission):
         if lookup_url_kwarg not in view.kwargs:
             return None
 
+        queryset = Gateway.objects.all()
+        tenant_id = get_request_tenant_id(request)
+        if tenant_id:
+            queryset = gateway_filter_by_app_tenant_id(queryset, tenant_id)
+
         filter_kwargs = {"name": view.kwargs[lookup_url_kwarg]}
-        return get_object_or_None(Gateway, **filter_kwargs)
+        return get_object_or_None(queryset, **filter_kwargs)
 
 
 class OpenAPIV2GatewayRelatedAppPermission(permissions.BasePermission):

--- a/src/dashboard/apigateway/apigateway/tests/apis/v2/test_permissions.py
+++ b/src/dashboard/apigateway/apigateway/tests/apis/v2/test_permissions.py
@@ -3,17 +3,19 @@ from unittest import mock
 import pytest
 from ddf import G
 from django.http import Http404
+from rest_framework.exceptions import ValidationError
 from rest_framework.request import Request
 from rest_framework.test import APIRequestFactory
 
 from apigateway.apis.v2.permissions import OpenAPIV2GatewayNamePermission, OpenAPIV2Permission
+from apigateway.common.tenant.constants import TenantModeEnum
 from apigateway.core.models import Gateway
 
 
 @pytest.mark.parametrize("permission_class", [OpenAPIV2Permission, OpenAPIV2GatewayNamePermission])
 def test_openapi_permission_sets_tenant_id_in_multi_tenant_mode(settings, permission_class):
     settings.ENABLE_MULTI_TENANT_MODE = True
-    gateway = G(Gateway, name="tenant-gateway")
+    gateway = G(Gateway, name="tenant-gateway", tenant_mode=TenantModeEnum.GLOBAL.value, tenant_id="")
     request = Request(
         APIRequestFactory().get(
             "/",
@@ -43,3 +45,73 @@ def test_openapi_gateway_name_permission_sets_tenant_id_before_gateway_lookup(se
         permission.has_permission(request, view)
 
     assert request.tenant_id == "tenant-b"
+
+
+@pytest.mark.parametrize(
+    ("gateway_tenant_mode", "gateway_tenant_id"),
+    [
+        (TenantModeEnum.GLOBAL.value, ""),
+        (TenantModeEnum.SINGLE.value, "tenant-a"),
+    ],
+)
+def test_openapi_gateway_name_permission_allows_visible_gateway(
+    settings,
+    gateway_tenant_mode,
+    gateway_tenant_id,
+):
+    settings.ENABLE_MULTI_TENANT_MODE = True
+    gateway = G(
+        Gateway,
+        name="visible-gateway",
+        tenant_mode=gateway_tenant_mode,
+        tenant_id=gateway_tenant_id,
+    )
+    request = Request(APIRequestFactory().get("/", HTTP_X_BK_TENANT_ID="tenant-a"))
+    request.app = mock.MagicMock(app_code="bk_auth")
+    view = mock.MagicMock(kwargs={"gateway_name": gateway.name})
+
+    assert OpenAPIV2GatewayNamePermission().has_permission(request, view) is True
+    assert request.gateway == gateway
+
+
+def test_openapi_gateway_name_permission_hides_cross_tenant_gateway(settings):
+    settings.ENABLE_MULTI_TENANT_MODE = True
+    gateway = G(
+        Gateway,
+        name="cross-tenant-gateway",
+        tenant_mode=TenantModeEnum.SINGLE.value,
+        tenant_id="tenant-b",
+    )
+    request = Request(APIRequestFactory().get("/", HTTP_X_BK_TENANT_ID="tenant-a"))
+    request.app = mock.MagicMock(app_code="bk_auth")
+    view = mock.MagicMock(kwargs={"gateway_name": gateway.name})
+
+    with pytest.raises(Http404):
+        OpenAPIV2GatewayNamePermission().has_permission(request, view)
+
+
+def test_openapi_gateway_name_permission_requires_tenant_header(settings):
+    settings.ENABLE_MULTI_TENANT_MODE = True
+    gateway = G(Gateway, name="tenant-gateway", tenant_mode=TenantModeEnum.GLOBAL.value, tenant_id="")
+    request = Request(APIRequestFactory().get("/"))
+    request.app = mock.MagicMock(app_code="bk_auth")
+    view = mock.MagicMock(kwargs={"gateway_name": gateway.name})
+
+    with pytest.raises(ValidationError, match="tenant_id is required in multi-tenant mode"):
+        OpenAPIV2GatewayNamePermission().has_permission(request, view)
+
+
+def test_openapi_gateway_name_permission_keeps_single_tenant_mode_behavior(settings):
+    settings.ENABLE_MULTI_TENANT_MODE = False
+    gateway = G(
+        Gateway,
+        name="single-tenant-mode-gateway",
+        tenant_mode=TenantModeEnum.SINGLE.value,
+        tenant_id="another-tenant",
+    )
+    request = Request(APIRequestFactory().get("/"))
+    request.app = mock.MagicMock(app_code="bk_auth")
+    view = mock.MagicMock(kwargs={"gateway_name": gateway.name})
+
+    assert OpenAPIV2GatewayNamePermission().has_permission(request, view) is True
+    assert request.gateway == gateway


### PR DESCRIPTION
## Summary

- filter OpenAPIV2GatewayNamePermission gateway lookup to global gateways and request-tenant gateways
- return 404 for cross-tenant gateway names and require the tenant header in multi-tenant mode
- keep single-tenant behavior unchanged; do not change Inner app permissions, MCP, or Sync permissions

## Verification

- 8 permission tests passed
- 161 related Open/Inner view tests passed
- 3891 dashboard tests passed
- make lint-check passed