### PR TITLE
fix(ai-backend): support service endpoints with actionable validation errors

### DIFF
--- a/src/dashboard/apigateway/apigateway/apis/web/ai_backend/serializers.py
+++ b/src/dashboard/apigateway/apigateway/apis/web/ai_backend/serializers.py
@@ -1,9 +1,55 @@
 from collections.abc import Mapping
+from urllib.parse import urlsplit
 
+from django.utils.http import MAX_URL_LENGTH
+from django.utils.translation import gettext_lazy as _
 from rest_framework import serializers
 
+from apigateway.common.security import is_forbidden_host
 from apigateway.core.ai_backend import get_ai_backend_provider_config
-from apigateway.core.constants import AIBackendProviderEnum
+from apigateway.core.constants import HOST_WITHOUT_SCHEME_PATTERN, AIBackendProviderEnum
+
+
+class AIBackendEndpointField(serializers.CharField):
+    class Meta:
+        swagger_schema_fields = {"format": "uri"}
+
+    def to_internal_value(self, data):
+        value = super().to_internal_value(data)
+        if len(value) > MAX_URL_LENGTH:
+            raise serializers.ValidationError(
+                _("URL 长度不能超过 {max_length} 个字符。").format(max_length=MAX_URL_LENGTH), code="invalid"
+            )
+        if any(char.isspace() or ord(char) < 32 for char in value):
+            raise serializers.ValidationError(_("URL 中不能包含空白或控制字符。"), code="invalid")
+        try:
+            parsed = urlsplit(value)
+        except ValueError:
+            raise serializers.ValidationError(
+                _("主机名或 IP 格式不合法，支持 Service 短名称。"), code="invalid"
+            ) from None
+
+        if parsed.scheme not in {"http", "https"}:
+            raise serializers.ValidationError(
+                _("仅支持 HTTP/HTTPS 协议，请以 http:// 或 https:// 开头。"), code="invalid"
+            )
+        if not parsed.hostname:
+            raise serializers.ValidationError(_("URL 缺少主机名或 IP 地址。"), code="invalid")
+        if parsed.username is not None or parsed.password is not None:
+            raise serializers.ValidationError(_("URL 中不能包含用户名或密码。"), code="invalid")
+        try:
+            port = parsed.port
+        except ValueError:
+            raise serializers.ValidationError(_("端口必须是 1～65535 的整数。"), code="invalid") from None
+        if port == 0 or parsed.netloc.endswith(":"):
+            raise serializers.ValidationError(_("端口必须是 1～65535 的整数。"), code="invalid")
+
+        # Reuse standard backend host:port rules, including single-label service names.
+        if not HOST_WITHOUT_SCHEME_PATTERN.fullmatch(parsed.netloc):
+            raise serializers.ValidationError(_("主机名或 IP 格式不合法，支持 Service 短名称。"), code="invalid")
+        if is_forbidden_host(parsed.hostname) or is_forbidden_host(parsed.netloc):
+            raise serializers.ValidationError(_("该主机或端口不允许使用。"), code="invalid")
+        return value
 
 
 class _StrictSerializer(serializers.Serializer):
@@ -22,8 +68,8 @@ class AIBackendAuthHeaderSLZ(_StrictSerializer):
 
 class AIBackendWebInputSLZ(_StrictSerializer):
     provider = serializers.ChoiceField(choices=AIBackendProviderEnum.get_choices())
-    endpoint = serializers.URLField(required=False)
-    model_endpoint = serializers.URLField(required=False, allow_null=True)
+    endpoint = AIBackendEndpointField(required=False)
+    model_endpoint = AIBackendEndpointField(required=False, allow_null=True)
     api_key = serializers.CharField(required=False, allow_null=True, allow_blank=False, trim_whitespace=False)
     auth_header = AIBackendAuthHeaderSLZ(required=False, allow_null=True)
     model = serializers.CharField(required=False, allow_null=True, allow_blank=False)

--- a/src/dashboard/apigateway/apigateway/tests/apis/web/ai_backend/test_serializers.py
+++ b/src/dashboard/apigateway/apigateway/tests/apis/web/ai_backend/test_serializers.py
@@ -43,6 +43,78 @@ def test_custom_web_input_accepts_optional_auth_model_and_models_endpoint():
     }
 
 
+@pytest.mark.parametrize("field", ["endpoint", "model_endpoint"])
+@pytest.mark.parametrize(
+    "url",
+    [
+        "https://apidemo/component",
+        "http://apidemo:8080/v1/chat/completions",
+        "https://apidemo.default.svc.cluster.local/component",
+        "https://llm.example.com:8443/component?api-version=2026-01-01",
+        "http://10.0.0.10:8080/component",
+        "http://[fd00::10]:8080/component",
+    ],
+)
+def test_custom_web_endpoints_accept_backend_service_addresses(field, url):
+    slz = AIBackendWebInputSLZ(
+        data={"provider": "openai-compatible", "endpoint": "https://llm.example.com/component", field: url}
+    )
+
+    slz.is_valid(raise_exception=True)
+
+    assert slz.validated_data[field] == url
+
+
+@pytest.mark.parametrize("field", ["endpoint", "model_endpoint"])
+@pytest.mark.parametrize(
+    "url, reason",
+    [
+        ("ftp://llm.example.com/component", "仅支持 HTTP/HTTPS 协议"),
+        ("https:///component", "缺少主机名或 IP 地址"),
+        ("https://user:secret@llm.example.com/component", "不能包含用户名或密码"),
+        ("https://bad_host.example.com/component", "主机名或 IP 格式不合法"),
+        ("https://llm.example.com:invalid/component", "端口必须是 1～65535 的整数"),
+        ("https://llm.example.com:0/component", "端口必须是 1～65535 的整数"),
+        ("https://llm.example.com:65536/component", "端口必须是 1～65535 的整数"),
+        ("https://llm.example.com:/component", "端口必须是 1～65535 的整数"),
+        ("https://[invalid]/component", "主机名或 IP 格式不合法"),
+        ("\x01https://llm.example.com/component", "不能包含空白或控制字符"),
+        ("https://llm.exa\nmple.com/component", "不能包含空白或控制字符"),
+        ("https://llm.example.com/com ponent", "不能包含空白或控制字符"),
+        ("https://llm.example.com/" + "a" * 2048, "URL 长度不能超过 2048 个字符"),
+    ],
+)
+def test_custom_web_endpoints_reject_invalid_urls(field, url, reason):
+    slz = AIBackendWebInputSLZ(
+        data={"provider": "openai-compatible", "endpoint": "https://llm.example.com/component", field: url}
+    )
+
+    assert not slz.is_valid()
+    assert reason in str(slz.errors[field][0])
+    assert slz.errors[field][0].code == "invalid"
+    assert "secret" not in str(slz.errors)
+
+
+@pytest.mark.parametrize("field", ["endpoint", "model_endpoint"])
+@pytest.mark.parametrize(
+    "host", ["blocked.example.com", "blocked.example.com:443", "llm.example.com:8443", "llm.example.com:8080"]
+)
+def test_custom_web_endpoints_reject_forbidden_backend_addresses(settings, field, host):
+    settings.FORBIDDEN_HOSTS = ["blocked.example.com", "llm.example.com:8443"]
+    settings.FORBIDDEN_PORTS = [8080]
+    slz = AIBackendWebInputSLZ(
+        data={
+            "provider": "openai-compatible",
+            "endpoint": "https://llm.example.com/component",
+            field: f"https://{host}/component",
+        }
+    )
+
+    assert not slz.is_valid()
+    assert "该主机或端口不允许使用" in str(slz.errors[field][0])
+    assert slz.errors[field][0].code == "invalid"
+
+
 def test_custom_web_input_rejects_model_inside_model_options():
     slz = AIBackendWebInputSLZ(
         data={

--- a/src/dashboard/apigateway/apigateway/tests/apis/web/backend/test_views.py
+++ b/src/dashboard/apigateway/apigateway/tests/apis/web/backend/test_views.py
@@ -457,24 +457,35 @@ class TestBackendConnectivityApi:
             allow_redirects=False,
         )
 
-    def test_openai_compatible_uses_custom_models_endpoint(self, mocker, request_view, fake_stage):
+    @pytest.mark.parametrize(
+        "endpoint, model_endpoint",
+        [
+            (
+                "https://models.example.com/v1/chat/completions?api-version=2026-01-01",
+                "https://catalog.example.com/custom/models?api-version=2026-01-01",
+            ),
+            ("https://apidemo/component", "https://apidemo/custom/models"),
+        ],
+    )
+    def test_openai_compatible_uses_custom_models_endpoint(
+        self, mocker, request_view, fake_stage, endpoint, model_endpoint
+    ):
         fake_stage.gateway.kind = GatewayKindEnum.AI.value
         fake_stage.gateway.save()
         config = _ai_config(fake_stage.id)
         config.update(
             {
                 "provider": "openai-compatible",
-                "endpoint": "https://models.example.com/v1/chat/completions?api-version=2026-01-01",
+                "endpoint": endpoint,
                 "auth_header": {"name": "X-Api-Key", "value": "secret"},
             }
         )
         config.pop("api_key")
         resolver = mocker.patch(
             "socket.getaddrinfo",
-            return_value=[(2, 1, 6, "", ("8.8.8.8", 443))],
+            return_value=[(2, 1, 6, "", ("10.0.0.10", 443))],
         )
         http_get = _mock_model_response(mocker, {"data": [{"id": "custom-model"}]})
-        model_endpoint = "https://catalog.example.com/custom/models?api-version=2026-01-01"
         config["model_endpoint"] = model_endpoint
 
         response = request_view(
@@ -486,6 +497,7 @@ class TestBackendConnectivityApi:
         )
 
         assert response.status_code == 200, response.json()
+        assert response.json()["data"] == {"models": ["custom-model"]}
         http_get.assert_called_once_with(
             model_endpoint,
             {},


### PR DESCRIPTION
### Description

新建 `openai-compatible` 模型服务时，`https://apidemo/component` 等 Kubernetes Service 短名称地址会被默认 `URLField` 拒绝，连接测试返回“请输入合法的URL”。

为 Web `endpoint` 和 `model_endpoint` 使用专用字段，拆分完整 URL 后复用普通后端服务的 `host:port` 正则和禁用地址/端口检查，支持短 Service 名、域名和 IP 地址。保留 HTTP/HTTPS、凭据、端口、字符和长度校验，并在对应字段返回具体中文原因，错误码仍为 `invalid`。本次调整仅作用于 Web 输入，自动化同步保持原有校验。

包含地址校验、错误原因和连接测试回归用例。连接测试中的 DNS 和上游 HTTP 响应使用模拟数据，未验证真实 Kubernetes 环境。

本地验证（基于最新 `upstream/master` 的独立工作区）：
- 相关测试：170 passed。
- `uv run make lint-check`：通过；OpenAPI 一致性检查 0 错误、39 条警告。
- `PYTEST_XDIST_AUTO_NUM_WORKERS=4 uv run make test`：3971 passed。

### Checklist

- [x] 填写 PR 描述（未关联 issue）
- [x] 代码风格检查通过
- [x] PR 中包含单元测试
- [x] 单元测试通过
- [ ] 本地开发联调环境验证通过
