### PR TITLE
fix(dashboard): block overlapping stage releases

### DIFF
--- a/src/dashboard/apigateway/apigateway/apis/web/release/views.py
+++ b/src/dashboard/apigateway/apigateway/apis/web/release/views.py
@@ -42,7 +42,7 @@ from apigateway.components.bkpaas import (
     get_paas_offline_result,
     get_pass_deploy_streams_history_events,
 )
-from apigateway.core.constants import PublishSourceEnum
+from apigateway.core.constants import PublishSourceEnum, ReleaseHistoryStatusEnum, ReleaseStatusEnum
 from apigateway.core.models import Backend, PublishEvent, Release, ReleaseHistory, ResourceVersion
 from apigateway.service.resource import get_resource_id_to_labels_by_label_ids
 from apigateway.service.resource_version import get_resource_schema
@@ -210,6 +210,17 @@ class ReleaseCreateApi(generics.CreateAPIView):
                 timeout=settings.REDIS_PUBLISH_LOCK_TIMEOUT,
                 try_get_times=settings.REDIS_PUBLISH_LOCK_RETRY_GET_TIMES,
             ):
+                stage_publish_status = release_biz.ReleaseHandler.batch_get_stage_release_status([stage_id]).get(
+                    stage_id, {}
+                )
+                if stage_publish_status.get("status") in (
+                    ReleaseHistoryStatusEnum.DOING.value,
+                    ReleaseStatusEnum.PENDING.value,
+                ):
+                    raise error_codes.FAILED_PRECONDITION.format(
+                        _("当前环境正在发布或下架，请稍后再试。"), replace=True
+                    )
+
                 history = release_biz.release_gateway(
                     gateway=request.gateway,
                     stage_id=slz.validated_data["stage_id"],

--- a/src/dashboard/apigateway/apigateway/apis/web/stage/serializers.py
+++ b/src/dashboard/apigateway/apigateway/apis/web/stage/serializers.py
@@ -45,6 +45,7 @@ from apigateway.core.backend_config import BACKEND_CONFIG_TYPES
 from apigateway.core.constants import (
     STAGE_NAME_PATTERN,
     PublishEventStatusEnum,
+    ReleaseHistoryStatusEnum,
     ReleaseStatusEnum,
     StageStatusEnum,
 )
@@ -93,13 +94,14 @@ class StageOutputSLZ(serializers.ModelSerializer):
     def get_release(self, obj):
         # 获取stage发布状态
         has_release = self.context["stage_release"].get(obj.id, {}).get("release_status", False)
+        publish_status = self.context["stage_publish_status"].get(obj.id, {}).get("status")
 
-        # 如果stage有发布，则获取其实时发布状态，否则则为未发布
-        status = (
-            self.context["stage_publish_status"].get(obj.id, {}).get("status", ReleaseStatusEnum.SUCCESS.value)
-            if has_release
-            else ReleaseStatusEnum.UNRELEASED.value
-        )
+        if publish_status in (ReleaseHistoryStatusEnum.DOING.value, ReleaseStatusEnum.PENDING.value):
+            status = ReleaseHistoryStatusEnum.DOING.value
+        elif has_release:
+            status = publish_status or ReleaseStatusEnum.SUCCESS.value
+        else:
+            status = ReleaseStatusEnum.UNRELEASED.value
 
         release_time = self.context["stage_release"].get(obj.id, {}).get("release_time", "")
 
@@ -147,6 +149,10 @@ class StageOutputSLZ(serializers.ModelSerializer):
         # 如果是编程网关，直接返回空字符串，编程网关部署的时候才会进行各种资源的注册
         if obj.gateway.is_programmable:
             return ""
+
+        publish_status = self.context["stage_publish_status"].get(obj.id, {}).get("status")
+        if publish_status in (ReleaseHistoryStatusEnum.DOING.value, ReleaseStatusEnum.PENDING.value):
+            return _("当前环境正在发布或下架，请稍后再试。")
 
         validate_err_message: str = ""
 

--- a/src/dashboard/apigateway/apigateway/tests/apis/web/release/test_views.py
+++ b/src/dashboard/apigateway/apigateway/tests/apis/web/release/test_views.py
@@ -31,6 +31,7 @@ from apigateway.apps.openapi.models import OpenAPIResourceSchemaVersion
 from apigateway.core.constants import PublishEventNameTypeEnum, PublishEventStatusTypeEnum
 from apigateway.core.models import PublishEvent, Release, ReleaseHistory, ResourceVersion, Stage
 from apigateway.tests.utils.testing import dummy_time
+from apigateway.utils.time import now_datetime
 
 pytestmark = pytest.mark.django_db
 
@@ -41,6 +42,44 @@ def test_programmable_deploy_retrieve_api_description():
 
 
 class TestReleaseCreateApi:
+    def test_rejects_release_while_stage_operation_is_running(
+        self,
+        request_view,
+        fake_admin_user,
+        fake_gateway,
+        fake_stage,
+        fake_resource_version,
+        fake_release_history,
+        fake_publish_event,
+        mocker,
+    ):
+        fake_publish_event.created_time = now_datetime()
+        fake_publish_event.save(update_fields=["created_time"])
+        mocker.patch("apigateway.apis.web.release.views.Lock", return_value=MagicMock())
+        mocker.patch(
+            "apigateway.apis.web.release.views.release_biz.release_gateway",
+            return_value=fake_release_history,
+        )
+
+        response = request_view(
+            method="POST",
+            view_name="gateway.release.create",
+            gateway=fake_gateway,
+            path_params={"gateway_id": fake_gateway.id},
+            data={
+                "stage_id": fake_stage.id,
+                "resource_version_id": fake_resource_version.id,
+            },
+            user=fake_admin_user,
+        )
+
+        assert response.status_code == 400
+        assert response.json()["error"] == {
+            "code": "FAILED_PRECONDITION",
+            "message": "当前环境正在发布或下架，请稍后再试。",
+            "data": None,
+        }
+
     def test_release_with_hosts(self, request_view, fake_admin_user, mocker, fake_gateway, fake_resource_version):
         """Test release API with different hosts config of stage objects."""
         stage_1 = G(Stage, gateway=fake_gateway, name="prod", status=0)
@@ -69,6 +108,13 @@ class TestReleaseCreateApi:
                 stage=stage,
                 resource_version=fake_resource_version,
                 created_time=dummy_time.time,
+            )
+            G(
+                PublishEvent,
+                publish=release_history,
+                name=PublishEventNameTypeEnum.LOAD_CONFIGURATION.value,
+                status=PublishEventStatusTypeEnum.SUCCESS.value,
+                created_time=now_datetime(),
             )
             # TODO: mock the releaser
             mocker.patch("apigateway.apis.web.release.views.release_biz.release_gateway", return_value=release_history)

--- a/src/dashboard/apigateway/apigateway/tests/apis/web/stage/test_views.py
+++ b/src/dashboard/apigateway/apigateway/tests/apis/web/stage/test_views.py
@@ -16,6 +16,7 @@
 # We undertake not to change the open source license (MIT license) applicable
 # to the current version of the project delivered to anyone in the future.
 #
+import pytest
 from django_dynamic_fixture import G
 
 from apigateway.apis.web.ai_backend import AIBackendWebConfigAdapter
@@ -23,7 +24,13 @@ from apigateway.apps.audit.constants import OpObjectTypeEnum
 from apigateway.apps.audit.models import AuditEventLog
 from apigateway.apps.mcp_server.constants import MCPServerStatusEnum
 from apigateway.apps.mcp_server.models import MCPServer
-from apigateway.core.constants import BackendKindEnum, GatewayKindEnum, StageStatusEnum
+from apigateway.core.constants import (
+    BackendKindEnum,
+    GatewayKindEnum,
+    ReleaseHistoryStatusEnum,
+    ReleaseStatusEnum,
+    StageStatusEnum,
+)
 from apigateway.core.models import Backend, BackendConfig, Stage
 
 
@@ -38,6 +45,45 @@ def _ai_config():
 
 
 class TestStageApi:
+    @pytest.mark.parametrize(
+        "release_status",
+        [ReleaseHistoryStatusEnum.DOING.value, ReleaseStatusEnum.PENDING.value],
+    )
+    def test_list_keeps_running_status_for_inactive_stage(
+        self,
+        request_view,
+        fake_stage,
+        mocker,
+        release_status,
+    ):
+        fake_stage.status = StageStatusEnum.INACTIVE.value
+        fake_stage.save(update_fields=["status"])
+        mocker.patch(
+            "apigateway.apis.web.stage.views.ReleasedResourceHandler.get_stage_release",
+            return_value={},
+        )
+        mocker.patch(
+            "apigateway.apis.web.stage.views.ReleaseHandler.batch_get_stage_release_status",
+            return_value={fake_stage.id: {"status": release_status}},
+        )
+        mocker.patch(
+            "apigateway.apis.web.stage.views.ResourceVersionHandler.get_latest_version_by_gateway",
+            return_value="",
+        )
+
+        response = request_view(
+            "GET",
+            "stage.list-create",
+            path_params={"gateway_id": fake_stage.gateway.id},
+            gateway=fake_stage.gateway,
+        )
+
+        assert response.status_code == 200
+        stage = response.json()["data"][0]
+        assert stage["status"] == StageStatusEnum.INACTIVE.value
+        assert stage["release"]["status"] == ReleaseHistoryStatusEnum.DOING.value
+        assert stage["publish_validate_msg"] == "当前环境正在发布或下架，请稍后再试。"
+
     def test_create_with_ai_backend(self, request_view, fake_gateway, fake_default_backend):
         fake_gateway.kind = GatewayKindEnum.AI.value
         fake_gateway.save()


### PR DESCRIPTION
## Summary

- keep a running publish/down task visible as doing in the stage API even after the stage becomes inactive, and return a temporary publish validation message so the existing UI disables both actions
- reject release requests while the latest stage operation is doing or pending, preventing overlapping publish/down executions at the backend boundary
- add regression coverage for inactive-stage response state and release API rejection

## Verification

- uv run make lint-check
- focused stage/release API tests: 27 passed
- uv run make test: 3910 passed
- git diff --check upstream/master..HEAD