### PR TITLE
feat(dashboard): expose released resource OAuth2 flags

### DIFF
--- a/src/dashboard/apigateway/apigateway/apis/v2/inner/serializers.py
+++ b/src/dashboard/apigateway/apigateway/apis/v2/inner/serializers.py
@@ -62,7 +62,16 @@ from apigateway.service.oauth2_client_scope import OAUTH2_CLIENT_TYPES
 from apigateway.utils import time
 
 logger = logging.getLogger(__name__)
-RELEASED_RESOURCE_FIELDS = frozenset({"id", "name", "description", "is_public"})
+RELEASED_RESOURCE_FIELDS = frozenset(
+    {
+        "id",
+        "name",
+        "description",
+        "is_public",
+        "oauth2_public_client_enabled",
+        "oauth2_personal_client_enabled",
+    }
+)
 MCP_SERVER_LIST_FIELDS = frozenset(
     {
         "id",
@@ -216,6 +225,8 @@ class GatewayReleasedResourceOutputSLZ(_SelectableFieldsOutputSLZMixin, serializ
     id = serializers.IntegerField(read_only=True)
     name = serializers.CharField(read_only=True)
     is_public = serializers.BooleanField(read_only=True)
+    oauth2_public_client_enabled = serializers.BooleanField(read_only=True)
+    oauth2_personal_client_enabled = serializers.BooleanField(read_only=True)
     description = SerializerTranslatedField(
         translated_fields={"en": "description_en"},
         allow_blank=True,

--- a/src/dashboard/apigateway/apigateway/apis/v2/inner/views.py
+++ b/src/dashboard/apigateway/apigateway/apis/v2/inner/views.py
@@ -276,6 +276,8 @@ class _GatewayReleasedResourceApiMixin:
                 "id": resource.resource_id,
                 "name": resource.resource_name,
                 "is_public": resource.is_public,
+                "oauth2_public_client_enabled": resource.oauth2_public_client_enabled,
+                "oauth2_personal_client_enabled": resource.oauth2_personal_client_enabled,
                 "description": (resource.data or {}).get("description", ""),
                 "description_en": (resource.data or {}).get("description_en"),
             }

--- a/src/dashboard/apigateway/apigateway/data/apidocs/zh/v2_inner_list_gateway_released_resources.md
+++ b/src/dashboard/apigateway/apigateway/data/apidocs/zh/v2_inner_list_gateway_released_resources.md
@@ -18,7 +18,7 @@
 
 | 参数名称 | 参数类型 | 必选 | 描述 |
 |---|---|---|---|
-| fields | string | 否 | 返回字段列表，多个以逗号分隔；支持 `id`、`name`、`description`、`is_public`，不传返回全部字段 |
+| fields | string | 否 | 返回字段列表，多个以逗号分隔；支持 `id`、`name`、`description`、`is_public`、`oauth2_public_client_enabled`、`oauth2_personal_client_enabled`，不传返回全部字段 |
 | limit | int | 否 | 每页数量，默认 10，最大 20 |
 | offset | int | 否 | 分页偏移量，默认 0 |
 
@@ -33,7 +33,9 @@
         "id": 101,
         "name": "get_user",
         "description": "查询用户",
-        "is_public": true
+        "is_public": true,
+        "oauth2_public_client_enabled": true,
+        "oauth2_personal_client_enabled": false
       }
     ]
   }
@@ -51,5 +53,7 @@
 | data.results[].name | string | 资源名称 |
 | data.results[].description | string | 当前快照中的资源描述，随请求语言返回中文或英文 |
 | data.results[].is_public | bool | 资源是否公开 |
+| data.results[].oauth2_public_client_enabled | bool | 资源是否允许 OAuth2 公共客户端访问 |
+| data.results[].oauth2_personal_client_enabled | bool | 资源是否允许 OAuth2 个人客户端访问 |
 
 网关不存在或对当前租户不可见时返回 `404`；网关不存在当前发布版本时返回空分页结果。

--- a/src/dashboard/apigateway/apigateway/data/apidocs/zh/v2_inner_lookup_gateway_released_resources.md
+++ b/src/dashboard/apigateway/apigateway/data/apidocs/zh/v2_inner_lookup_gateway_released_resources.md
@@ -19,7 +19,7 @@
 | 参数名称 | 参数类型 | 必选 | 描述 |
 |---|---|---|---|
 | names | string | 是 | 资源名称列表，精确匹配，多个以逗号分隔，去重后最多 50 个 |
-| fields | string | 否 | 返回字段列表，多个以逗号分隔；支持 `id`、`name`、`description`、`is_public`，不传返回全部字段 |
+| fields | string | 否 | 返回字段列表，多个以逗号分隔；支持 `id`、`name`、`description`、`is_public`、`oauth2_public_client_enabled`、`oauth2_personal_client_enabled`，不传返回全部字段 |
 
 ### 响应示例
 
@@ -30,7 +30,9 @@
       "id": 101,
       "name": "get_user",
       "description": "查询用户",
-      "is_public": true
+      "is_public": true,
+      "oauth2_public_client_enabled": true,
+      "oauth2_personal_client_enabled": false
     }
   ]
 }
@@ -45,5 +47,7 @@
 | data[].name | string | 资源名称 |
 | data[].description | string | 当前快照中的资源描述，随请求语言返回中文或英文 |
 | data[].is_public | bool | 资源是否公开 |
+| data[].oauth2_public_client_enabled | bool | 资源是否允许 OAuth2 公共客户端访问 |
+| data[].oauth2_personal_client_enabled | bool | 资源是否允许 OAuth2 个人客户端访问 |
 
 网关不存在或对当前租户不可见时返回 `404`；网关不存在当前发布版本或名称均未匹配时返回空数组。

--- a/src/dashboard/apigateway/apigateway/data/apigw-definitions/bk-apigateway-resources.yaml
+++ b/src/dashboard/apigateway/apigateway/data/apigw-definitions/bk-apigateway-resources.yaml
@@ -6400,7 +6400,7 @@ paths:
           required: false
           schema:
             type: string
-          description: 返回字段列表，多个以逗号分隔；支持 id、name、description、is_public
+          description: 返回字段列表，多个以逗号分隔；支持 id、name、description、is_public、oauth2_public_client_enabled、oauth2_personal_client_enabled
         - name: limit
           in: query
           required: false
@@ -6449,6 +6449,12 @@ paths:
                             is_public:
                               type: boolean
                               description: 资源是否公开
+                            oauth2_public_client_enabled:
+                              type: boolean
+                              description: 资源是否允许 OAuth2 公共客户端访问
+                            oauth2_personal_client_enabled:
+                              type: boolean
+                              description: 资源是否允许 OAuth2 个人客户端访问
       x-bk-apigateway-resource:
         isPublic: false
         allowApplyPermission: false
@@ -6490,7 +6496,7 @@ paths:
           required: false
           schema:
             type: string
-          description: 返回字段列表，多个以逗号分隔；支持 id、name、description、is_public
+          description: 返回字段列表，多个以逗号分隔；支持 id、name、description、is_public、oauth2_public_client_enabled、oauth2_personal_client_enabled
       responses:
         '200':
           description: 成功返回匹配的当前已发布资源列表，无分页包装
@@ -6516,6 +6522,12 @@ paths:
                         is_public:
                           type: boolean
                           description: 资源是否公开
+                        oauth2_public_client_enabled:
+                          type: boolean
+                          description: 资源是否允许 OAuth2 公共客户端访问
+                        oauth2_personal_client_enabled:
+                          type: boolean
+                          description: 资源是否允许 OAuth2 个人客户端访问
       x-bk-apigateway-resource:
         isPublic: false
         allowApplyPermission: false

--- a/src/dashboard/apigateway/apigateway/tests/apis/v2/inner/test_gateway_lookup_views.py
+++ b/src/dashboard/apigateway/apigateway/tests/apis/v2/inner/test_gateway_lookup_views.py
@@ -20,7 +20,16 @@ def _release_version(gateway, resource_version, stage_name, *, stage_status=Stag
     )
 
 
-def _make_snapshot(gateway, resource_version, *, resource_id, name, is_public=False):
+def _make_snapshot(
+    gateway,
+    resource_version,
+    *,
+    resource_id,
+    name,
+    is_public=False,
+    oauth2_public_client_enabled=False,
+    oauth2_personal_client_enabled=False,
+):
     return G(
         ReleasedResource,
         gateway=gateway,
@@ -30,8 +39,8 @@ def _make_snapshot(gateway, resource_version, *, resource_id, name, is_public=Fa
         resource_method="GET",
         resource_path=f"/{name}",
         is_public=is_public,
-        oauth2_public_client_enabled=False,
-        oauth2_personal_client_enabled=False,
+        oauth2_public_client_enabled=oauth2_public_client_enabled,
+        oauth2_personal_client_enabled=oauth2_personal_client_enabled,
         data={
             "id": resource_id,
             "name": name,
@@ -274,7 +283,15 @@ class TestGatewayReleasedResourceApi:
         new_version = G(ResourceVersion, gateway=gateway, version="2.0.0", _data="[]")
         _release_version(gateway, old_version, "prod")
         _release_version(gateway, new_version, "test")
-        first = _make_snapshot(gateway, old_version, resource_id=1, name="first_resource", is_public=True)
+        first = _make_snapshot(
+            gateway,
+            old_version,
+            resource_id=1,
+            name="first_resource",
+            is_public=True,
+            oauth2_public_client_enabled=True,
+            oauth2_personal_client_enabled=True,
+        )
         _make_snapshot(gateway, old_version, resource_id=2, name="shared_old")
         latest = _make_snapshot(gateway, new_version, resource_id=2, name="shared_new")
 
@@ -295,12 +312,16 @@ class TestGatewayReleasedResourceApi:
                         "name": "first_resource",
                         "description": "first_resource description",
                         "is_public": True,
+                        "oauth2_public_client_enabled": True,
+                        "oauth2_personal_client_enabled": True,
                     },
                     {
                         "id": latest.resource_id,
                         "name": "shared_new",
                         "description": "shared_new description",
                         "is_public": False,
+                        "oauth2_public_client_enabled": False,
+                        "oauth2_personal_client_enabled": False,
                     },
                 ],
             }
@@ -321,11 +342,24 @@ class TestGatewayReleasedResourceApi:
             view_name="openapi.v2.inner.gateway.released_resource.lookup",
             path_params={"gateway_name": gateway.name},
             app=mock.MagicMock(app_code="bk_auth"),
-            data={"names": " exact_name,missing,exact_name ", "fields": "id,name,is_public"},
+            data={
+                "names": " exact_name,missing,exact_name ",
+                "fields": "id,name,is_public,oauth2_public_client_enabled,oauth2_personal_client_enabled",
+            },
         )
 
         assert response.status_code == 200
-        assert response.json() == {"data": [{"id": old.resource_id, "name": "exact_name", "is_public": False}]}
+        assert response.json() == {
+            "data": [
+                {
+                    "id": old.resource_id,
+                    "name": "exact_name",
+                    "is_public": False,
+                    "oauth2_public_client_enabled": False,
+                    "oauth2_personal_client_enabled": False,
+                }
+            ]
+        }
 
     def test_excludes_inactive_stage_releases(self, request_view):
         gateway = G(Gateway, name="inactive-stage-released-resource")
@@ -353,6 +387,8 @@ class TestGatewayReleasedResourceApi:
                         "name": "active_resource",
                         "description": "active_resource description",
                         "is_public": False,
+                        "oauth2_public_client_enabled": False,
+                        "oauth2_personal_client_enabled": False,
                     },
                 ],
             }
@@ -379,6 +415,8 @@ class TestGatewayReleasedResourceApi:
                 "name": "translated",
                 "description": "translated description en",
                 "is_public": False,
+                "oauth2_public_client_enabled": False,
+                "oauth2_personal_client_enabled": False,
             }
         ]
 


### PR DESCRIPTION
## Summary

- return `oauth2_public_client_enabled` and `oauth2_personal_client_enabled` from the v2 inner released-resource list and lookup APIs
- allow callers to request both values through the `fields` query parameter
- synchronize the OpenAPI YAML, endpoint documentation, and regression coverage

## Verification

- focused released-resource API tests: 14 passed
- dashboard lint gate: Ruff, mypy, import contracts, and API consistency passed
- full dashboard test suite: 3,895 passed
- API consistency reported 0 errors and 39 existing warnings
