### PR TITLE
refactor(itsm): align permission dimension display labels

### DIFF
--- a/src/dashboard/apigateway/apigateway/apps/bk_itsm/management/system_bk-apigateway.json
+++ b/src/dashboard/apigateway/apigateway/apps/bk_itsm/management/system_bk-apigateway.json
@@ -341,24 +341,24 @@
               "itsm_options": [
                 {
                   "translations": {
-                    "name": "gateway",
+                    "name": "按网关",
                     "name_en": "Option1",
-                    "name_zh_hans": "gateway",
+                    "name_zh_hans": "按网关",
                     "name_zh_hant": "選項1"
                   },
                   "key": "gateway",
-                  "name": "gateway",
+                  "name": "按网关",
                   "parent": null
                 },
                 {
                   "translations": {
-                    "name": "resource",
+                    "name": "按资源",
                     "name_en": "Option2",
-                    "name_zh_hans": "resource",
+                    "name_zh_hans": "按资源",
                     "name_zh_hant": "選項2"
                   },
                   "key": "resource",
-                  "name": "resource",
+                  "name": "按资源",
                   "parent": null
                 },
                 {
@@ -393,23 +393,23 @@
                 "value": [
                   {
                     "key": "gateway",
-                    "name": "gateway",
+                    "name": "按网关",
                     "selected": false,
                     "translations": {
-                      "name": "gateway",
+                      "name": "按网关",
                       "name_en": "Option1",
-                      "name_zh_hans": "gateway",
+                      "name_zh_hans": "按网关",
                       "name_zh_hant": "選項1"
                     }
                   },
                   {
                     "key": "resource",
-                    "name": "resource",
+                    "name": "按资源",
                     "selected": false,
                     "translations": {
-                      "name": "resource",
+                      "name": "按资源",
                       "name_en": "Option2",
-                      "name_zh_hans": "resource",
+                      "name_zh_hans": "按资源",
                       "name_zh_hant": "選項2"
                     }
                   },
@@ -1252,23 +1252,23 @@
                               "value": [
                                 {
                                   "key": "gateway",
-                                  "name": "gateway",
+                                  "name": "按网关",
                                   "selected": false,
                                   "translations": {
-                                    "name": "gateway",
+                                    "name": "按网关",
                                     "name_en": "Option1",
-                                    "name_zh_hans": "gateway",
+                                    "name_zh_hans": "按网关",
                                     "name_zh_hant": "選項1"
                                   }
                                 },
                                 {
                                   "key": "resource",
-                                  "name": "resource",
+                                  "name": "按资源",
                                   "selected": false,
                                   "translations": {
-                                    "name": "resource",
+                                    "name": "按资源",
                                     "name_en": "Option2",
-                                    "name_zh_hans": "resource",
+                                    "name_zh_hans": "按资源",
                                     "name_zh_hant": "選項2"
                                   }
                                 },
@@ -1885,24 +1885,24 @@
                 "itsm_options": [
                   {
                     "translations": {
-                      "name": "gateway",
+                      "name": "按网关",
                       "name_en": "Option1",
-                      "name_zh_hans": "gateway",
+                      "name_zh_hans": "按网关",
                       "name_zh_hant": "選項1"
                     },
                     "key": "gateway",
-                    "name": "gateway",
+                    "name": "按网关",
                     "parent": null
                   },
                   {
                     "translations": {
-                      "name": "resource",
+                      "name": "按资源",
                       "name_en": "Option2",
-                      "name_zh_hans": "resource",
+                      "name_zh_hans": "按资源",
                       "name_zh_hant": "選項2"
                     },
                     "key": "resource",
-                    "name": "resource",
+                    "name": "按资源",
                     "parent": null
                   },
                   {
@@ -3269,23 +3269,23 @@
                               "value": [
                                 {
                                   "key": "gateway",
-                                  "name": "gateway",
+                                  "name": "按网关",
                                   "selected": false,
                                   "translations": {
-                                    "name": "gateway",
+                                    "name": "按网关",
                                     "name_en": "Option1",
-                                    "name_zh_hans": "gateway",
+                                    "name_zh_hans": "按网关",
                                     "name_zh_hant": "選項1"
                                   }
                                 },
                                 {
                                   "key": "resource",
-                                  "name": "resource",
+                                  "name": "按资源",
                                   "selected": false,
                                   "translations": {
-                                    "name": "resource",
+                                    "name": "按资源",
                                     "name_en": "Option2",
-                                    "name_zh_hans": "resource",
+                                    "name_zh_hans": "按资源",
                                     "name_zh_hant": "選項2"
                                   }
                                 },
@@ -3902,24 +3902,24 @@
                 "itsm_options": [
                   {
                     "translations": {
-                      "name": "gateway",
+                      "name": "按网关",
                       "name_en": "Option1",
-                      "name_zh_hans": "gateway",
+                      "name_zh_hans": "按网关",
                       "name_zh_hant": "選項1"
                     },
                     "key": "gateway",
-                    "name": "gateway",
+                    "name": "按网关",
                     "parent": null
                   },
                   {
                     "translations": {
-                      "name": "resource",
+                      "name": "按资源",
                       "name_en": "Option2",
-                      "name_zh_hans": "resource",
+                      "name_zh_hans": "按资源",
                       "name_zh_hant": "選項2"
                     },
                     "key": "resource",
-                    "name": "resource",
+                    "name": "按资源",
                     "parent": null
                   },
                   {

--- a/src/dashboard/apigateway/apigateway/apps/bk_itsm/management/system_bk-apigateway.json
+++ b/src/dashboard/apigateway/apigateway/apps/bk_itsm/management/system_bk-apigateway.json
@@ -341,24 +341,24 @@
               "itsm_options": [
                 {
                   "translations": {
-                    "name": "按网关",
+                    "name": "网关",
                     "name_en": "Option1",
-                    "name_zh_hans": "按网关",
+                    "name_zh_hans": "网关",
                     "name_zh_hant": "選項1"
                   },
                   "key": "gateway",
-                  "name": "按网关",
+                  "name": "网关",
                   "parent": null
                 },
                 {
                   "translations": {
-                    "name": "按资源",
+                    "name": "资源",
                     "name_en": "Option2",
-                    "name_zh_hans": "按资源",
+                    "name_zh_hans": "资源",
                     "name_zh_hant": "選項2"
                   },
                   "key": "resource",
-                  "name": "按资源",
+                  "name": "资源",
                   "parent": null
                 },
                 {
@@ -393,23 +393,23 @@
                 "value": [
                   {
                     "key": "gateway",
-                    "name": "按网关",
+                    "name": "网关",
                     "selected": false,
                     "translations": {
-                      "name": "按网关",
+                      "name": "网关",
                       "name_en": "Option1",
-                      "name_zh_hans": "按网关",
+                      "name_zh_hans": "网关",
                       "name_zh_hant": "選項1"
                     }
                   },
                   {
                     "key": "resource",
-                    "name": "按资源",
+                    "name": "资源",
                     "selected": false,
                     "translations": {
-                      "name": "按资源",
+                      "name": "资源",
                       "name_en": "Option2",
-                      "name_zh_hans": "按资源",
+                      "name_zh_hans": "资源",
                       "name_zh_hant": "選項2"
                     }
                   },
@@ -1252,23 +1252,23 @@
                               "value": [
                                 {
                                   "key": "gateway",
-                                  "name": "按网关",
+                                  "name": "网关",
                                   "selected": false,
                                   "translations": {
-                                    "name": "按网关",
+                                    "name": "网关",
                                     "name_en": "Option1",
-                                    "name_zh_hans": "按网关",
+                                    "name_zh_hans": "网关",
                                     "name_zh_hant": "選項1"
                                   }
                                 },
                                 {
                                   "key": "resource",
-                                  "name": "按资源",
+                                  "name": "资源",
                                   "selected": false,
                                   "translations": {
-                                    "name": "按资源",
+                                    "name": "资源",
                                     "name_en": "Option2",
-                                    "name_zh_hans": "按资源",
+                                    "name_zh_hans": "资源",
                                     "name_zh_hant": "選項2"
                                   }
                                 },
@@ -1885,24 +1885,24 @@
                 "itsm_options": [
                   {
                     "translations": {
-                      "name": "按网关",
+                      "name": "网关",
                       "name_en": "Option1",
-                      "name_zh_hans": "按网关",
+                      "name_zh_hans": "网关",
                       "name_zh_hant": "選項1"
                     },
                     "key": "gateway",
-                    "name": "按网关",
+                    "name": "网关",
                     "parent": null
                   },
                   {
                     "translations": {
-                      "name": "按资源",
+                      "name": "资源",
                       "name_en": "Option2",
-                      "name_zh_hans": "按资源",
+                      "name_zh_hans": "资源",
                       "name_zh_hant": "選項2"
                     },
                     "key": "resource",
-                    "name": "按资源",
+                    "name": "资源",
                     "parent": null
                   },
                   {
@@ -3269,23 +3269,23 @@
                               "value": [
                                 {
                                   "key": "gateway",
-                                  "name": "按网关",
+                                  "name": "网关",
                                   "selected": false,
                                   "translations": {
-                                    "name": "按网关",
+                                    "name": "网关",
                                     "name_en": "Option1",
-                                    "name_zh_hans": "按网关",
+                                    "name_zh_hans": "网关",
                                     "name_zh_hant": "選項1"
                                   }
                                 },
                                 {
                                   "key": "resource",
-                                  "name": "按资源",
+                                  "name": "资源",
                                   "selected": false,
                                   "translations": {
-                                    "name": "按资源",
+                                    "name": "资源",
                                     "name_en": "Option2",
-                                    "name_zh_hans": "按资源",
+                                    "name_zh_hans": "资源",
                                     "name_zh_hant": "選項2"
                                   }
                                 },
@@ -3902,24 +3902,24 @@
                 "itsm_options": [
                   {
                     "translations": {
-                      "name": "按网关",
+                      "name": "网关",
                       "name_en": "Option1",
-                      "name_zh_hans": "按网关",
+                      "name_zh_hans": "网关",
                       "name_zh_hant": "選項1"
                     },
                     "key": "gateway",
-                    "name": "按网关",
+                    "name": "网关",
                     "parent": null
                   },
                   {
                     "translations": {
-                      "name": "按资源",
+                      "name": "资源",
                       "name_en": "Option2",
-                      "name_zh_hans": "按资源",
+                      "name_zh_hans": "资源",
                       "name_zh_hant": "選項2"
                     },
                     "key": "resource",
-                    "name": "按资源",
+                    "name": "资源",
                     "parent": null
                   },
                   {

--- a/src/dashboard/apigateway/apigateway/service/bk_itsm.py
+++ b/src/dashboard/apigateway/apigateway/service/bk_itsm.py
@@ -182,8 +182,8 @@ class ItsmPermissionApplyHelper:
     def _build_form_options(grant_dimension: str) -> Dict[str, List[Dict[str, Optional[str]]]]:
         """构建 ITSM ticket_create 所需 options（选项型字段明细）"""
         grant_dimension_option_name_map = {
-            FormattedGrantDimensionEnum.GATEWAY.value: "gateway",
-            FormattedGrantDimensionEnum.RESOURCE.value: "resource",
+            FormattedGrantDimensionEnum.GATEWAY.value: "按网关",
+            FormattedGrantDimensionEnum.RESOURCE.value: "按资源",
             FormattedGrantDimensionEnum.MCP_SERVER.value: "MCP Server",
         }
         return {

--- a/src/dashboard/apigateway/apigateway/service/bk_itsm.py
+++ b/src/dashboard/apigateway/apigateway/service/bk_itsm.py
@@ -182,8 +182,8 @@ class ItsmPermissionApplyHelper:
     def _build_form_options(grant_dimension: str) -> Dict[str, List[Dict[str, Optional[str]]]]:
         """构建 ITSM ticket_create 所需 options（选项型字段明细）"""
         grant_dimension_option_name_map = {
-            FormattedGrantDimensionEnum.GATEWAY.value: "按网关",
-            FormattedGrantDimensionEnum.RESOURCE.value: "按资源",
+            FormattedGrantDimensionEnum.GATEWAY.value: "网关",
+            FormattedGrantDimensionEnum.RESOURCE.value: "资源",
             FormattedGrantDimensionEnum.MCP_SERVER.value: "MCP Server",
         }
         return {

--- a/src/dashboard/apigateway/apigateway/tests/service/test_bk_itsm.py
+++ b/src/dashboard/apigateway/apigateway/tests/service/test_bk_itsm.py
@@ -71,7 +71,7 @@ class TestItsmPermissionApplyHelper:
         assert kwargs["form_data"]["apply_reason"] == "need access for daily ops"
         assert kwargs["form_data"]["instance_approvers"] == ["u1", "u2"]
         assert kwargs["options"] == {
-            "grant_dimension": [{"name": "按资源", "key": "resource", "parent": None}],
+            "grant_dimension": [{"name": "资源", "key": "resource", "parent": None}],
         }
         assert "reason" not in kwargs["form_data"]
         assert "expire_days" not in kwargs["form_data"]
@@ -567,11 +567,11 @@ class TestItsmPermissionApplyHelper:
 
     def test_build_form_options_uses_enum(self):
         options = ItsmPermissionApplyHelper._build_form_options(FormattedGrantDimensionEnum.GATEWAY.value)
-        assert options["grant_dimension"][0]["name"] == "按网关"
+        assert options["grant_dimension"][0]["name"] == "网关"
         assert options["grant_dimension"][0]["key"] == FormattedGrantDimensionEnum.GATEWAY.value
 
         options = ItsmPermissionApplyHelper._build_form_options(FormattedGrantDimensionEnum.RESOURCE.value)
-        assert options["grant_dimension"][0]["name"] == "按资源"
+        assert options["grant_dimension"][0]["name"] == "资源"
         assert options["grant_dimension"][0]["key"] == FormattedGrantDimensionEnum.RESOURCE.value
 
         options = ItsmPermissionApplyHelper._build_form_options(FormattedGrantDimensionEnum.MCP_SERVER.value)

--- a/src/dashboard/apigateway/apigateway/tests/service/test_bk_itsm.py
+++ b/src/dashboard/apigateway/apigateway/tests/service/test_bk_itsm.py
@@ -71,7 +71,7 @@ class TestItsmPermissionApplyHelper:
         assert kwargs["form_data"]["apply_reason"] == "need access for daily ops"
         assert kwargs["form_data"]["instance_approvers"] == ["u1", "u2"]
         assert kwargs["options"] == {
-            "grant_dimension": [{"name": "resource", "key": "resource", "parent": None}],
+            "grant_dimension": [{"name": "按资源", "key": "resource", "parent": None}],
         }
         assert "reason" not in kwargs["form_data"]
         assert "expire_days" not in kwargs["form_data"]
@@ -567,8 +567,12 @@ class TestItsmPermissionApplyHelper:
 
     def test_build_form_options_uses_enum(self):
         options = ItsmPermissionApplyHelper._build_form_options(FormattedGrantDimensionEnum.GATEWAY.value)
-        assert options["grant_dimension"][0]["name"] == "gateway"
+        assert options["grant_dimension"][0]["name"] == "按网关"
         assert options["grant_dimension"][0]["key"] == FormattedGrantDimensionEnum.GATEWAY.value
+
+        options = ItsmPermissionApplyHelper._build_form_options(FormattedGrantDimensionEnum.RESOURCE.value)
+        assert options["grant_dimension"][0]["name"] == "按资源"
+        assert options["grant_dimension"][0]["key"] == FormattedGrantDimensionEnum.RESOURCE.value
 
         options = ItsmPermissionApplyHelper._build_form_options(FormattedGrantDimensionEnum.MCP_SERVER.value)
         assert options["grant_dimension"][0]["name"] == "MCP Server"


### PR DESCRIPTION
- 修改：ITSM 审批单详情中「权限维度」显示英文枚举值的问题，将 `gateway` 和 `resource` 的展示文案统一为「按网关」和「按资源」，与蓝鲸 API 网关保持一致。需要更新表单：uv run python manage.py register_to_itsm --update-form-model
