### PR TITLE
fix(Resource): 可编程网关下MCP Server 编辑 资源未配置请求参数时 tooltip 里的去配置按钮点击失效 --story=163464222

### DIFF
--- a/src/dashboard-front/src/locales/cn.json
+++ b/src/dashboard-front/src/locales/cn.json
@@ -2693,5 +2693,6 @@
   "导入 JSON": "导入 JSON",
   "新增字段": "新增字段",
   "支持 OpenAPI Operation，或按 header、query、path、body 分组的请求 JSON；普通 JSON 将作为 Body 生成。": "支持 OpenAPI Operation，或按 header、query、path、body 分组的请求 JSON；普通 JSON 将作为 Body 生成。",
-  "无插件": "无插件"
+  "无插件": "无插件",
+  "可编程网关请参考框架文档，配置资源请求参数声明": "可编程网关请参考框架文档，配置资源请求参数声明"
 }

--- a/src/dashboard-front/src/locales/en.json
+++ b/src/dashboard-front/src/locales/en.json
@@ -2693,5 +2693,6 @@
   "导入 JSON": "Import JSON",
   "新增字段": "Add Field",
   "支持 OpenAPI Operation，或按 header、query、path、body 分组的请求 JSON；普通 JSON 将作为 Body 生成。": "Supports an OpenAPI Operation or request JSON grouped by header, query, path, and body. Plain JSON is treated as the Body.",
-  "无插件": "No plugin"
+  "无插件": "No plugin",
+  "可编程网关请参考框架文档，配置资源请求参数声明": "For programmable gateways, please refer to the framework documentation to configure the resource request parameter declaration"
 }

--- a/src/dashboard-front/src/views/mcp-server/components/CreateSlider.vue
+++ b/src/dashboard-front/src/views/mcp-server/components/CreateSlider.vue
@@ -178,7 +178,7 @@
                                 <div class="flex items-center">
                                   <div>{{ row?.selectionTip }}</div>
                                   <div
-                                    v-if="!row.has_openapi_schema "
+                                    v-if="!row.has_openapi_schema && !isProgrammableGateway"
                                     class="ml-16px color-#699df4 cursor-pointer"
                                     @click="handleToolNameClick(row)"
                                   >
@@ -1009,6 +1009,7 @@ let resizeLayoutConfig: IResizeLayoutConfig = {
 };
 
 const gatewayId = computed<number | undefined>(() => gatewayStore.currentGateway?.id);
+const isProgrammableGateway = computed<boolean>(() => gatewayStore.isProgrammableGateway);
 const isEditMode = computed<boolean>(() => !!serverId);
 const isEnablePrompt = computed<boolean>(() => featureFlagStore?.flags?.ENABLE_MCP_SERVER_PROMPT);
 const stage = computed<IStageListOutput | undefined>(() =>
@@ -1322,9 +1323,14 @@ const toolDisabledSelection = (row: TableRowData): boolean => {
   const selected = isSelectedTool(row);
   // 无openapi_schema 优先级最高
   if (!row.has_openapi_schema) {
-    row.selectionTip = selected
-      ? t('该资源数据有变更，请确认一下请求参数是否正确配置。')
-      : t('该资源未配置请求参数声明，不能添加到 MCP');
+    if (isProgrammableGateway.value) {
+      row.selectionTip = t('可编程网关请参考框架文档，配置资源请求参数声明');
+    }
+    else {
+      row.selectionTip = selected
+        ? t('该资源数据有变更，请确认一下请求参数是否正确配置。')
+        : t('该资源未配置请求参数声明，不能添加到 MCP');
+    }
     // 未选中才禁用；已选中只是改提示，不禁用
     return !selected;
   }


### PR DESCRIPTION
…应 --story=163464222

### Description

<!-- 关联相关issue Please include a summary of the change and which issue is fixed. -->
<!-- 给出必要的上下文以及review需要的必要信息 Please also include relevant motivation and context. -->

Fixes # (issue)

### Checklist

- [ ] 填写 PR 描述及相关 issue (write PR description and related issue)
- [ ] 代码风格检查通过 (code style check passed)
- [ ] PR 中包含单元测试 (include unit test)
- [ ] 单元测试通过 (unit test passed)
- [ ] 本地开发联调环境验证通过 (local development environment verification passed)
