### PR TITLE
fix(itsm): replace /api/v1/ticket_search/full_text_search/ with /api/v1/approval_tasks/

### DIFF
--- a/src/dashboard/apigateway/apigateway/apps/permission/tasks.py
+++ b/src/dashboard/apigateway/apigateway/apps/permission/tasks.py
@@ -45,7 +45,7 @@ from apigateway.apps.permission.models import (
 from apigateway.biz.permission import PermissionDimensionManager
 from apigateway.common.tenant.request import get_tenant_id_for_gateway_maintainers
 from apigateway.components.bkcmsi import cmsi_component
-from apigateway.components.bkitsm import get_ticket_by_id
+from apigateway.components.bkitsm import list_approval_tasks
 from apigateway.components.bkpaas import get_app_maintainers, get_tenant_id_for_app_developers
 from apigateway.core.constants import ContextScopeTypeEnum, ContextTypeEnum, GatewayStatusEnum
 from apigateway.core.models import Context, Gateway, Resource
@@ -242,13 +242,12 @@ def _update_gateway_or_resource_permission_record_handled_by(
 
 def _get_itsm_approver_for_backfill(ticket_id: str) -> str:
     try:
-        # /ticket/detail/ 暂无法返回 history_processors，先用工单搜索接口，修复后可切回详情接口。
-        ticket_search_result = get_ticket_by_id(ticket_id)
+        approval_tasks = list_approval_tasks(ticket_id)
     except Exception:
-        logger.warning("query or parse itsm ticket failed, ticket_id=%s", ticket_id, exc_info=True)
+        logger.warning("query or parse itsm approval tasks failed, ticket_id=%s", ticket_id, exc_info=True)
         return ""
 
-    approver = ticket_search_result.actual_approver
+    approver = approval_tasks.get_actual_approver()
     if not approver:
         logger.info("skip filling itsm approver because approver is empty, ticket_id=%s", ticket_id)
         return ""

--- a/src/dashboard/apigateway/apigateway/components/bkitsm.py
+++ b/src/dashboard/apigateway/apigateway/components/bkitsm.py
@@ -18,10 +18,10 @@
 #
 import json
 import logging
-from typing import Any, Dict, Optional
+from typing import Any, ClassVar, Dict, Optional
 
 from django.conf import settings
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 from apigateway.utils.url import url_join
 
@@ -76,36 +76,35 @@ class ItsmFormModelUpdateResult(BaseModel):
         return frozenset(self.meta.fields.keys())
 
 
-class ItsmTicketProcessor(BaseModel):
-    id: str
-    type: str
-    display: str = ""
+class ItsmApprovalTask(BaseModel):
+    """ITSM 审批任务。只建模回填审批人需要的字段，其余响应字段忽略。"""
+
+    APPROVED_STATUS: ClassVar[str] = "approve"
+    USER_OPERATOR_TYPE: ClassVar[str] = "user"
+
+    status: str = ""
+    operator: str = ""
+    operator_type: str = ""
 
 
-class ItsmTicketItem(BaseModel):
-    id: str
-    history_processors: Optional[list[ItsmTicketProcessor]] = None
-
-    @property
-    def actual_approver(self) -> str:
-        history_processors = [processor for processor in (self.history_processors or []) if processor.type == "user"]
-        return history_processors[0].id if history_processors else ""
-
-
-class ItsmTicketSearchResult(BaseModel):
-    results: list[ItsmTicketItem]
-    page: int = 1
-    page_size: int = 10
-    count: int
+class ItsmApprovalTaskList(BaseModel):
+    items: list[ItsmApprovalTask] = Field(default_factory=list)
 
     @classmethod
-    def from_response(cls, resp: Any) -> "ItsmTicketSearchResult":
-        return cls.model_validate(resp)
+    def from_response(cls, resp: Any) -> "ItsmApprovalTaskList":
+        return cls.model_validate(resp or {})
 
-    @property
-    def actual_approver(self) -> str:
-        approvers = [ticket.actual_approver for ticket in self.results if ticket.actual_approver]
-        return approvers[0] if approvers else ""
+    def get_actual_approver(self) -> str:
+        """取 items 中最后一个同意任务的用户操作人；不满足则返回空串。"""
+        approved_tasks = [task for task in self.items if task.status == ItsmApprovalTask.APPROVED_STATUS]
+        if not approved_tasks:
+            return ""
+
+        last_approved = approved_tasks[-1]
+        if last_approved.operator_type != ItsmApprovalTask.USER_OPERATOR_TYPE:
+            return ""
+
+        return last_approved.operator.strip()
 
 
 def _call_bkitsm_api(
@@ -296,26 +295,17 @@ def create_ticket(
     )
 
 
-def get_ticket_by_id(ticket_id: str, operator: Optional[str] = None) -> ItsmTicketSearchResult:
+def list_approval_tasks(ticket_id: str) -> ItsmApprovalTaskList:
     """
-    按工单 ID 查询单条 ITSM 工单。
+    按工单 ID 查询审批任务列表，用于回填真实审批人。
 
-    因 /ticket/detail/ 暂无法返回 history_processors，先走搜索接口按 id__in 精确查询。
-    调用接口: ticket_search_full_text_search (POST)
-    路径: /api/v1/ticket_search/full_text_search/
+    调用接口: approval_tasks (POST)
+    路径: /api/v1/approval_tasks/
     """
-    data = {
-        "page": 1,
-        # 按单个 ticket_id 查询，只需返回一条
-        "page_size": 1,
-        "id__in": ticket_id,
-        "operator": operator or settings.BK_ITSM4_QUERY_OPERATOR,
-        "group_key": "all",
-    }
     resp = _call_bkitsm_api(
         http_post,
-        "/api/v1/ticket_search/full_text_search/",
-        data,
+        "/api/v1/approval_tasks/",
+        {"ticket_id": ticket_id},
         timeout=settings.BK_ITSM4_API_TIMEOUT,
     )
-    return ItsmTicketSearchResult.from_response(resp)
+    return ItsmApprovalTaskList.from_response(resp)

--- a/src/dashboard/apigateway/apigateway/tests/apps/permission/test_tasks.py
+++ b/src/dashboard/apigateway/apigateway/tests/apps/permission/test_tasks.py
@@ -114,22 +114,22 @@ class TestRenewAppResourcePermission:
 class TestAsyncFillItsmApprover:
     def test_get_itsm_approver_returns_structured_result(self, mocker):
         mocker.patch(
-            "apigateway.apps.permission.tasks.get_ticket_by_id",
-            return_value=mocker.Mock(actual_approver="admin"),
+            "apigateway.apps.permission.tasks.list_approval_tasks",
+            return_value=mocker.Mock(get_actual_approver=mocker.Mock(return_value="admin")),
         )
 
         assert _get_itsm_approver_for_backfill("ticket-001") == "admin"
 
     def test_get_itsm_approver_returns_empty_when_ticket_has_no_approver(self, mocker):
         mocker.patch(
-            "apigateway.apps.permission.tasks.get_ticket_by_id",
-            return_value=mocker.Mock(actual_approver=""),
+            "apigateway.apps.permission.tasks.list_approval_tasks",
+            return_value=mocker.Mock(get_actual_approver=mocker.Mock(return_value="")),
         )
 
         assert _get_itsm_approver_for_backfill("ticket-001") == ""
 
     def test_get_itsm_approver_returns_empty_when_query_failed(self, mocker):
-        mocker.patch("apigateway.apps.permission.tasks.get_ticket_by_id", side_effect=Exception("remote error"))
+        mocker.patch("apigateway.apps.permission.tasks.list_approval_tasks", side_effect=Exception("remote error"))
 
         assert _get_itsm_approver_for_backfill("ticket-001") == ""
 
@@ -150,8 +150,8 @@ class TestAsyncFillItsmApprover:
             handled_by="itsm",
         )
         mocker.patch(
-            "apigateway.apps.permission.tasks.get_ticket_by_id",
-            return_value=mocker.Mock(actual_approver="admin"),
+            "apigateway.apps.permission.tasks.list_approval_tasks",
+            return_value=mocker.Mock(get_actual_approver=mocker.Mock(return_value="admin")),
         )
 
         async_fill_gateway_or_resource_itsm_approver(GrantDimensionEnum.API.value, record.id, "ticket-001")
@@ -180,8 +180,8 @@ class TestAsyncFillItsmApprover:
             handled_by="itsm",
         )
         mocker.patch(
-            "apigateway.apps.permission.tasks.get_ticket_by_id",
-            return_value=mocker.Mock(actual_approver="admin"),
+            "apigateway.apps.permission.tasks.list_approval_tasks",
+            return_value=mocker.Mock(get_actual_approver=mocker.Mock(return_value="admin")),
         )
 
         async_fill_gateway_or_resource_itsm_approver(GrantDimensionEnum.RESOURCE.value, record.id, "ticket-001")
@@ -201,8 +201,8 @@ class TestAsyncFillItsmApprover:
             handled_by="itsm",
         )
         mocker.patch(
-            "apigateway.apps.permission.tasks.get_ticket_by_id",
-            return_value=mocker.Mock(actual_approver="admin"),
+            "apigateway.apps.permission.tasks.list_approval_tasks",
+            return_value=mocker.Mock(get_actual_approver=mocker.Mock(return_value="admin")),
         )
 
         async_fill_mcp_server_itsm_approver(apply.id, "ticket-001")

--- a/src/dashboard/apigateway/apigateway/tests/components/test_bkitsm.py
+++ b/src/dashboard/apigateway/apigateway/tests/components/test_bkitsm.py
@@ -22,13 +22,12 @@ from pydantic import ValidationError
 
 from apigateway.common.error_codes import error_codes
 from apigateway.components.bkitsm import (
+    ItsmApprovalTaskList,
     ItsmFormModelUpdateResult,
-    ItsmTicketItem,
-    ItsmTicketSearchResult,
     ItsmWorkflowList,
     _call_bkitsm_api,
     create_ticket,
-    get_ticket_by_id,
+    list_approval_tasks,
     system_workflow_list,
     update_form_model,
 )
@@ -127,67 +126,128 @@ def test_itsm_form_model_update_result_extract_updated_fields():
     assert result.updated_field_keys == frozenset({"apply_reason", "gateway_name"})
 
 
-def test_itsm_ticket_item_prefers_first_history_user():
-    detail = ItsmTicketItem.model_validate(
+def test_itsm_approval_task_list_extracts_approver_from_real_payload():
+    result = ItsmApprovalTaskList.from_response(
         {
-            "id": "t-001",
-            "history_processors": [
-                {"id": "admin", "type": "user", "display": "管理员(admin)"},
-                {"id": "neoling", "type": "user", "display": "neoling"},
-            ],
-        }
-    )
-
-    assert detail.actual_approver == "admin"
-
-
-def test_itsm_ticket_item_returns_empty_without_history_user():
-    detail = ItsmTicketItem.model_validate(
-        {
-            "id": "t-001",
-            "history_processors": [
-                {"id": "group-a", "type": "group", "display": "group-a"},
-            ],
-        }
-    )
-
-    assert detail.actual_approver == ""
-
-
-def test_itsm_ticket_item_requires_processors_list():
-    with pytest.raises(ValidationError):
-        ItsmTicketItem.model_validate(
-            {
-                "id": "t-001",
-                "history_processors": {"id": "admin", "type": "user"},
-            }
-        )
-
-
-def test_itsm_ticket_search_result_extract_actual_approver():
-    result = ItsmTicketSearchResult.from_response(
-        {
-            "results": [
+            "items": [
                 {
-                    "id": "t-001",
-                    "history_processors": [
-                        {"id": "admin", "type": "user", "display": "管理员(admin)"},
-                        {"id": "neoling", "type": "user", "display": "neoling"},
-                    ],
+                    "id": "task-001",
+                    "name": "审批节点: 任务[task-001]",
+                    "activity_key": "activityobject_1",
+                    "desc": "提单人自动审批同意",
+                    "type": "APPROVE_TASK",
+                    "status": "approve",
+                    "status_display": "同意",
+                    "operator": "admin",
+                    "operator_type": "user",
+                    "operator_at": "2026-01-01T00:00:00+08:00",
+                    "current_processors": [],
                 }
-            ],
-            "page": 1,
-            "page_size": 10,
-            "count": 1,
+            ]
         }
     )
 
-    assert result.actual_approver == "admin"
+    assert result.get_actual_approver() == "admin"
 
 
-def test_itsm_ticket_search_result_requires_results_list():
+def test_itsm_approval_task_list_uses_last_approved_user():
+    result = ItsmApprovalTaskList.from_response(
+        {
+            "items": [
+                {
+                    "status": "approve",
+                    "operator": "admin",
+                    "operator_type": "user",
+                },
+                {
+                    "status": "approve",
+                    "operator": "admin_user",
+                    "operator_type": "user",
+                },
+            ]
+        }
+    )
+
+    assert result.get_actual_approver() == "admin_user"
+
+
+def test_itsm_approval_task_list_returns_empty_when_last_approve_is_not_user():
+    result = ItsmApprovalTaskList.from_response(
+        {
+            "items": [
+                {
+                    "status": "approve",
+                    "operator": "admin",
+                    "operator_type": "user",
+                },
+                {
+                    "status": "approve",
+                    "operator": "gateway-maintainers",
+                    "operator_type": "group",
+                },
+            ]
+        }
+    )
+
+    assert result.get_actual_approver() == ""
+
+
+def test_itsm_approval_task_list_returns_empty_without_approve_task():
+    result = ItsmApprovalTaskList.from_response(
+        {
+            "items": [
+                {
+                    "status": "reject",
+                    "operator": "admin",
+                    "operator_type": "user",
+                }
+            ]
+        }
+    )
+
+    assert result.get_actual_approver() == ""
+
+
+def test_itsm_approval_task_list_returns_empty_when_operator_blank():
+    result = ItsmApprovalTaskList.from_response(
+        {
+            "items": [
+                {
+                    "status": "approve",
+                    "operator": "  ",
+                    "operator_type": "user",
+                }
+            ]
+        }
+    )
+
+    assert result.get_actual_approver() == ""
+
+
+def test_itsm_approval_task_list_ignores_non_approve_after_user_approve():
+    result = ItsmApprovalTaskList.from_response(
+        {
+            "items": [
+                {
+                    "status": "approve",
+                    "operator": "admin",
+                    "operator_type": "user",
+                },
+                {
+                    "status": "running",
+                    "operator": "admin",
+                    "operator_type": "user",
+                },
+            ]
+        }
+    )
+
+    assert result.get_actual_approver() == "admin"
+
+
+def test_itsm_approval_task_list_requires_items_list():
     with pytest.raises(ValidationError):
-        ItsmTicketSearchResult.from_response({"results": {}, "count": 1})
+        ItsmApprovalTaskList.from_response({"items": {}})
 
 
 def test_create_ticket_prefers_system_token(settings, mocker):
@@ -247,30 +307,27 @@ def test_update_form_model_fallback_to_global_token(settings, mocker):
     assert result.updated_field_keys == frozenset({"apply_reason"})
 
 
-def test_get_ticket_by_id(settings, mocker):
+def test_list_approval_tasks(settings, mocker):
     settings.BK_ITSM4_URL_PREFIX = "http://bk-itsm4.example.com/prod"
     settings.BK_ITSM4_API_TIMEOUT = 30
-    settings.BK_ITSM4_QUERY_OPERATOR = "admin"
 
     mock_call = mocker.patch(
         "apigateway.components.bkitsm._call_bkitsm_api",
         return_value={
-            "results": [{"id": "t-001", "history_processors": [{"id": "admin", "type": "user"}]}],
-            "count": 1,
+            "items": [
+                {
+                    "status": "approve",
+                    "operator": "admin",
+                    "operator_type": "user",
+                }
+            ]
         },
     )
 
-    result = get_ticket_by_id("t-001")
+    result = list_approval_tasks("t-001")
 
     args, kwargs = mock_call.call_args
-    assert args[1] == "/api/v1/ticket_search/full_text_search/"
-    assert args[2] == {
-        "page": 1,
-        "page_size": 1,
-        "id__in": "t-001",
-        "operator": "admin",
-        "group_key": "all",
-    }
+    assert args[1] == "/api/v1/approval_tasks/"
+    assert args[2] == {"ticket_id": "t-001"}
     assert kwargs["timeout"] == 30
-    assert result.actual_approver == "admin"
-    assert result.count == 1
+    assert result.get_actual_approver() == "admin"


### PR DESCRIPTION
- 修复回填后没有正常显示审批单据的问题：ITSM 的 history_processors 返回的并不是历史审批人，改为 approval_tasks 接口去获取最后审批人并回填。