### PR TITLE
feat(dashboard): expose released resource visibility

### DIFF
--- a/src/dashboard/apigateway/apigateway/apis/v2/inner/serializers.py
+++ b/src/dashboard/apigateway/apigateway/apis/v2/inner/serializers.py
@@ -61,7 +61,7 @@ from apigateway.service.oauth2_client_scope import OAUTH2_CLIENT_TYPES
 from apigateway.utils import time
 
 logger = logging.getLogger(__name__)
-RELEASED_RESOURCE_FIELDS = frozenset({"id", "name", "description"})
+RELEASED_RESOURCE_FIELDS = frozenset({"id", "name", "description", "is_public"})
 MCP_SERVER_LIST_FIELDS = frozenset(
     {
         "id",
@@ -209,6 +209,7 @@ GATEWAY_LOOKUP_DEFAULT_FIELDS = GATEWAY_LOOKUP_FIELDS - {"maintainers"}
 class GatewayReleasedResourceOutputSLZ(_SelectableFieldsOutputSLZMixin, serializers.Serializer):
     id = serializers.IntegerField(read_only=True)
     name = serializers.CharField(read_only=True)
+    is_public = serializers.BooleanField(read_only=True)
     description = SerializerTranslatedField(
         translated_fields={"en": "description_en"},
         allow_blank=True,

--- a/src/dashboard/apigateway/apigateway/apis/v2/inner/views.py
+++ b/src/dashboard/apigateway/apigateway/apis/v2/inner/views.py
@@ -270,6 +270,7 @@ class _GatewayReleasedResourceApiMixin:
             {
                 "id": resource.resource_id,
                 "name": resource.resource_name,
+                "is_public": resource.is_public,
                 "description": (resource.data or {}).get("description", ""),
                 "description_en": (resource.data or {}).get("description_en"),
             }

--- a/src/dashboard/apigateway/apigateway/data/apidocs/zh/v2_inner_list_gateway_released_resources.md
+++ b/src/dashboard/apigateway/apigateway/data/apidocs/zh/v2_inner_list_gateway_released_resources.md
@@ -18,7 +18,7 @@
 
 | 参数名称 | 参数类型 | 必选 | 描述 |
 |---|---|---|---|
-| fields | string | 否 | 返回字段列表，多个以逗号分隔；支持 `id`、`name`、`description`，不传返回全部字段 |
+| fields | string | 否 | 返回字段列表，多个以逗号分隔；支持 `id`、`name`、`description`、`is_public`，不传返回全部字段 |
 | limit | int | 否 | 每页数量，默认 10，最大 20 |
 | offset | int | 否 | 分页偏移量，默认 0 |
 
@@ -32,7 +32,8 @@
       {
         "id": 101,
         "name": "get_user",
-        "description": "查询用户"
+        "description": "查询用户",
+        "is_public": true
       }
     ]
   }
@@ -49,5 +50,6 @@
 | data.results[].id | int | 资源 ID |
 | data.results[].name | string | 资源名称 |
 | data.results[].description | string | 当前快照中的资源描述，随请求语言返回中文或英文 |
+| data.results[].is_public | bool | 资源是否公开 |
 
 网关不存在或对当前租户不可见时返回 `404`；网关不存在当前发布版本时返回空分页结果。

--- a/src/dashboard/apigateway/apigateway/data/apidocs/zh/v2_inner_lookup_gateway_released_resources.md
+++ b/src/dashboard/apigateway/apigateway/data/apidocs/zh/v2_inner_lookup_gateway_released_resources.md
@@ -19,7 +19,7 @@
 | 参数名称 | 参数类型 | 必选 | 描述 |
 |---|---|---|---|
 | names | string | 是 | 资源名称列表，精确匹配，多个以逗号分隔，去重后最多 50 个 |
-| fields | string | 否 | 返回字段列表，多个以逗号分隔；支持 `id`、`name`、`description`，不传返回全部字段 |
+| fields | string | 否 | 返回字段列表，多个以逗号分隔；支持 `id`、`name`、`description`、`is_public`，不传返回全部字段 |
 
 ### 响应示例
 
@@ -29,7 +29,8 @@
     {
       "id": 101,
       "name": "get_user",
-      "description": "查询用户"
+      "description": "查询用户",
+      "is_public": true
     }
   ]
 }
@@ -43,5 +44,6 @@
 | data[].id | int | 资源 ID |
 | data[].name | string | 资源名称 |
 | data[].description | string | 当前快照中的资源描述，随请求语言返回中文或英文 |
+| data[].is_public | bool | 资源是否公开 |
 
 网关不存在或对当前租户不可见时返回 `404`；网关不存在当前发布版本或名称均未匹配时返回空数组。

--- a/src/dashboard/apigateway/apigateway/data/apigw-definitions/bk-apigateway-resources.yaml
+++ b/src/dashboard/apigateway/apigateway/data/apigw-definitions/bk-apigateway-resources.yaml
@@ -5844,7 +5844,7 @@ paths:
           required: false
           schema:
             type: string
-          description: 返回字段列表，多个以逗号分隔；支持 id、name、description
+          description: 返回字段列表，多个以逗号分隔；支持 id、name、description、is_public
         - name: limit
           in: query
           required: false
@@ -5890,6 +5890,9 @@ paths:
                             description:
                               type: string
                               description: 资源描述
+                            is_public:
+                              type: boolean
+                              description: 资源是否公开
       x-bk-apigateway-resource:
         isPublic: false
         allowApplyPermission: false
@@ -5931,7 +5934,7 @@ paths:
           required: false
           schema:
             type: string
-          description: 返回字段列表，多个以逗号分隔；支持 id、name、description
+          description: 返回字段列表，多个以逗号分隔；支持 id、name、description、is_public
       responses:
         '200':
           description: 成功返回匹配的当前已发布资源列表，无分页包装
@@ -5954,6 +5957,9 @@ paths:
                         description:
                           type: string
                           description: 资源描述
+                        is_public:
+                          type: boolean
+                          description: 资源是否公开
       x-bk-apigateway-resource:
         isPublic: false
         allowApplyPermission: false

--- a/src/dashboard/apigateway/apigateway/service/gateway_released_resource.py
+++ b/src/dashboard/apigateway/apigateway/service/gateway_released_resource.py
@@ -32,7 +32,7 @@ def get_gateway_released_resources(
         eligible = eligible.filter(resource_name__in=resource_names)
 
     # A gateway normally has only one released resource version, so no deduplication is needed.
-    # SELECT id, resource_id, resource_name, data
+    # SELECT id, resource_id, resource_name, is_public, data
     # FROM core_released_resource
     # WHERE api_id = %(gateway_id)s
     #   AND resource_version_id IN (%(resource_version_ids)s)
@@ -52,7 +52,7 @@ def get_gateway_released_resources(
         for resource_id, snapshot_id in candidates:
             latest_snapshot_ids.setdefault(resource_id, snapshot_id)
 
-        # SELECT id, resource_id, resource_name, data
+        # SELECT id, resource_id, resource_name, is_public, data
         # FROM core_released_resource
         # WHERE api_id = %(gateway_id)s
         #   AND resource_version_id IN (%(resource_version_ids)s)
@@ -61,4 +61,4 @@ def get_gateway_released_resources(
         # ORDER BY resource_name, resource_id;
         eligible = eligible.filter(id__in=list(latest_snapshot_ids.values()))
 
-    return eligible.only("resource_id", "resource_name", "data").order_by("resource_name", "resource_id")
+    return eligible.only("resource_id", "resource_name", "is_public", "data").order_by("resource_name", "resource_id")

--- a/src/dashboard/apigateway/apigateway/tests/apis/v2/inner/test_gateway_lookup_views.py
+++ b/src/dashboard/apigateway/apigateway/tests/apis/v2/inner/test_gateway_lookup_views.py
@@ -20,7 +20,7 @@ def _release_version(gateway, resource_version, stage_name, *, stage_status=Stag
     )
 
 
-def _make_snapshot(gateway, resource_version, *, resource_id, name):
+def _make_snapshot(gateway, resource_version, *, resource_id, name, is_public=False):
     return G(
         ReleasedResource,
         gateway=gateway,
@@ -29,7 +29,7 @@ def _make_snapshot(gateway, resource_version, *, resource_id, name):
         resource_name=name,
         resource_method="GET",
         resource_path=f"/{name}",
-        is_public=False,
+        is_public=is_public,
         oauth2_public_client_enabled=False,
         oauth2_personal_client_enabled=False,
         data={
@@ -273,7 +273,7 @@ class TestGatewayReleasedResourceApi:
         new_version = G(ResourceVersion, gateway=gateway, version="2.0.0", _data="[]")
         _release_version(gateway, old_version, "prod")
         _release_version(gateway, new_version, "test")
-        first = _make_snapshot(gateway, old_version, resource_id=1, name="first_resource")
+        first = _make_snapshot(gateway, old_version, resource_id=1, name="first_resource", is_public=True)
         _make_snapshot(gateway, old_version, resource_id=2, name="shared_old")
         latest = _make_snapshot(gateway, new_version, resource_id=2, name="shared_new")
 
@@ -289,8 +289,18 @@ class TestGatewayReleasedResourceApi:
             "data": {
                 "count": 2,
                 "results": [
-                    {"id": first.resource_id, "name": "first_resource", "description": "first_resource description"},
-                    {"id": latest.resource_id, "name": "shared_new", "description": "shared_new description"},
+                    {
+                        "id": first.resource_id,
+                        "name": "first_resource",
+                        "description": "first_resource description",
+                        "is_public": True,
+                    },
+                    {
+                        "id": latest.resource_id,
+                        "name": "shared_new",
+                        "description": "shared_new description",
+                        "is_public": False,
+                    },
                 ],
             }
         }
@@ -310,11 +320,11 @@ class TestGatewayReleasedResourceApi:
             view_name="openapi.v2.inner.gateway.released_resource.lookup",
             path_params={"gateway_name": gateway.name},
             app=mock.MagicMock(app_code="bk_auth"),
-            data={"names": " exact_name,missing,exact_name ", "fields": "id,name"},
+            data={"names": " exact_name,missing,exact_name ", "fields": "id,name,is_public"},
         )
 
         assert response.status_code == 200
-        assert response.json() == {"data": [{"id": old.resource_id, "name": "exact_name"}]}
+        assert response.json() == {"data": [{"id": old.resource_id, "name": "exact_name", "is_public": False}]}
 
     def test_excludes_inactive_stage_releases(self, request_view):
         gateway = G(Gateway, name="inactive-stage-released-resource")
@@ -341,6 +351,7 @@ class TestGatewayReleasedResourceApi:
                         "id": active.resource_id,
                         "name": "active_resource",
                         "description": "active_resource description",
+                        "is_public": False,
                     },
                 ],
             }
@@ -362,7 +373,12 @@ class TestGatewayReleasedResourceApi:
 
         assert response.status_code == 200
         assert response.json()["data"]["results"] == [
-            {"id": snapshot.resource_id, "name": "translated", "description": "translated description en"}
+            {
+                "id": snapshot.resource_id,
+                "name": "translated",
+                "description": "translated description en",
+                "is_public": False,
+            }
         ]
 
     def test_returns_empty_page_without_current_release(self, request_view):


### PR DESCRIPTION
## Summary
- backport #3191 to `release/1.23`
- return `is_public` from the v2 inner released-resource list and lookup APIs
- synchronize selectable fields, tests, OpenAPI YAML, and Chinese API documentation

## Verification
- `uv run make check-openapi` (0 errors)
- focused v2 inner gateway lookup/released-resource tests: 32 passed
- `uv run make edition-ee && uv run make lint-check`
- `uv run make edition-ee && uv run make test` (3340 passed)

Cherry-picked from `e4c47b2e35ff5d920b26bd97675d66ef3663eb67` with `-x`.