### PR TITLE
feat(esb): 支持配置 CC 请求携带 JWT

### DIFF
--- a/src/esb/README.md
+++ b/src/esb/README.md
@@ -44,6 +44,20 @@ JOB_CLIENT_CERT = "xxx"
 JOB_CLIENT_KEY = "xxx"
 ```
 
+#### CC 请求携带 JWT
+
+在 ESB 部署环境中设置以下环境变量，并重启 ESB 进程：
+
+```bash
+BK_ESB_CC_JWT_ENABLED=true
+```
+
+默认值为 `false`。开启后，通过 `CCClient` 转发的 CC 请求会携带 ESB 签发的
+`X-Bkapi-JWT`，原有身份请求头保持不变。
+
+ESB 需要已配置 JWT 签名私钥，否则 JWT 为空；CC 如需验签，应使用对应公钥。
+此开关只控制 ESB 发送 JWT，不会开启 CC 服务端的验签功能。
+
 ### 2. 开发新组件
 
 以系统 my_app，组件 get_hello_msg 为例，说明新组件开发过程

--- a/src/esb/esb/components/bk/apisv2/cc/toolkit/configs.py
+++ b/src/esb/esb/components/bk/apisv2/cc/toolkit/configs.py
@@ -26,3 +26,5 @@ SYSTEM_NAME = "CC"
 host = SmartHost(host_prod=getattr(settings, "HOST_CC_V3", ""))
 
 DEFAULT_BK_SUPPLIER_ACCOUNT = "0"
+
+JWT_ENABLED = getattr(settings, "BK_ESB_CC_JWT_ENABLED", False)

--- a/src/esb/esb/components/bk/apisv2/cc/toolkit/tools.py
+++ b/src/esb/esb/components/bk/apisv2/cc/toolkit/tools.py
@@ -49,6 +49,7 @@ class CCClient(object):
                 "HTTP_BLUEKING_SUPPLIER_ID": "0",
             }
         )
+        kwargs["with_jwt_header"] = configs.JWT_ENABLED
         return self.http_client.request(
             method,
             host,

--- a/src/esb/esb/conf/default.py
+++ b/src/esb/esb/conf/default.py
@@ -253,6 +253,8 @@ HOST_CC = env.str("BK_CMDB_URL", "")
 
 # host for cc v3
 HOST_CC_V3 = env.str("BK_CMDB_V3_URL", "")
+# Include an ESB-signed JWT in requests to CC when enabled.
+BK_ESB_CC_JWT_ENABLED = env.bool("BK_ESB_CC_JWT_ENABLED", False)
 
 # host for job, default 80 for http/8443 for https
 HOST_JOB = env.str("BK_JOB_URL", "")

--- a/src/esb/esb/tests/components/test_cc_client.py
+++ b/src/esb/esb/tests/components/test_cc_client.py
@@ -1,0 +1,40 @@
+# -*- coding: utf-8 -*-
+#
+# TencentBlueKing is pleased to support the open source community by making
+# 蓝鲸智云 - API 网关(BlueKing - APIGateway) available.
+# Copyright (C) Tencent. All rights reserved.
+# Licensed under the MIT License (the "License"); you may not use this file except
+# in compliance with the License. You may obtain a copy of the License at
+#
+#     http://opensource.org/licenses/MIT
+#
+# Unless required by applicable law or agreed to in writing, software distributed under
+# the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+# either express or implied. See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# We undertake not to change the open source license (MIT license) applicable
+# to the current version of the project delivered to anyone in the future.
+#
+import pytest
+
+from components.bk.apisv2.cc.toolkit import configs
+from components.bk.apisv2.cc.toolkit.tools import CCClient
+
+
+@pytest.mark.parametrize("enabled", [False, True])
+@pytest.mark.parametrize("method", ["get", "post", "put", "delete"])
+def test_cc_jwt_enabled(mocker, enabled, method):
+    mocker.patch.object(configs, "JWT_ENABLED", enabled)
+    component = mocker.MagicMock()
+    component.current_user.username = "test-user"
+    component.request.app_code = "test-app"
+    component.outgoing.http_client.request.return_value = '{"code": 0, "data": {}}'
+
+    result = getattr(CCClient(component), method)(host="http://cc.example.com", path="/api/v3/test")
+
+    assert result["result"] is True
+    kwargs = component.outgoing.http_client.request.call_args[1]
+    assert kwargs["with_jwt_header"] is enabled
+    assert kwargs["headers"]["Bk-Username"] == "test-user"
+    assert kwargs["headers"]["Bk-App-Code"] == "test-app"


### PR DESCRIPTION
### Description

CC 组件此前不会向下游发送 ESB 签发的 JWT。新增环境变量 `BK_ESB_CC_JWT_ENABLED`，默认 `false`；设置为 `true` 并重启 ESB 后，经 `CCClient` 转发的请求会携带 `X-Bkapi-JWT`，保留原有身份请求头。

复用现有 JWT 签发逻辑，需要 ESB 已配置签名私钥。此开关不启用 CC 服务端验签。README 包含开启方法和前提。

改动文件不在流水线 rsync 的 `components/confapis/` 目录内，不会被该同步覆盖；未取得实际 `legacy_paas_tag`，未验证同步后的接口定义是否全部使用该公共客户端。

验证使用 Python 3.7.17 容器及仓库锁定依赖：
- 原始 master `make test`：246 passed；修改后 `make test`：254 passed。
- 新增 8 个测试覆盖四种 HTTP 方法、JWT 开关以及原有身份请求头。
- 环境变量未设置 / false / true 的实际配置加载检查通过。
- 改动 Python 文件 Black/Ruff 检查通过，全量 mypy 通过。
- `make lint` 在原始 master 和修改后均通过，但会格式化两个已有文件；已撤回这些无关格式化。提交时仅跳过会修改无关文件的全目录 Ruff 钩子，使用已通过的定向 Ruff 检查；其他适用钩子通过。
- 未构建镜像或进行线上 CC 联调。

### Checklist

- [x] 填写 PR 描述及相关 issue (write PR description and related issue; no linked issue)
- [x] 代码风格检查通过 (code style check passed for changed files)
- [x] PR 中包含单元测试 (include unit test)
- [x] 单元测试通过 (unit test passed)
- [ ] 本地开发联调环境验证通过 (local development environment verification passed)
