### PR TITLE
fix(backend): align released resource association count

### DIFF
--- a/src/dashboard/apigateway/apigateway/apis/web/backend/views.py
+++ b/src/dashboard/apigateway/apigateway/apis/web/backend/views.py
@@ -83,13 +83,19 @@ class BackendListCreateApi(BackendQuerySetMixin, generics.ListCreateAPIView):
         if page is not None:
             backend_ids = [backend.id for backend in page]
             serializer = BackendListOutputSLZ(
-                page, many=True, context={"resource_count": ProxyHandler.get_resource_count_by_backend(backend_ids)}
+                page,
+                many=True,
+                context={
+                    "resource_count": ProxyHandler.get_resource_count_by_backend(request.gateway.id, backend_ids)
+                },
             )
             return self.get_paginated_response(serializer.data)
 
         backend_ids = [backend.id for backend in queryset]
         serializer = BackendListOutputSLZ(
-            page, many=True, context={"resource_count": ProxyHandler.get_resource_count_by_backend(backend_ids)}
+            page,
+            many=True,
+            context={"resource_count": ProxyHandler.get_resource_count_by_backend(request.gateway.id, backend_ids)},
         )
         return OKJsonResponse(data=serializer.data)
 

--- a/src/dashboard/apigateway/apigateway/biz/resource/proxy.py
+++ b/src/dashboard/apigateway/apigateway/biz/resource/proxy.py
@@ -19,13 +19,17 @@ from collections import defaultdict
 from typing import DefaultDict, Dict, List, Set
 
 from apigateway.core.constants import StageStatusEnum
-from apigateway.core.models import Proxy, Release
+from apigateway.core.models import Proxy, Release, ResourceVersion
 
 
 class ProxyHandler:
     @staticmethod
     def get_resource_count_by_backend(gateway_id: int, backend_ids: List[int]) -> Dict[int, int]:
-        """获取每个 backend 对应的资源个数"""
+        """获取每个 backend 关联的资源个数。
+
+        资源数是当前 Proxy 关联与 ACTIVE 环境已发布资源快照的资源 ID 并集，
+        因此包含已从编辑区删除、但仍存在于已发布版本中的资源。
+        """
         if not backend_ids:
             return {}
 
@@ -37,12 +41,13 @@ class ProxyHandler:
         ):
             resource_ids_by_backend[backend_id].add(resource_id)
 
-        releases = Release.objects.filter(
+        resource_version_ids = Release.objects.filter(
             gateway_id=gateway_id,
             stage__status=StageStatusEnum.ACTIVE.value,
-        ).select_related("resource_version")
-        for release in releases:
-            for resource_data in release.resource_version.data:
+        ).values_list("resource_version_id", flat=True)
+        resource_versions = ResourceVersion.objects.filter(id__in=resource_version_ids)
+        for resource_version in resource_versions:
+            for resource_data in resource_version.data:
                 backend_id = resource_data.get("proxy", {}).get("backend_id")
                 resource_id = resource_data.get("id")
                 if backend_id in backend_id_set and resource_id is not None:

--- a/src/dashboard/apigateway/apigateway/biz/resource/proxy.py
+++ b/src/dashboard/apigateway/apigateway/biz/resource/proxy.py
@@ -15,16 +15,37 @@
 # We undertake not to change the open source license (MIT license) applicable
 # to the current version of the project delivered to anyone in the future.
 #
-from typing import Dict, List
+from collections import defaultdict
+from typing import DefaultDict, Dict, List, Set
 
-from django.db.models import Count
-
-from apigateway.core.models import Proxy
+from apigateway.core.constants import StageStatusEnum
+from apigateway.core.models import Proxy, Release
 
 
 class ProxyHandler:
     @staticmethod
-    def get_resource_count_by_backend(backend_ids: List[int]) -> Dict[int, int]:
+    def get_resource_count_by_backend(gateway_id: int, backend_ids: List[int]) -> Dict[int, int]:
         """获取每个 backend 对应的资源个数"""
-        qs = Proxy.objects.filter(backend_id__in=backend_ids).values("backend_id").annotate(count=Count("backend_id"))
-        return {i["backend_id"]: i["count"] for i in qs}
+        if not backend_ids:
+            return {}
+
+        backend_id_set = set(backend_ids)
+        resource_ids_by_backend: DefaultDict[int, Set[int]] = defaultdict(set)
+
+        for backend_id, resource_id in Proxy.objects.filter(backend_id__in=backend_ids).values_list(
+            "backend_id", "resource_id"
+        ):
+            resource_ids_by_backend[backend_id].add(resource_id)
+
+        releases = Release.objects.filter(
+            gateway_id=gateway_id,
+            stage__status=StageStatusEnum.ACTIVE.value,
+        ).select_related("resource_version")
+        for release in releases:
+            for resource_data in release.resource_version.data:
+                backend_id = resource_data.get("proxy", {}).get("backend_id")
+                resource_id = resource_data.get("id")
+                if backend_id in backend_id_set and resource_id is not None:
+                    resource_ids_by_backend[backend_id].add(resource_id)
+
+        return {backend_id: len(resource_ids) for backend_id, resource_ids in resource_ids_by_backend.items()}

--- a/src/dashboard/apigateway/apigateway/tests/apis/web/backend/test_views.py
+++ b/src/dashboard/apigateway/apigateway/tests/apis/web/backend/test_views.py
@@ -22,7 +22,7 @@ import pytest
 from django.urls import get_resolver
 from django_dynamic_fixture import G
 
-from apigateway.core.constants import BackendKindEnum, GatewayKindEnum
+from apigateway.core.constants import BackendKindEnum, GatewayKindEnum, StageStatusEnum
 from apigateway.core.models import Backend, BackendConfig, Release, ResourceVersion, Stage
 
 
@@ -297,7 +297,12 @@ class TestBackendApi:
         resource_version.data = [{"id": 1, "proxy": {"backend_id": backend.id}}]
         resource_version.save()
         G(Release, gateway=fake_stage.gateway, stage=fake_stage, resource_version=resource_version)
-        another_stage = G(Stage, gateway=fake_stage.gateway, status=1, name="another-stage")
+        another_stage = G(
+            Stage,
+            gateway=fake_stage.gateway,
+            status=StageStatusEnum.ACTIVE.value,
+            name="another-stage",
+        )
         G(Release, gateway=fake_stage.gateway, stage=another_stage, resource_version=resource_version)
 
         response = request_view(

--- a/src/dashboard/apigateway/apigateway/tests/apis/web/backend/test_views.py
+++ b/src/dashboard/apigateway/apigateway/tests/apis/web/backend/test_views.py
@@ -20,9 +20,10 @@ import logging
 
 import pytest
 from django.urls import get_resolver
+from django_dynamic_fixture import G
 
 from apigateway.core.constants import BackendKindEnum, GatewayKindEnum
-from apigateway.core.models import Backend, BackendConfig
+from apigateway.core.models import Backend, BackendConfig, Release, ResourceVersion, Stage
 
 
 def _ai_config(stage_id):
@@ -289,6 +290,27 @@ class TestBackendApi:
         assert response.status_code == 200
         data = response.json()
         assert data["data"]["count"] == 1
+
+    def test_list_counts_backend_referenced_only_by_released_resource(self, request_view, fake_stage):
+        backend = G(Backend, gateway=fake_stage.gateway, name="released-backend")
+        resource_version = G(ResourceVersion, gateway=fake_stage.gateway)
+        resource_version.data = [{"id": 1, "proxy": {"backend_id": backend.id}}]
+        resource_version.save()
+        G(Release, gateway=fake_stage.gateway, stage=fake_stage, resource_version=resource_version)
+        another_stage = G(Stage, gateway=fake_stage.gateway, status=1, name="another-stage")
+        G(Release, gateway=fake_stage.gateway, stage=another_stage, resource_version=resource_version)
+
+        response = request_view(
+            "GET",
+            "backend.list-create",
+            path_params={"gateway_id": fake_stage.gateway.id},
+            gateway=fake_stage.gateway,
+        )
+
+        assert response.status_code == 200
+        result = response.json()["data"]["results"][0]
+        assert result["resource_count"] == 1
+        assert result["deletable"] is False
 
     def test_retrieve(self, request_view, fake_stage):
         fake_gateway = fake_stage.gateway

--- a/src/dashboard/apigateway/apigateway/tests/biz/resource/test_proxy.py
+++ b/src/dashboard/apigateway/apigateway/tests/biz/resource/test_proxy.py
@@ -1,0 +1,106 @@
+# -*- coding: utf-8 -*-
+#
+# TencentBlueKing is pleased to support the open source community by making
+# 蓝鲸智云 - API 网关(BlueKing - APIGateway) available.
+# Copyright (C) Tencent. All rights reserved.
+# Licensed under the MIT License (the "License"); you may not use this file except
+# in compliance with the License. You may obtain a copy of the License at
+#
+# Unless required by applicable law or agreed to in writing, software distributed under
+# the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+# either express or implied. See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# We undertake not to change the open source license (MIT license) applicable
+# to the current version of the project delivered to anyone in the future.
+#
+from django_dynamic_fixture import G
+
+from apigateway.biz.resource import ProxyHandler
+from apigateway.core.constants import StageStatusEnum
+from apigateway.core.models import Backend, Proxy, Release, Resource, ResourceVersion, Stage
+
+
+class TestProxyHandler:
+    def test_get_resource_count_by_backend_returns_empty_without_backend_ids(
+        self, django_assert_num_queries, fake_gateway
+    ):
+        with django_assert_num_queries(0):
+            result = ProxyHandler.get_resource_count_by_backend(fake_gateway.id, [])
+
+        assert result == {}
+
+    def test_get_resource_count_by_backend_combines_current_and_active_released_resources(self, fake_gateway):
+        backend = G(Backend, gateway=fake_gateway)
+        current_resource = G(Resource, gateway=fake_gateway)
+        G(Proxy, resource=current_resource, backend=backend)
+
+        released_only_resource_id = current_resource.id + 1_000_000
+        active_resource_version = G(ResourceVersion, gateway=fake_gateway)
+        active_resource_version.data = [
+            {"id": current_resource.id, "proxy": {"backend_id": backend.id}},
+            {"id": released_only_resource_id, "proxy": {"backend_id": backend.id}},
+        ]
+        active_resource_version.save()
+        active_stage = G(Stage, gateway=fake_gateway, status=StageStatusEnum.ACTIVE.value)
+        G(Release, gateway=fake_gateway, stage=active_stage, resource_version=active_resource_version)
+
+        inactive_resource_version = G(ResourceVersion, gateway=fake_gateway)
+        inactive_resource_version.data = [
+            {"id": released_only_resource_id + 1, "proxy": {"backend_id": backend.id}},
+        ]
+        inactive_resource_version.save()
+        inactive_stage = G(Stage, gateway=fake_gateway, status=StageStatusEnum.INACTIVE.value)
+        G(Release, gateway=fake_gateway, stage=inactive_stage, resource_version=inactive_resource_version)
+
+        result = ProxyHandler.get_resource_count_by_backend(fake_gateway.id, [backend.id])
+
+        assert result == {backend.id: 2}
+
+    def test_get_resource_count_by_backend_ignores_incomplete_released_resource_data(self, fake_gateway):
+        backend = G(Backend, gateway=fake_gateway)
+        other_backend = G(Backend, gateway=fake_gateway)
+        resource_version = G(ResourceVersion, gateway=fake_gateway)
+        resource_version.data = [
+            {"proxy": {"backend_id": backend.id}},
+            {"id": 1},
+            {"id": 2, "proxy": {}},
+            {"id": 3, "proxy": {"backend_id": other_backend.id}},
+            {"id": 4, "proxy": {"backend_id": backend.id}},
+        ]
+        resource_version.save()
+        stage = G(Stage, gateway=fake_gateway, status=StageStatusEnum.ACTIVE.value)
+        G(Release, gateway=fake_gateway, stage=stage, resource_version=resource_version)
+
+        result = ProxyHandler.get_resource_count_by_backend(fake_gateway.id, [backend.id])
+
+        assert result == {backend.id: 1}
+
+    def test_get_resource_count_by_backend_loads_shared_resource_version_once(self, monkeypatch, fake_gateway):
+        backend = G(Backend, gateway=fake_gateway)
+        resource_version = G(ResourceVersion, gateway=fake_gateway)
+        resource_version.data = [{"id": 1, "proxy": {"backend_id": backend.id}}]
+        resource_version.save()
+
+        for name in ["stage-1", "stage-2"]:
+            stage = G(Stage, gateway=fake_gateway, status=StageStatusEnum.ACTIVE.value, name=name)
+            G(Release, gateway=fake_gateway, stage=stage, resource_version=resource_version)
+
+        original_data_property = ResourceVersion.data
+        data_load_count = 0
+
+        def get_data(instance):
+            nonlocal data_load_count
+            data_load_count += 1
+            return original_data_property.fget(instance)
+
+        monkeypatch.setattr(
+            ResourceVersion,
+            "data",
+            property(get_data, original_data_property.fset),
+        )
+
+        result = ProxyHandler.get_resource_count_by_backend(fake_gateway.id, [backend.id])
+
+        assert result == {backend.id: 1}
+        assert data_load_count == 1


### PR DESCRIPTION
## Summary
- count distinct backend resource associations across current proxy rows and active released resource versions
- keep model-service list counts and deletion availability aligned after an associated resource is removed but not yet published
- add regression coverage for one released resource shared by multiple active stages

## Verification
- `uv run make edition-ee && uv run make lint-check` (passed; API consistency: 0 errors, 39 warnings)
- `uv run make edition-ee && uv run make test` (3924 passed)
- commit hooks: Ruff formatter, Ruff, mypy, import-linter, and sensitive-information checks passed
