### PR TITLE
fix: align concurrency metadata policy validation

### DIFF
--- a/src/dashboard/apigateway/apigateway/conf/utils.py
+++ b/src/dashboard/apigateway/apigateway/conf/utils.py
@@ -108,6 +108,7 @@ def get_plugin_metadata_config(env: Env) -> dict:
             "default_conn_delay": env.int("GATEWAY_CONCURRENCY_LIMIT_DEFAULT_CONN_DELAY", 1),  # second
             "key_type": "var",
             "key": "bk_concurrency_limit_key",
+            "policy": "local",
             "allow_degradation": True,
         },
         "bk-real-ip": {

--- a/src/dashboard/apigateway/apigateway/tests/conf/test_utils.py
+++ b/src/dashboard/apigateway/apigateway/tests/conf/test_utils.py
@@ -19,7 +19,13 @@
 
 from environ import Env
 
-from apigateway.conf.utils import get_default_feature_flags, get_frontend_env_vars
+from apigateway.conf.utils import get_default_feature_flags, get_frontend_env_vars, get_plugin_metadata_config
+
+
+def test_get_plugin_metadata_config_uses_local_concurrency_policy():
+    config = get_plugin_metadata_config(Env())
+
+    assert config["bk-concurrency-limit"]["policy"] == "local"
 
 
 def test_get_default_feature_flags_mcp_server_oauth2_personal_client(monkeypatch):

--- a/src/operator/pkg/core/validator/validator_test.go
+++ b/src/operator/pkg/core/validator/validator_test.go
@@ -59,7 +59,17 @@ func TestValidateAIServiceAndRoute(t *testing.T) {
 	}
 }
 
-func TestValidatePluginMetadataAppliesSchemaDefaults(t *testing.T) {
+func TestValidateRequiredPluginFieldsAreNotDefaulted(t *testing.T) {
+	route := []byte(`{
+		"id":"route-1",
+		"uris":["/"],
+		"plugins":{"jwe-decrypt":{}}
+	}`)
+
+	require.Error(t, ValidateApisixJsonSchema("3.16", constant.Route, route))
+}
+
+func TestValidatePluginMetadataConditionalPolicy(t *testing.T) {
 	tests := []struct {
 		name      string
 		config    string

--- a/src/operator/pkg/core/validator/validator_test.go
+++ b/src/operator/pkg/core/validator/validator_test.go
@@ -58,3 +58,64 @@ func TestValidateAIServiceAndRoute(t *testing.T) {
 		})
 	}
 }
+
+func TestValidatePluginMetadataAppliesSchemaDefaults(t *testing.T) {
+	tests := []struct {
+		name      string
+		config    string
+		wantError string
+	}{
+		{
+			name: "missing policy uses local default",
+			config: `{
+				"id":"bk-concurrency-limit",
+				"conn":2000,
+				"burst":1000,
+				"default_conn_delay":1,
+				"key_type":"var",
+				"key":"bk_concurrency_limit_key",
+				"allow_degradation":true
+			}`,
+		},
+		{
+			name: "explicit redis still requires host",
+			config: `{
+				"id":"bk-concurrency-limit",
+				"conn":2000,
+				"burst":1000,
+				"default_conn_delay":1,
+				"key_type":"var",
+				"key":"bk_concurrency_limit_key",
+				"allow_degradation":true,
+				"policy":"redis"
+			}`,
+			wantError: "redis_host is required",
+		},
+		{
+			name: "explicit redis with host",
+			config: `{
+				"id":"bk-concurrency-limit",
+				"conn":2000,
+				"burst":1000,
+				"default_conn_delay":1,
+				"key_type":"var",
+				"key":"bk_concurrency_limit_key",
+				"allow_degradation":true,
+				"policy":"redis",
+				"redis_host":"redis.example.com"
+			}`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := ValidateApisixJsonSchema("3.18", constant.PluginMetadata, []byte(tt.config))
+			if tt.wantError != "" {
+				require.Error(t, err)
+				require.Contains(t, err.Error(), tt.wantError)
+				return
+			}
+			require.NoError(t, err)
+		})
+	}
+}

--- a/src/operator/pkg/utils/schema/3.18/schema.json
+++ b/src/operator/pkg/utils/schema/3.18/schema.json
@@ -7237,7 +7237,10 @@
                   "redis-cluster"
                 ]
               }
-            }
+            },
+            "required": [
+              "policy"
+            ]
           },
           "then": {
             "properties": {
@@ -7301,7 +7304,10 @@
                 "redis"
               ]
             }
-          }
+          },
+          "required": [
+            "policy"
+          ]
         },
         "oneOf": [
           {

--- a/src/operator/pkg/utils/schema/validate.go
+++ b/src/operator/pkg/utils/schema/validate.go
@@ -166,6 +166,31 @@ func getPlugins(conf any) (map[string]any, string) {
 	return nil, ""
 }
 
+func applyPropertyDefaults(schema, conf map[string]any) {
+	properties, ok := schema["properties"].(map[string]any)
+	if !ok {
+		return
+	}
+
+	for name, value := range properties {
+		if _, exists := conf[name]; exists {
+			continue
+		}
+
+		propertySchema, ok := value.(map[string]any)
+		if !ok {
+			continue
+		}
+
+		defaultValue, exists := propertySchema["default"]
+		if !exists || defaultValue == nil {
+			continue
+		}
+
+		conf[name] = defaultValue
+	}
+}
+
 // cHashKeySchemaCheck validates the hash key configuration for an upstream based on the hash type
 // It checks if the hash type is valid and verifies the key against the appropriate schema
 // Parameters:
@@ -501,6 +526,9 @@ func (v *APISIXJsonSchemaValidator) Validate(rawConfig json.RawMessage) error { 
 			return fmt.Errorf("资源:%s schema 验证失败: 插件配置格式错误, 插件: %s",
 				resourceIdentification, pluginName)
 		}
+		// APISIX's Lua JSON Schema validator applies property defaults before evaluating
+		// conditional schemas. Materialize the same defaults on this validation-only copy.
+		applyPropertyDefaults(schemaMap, conf)
 		var exchange bool
 		disable, ok := conf["disable"]
 		if ok {

--- a/src/operator/pkg/utils/schema/validate.go
+++ b/src/operator/pkg/utils/schema/validate.go
@@ -166,31 +166,6 @@ func getPlugins(conf any) (map[string]any, string) {
 	return nil, ""
 }
 
-func applyPropertyDefaults(schema, conf map[string]any) {
-	properties, ok := schema["properties"].(map[string]any)
-	if !ok {
-		return
-	}
-
-	for name, value := range properties {
-		if _, exists := conf[name]; exists {
-			continue
-		}
-
-		propertySchema, ok := value.(map[string]any)
-		if !ok {
-			continue
-		}
-
-		defaultValue, exists := propertySchema["default"]
-		if !exists || defaultValue == nil {
-			continue
-		}
-
-		conf[name] = defaultValue
-	}
-}
-
 // cHashKeySchemaCheck validates the hash key configuration for an upstream based on the hash type
 // It checks if the hash type is valid and verifies the key against the appropriate schema
 // Parameters:
@@ -526,9 +501,6 @@ func (v *APISIXJsonSchemaValidator) Validate(rawConfig json.RawMessage) error { 
 			return fmt.Errorf("资源:%s schema 验证失败: 插件配置格式错误, 插件: %s",
 				resourceIdentification, pluginName)
 		}
-		// APISIX's Lua JSON Schema validator applies property defaults before evaluating
-		// conditional schemas. Materialize the same defaults on this validation-only copy.
-		applyPropertyDefaults(schemaMap, conf)
 		var exchange bool
 		disable, ok := conf["disable"]
 		if ok {
@@ -553,7 +525,7 @@ func (v *APISIXJsonSchemaValidator) Validate(rawConfig json.RawMessage) error { 
 
 		if !ret.Valid() {
 			errString := GetSchemaValidateFailed(ret)
-			log.Errorf("schema validate failed:s: %v, obj: %#v", v.schemaDef, rawConfig)
+			log.Errorf("schema validate failed:s: %v, obj: %s", v.schemaDef, rawConfig)
 			return fmt.Errorf("资源:%s 插件:%s schema 验证失败: %s", resourceIdentification, pluginName,
 				errString)
 		}


### PR DESCRIPTION
## Summary

- set policy to local in Dashboard-generated bk-concurrency-limit metadata for new configurations
- align the Operator 3.18 embedded schema so missing policy does not enter Redis conditional branches
- remove generic schema-default materialization so existing 3.13/3.16 required-field validation is unchanged
- log invalid json.RawMessage payloads as readable JSON instead of hexadecimal byte arrays

## Compatibility

- legacy metadata without policy passes Operator validation and APISIX continues to apply its local default
- explicit Redis policies still require redis_host
- 3.13 and 3.16 schema snapshots are unchanged; a 3.16 jwe-decrypt regression test protects required fields

## Related

- APISIX schema source fix: https://github.com/TencentBlueKing/blueking-apigateway-apisix/pull/183

## Verification

Dashboard:
- focused config test: 1 passed
- uv run make edition-ee && uv run make lint-check
- uv run make test: 3893 passed

Operator:
- focused validator regression tests
- make fmt
- make build
- make lint: 0 issues
- make test: 19 suites passed
- make integration: 1 spec passed