### PR TITLE
fix(dashboard): resolve inner MCP permission handler names

### DIFF
--- a/src/dashboard/apigateway/apigateway/apis/v2/inner/serializers.py
+++ b/src/dashboard/apigateway/apigateway/apis/v2/inner/serializers.py
@@ -568,8 +568,16 @@ class MCPServerPermissionBaseSLZ(serializers.Serializer):
     status = serializers.CharField(help_text="MCPServer 权限状态")
     action = serializers.CharField(help_text="MCPServer 权限操作")
     expires_in = serializers.IntegerField(help_text="MCPServer 权限过期时间")
-    handled_by = serializers.ListField(child=serializers.CharField(), help_text="处理人")
+    handled_by = serializers.SerializerMethodField(help_text="处理人")
     approval_url = serializers.SerializerMethodField(help_text="权限审批 URL")
+
+    @swagger_serializer_method(serializer_or_field=serializers.ListField(child=serializers.CharField()))
+    def get_handled_by(self, obj):
+        return ResourcePermissionHandler.convert_gateway_maintainers_to_display_names(
+            obj.get("tenant_mode", ""),
+            obj.get("tenant_id", ""),
+            obj.get("handled_by") or [],
+        )
 
     def get_approval_url(self, obj) -> str:
         """获取审批 URL"""

--- a/src/dashboard/apigateway/apigateway/apis/v2/inner/views.py
+++ b/src/dashboard/apigateway/apigateway/apis/v2/inner/views.py
@@ -1008,6 +1008,8 @@ class MCPServerPermissionListApi(generics.ListAPIView):
                         "mcp_server_id": obj.id,
                         "gateway_id": obj.gateway_id,
                         "itsm_ticket_id": itsm_ticket_id,
+                        "tenant_mode": obj.gateway.tenant_mode,
+                        "tenant_id": obj.gateway.tenant_id,
                     },
                 }
             )
@@ -1115,6 +1117,8 @@ class MCPServerAppPermissionListApi(generics.ListAPIView):
                     "handled_by": [handled_by_map.get(perm.mcp_server_id, "")],
                     "mcp_server_id": perm.mcp_server_id,
                     "gateway_id": perm.mcp_server.gateway_id,
+                    "tenant_mode": perm.mcp_server.gateway.tenant_mode,
+                    "tenant_id": perm.mcp_server.gateway.tenant_id,
                 },
             }
             for perm in granted_permissions

--- a/src/dashboard/apigateway/apigateway/tests/apis/v2/inner/test_views.py
+++ b/src/dashboard/apigateway/apigateway/tests/apis/v2/inner/test_views.py
@@ -230,6 +230,47 @@ class TestGatewayAppPermissionApplyCreateApi:
 
 
 class TestMCPServerPermissionListApi:
+    @patch("apigateway.biz.permission.permission.settings.ENABLE_MULTI_TENANT_MODE", True)
+    @patch("apigateway.biz.permission.permission.query_display_names_for_readonly")
+    def test_list_converts_handled_by_to_display_names(
+        self,
+        mock_query_display_names_for_readonly,
+        request_view,
+        fake_gateway,
+        fake_stage,
+    ):
+        mock_query_display_names_for_readonly.return_value = ["管理员"]
+        fake_gateway.tenant_mode = TenantModeEnum.GLOBAL.value
+        fake_gateway.tenant_id = ""
+        fake_gateway.save(update_fields=["tenant_mode", "tenant_id"])
+        mcp_server = G(
+            MCPServer,
+            gateway=fake_gateway,
+            stage=fake_stage,
+            name="test-mcp-server",
+            is_public=True,
+            status=MCPServerStatusEnum.ACTIVE.value,
+        )
+        G(
+            MCPServerAppPermissionApply,
+            bk_app_code="test-app",
+            mcp_server=mcp_server,
+            status=MCPServerAppPermissionApplyStatusEnum.APPROVED.value,
+            handled_by="7idwx3b7nzk6xigs",
+        )
+
+        resp = request_view(
+            method="GET",
+            view_name="openapi.v2.inner.mcp_server.permission.list",
+            data={"target_app_code": "test-app"},
+            app=mock.MagicMock(app_code="test"),
+            HTTP_X_BK_TENANT_ID="tenant-1",
+        )
+
+        assert resp.status_code == 200
+        assert resp.json()["data"][0]["permission"]["handled_by"] == ["管理员"]
+        mock_query_display_names_for_readonly.assert_called_once_with("system", ["7idwx3b7nzk6xigs"])
+
     def test_list_with_protocol_type(self, request_view, fake_gateway, fake_stage):
         """测试 MCP Server 权限列表包含协议类型数据"""
         # 创建 MCP Server
@@ -770,6 +811,53 @@ class TestMCPServerAppPermissionApplyCreateApi:
 
 
 class TestMCPServerAppPermissionListApi:
+    @patch("apigateway.biz.permission.permission.settings.ENABLE_MULTI_TENANT_MODE", True)
+    @patch("apigateway.biz.permission.permission.query_display_names_for_readonly")
+    def test_list_converts_handled_by_to_display_names(
+        self,
+        mock_query_display_names_for_readonly,
+        request_view,
+        fake_gateway,
+        fake_stage,
+    ):
+        mock_query_display_names_for_readonly.return_value = ["管理员"]
+        fake_gateway.tenant_mode = TenantModeEnum.GLOBAL.value
+        fake_gateway.tenant_id = ""
+        fake_gateway.save(update_fields=["tenant_mode", "tenant_id"])
+        mcp_server = G(
+            MCPServer,
+            gateway=fake_gateway,
+            stage=fake_stage,
+            name="test-mcp-server",
+            is_public=True,
+            status=MCPServerStatusEnum.ACTIVE.value,
+        )
+        G(
+            MCPServerAppPermissionApply,
+            bk_app_code="test-app",
+            mcp_server=mcp_server,
+            status=MCPServerAppPermissionApplyStatusEnum.APPROVED.value,
+            handled_by="7idwx3b7nzk6xigs",
+        )
+        G(
+            MCPServerAppPermission,
+            bk_app_code="test-app",
+            mcp_server=mcp_server,
+            grant_type=MCPServerAppPermissionGrantTypeEnum.APPLY.value,
+        )
+
+        resp = request_view(
+            method="GET",
+            view_name="openapi.v2.inner.mcp_server.permission.app-permissions",
+            data={"target_app_code": "test-app"},
+            app=mock.MagicMock(app_code="test"),
+            HTTP_X_BK_TENANT_ID="tenant-1",
+        )
+
+        assert resp.status_code == 200
+        assert resp.json()["data"][0]["permission"]["handled_by"] == ["管理员"]
+        mock_query_display_names_for_readonly.assert_called_once_with("system", ["7idwx3b7nzk6xigs"])
+
     def test_list_with_protocol_type(self, request_view, fake_gateway, fake_stage):
         """测试已申请权限列表包含协议类型数据"""
         mcp_server = G(


### PR DESCRIPTION
## Summary
- resolve handled_by with the gateway tenant for both inner MCP permission list APIs
- preserve the existing list response shape and fallback to original usernames when lookup fails
- add endpoint-level regression coverage for cross-tenant display names

## Verification
- focused MCP permission list tests: 19 passed
- uv run make edition-ee && uv run make lint-check
- uv run make edition-ee && uv run make test: 3907 passed