### PR TITLE
feat(dashboard): raise inner list page limit to 1000 for release/1.23

### DIFF
--- a/src/dashboard/apigateway/apigateway/apis/v2/inner/views.py
+++ b/src/dashboard/apigateway/apigateway/apis/v2/inner/views.py
@@ -91,7 +91,7 @@ logger = logging.getLogger(__name__)
 
 # Inner list endpoints share the same bounded pagination contract documented in OpenAPI.
 INNER_BOUNDED_LIST_DEFAULT_LIMIT = 10
-INNER_BOUNDED_LIST_MAX_LIMIT = 20
+INNER_BOUNDED_LIST_MAX_LIMIT = 1000
 
 
 class OAuth2ClientScopePagination(BoundedLimitOffsetPagination):

--- a/src/dashboard/apigateway/apigateway/data/apidocs/zh/v2_inner_list_gateway_released_resources.md
+++ b/src/dashboard/apigateway/apigateway/data/apidocs/zh/v2_inner_list_gateway_released_resources.md
@@ -19,7 +19,7 @@
 | 参数名称 | 参数类型 | 必选 | 描述 |
 |---|---|---|---|
 | fields | string | 否 | 返回字段列表，多个以逗号分隔；支持 `id`、`name`、`description`、`is_public`、`oauth2_public_client_enabled`、`oauth2_personal_client_enabled`，不传返回全部字段 |
-| limit | int | 否 | 每页数量，默认 10，最大 20 |
+| limit | int | 否 | 每页数量，默认 10，最大 1000 |
 | offset | int | 否 | 分页偏移量，默认 0 |
 
 ### 响应示例

--- a/src/dashboard/apigateway/apigateway/data/apidocs/zh/v2_inner_list_mcp_server.md
+++ b/src/dashboard/apigateway/apigateway/data/apidocs/zh/v2_inner_list_mcp_server.md
@@ -14,7 +14,7 @@
 | keyword | string | 否  | MCPServer 筛选条件，支持模糊匹配 MCPServer 名称或描述 |
 | order_by | string | 否  | 排序字段，支持 id, name, updated_time, created_time，前缀 - 表示降序，默认 -updated_time |
 | fields | string | 否  | 指定返回的字段列表，多个以逗号分割，例如 `fields=name,title`；支持的字段见 `data.results`；不传时返回全部字段，包含不支持的字段时返回参数校验错误 |
-| limit | int | 否 | 每页数量，取值范围 1～20，默认 10 |
+| limit | int | 否 | 每页数量，取值范围 1～1000，默认 10 |
 | offset | int | 否 | 分页偏移量，必须大于或等于 0，默认 0 |
 
 

--- a/src/dashboard/apigateway/apigateway/data/apidocs/zh/v2_inner_list_oauth2_mcp_server_scopes.md
+++ b/src/dashboard/apigateway/apigateway/data/apidocs/zh/v2_inner_list_oauth2_mcp_server_scopes.md
@@ -13,7 +13,7 @@
 | oauth_client_type | string | 是 | OAuth2 客户端类型：`personal` 或 `public` |
 | gateway_name | string | 否 | 网关名称，包含匹配，最长 64 个字符 |
 | mcp_server_name | string | 否 | MCP Server 名称，包含匹配，最长 64 个字符 |
-| limit | int | 否 | 每页网关数量，范围 1～20，默认 10 |
+| limit | int | 否 | 每页网关数量，范围 1～1000，默认 10 |
 | offset | int | 否 | 网关分页偏移量，必须大于或等于 0，默认 0 |
 
 同时传入 `gateway_name` 和 `mcp_server_name` 时，两个过滤条件均须满足。

--- a/src/dashboard/apigateway/apigateway/data/apidocs/zh/v2_inner_list_oauth2_resource_scopes.md
+++ b/src/dashboard/apigateway/apigateway/data/apidocs/zh/v2_inner_list_oauth2_resource_scopes.md
@@ -15,7 +15,7 @@
 | oauth_client_type | string | 是 | OAuth2 客户端类型：`personal` 或 `public` |
 | gateway_name | string | 否 | 网关名称，包含匹配，最长 64 个字符 |
 | resource_name | string | 否 | 资源名称，包含匹配，最长 256 个字符 |
-| limit | int | 否 | 每页网关数量，范围 1～20，默认 10 |
+| limit | int | 否 | 每页网关数量，范围 1～1000，默认 10 |
 | offset | int | 否 | 网关分页偏移量，必须大于或等于 0，默认 0 |
 
 同时传入 `gateway_name` 和 `resource_name` 时，两个过滤条件均须满足。

--- a/src/dashboard/apigateway/apigateway/data/apigw-definitions/bk-apigateway-resources.yaml
+++ b/src/dashboard/apigateway/apigateway/data/apigw-definitions/bk-apigateway-resources.yaml
@@ -5851,9 +5851,9 @@ paths:
           schema:
             type: integer
             minimum: 1
-            maximum: 20
+            maximum: 1000
             default: 10
-          description: 每页数量，最大 20
+          description: 每页数量，最大 1000
         - name: offset
           in: query
           required: false
@@ -7221,7 +7221,7 @@ paths:
           schema:
             type: integer
             minimum: 1
-            maximum: 20
+            maximum: 1000
             default: 10
           description: 每页 MCPServer 数量
         - name: offset
@@ -7347,7 +7347,7 @@ paths:
           schema:
             type: integer
             minimum: 1
-            maximum: 20
+            maximum: 1000
             default: 10
           description: 每页网关数量
         - name: offset
@@ -7458,7 +7458,7 @@ paths:
           schema:
             type: integer
             minimum: 1
-            maximum: 20
+            maximum: 1000
             default: 10
           description: 每页网关数量
         - name: offset

--- a/src/dashboard/apigateway/apigateway/tests/apis/v2/inner/test_gateway_lookup_views.py
+++ b/src/dashboard/apigateway/apigateway/tests/apis/v2/inner/test_gateway_lookup_views.py
@@ -483,7 +483,7 @@ class TestGatewayReleasedResourceApi:
         "query",
         [
             {"limit": 0},
-            {"limit": 21},
+            {"limit": 1001},
             {"limit": "invalid"},
             {"offset": -1},
             {"offset": "invalid"},
@@ -514,7 +514,7 @@ class TestGatewayReleasedResourceApi:
             view_name="openapi.v2.inner.gateway.released_resource.list",
             path_params={"gateway_name": gateway.name},
             app=mock.MagicMock(app_code="bk_auth"),
-            data={"fields": "id,name", "limit": 20, "offset": 10},
+            data={"fields": "id,name", "limit": 1000, "offset": 10},
         )
 
         assert response.status_code == 200

--- a/src/dashboard/apigateway/apigateway/tests/apis/v2/inner/test_oauth2_client_scope_views.py
+++ b/src/dashboard/apigateway/apigateway/tests/apis/v2/inner/test_oauth2_client_scope_views.py
@@ -93,7 +93,7 @@ def test_scope_list_rejects_missing_or_unknown_client_type(request_view, view_na
     "query",
     [
         {"limit": 0},
-        {"limit": 21},
+        {"limit": 1001},
         {"limit": "invalid"},
         {"offset": -1},
         {"offset": "invalid"},
@@ -108,6 +108,18 @@ def test_resource_scope_list_rejects_invalid_pagination(request_view, query):
     )
 
     assert response.status_code == 400
+
+
+@pytest.mark.parametrize("view_name", [MCP_SCOPE_VIEW, RESOURCE_SCOPE_VIEW])
+def test_scope_list_accepts_limit_1000(request_view, view_name):
+    response = request_view(
+        method="GET",
+        view_name=view_name,
+        app=mock.MagicMock(app_code="test"),
+        data={"oauth_client_type": "public", "limit": 1000},
+    )
+
+    assert response.status_code == 200
 
 
 @pytest.mark.parametrize(

--- a/src/dashboard/apigateway/apigateway/tests/apis/v2/inner/test_views.py
+++ b/src/dashboard/apigateway/apigateway/tests/apis/v2/inner/test_views.py
@@ -1951,7 +1951,7 @@ class TestMCPServerListApi:
 
         assert resp.status_code == 400
 
-    @pytest.mark.parametrize("limit", [0, 21, "invalid"])
+    @pytest.mark.parametrize("limit", [0, 1001, "invalid"])
     def test_list_rejects_invalid_limit(self, request_view, limit):
         resp = request_view(
             method="GET",
@@ -1961,6 +1961,16 @@ class TestMCPServerListApi:
         )
 
         assert resp.status_code == 400
+
+    def test_list_accepts_limit_1000(self, request_view):
+        resp = request_view(
+            method="GET",
+            view_name="openapi.v2.inner.mcp_server.list",
+            data={"limit": 1000},
+            app=mock.MagicMock(app_code="test"),
+        )
+
+        assert resp.status_code == 200
 
     def test_list_rejects_unsupported_fields(self, request_view):
         resp = request_view(


### PR DESCRIPTION
## Summary
- backport #3218 to `release/1.23`
- source PR: https://github.com/TencentBlueKing/blueking-apigateway/pull/3218
- keep app request-log and alarm-record pagination behavior unchanged

## Cherry-picked commits
- `7a847465911bb6ba69efdecfefb1c57c2e8e30f0` feat(dashboard): raise inner list page limit to 1000

## Verification
- focused pagination tests: 146 passed
- `uv run make check-openapi`: 0 errors (41 existing warnings)
- `uv run make edition-ee && uv run make lint-check`: passed
- `uv run make edition-ee && uv run make test`: 3349 passed