### PR TITLE
feat(mcp-server): 按认证开关分段渲染 MCP Server 使用指南

### DIFF
--- a/src/dashboard-front/src/services/source/basic.ts
+++ b/src/dashboard-front/src/services/source/basic.ts
@@ -131,6 +131,7 @@ export function getEnv() {
       USER_API: string
       UPGRADE_TO_113_TIP: string
       MCP_SERVER_PERMISSION_APPLY: string
+      PERSONAL_TOKEN: string
       PLUGIN_AI_PROXY: string
       PLUGIN_AI_RATE_LIMITING: string
       PLUGIN_API_BREAKER: string

--- a/src/dashboard-front/src/stores/useEnv.ts
+++ b/src/dashboard-front/src/stores/useEnv.ts
@@ -99,6 +99,8 @@ export const useEnv = defineStore('useEnv', {
         UPGRADE_TO_113_TIP: '',
         // mcp 权限申请指引
         MCP_SERVER_PERMISSION_APPLY: '',
+        // 个人令牌
+        PERSONAL_TOKEN: '',
         // 负载均衡帮助文档
         LOADBALANCE: '',
         PLUGIN_AI_PROXY: '',

--- a/src/dashboard/apigateway/apigateway/apis/web/setting/views.py
+++ b/src/dashboard/apigateway/apigateway/apis/web/setting/views.py
@@ -19,13 +19,13 @@
 import copy
 
 from django.conf import settings
-from django.utils import translation
 from django.utils.decorators import method_decorator
 from drf_yasg.utils import swagger_auto_schema
 from rest_framework import generics, status
 
 from apigateway.apps.data_plane.models import DataPlane
 from apigateway.apps.feature.models import UserFeatureFlag
+from apigateway.common.django.translation import get_current_language_code
 from apigateway.conf.utils import get_doc_links
 from apigateway.utils.responses import OKJsonResponse
 
@@ -42,9 +42,8 @@ class EnvVarListApi(generics.ListAPIView):
     def list(self, request, *args, **kwargs):
         env_vars = copy.copy(settings.ENV_VARS_FOR_FRONTEND)
 
-        lang = "EN" if translation.get_language() == "en" else "ZH"
-        doc_links = get_doc_links(settings.BK_APIGATEWAY_VERSION, settings.BK_DOCS_URL_PREFIX, lang)
-        env_vars["DOC_LINKS"] = doc_links
+        lang = "EN" if get_current_language_code() == "en" else "ZH"
+        env_vars["DOC_LINKS"] = get_doc_links(settings.BK_APIGATEWAY_VERSION, settings.BK_DOCS_URL_PREFIX, lang)
 
         env_vars["BK_DATA_PLANE_API_URL_TMPL_MAP"] = {
             dp.name: dp.bk_api_url_tmpl for dp in DataPlane.objects.get_active_data_planes() if dp.bk_api_url_tmpl

--- a/src/dashboard/apigateway/apigateway/biz/mcp_server/mcp_server.py
+++ b/src/dashboard/apigateway/apigateway/biz/mcp_server/mcp_server.py
@@ -61,6 +61,7 @@ from apigateway.biz.released_resource import ReleasedResourceData, ReleasedResou
 from apigateway.biz.released_resource_doc import DocGenerator, ReleasedResourceDocHandler
 from apigateway.biz.resource_doc import ResourceDocHandler
 from apigateway.common.django.translation import get_current_language_code
+from apigateway.common.doc_link import get_doc_link
 from apigateway.common.error_codes import error_codes
 from apigateway.components import bkaidev
 from apigateway.core.constants import GatewayStatusEnum, ResourceKindEnum, StageStatusEnum
@@ -698,7 +699,8 @@ class MCPServerHandler:
             渲染后的 guideline 内容（Markdown 格式）
         """
         mcp_url = MCPServerHandler.get_mcp_server_url(instance, least_privilege)
-        template_name = f"mcp_server/{get_current_language_code()}/guideline.md"
+        language_code = get_current_language_code()
+        template_name = f"mcp_server/{language_code}/guideline.md"
         return render_to_string(
             template_name,
             context={
@@ -707,9 +709,12 @@ class MCPServerHandler:
                 "description": instance.description,
                 "bk_login_ticket_key": settings.BK_LOGIN_TICKET_KEY,
                 "bk_access_token_doc_url": settings.BK_ACCESS_TOKEN_DOC_URL,
+                "bk_personal_token_doc_url": get_doc_link("PERSONAL_TOKEN"),
                 "enable_multi_tenant_mode": settings.ENABLE_MULTI_TENANT_MODE,
                 "user_tenant_id": user_tenant_id,
                 "protocol_type": instance.protocol_type,
+                "oauth2_public_client_enabled": instance.oauth2_public_client_enabled,
+                "oauth2_personal_client_enabled": instance.oauth2_personal_client_enabled,
             },
         )
 

--- a/src/dashboard/apigateway/apigateway/common/doc_link.py
+++ b/src/dashboard/apigateway/apigateway/common/doc_link.py
@@ -1,0 +1,35 @@
+# -*- coding: utf-8 -*-
+#
+# TencentBlueKing is pleased to support the open source community by making
+# 蓝鲸智云 - API 网关(BlueKing - APIGateway) available.
+# Copyright (C) Tencent. All rights reserved.
+# Licensed under the MIT License (the "License"); you may not use this file except
+# in compliance with the License. You may obtain a copy of the License at
+#
+#     http://opensource.org/licenses/MIT
+#
+# Unless required by applicable law or agreed to in writing, software distributed under
+# the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+# either express or implied. See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# We undertake not to change the open source license (MIT license) applicable
+# to the current version of the project delivered to anyone in the future.
+#
+from django.conf import settings
+
+from apigateway.common.django.translation import get_current_language_code
+from apigateway.conf.utils import get_doc_links
+
+
+def get_doc_link(name: str) -> str:
+    """从 get_doc_links 中获取指定文档地址，用于模板渲染。
+
+    文档站语言由当前请求语言决定：en -> EN，其余 -> ZH。
+    """
+    lang = "EN" if get_current_language_code() == "en" else "ZH"
+    return get_doc_links(
+        settings.BK_APIGATEWAY_VERSION,
+        settings.BK_DOCS_URL_PREFIX,
+        lang,
+    )[name]

--- a/src/dashboard/apigateway/apigateway/conf/utils.py
+++ b/src/dashboard/apigateway/apigateway/conf/utils.py
@@ -381,6 +381,11 @@ def get_doc_links(bk_apigw_version: str, bk_docs_url_prefix: str, lang: str = "Z
             "DOC_LINK_MCP_SERVER_PERMISSION_APPLY",
             default=f"{doc_link_prefix}/UserGuide/HowTo/apply-mcp-server-permission.md",
         ),
+        # 个人令牌
+        "PERSONAL_TOKEN": env.str(
+            "DOC_LINK_PERSONAL_TOKEN",
+            default=f"{doc_link_prefix}/UserGuide/Explanation/personal-token.md",
+        ),
         # bk-cors
         "PLUGIN_BK_CORS": f"{doc_link_prefix}/UserGuide/HowTo/Plugins/bk-cors.md",
         # bk-ip-restriction

--- a/src/dashboard/apigateway/apigateway/templates/mcp_server/en/guideline.md
+++ b/src/dashboard/apigateway/apigateway/templates/mcp_server/en/guideline.md
@@ -1,7 +1,29 @@
 ## Authentication
 
-> **Note**: If the MCP Server has **Public Client Mode** (OAuth2 Public Client) enabled, the `X-Bkapi-Authorization` header is not required in the client configuration — authentication will be handled automatically via the OAuth2 flow. However, the `X-Bkapi-Authorization` header is still supported; if provided, the system will process the authentication as usual.
+{% if oauth2_public_client_enabled %}
+### OAuth2 Public Client Mode
 
+This MCP Server has **OAuth2 Public Client Mode** enabled. The `X-Bkapi-Authorization` header is not required in the client configuration — after the user completes OAuth2 authorization in the browser, authentication will be handled automatically.
+
+{% endif %}
+{% if oauth2_personal_client_enabled %}
+### Personal Token
+
+This MCP Server has **Personal Token** (OAuth2 Personal Client) enabled. Users can call this MCP Server with a personal token without manually configuring app credentials. Add the following header in the MCP client:
+
+```shell
+Authorization: Bearer <your_personal_token>
+```
+
+> For acquisition methods, see [personal token documentation]({{bk_personal_token_doc_url}})
+
+{% endif %}
+### X-Bkapi-Authorization
+
+{% if oauth2_public_client_enabled or oauth2_personal_client_enabled %}
+> **Note**: The `X-Bkapi-Authorization` header is always valid. If provided, the system will process the authentication as usual.
+
+{% endif %}
 The MCP proxy currently integrates with BlueKing API Gateway, requiring both `user authentication` and `app authentication`. When configuring MCP Server, additional authentication headers must be configured as JSON-formatted strings.
 
 ```shell

--- a/src/dashboard/apigateway/apigateway/templates/mcp_server/zh-hans/guideline.md
+++ b/src/dashboard/apigateway/apigateway/templates/mcp_server/zh-hans/guideline.md
@@ -1,7 +1,29 @@
 ## 认证
 
-> **注意**：如果该 MCP Server 开启了**公共客户端模式**（OAuth2 Public Client），客户端配置中无需填写 `X-Bkapi-Authorization` 请求头，系统将通过 OAuth2 流程自动完成认证。但 `X-Bkapi-Authorization` 请求头仍然有效，如果同时配置了该请求头，系统同样会正常处理认证。
+{% if oauth2_public_client_enabled %}
+### OAuth2 公开客户端模式
 
+该 MCP Server 已开启 **OAuth2 公开客户端模式**（OAuth2 Public Client）。客户端配置中无需填写 `X-Bkapi-Authorization` 请求头，用户通过浏览器完成 OAuth2 授权后即可使用，系统将自动完成认证。
+
+{% endif %}
+{% if oauth2_personal_client_enabled %}
+### 个人令牌
+
+该 MCP Server 已开启 **个人令牌**（OAuth2 Personal Client）。用户可以使用个人令牌调用该 MCP Server，无需手动配置应用凭证。请在 MCP 客户端的请求头中配置：
+
+```shell
+Authorization: Bearer <your_personal_token>
+```
+
+> 具体获取方法见 [个人令牌说明]({{bk_personal_token_doc_url}})
+
+{% endif %}
+### X-Bkapi-Authorization
+
+{% if oauth2_public_client_enabled or oauth2_personal_client_enabled %}
+> **注意**：`X-Bkapi-Authorization` 请求头始终有效。如果同时配置了该请求头，系统同样会正常处理认证。
+
+{% endif %}
 目前 MCP proxy 接入了蓝鲸 API 网关，目前需要进行 `用户认证` 和 `应用认证` 双重认证，在配置 MCP Server 的过程中，还需要额外配置认证请求头，值为 JSON 格式字符串。
 
 ```shell

--- a/src/dashboard/apigateway/apigateway/tests/biz/mcp_server/test_mcp_server.py
+++ b/src/dashboard/apigateway/apigateway/tests/biz/mcp_server/test_mcp_server.py
@@ -16,12 +16,14 @@
 # to the current version of the project delivered to anyone in the future.
 #
 import json
+import re
 from unittest.mock import patch
 
 import pytest
 from ddf import G
 from django.db import connection
 from django.test.utils import CaptureQueriesContext
+from django.utils import translation
 
 from apigateway.apps.mcp_server.constants import (
     OFFICIAL_MCP_CATEGORY_NAME,
@@ -1482,9 +1484,11 @@ class TestMCPServerHandler:
             status=MCPServerStatusEnum.ACTIVE.value,
             name="test-mcp",
             description="A test MCP server",
+            oauth2_public_client_enabled=True,
+            oauth2_personal_client_enabled=False,
         )
 
-        mocker.patch(
+        mock_render = mocker.patch(
             "apigateway.biz.mcp_server.mcp_server.render_to_string",
             return_value="# Guideline for test-mcp",
         )
@@ -1492,6 +1496,10 @@ class TestMCPServerHandler:
         result = MCPServerHandler.build_guideline(mcp_server, user_tenant_id="tenant_1")
 
         assert result == "# Guideline for test-mcp"
+        context = mock_render.call_args.kwargs["context"]
+        assert context["oauth2_public_client_enabled"] is True
+        assert context["oauth2_personal_client_enabled"] is False
+        assert "personal-token.md" in context["bk_personal_token_doc_url"]
 
     def test_build_guideline_with_least_privilege(self, fake_gateway, fake_stage, mocker):
         """测试 build_guideline 传入 least_privilege 参数"""
@@ -1515,6 +1523,87 @@ class TestMCPServerHandler:
 
         # 验证 render_to_string 被调用
         mock_render.assert_called_once()
+
+    @pytest.mark.parametrize(
+        ("public_enabled", "personal_enabled", "language", "others_heading", "expected_headings", "always_valid_text"),
+        [
+            (
+                False,
+                False,
+                "zh-hans",
+                "## 其他",
+                ["### X-Bkapi-Authorization"],
+                "始终有效",
+            ),
+            (
+                True,
+                False,
+                "zh-hans",
+                "## 其他",
+                ["### OAuth2 公开客户端模式", "### X-Bkapi-Authorization"],
+                "始终有效",
+            ),
+            (
+                False,
+                True,
+                "zh-hans",
+                "## 其他",
+                ["### 个人令牌", "### X-Bkapi-Authorization"],
+                "始终有效",
+            ),
+            (
+                True,
+                True,
+                "zh-hans",
+                "## 其他",
+                ["### OAuth2 公开客户端模式", "### 个人令牌", "### X-Bkapi-Authorization"],
+                "始终有效",
+            ),
+            (
+                True,
+                True,
+                "en",
+                "## Others",
+                ["### OAuth2 Public Client Mode", "### Personal Token", "### X-Bkapi-Authorization"],
+                "always valid",
+            ),
+        ],
+    )
+    def test_build_guideline_auth_sections(
+        self,
+        fake_gateway,
+        fake_stage,
+        public_enabled,
+        personal_enabled,
+        language,
+        others_heading,
+        expected_headings,
+        always_valid_text,
+    ):
+        """按开关渲染认证说明，顺序为公开客户端、个人令牌、X-Bkapi-Authorization"""
+        mcp_server = G(
+            MCPServer,
+            gateway=fake_gateway,
+            stage=fake_stage,
+            status=MCPServerStatusEnum.ACTIVE.value,
+            name="test-mcp",
+            oauth2_public_client_enabled=public_enabled,
+            oauth2_personal_client_enabled=personal_enabled,
+        )
+
+        with translation.override(language):
+            result = MCPServerHandler.build_guideline(mcp_server)
+
+        auth_section = result.split(others_heading)[0]
+        headings = re.findall(r"^### .+$", auth_section, re.M)
+        assert headings == expected_headings
+        assert (always_valid_text in auth_section) is (public_enabled or personal_enabled)
+        assert "### X-Bkapi-Authorization" in result
+        if personal_enabled:
+            assert "personal-token.md" in auth_section
+            assert "{{bk_personal_token_doc_url}}" not in result
+        else:
+            assert "personal-token.md" not in auth_section
 
     # ========== apply_category_filter 测试 ==========
 

--- a/src/dashboard/apigateway/apigateway/tests/common/test_doc_link.py
+++ b/src/dashboard/apigateway/apigateway/tests/common/test_doc_link.py
@@ -1,0 +1,37 @@
+# -*- coding: utf-8 -*-
+#
+# TencentBlueKing is pleased to support the open source community by making
+# 蓝鲸智云 - API 网关(BlueKing - APIGateway) available.
+# Copyright (C) Tencent. All rights reserved.
+# Licensed under the MIT License (the "License"); you may not use this file except
+# in compliance with the License. You may obtain a copy of the License at
+#
+#     http://opensource.org/licenses/MIT
+#
+# Unless required by applicable law or agreed to in writing, software distributed under
+# the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+# either express or implied. See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# We undertake not to change the open source license (MIT license) applicable
+# to the current version of the project delivered to anyone in the future.
+#
+import pytest
+from django.utils import translation
+
+from apigateway.common.doc_link import get_doc_link
+
+
+@pytest.mark.parametrize(
+    ("django_language", "expected_lang"),
+    [
+        ("en", "EN"),
+        ("zh-hans", "ZH"),
+        ("zh-cn", "ZH"),
+    ],
+)
+def test_get_doc_link_uses_current_language(django_language, expected_lang):
+    with translation.override(django_language):
+        url = get_doc_link("PERSONAL_TOKEN")
+    assert f"/{expected_lang}/" in url
+    assert url.endswith("/UserGuide/Explanation/personal-token.md")

--- a/src/dashboard/apigateway/apigateway/tests/conf/test_utils.py
+++ b/src/dashboard/apigateway/apigateway/tests/conf/test_utils.py
@@ -19,7 +19,12 @@
 
 from environ import Env
 
-from apigateway.conf.utils import get_default_feature_flags, get_frontend_env_vars, get_plugin_metadata_config
+from apigateway.conf.utils import (
+    get_default_feature_flags,
+    get_doc_links,
+    get_frontend_env_vars,
+    get_plugin_metadata_config,
+)
 
 
 def test_get_plugin_metadata_config_uses_local_concurrency_policy():
@@ -71,3 +76,18 @@ def test_get_frontend_env_vars_includes_paas_developer_center_link(monkeypatch):
     assert env_vars["PAAS_DEVELOPER_CENTER_LINK"] == "https://paas.example.com/developer-center"
     assert env_vars["PAAS_APP_CREATE_LINK"] == "https://paas.example.com/developer-center/app/create"
     assert env_vars["BK_USER_PERSONAL_CENTER_LINK"] == "https://user.example.com/personal-center"
+
+
+def test_get_doc_links_includes_personal_token():
+    links = get_doc_links("1.24.0", "https://docs.example.com", "ZH")
+
+    assert (
+        links["PERSONAL_TOKEN"]
+        == "https://docs.example.com/markdown/ZH/APIGateway/1.24/UserGuide/Explanation/personal-token.md"
+    )
+
+    en_links = get_doc_links("1.24.0", "https://docs.example.com", "EN")
+    assert (
+        en_links["PERSONAL_TOKEN"]
+        == "https://docs.example.com/markdown/EN/APIGateway/1.24/UserGuide/Explanation/personal-token.md"
+    )


### PR DESCRIPTION
## Summary
- MCP Server 使用指南按 `oauth2_public_client_enabled` / `oauth2_personal_client_enabled` 分段渲染：公开客户端和个人令牌按开关展示，`X-Bkapi-Authorization` 始终展示；两者都开启时顺序为公开客户端 → 个人令牌 → `X-Bkapi-Authorization`，并注明该请求头始终有效。
- 新增 `PERSONAL_TOKEN` 文档链接，并通过 `get_doc_link` 按当前请求语言（en → EN，其余 → ZH）注入个人令牌说明。

## Test plan
- [ ] 关闭两个 OAuth2 开关时，认证区只出现 `### X-Bkapi-Authorization`，且不含“始终有效”提示
- [ ] 仅开启公开客户端时，先出现公开客户端说明，再出现 `X-Bkapi-Authorization` 及“始终有效”提示
- [ ] 仅开启个人令牌时，出现 Bearer 请求头示例和个人令牌文档链接
- [ ] 两个开关都开启时，标题顺序为公开客户端 → 个人令牌 → `X-Bkapi-Authorization`
- [ ] 中英文模板均按当前语言渲染对应文档链接


Made with [Cursor](https://cursor.com)