### PR TITLE
fix(mcp): wait for release data before server sync for release/1.23

### DIFF
--- a/src/dashboard/apigateway/apigateway/apps/mcp_server/tasks.py
+++ b/src/dashboard/apigateway/apigateway/apps/mcp_server/tasks.py
@@ -28,7 +28,7 @@ from apigateway.biz.mcp_server import (
     MCPServerPromptHandler,
 )
 from apigateway.core.constants import ReleaseHistoryStatusEnum
-from apigateway.service.release import wait_release_done
+from apigateway.service.release import wait_release_ready
 
 logger = logging.getLogger(__name__)
 
@@ -242,7 +242,7 @@ def sync_mcp_server_after_release(
     """等待发布完成后同步 MCP Server 数据到 DB
 
     当同步 MCP Server 时检测到环境正在发布，将写入操作投递到此异步任务：
-    1. 等待 release_history_id 对应的发布完成
+    1. 等待 release_history_id 对应的发布完成且控制面数据就绪
     2. 发布成功：使用发布后的资源版本写入 MCP Server
     3. 发布失败/超时：跳过写入，记录日志
     """
@@ -255,11 +255,11 @@ def sync_mcp_server_after_release(
         release_history_id,
     )
 
-    final_status = wait_release_done(release_history_id)
+    final_status = wait_release_ready(release_history_id)
 
     if final_status != ReleaseHistoryStatusEnum.SUCCESS.value:
         logger.warning(
-            "sync_mcp_server_after_release: release failed (status=%s), "
+            "sync_mcp_server_after_release: release failed or release data not ready (status=%s), "
             "skip mcp server sync, gateway=%s(%d), stage=%s(%d), release_history_id=%d",
             final_status,
             gateway_name,

--- a/src/dashboard/apigateway/apigateway/service/release/__init__.py
+++ b/src/dashboard/apigateway/apigateway/service/release/__init__.py
@@ -16,7 +16,7 @@
 # to the current version of the project delivered to anyone in the future.
 #
 from .validation import PublishValidator, ReleaseValidationError, StageVarsValuesValidator
-from .wait import DEFAULT_WAIT_RELEASE_TIMEOUT, wait_release_done
+from .wait import DEFAULT_WAIT_RELEASE_TIMEOUT, wait_release_done, wait_release_ready
 
 __all__ = [
     # constant
@@ -28,5 +28,6 @@ __all__ = [
     "StageVarsValuesValidator",
     # functions
     "wait_release_done",
+    "wait_release_ready",
     # others
 ]

--- a/src/dashboard/apigateway/apigateway/service/release/wait.py
+++ b/src/dashboard/apigateway/apigateway/service/release/wait.py
@@ -21,8 +21,8 @@ import logging
 import time
 from datetime import datetime
 
-from apigateway.core.constants import ReleaseHistoryStatusEnum
-from apigateway.core.models import PublishEvent
+from apigateway.core.constants import ReleaseHistoryStatusEnum, StageStatusEnum
+from apigateway.core.models import PublishEvent, Release, ReleaseHistory
 
 logger = logging.getLogger(__name__)
 
@@ -64,3 +64,39 @@ def wait_release_done(release_history_id: int, timeout: int = DEFAULT_WAIT_RELEA
         status = latest_event.get_release_history_status()
         if status != ReleaseHistoryStatusEnum.DOING.value:
             return status
+
+
+def wait_release_ready(release_history_id: int, timeout: int = DEFAULT_WAIT_RELEASE_TIMEOUT) -> str:
+    """等待发布成功，并确认当前 Release 已切换到本次发布的资源版本。"""
+    start_time = datetime.now().timestamp()
+    final_status = wait_release_done(release_history_id, timeout=timeout)
+    if final_status != ReleaseHistoryStatusEnum.SUCCESS.value:
+        return final_status
+
+    release_history = ReleaseHistory.objects.only(
+        "gateway_id",
+        "stage_id",
+        "resource_version_id",
+    ).get(id=release_history_id)
+    wait_times = 0
+
+    while True:
+        if Release.objects.filter(
+            gateway_id=release_history.gateway_id,
+            stage_id=release_history.stage_id,
+            resource_version_id=release_history.resource_version_id,
+            stage__status=StageStatusEnum.ACTIVE.value,
+        ).exists():
+            return ReleaseHistoryStatusEnum.SUCCESS.value
+
+        now = datetime.now().timestamp()
+        if now - start_time > timeout:
+            logger.warning(
+                "wait_release_ready timeout after %ds, release_history_id=%d",
+                timeout,
+                release_history_id,
+            )
+            return ReleaseHistoryStatusEnum.FAILURE.value
+
+        time.sleep(1 * wait_times)
+        wait_times += 1

--- a/src/dashboard/apigateway/apigateway/service/release/wait.py
+++ b/src/dashboard/apigateway/apigateway/service/release/wait.py
@@ -68,35 +68,52 @@ def wait_release_done(release_history_id: int, timeout: int = DEFAULT_WAIT_RELEA
 
 def wait_release_ready(release_history_id: int, timeout: int = DEFAULT_WAIT_RELEASE_TIMEOUT) -> str:
     """等待发布成功，并确认当前 Release 已切换到本次发布的资源版本。"""
-    start_time = datetime.now().timestamp()
+    deadline = time.monotonic() + timeout
     final_status = wait_release_done(release_history_id, timeout=timeout)
     if final_status != ReleaseHistoryStatusEnum.SUCCESS.value:
         return final_status
 
-    release_history = ReleaseHistory.objects.only(
-        "gateway_id",
-        "stage_id",
-        "resource_version_id",
-    ).get(id=release_history_id)
+    release_history = (
+        ReleaseHistory.objects.only(
+            "gateway_id",
+            "stage_id",
+            "resource_version_id",
+        )
+        .filter(id=release_history_id)
+        .first()
+    )
+    if not release_history:
+        logger.warning(
+            "wait_release_ready release history no longer exists, release_history_id=%d",
+            release_history_id,
+        )
+        return ReleaseHistoryStatusEnum.FAILURE.value
+
     wait_times = 0
 
     while True:
-        if Release.objects.filter(
+        if time.monotonic() >= deadline:
+            break
+
+        is_ready = Release.objects.filter(
             gateway_id=release_history.gateway_id,
             stage_id=release_history.stage_id,
             resource_version_id=release_history.resource_version_id,
             stage__status=StageStatusEnum.ACTIVE.value,
-        ).exists():
+        ).exists()
+        if is_ready and time.monotonic() < deadline:
             return ReleaseHistoryStatusEnum.SUCCESS.value
 
-        now = datetime.now().timestamp()
-        if now - start_time > timeout:
-            logger.warning(
-                "wait_release_ready timeout after %ds, release_history_id=%d",
-                timeout,
-                release_history_id,
-            )
-            return ReleaseHistoryStatusEnum.FAILURE.value
+        remaining = deadline - time.monotonic()
+        if remaining <= 0:
+            break
 
-        time.sleep(1 * wait_times)
+        time.sleep(min(1 * wait_times, remaining))
         wait_times += 1
+
+    logger.warning(
+        "wait_release_ready timeout after %ds, release_history_id=%d",
+        timeout,
+        release_history_id,
+    )
+    return ReleaseHistoryStatusEnum.FAILURE.value

--- a/src/dashboard/apigateway/apigateway/tests/apps/mcp_server/test_tasks.py
+++ b/src/dashboard/apigateway/apigateway/tests/apps/mcp_server/test_tasks.py
@@ -65,9 +65,9 @@ class TestSyncMcpServerAfterRelease:
 
         with (
             patch(
-                "apigateway.apps.mcp_server.tasks.wait_release_done",
+                "apigateway.apps.mcp_server.tasks.wait_release_ready",
                 return_value=ReleaseHistoryStatusEnum.SUCCESS.value,
-            ),
+            ) as wait_ready,
             patch(
                 "apigateway.apps.mcp_server.tasks.MCPServerHandler.save_mcp_servers",
                 return_value=[{"name": "s1", "action": "updated", "id": mcp_server.id}],
@@ -83,6 +83,7 @@ class TestSyncMcpServerAfterRelease:
                 username="open-api-user",
             )
 
+        wait_ready.assert_called_once_with(release_history.id)
         mock_save.assert_called_once_with(
             gateway_id=fake_gateway.id,
             gateway_name=fake_gateway.name,
@@ -93,13 +94,13 @@ class TestSyncMcpServerAfterRelease:
             comment=None,
         )
 
-    def test_release_failed_skips_save(self, fake_gateway, fake_stage, release_history):
-        """发布失败时跳过写入"""
+    def test_release_not_ready_skips_save(self, fake_gateway, fake_stage, release_history):
+        """发布失败或发布数据未就绪时跳过写入"""
         mcp_data = [{"name": "s1"}]
 
         with (
             patch(
-                "apigateway.apps.mcp_server.tasks.wait_release_done",
+                "apigateway.apps.mcp_server.tasks.wait_release_ready",
                 return_value=ReleaseHistoryStatusEnum.FAILURE.value,
             ),
             patch(
@@ -123,7 +124,7 @@ class TestSyncMcpServerAfterRelease:
 
         with (
             patch(
-                "apigateway.apps.mcp_server.tasks.wait_release_done",
+                "apigateway.apps.mcp_server.tasks.wait_release_ready",
                 return_value=ReleaseHistoryStatusEnum.SUCCESS.value,
             ),
             patch(

--- a/src/dashboard/apigateway/apigateway/tests/service/release/test_wait.py
+++ b/src/dashboard/apigateway/apigateway/tests/service/release/test_wait.py
@@ -25,7 +25,7 @@ from apigateway.core.constants import (
     ReleaseHistoryStatusEnum,
     StageStatusEnum,
 )
-from apigateway.core.models import PublishEvent, Release
+from apigateway.core.models import PublishEvent, Release, ReleaseHistory, ResourceVersion
 from apigateway.service.release import wait_release_done, wait_release_ready
 
 
@@ -92,6 +92,39 @@ class TestWaitReleaseReady:
 
         assert result == ReleaseHistoryStatusEnum.SUCCESS.value
 
+    def test_success_waits_for_current_release_resource_version(self, fake_release_history):
+        fake_stage = fake_release_history.stage
+        fake_stage.status = StageStatusEnum.ACTIVE.value
+        fake_stage.save(update_fields=["status"])
+        old_resource_version = G(
+            ResourceVersion,
+            gateway=fake_release_history.gateway,
+            version="old-version",
+            _data="[]",
+        )
+        release = G(
+            Release,
+            gateway=fake_release_history.gateway,
+            stage=fake_stage,
+            resource_version=old_resource_version,
+        )
+
+        def switch_release_version(_seconds):
+            Release.objects.filter(id=release.id).update(resource_version_id=fake_release_history.resource_version_id)
+
+        with (
+            patch(
+                "apigateway.service.release.wait.wait_release_done",
+                return_value=ReleaseHistoryStatusEnum.SUCCESS.value,
+            ),
+            patch("apigateway.service.release.wait.time.sleep", side_effect=switch_release_version),
+        ):
+            result = wait_release_ready(fake_release_history.id)
+
+        release.refresh_from_db()
+        assert result == ReleaseHistoryStatusEnum.SUCCESS.value
+        assert release.resource_version_id == fake_release_history.resource_version_id
+
     def test_failure_does_not_require_release_history(self):
         missing_release_history_id = 2_147_483_647
 
@@ -119,5 +152,47 @@ class TestWaitReleaseReady:
             return_value=ReleaseHistoryStatusEnum.SUCCESS.value,
         ):
             result = wait_release_ready(fake_release_history.id, timeout=0)
+
+        assert result == ReleaseHistoryStatusEnum.FAILURE.value
+
+    def test_event_wait_consumes_total_timeout_budget(self, fake_release_history):
+        fake_stage = fake_release_history.stage
+        fake_stage.status = StageStatusEnum.ACTIVE.value
+        fake_stage.save(update_fields=["status"])
+        G(
+            Release,
+            gateway=fake_release_history.gateway,
+            stage=fake_stage,
+            resource_version=fake_release_history.resource_version,
+        )
+        current_time = 0.0
+
+        def finish_event_wait(_release_history_id, *, timeout):
+            nonlocal current_time
+            assert timeout == 150
+            current_time = 150.0
+            return ReleaseHistoryStatusEnum.SUCCESS.value
+
+        with (
+            patch("apigateway.service.release.wait.time.monotonic", side_effect=lambda: current_time),
+            patch("apigateway.service.release.wait.wait_release_done", side_effect=finish_event_wait),
+        ):
+            result = wait_release_ready(fake_release_history.id)
+
+        assert result == ReleaseHistoryStatusEnum.FAILURE.value
+
+    def test_success_event_with_deleted_release_history_returns_failure(self, fake_release_history):
+        release_history_id = fake_release_history.id
+
+        def delete_release_history(_release_history_id, *, timeout):
+            assert timeout == 150
+            ReleaseHistory.objects.filter(id=release_history_id).delete()
+            return ReleaseHistoryStatusEnum.SUCCESS.value
+
+        with patch(
+            "apigateway.service.release.wait.wait_release_done",
+            side_effect=delete_release_history,
+        ):
+            result = wait_release_ready(release_history_id)
 
         assert result == ReleaseHistoryStatusEnum.FAILURE.value

--- a/src/dashboard/apigateway/apigateway/tests/service/release/test_wait.py
+++ b/src/dashboard/apigateway/apigateway/tests/service/release/test_wait.py
@@ -23,9 +23,10 @@ from apigateway.core.constants import (
     PublishEventNameTypeEnum,
     PublishEventStatusTypeEnum,
     ReleaseHistoryStatusEnum,
+    StageStatusEnum,
 )
-from apigateway.core.models import PublishEvent
-from apigateway.service.release import wait_release_done
+from apigateway.core.models import PublishEvent, Release
+from apigateway.service.release import wait_release_done, wait_release_ready
 
 
 class TestWaitReleaseDone:
@@ -61,5 +62,62 @@ class TestWaitReleaseDone:
         """超时返回 FAILURE"""
         with patch("apigateway.service.release.wait.time.sleep"):
             result = wait_release_done(fake_release_history.id, timeout=0)
+
+        assert result == ReleaseHistoryStatusEnum.FAILURE.value
+
+
+class TestWaitReleaseReady:
+    def test_success_waits_for_matching_active_release(self, fake_release_history):
+        fake_stage = fake_release_history.stage
+        fake_stage.status = StageStatusEnum.INACTIVE.value
+        fake_stage.save(update_fields=["status"])
+        G(
+            Release,
+            gateway=fake_release_history.gateway,
+            stage=fake_stage,
+            resource_version=fake_release_history.resource_version,
+        )
+
+        def activate_stage(_seconds):
+            type(fake_stage).objects.filter(id=fake_stage.id).update(status=StageStatusEnum.ACTIVE.value)
+
+        with (
+            patch(
+                "apigateway.service.release.wait.wait_release_done",
+                return_value=ReleaseHistoryStatusEnum.SUCCESS.value,
+            ),
+            patch("apigateway.service.release.wait.time.sleep", side_effect=activate_stage),
+        ):
+            result = wait_release_ready(fake_release_history.id)
+
+        assert result == ReleaseHistoryStatusEnum.SUCCESS.value
+
+    def test_failure_does_not_require_release_history(self):
+        missing_release_history_id = 2_147_483_647
+
+        with patch(
+            "apigateway.service.release.wait.wait_release_done",
+            return_value=ReleaseHistoryStatusEnum.FAILURE.value,
+        ):
+            result = wait_release_ready(missing_release_history_id)
+
+        assert result == ReleaseHistoryStatusEnum.FAILURE.value
+
+    def test_success_event_without_ready_release_times_out(self, fake_release_history):
+        fake_stage = fake_release_history.stage
+        fake_stage.status = StageStatusEnum.INACTIVE.value
+        fake_stage.save(update_fields=["status"])
+        G(
+            Release,
+            gateway=fake_release_history.gateway,
+            stage=fake_stage,
+            resource_version=fake_release_history.resource_version,
+        )
+
+        with patch(
+            "apigateway.service.release.wait.wait_release_done",
+            return_value=ReleaseHistoryStatusEnum.SUCCESS.value,
+        ):
+            result = wait_release_ready(fake_release_history.id, timeout=0)
 
         assert result == ReleaseHistoryStatusEnum.FAILURE.value


### PR DESCRIPTION
### Description

将 #3207 backport 到 `release/1.23`。

源 PR：https://github.com/TencentBlueKing/blueking-apigateway/pull/3207

本修复避免发布成功事件已写入、但当前 Release 和 Stage 尚未完成控制面切换时，异步 MCP Server 同步偶发失败。发布成功后会继续等待 Stage ACTIVE，且当前 Release 资源版本与触发任务的 ReleaseHistory 一致。

Cherry-picked commits：

- `ffaf21017` → `9678e7079` — wait for finalized release state
- `abff0e801` → `48a4c6724` — sync servers after release state is ready
- `76d238fdc` → `371944acd` — harden release readiness waiting

第 2 个提交在 `apps/mcp_server/tasks.py` 的 import 区域发生冲突。`release/1.23` 不包含 master 后续新增的其他 task imports，因此解析时仅将 `wait_release_done` 替换为 `wait_release_ready`；函数体和测试变更保持与源 PR 一致。

### Verification

- MCP/release focused tests：50 passed
- `uv run make edition-ee`：通过
- `uv run make lint-check`：通过
- `uv run make test`：3346 passed
- `git diff --check upstream/release/1.23...HEAD`：通过
- `git range-diff`：除 `-x` 元数据及 release 分支缺少的 master-only imports 外，3 个提交与源 PR 对齐

未执行部署后 E2E，需在测试环境验证 6 个 Streamable HTTP MCP Bruno 用例。

### Checklist

- [x] 填写 PR 描述及相关 issue (write PR description and related issue)
- [x] 代码风格检查通过 (code style check passed)
- [x] PR 中包含单元测试 (include unit test)
- [x] 单元测试通过 (unit test passed)
- [ ] 本地开发联调环境验证通过 (local development environment verification passed)
